### PR TITLE
feat(server): sketch event types

### DIFF
--- a/packages/server/src/events.cairo
+++ b/packages/server/src/events.cairo
@@ -1,1 +1,33 @@
+//! Events emitted by the server contract.
+//! Used to index keys, channels, notes, and nullifiers.
 
+use server::objects::EncChannelInfo;
+use starknet::ContractAddress;
+
+#[derive(Drop, starknet::Event)]
+pub struct NoteCreated {
+    #[key]
+    pub note_id: felt252,
+    pub enc_amount: felt252,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct NullifierAdded {
+    #[key]
+    pub nullifier: felt252,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct ChannelOpened {
+    #[key]
+    pub channel_id: felt252,
+    pub recipient: ContractAddress,
+    pub enc_channel_info: EncChannelInfo,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct KeyRegistered {
+    #[key]
+    pub public_key: felt252,
+    pub user: ContractAddress,
+}

--- a/packages/server/src/server.cairo
+++ b/packages/server/src/server.cairo
@@ -2,6 +2,7 @@
 pub mod Server {
     use core::num::traits::Zero;
     use server::errors;
+    use server::events::{ChannelOpened, KeyRegistered, NoteCreated, NullifierAdded};
     use server::interface::IServer;
     use server::objects::{EncChannelInfo, EncChannelInfoTrait, EncNote};
     use starknet::storage::{
@@ -27,7 +28,11 @@ pub mod Server {
 
     #[event]
     #[derive(Drop, starknet::Event)]
-    pub enum Event { //event variables
+    pub enum Event {
+        NoteCreated: NoteCreated,
+        NullifierAdded: NullifierAdded,
+        ChannelOpened: ChannelOpened,
+        KeyRegistered: KeyRegistered,
     }
 
     #[constructor]
@@ -59,6 +64,12 @@ pub mod Server {
             // Write channel to storage.
             self.channel_exists.write(channel_id, true);
             self.recipient_channels.entry(recipient_addr).push(enc_channel_info);
+            self
+                .emit(
+                    Event::ChannelOpened(
+                        ChannelOpened { channel_id, recipient: recipient_addr, enc_channel_info },
+                    ),
+                );
         }
 
         fn channel_exists(self: @ContractState, channel_id: felt252) -> bool {
@@ -105,6 +116,7 @@ pub mod Server {
 
             // Write key to storage.
             self.public_key.write(user, public_key);
+            self.emit(Event::KeyRegistered(KeyRegistered { user, public_key }));
         }
 
         fn get_public_key(self: @ContractState, user: ContractAddress) -> felt252 {
@@ -125,6 +137,12 @@ pub mod Server {
 
             // Write note to storage.
             self.notes.write(note.id, note.enc_amount);
+            self
+                .emit(
+                    Event::NoteCreated(
+                        NoteCreated { note_id: note.id, enc_amount: note.enc_amount },
+                    ),
+                );
         }
 
         fn use_note(ref self: ContractState, nullifier: felt252) {
@@ -137,6 +155,7 @@ pub mod Server {
 
             // Write nullifier to storage.
             self.nullifiers.write(nullifier, true);
+            self.emit(Event::NullifierAdded(NullifierAdded { nullifier }));
         }
     }
 }


### PR DESCRIPTION
What:
These are the proposed event types, which can be indexed by the operator service. 

Why:
To speed up note discovery operators would provide API for the clients to query relevant data in batches.  
This will be the function of the indexing service running on the operator's machine.  
The proposed low code solution is to use Apibara (or similar service) which works best with events (also it reduces the load on the RPC node since events can be batch queried).

How:
Emit an event on every notable occasion:
- Opened channels: required to set up the scan ranges on the client
- Created notes and nullifiers: required to consolidate balances, build active utxo set, and recreate private tx history
- Registered keys: allows to quickly fetch the number of registered users

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/32)
<!-- Reviewable:end -->
