### PR TITLE
refactor: remove `prepare_` from client interface functions

### DIFF
--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -132,7 +132,7 @@ pub trait IClient<T> {
     ///
     /// #### Access Control
     /// - Can be called by anyone, but the transaction must be signed by `sender_addr`.
-    fn prepare_open_channel(
+    fn open_channel(
         self: @T,
         sender_addr: ContractAddress,
         sender_private_key: felt252,
@@ -291,7 +291,7 @@ pub trait IClient<T> {
     ///
     /// #### Access Control
     /// - Can be called by anyone, but the transaction must be signed by `owner_addr`.
-    fn prepare_transfer(
+    fn transfer(
         self: @T,
         owner_addr: ContractAddress,
         owner_private_key: felt252,
@@ -352,9 +352,7 @@ pub trait IClient<T> {
     ///
     /// #### Access Control
     /// - TODO
-    fn prepare_deposit(
-        self: @T, owner_private_key: felt252, new_note: NewNote,
-    ) -> Span<ServerAction>;
+    fn deposit(self: @T, owner_private_key: felt252, new_note: NewNote) -> Span<ServerAction>;
 
     /// Validates a withdrawal of a note and generates the nullifier and withdrawal details for the
     /// server.
@@ -404,7 +402,7 @@ pub trait IClient<T> {
     ///
     /// #### Access Control
     /// - TODO
-    fn prepare_withdraw(
+    fn withdraw(
         self: @T,
         owner_addr: ContractAddress,
         owner_private_key: felt252,

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -52,7 +52,7 @@ pub mod Privacy {
     // TODO: Use direct storage access instead of using views.
     #[abi(embed_v0)]
     pub impl ClientImpl of IClient<ContractState> {
-        fn prepare_open_channel(
+        fn open_channel(
             self: @ContractState,
             sender_addr: ContractAddress,
             sender_private_key: felt252,
@@ -179,7 +179,7 @@ pub mod Privacy {
                 .span()
         }
 
-        fn prepare_transfer(
+        fn transfer(
             self: @ContractState,
             owner_addr: ContractAddress,
             owner_private_key: felt252,
@@ -211,7 +211,7 @@ pub mod Privacy {
             actions.span()
         }
 
-        fn prepare_deposit(
+        fn deposit(
             self: @ContractState, owner_private_key: felt252, new_note: NewNote,
         ) -> Span<ServerAction> {
             // Assert input is valid.
@@ -231,7 +231,7 @@ pub mod Privacy {
                 .span()
         }
 
-        fn prepare_withdraw(
+        fn withdraw(
             self: @ContractState,
             owner_addr: ContractAddress,
             owner_private_key: felt252,

--- a/packages/privacy/src/tests/test_utils.cairo
+++ b/packages/privacy/src/tests/test_utils.cairo
@@ -70,7 +70,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .client
-            .prepare_transfer(
+            .transfer(
                 owner_addr: *self.address,
                 owner_private_key: *self.private_key,
                 :notes_to_use,
@@ -85,7 +85,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .safe_client
-            .prepare_transfer(
+            .transfer(
                 owner_addr: *self.address,
                 owner_private_key: *self.private_key,
                 :notes_to_use,
@@ -99,7 +99,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .client
-            .prepare_withdraw(
+            .withdraw(
                 owner_addr: *self.address,
                 owner_private_key: *self.private_key,
                 :withdrawal_target,
@@ -114,7 +114,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .safe_client
-            .prepare_withdraw(
+            .withdraw(
                 owner_addr: *self.address,
                 owner_private_key: *self.private_key,
                 :withdrawal_target,
@@ -128,7 +128,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .client
-            .prepare_open_channel(
+            .open_channel(
                 sender_addr: *self.address,
                 sender_private_key: *self.private_key,
                 recipient_addr: recipient.address,
@@ -145,7 +145,7 @@ pub(crate) impl UserImpl of UserTrait {
         self
             .privacy
             .safe_client
-            .prepare_open_channel(
+            .open_channel(
                 sender_addr: *self.address,
                 sender_private_key: *self.private_key,
                 recipient_addr: recipient.address,
@@ -355,12 +355,12 @@ pub(crate) impl UserImpl of UserTrait {
     }
 
     fn deposit(self: @User, new_note: NewNote) -> Span<ServerAction> {
-        self.privacy.client.prepare_deposit(owner_private_key: *self.private_key, :new_note)
+        self.privacy.client.deposit(owner_private_key: *self.private_key, :new_note)
     }
 
     #[feature("safe_dispatcher")]
     fn safe_deposit(self: @User, new_note: NewNote) -> Result<Span<ServerAction>, Array<felt252>> {
-        self.privacy.safe_client.prepare_deposit(owner_private_key: *self.private_key, :new_note)
+        self.privacy.safe_client.deposit(owner_private_key: *self.private_key, :new_note)
     }
 
     fn get_num_of_channels(self: @User) -> u64 {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/108)
<!-- Reviewable:end -->
