### PR TITLE
refactor(sdk): simplify nonce structure by removing slots

### DIFF
--- a/sdk/src/internal/index.ts
+++ b/sdk/src/internal/index.ts
@@ -18,108 +18,36 @@ function assert(condition: unknown, message: string): asserts condition {
 // Base nonce class with shared logic and methods.
 class Nonce {
   created?: BlockNumber;
-  readonly slot: number;
   readonly sequence: number;
 
-  protected constructor(slot: number, sequence: number, max: number, created?: BlockNumber) {
-    assert(
-      isUint(slot) && slot <= max,
-      `Invalid nonce: slot must be a non-negative integer <= ${max}`
-    );
+  protected constructor(sequence: number, created?: BlockNumber) {
     assert(isUint(sequence), "Invalid nonce: sequence must be a non-negative integer");
-    this.slot = slot;
     this.sequence = sequence;
     this.created = created;
   }
 
   /** Returns a new instance of the same class with the sequence incremented by 1. */
   increment(): this {
-    const Ctor = this.constructor as new (slot: number, sequence: number) => this;
-    return new Ctor(this.slot, this.sequence + 1);
+    const Ctor = this.constructor as new (sequence: number) => this;
+    return new Ctor(this.sequence + 1);
   }
 
   decrement(): this {
-    assert(this.sequence >= 0, "Invalid nonce: sequence must be non negative");
-    const Ctor = this.constructor as new (slot: number, sequence: number) => this;
-    return new Ctor(this.slot, this.sequence - 1);
-  }
-
-  /**
-   * Increments the nonce array in-place. Finds the nonce with the lowest `created`
-   * value (skipping those without one) and replaces it with an incremented version.
-   * If no nonces have `created` and there's room for a new slot, appends a new nonce.
-   *
-   * @param nonces - Array of nonces, assumed to have slots incrementing by 1
-   * @param maxSlots - Maximum number of slots allowed
-   * @param Ctor - Constructor for creating new nonces
-   * @returns The index of the changed nonce and the previous value (undefined if new slot)
-   */
-  protected static _increment<T extends Nonce>(
-    nonces: T[],
-    maxSlots: number,
-    Ctor: new (slot: number, sequence: number) => T
-  ): { nonce: T; index: number; previous: T | undefined } {
-    // Verify slots increment by 1
-    for (let i = 0; i < nonces.length; i++) {
-      assert(
-        nonces[i].slot === i,
-        `Invalid nonce array: expected slot ${i}, got ${nonces[i].slot}`
-      );
-    }
-
-    const withCreated = nonces.filter((n): n is T & { created: BlockNumber } => n.created != null);
-
-    if (withCreated.length === 0) {
-      // No nonces have been created yet - add a new slot if room available
-      assert(nonces.length < maxSlots, `Cannot add new slot: already at max slots (${maxSlots})`);
-      const index = nonces.length;
-      const nonce = new Ctor(index, 0);
-      nonces.push(nonce);
-      return { nonce, index, previous: undefined };
-    }
-
-    const oldest = withCreated.reduce((min, n) => (n.created! < min.created! ? n : min));
-    const index = oldest.slot;
-    const previous = nonces[index];
-
-    // TODO: add a check the oldest is old enough (at least 10 blocks old)
-
-    nonces[index] = oldest.increment() as T;
-    return { nonce: nonces[index], index, previous };
+    assert(this.sequence > 0, "Invalid nonce: cannot decrement below 0");
+    const Ctor = this.constructor as new (sequence: number) => this;
+    return new Ctor(this.sequence - 1);
   }
 }
 
 export class TokenNonce extends Nonce {
-  static readonly MAX_SLOTS = 10;
-
-  constructor(slot: number, sequence: number, created?: BlockNumber) {
-    super(slot, sequence, TokenNonce.MAX_SLOTS, created);
-  }
-
-  /** Increments the nonce array in-place, returns the changed index and previous value. */
-  static increment(nonces: TokenNonce[]): {
-    nonce: TokenNonce;
-    index: number;
-    previous: TokenNonce | undefined;
-  } {
-    return Nonce._increment(nonces, TokenNonce.MAX_SLOTS, TokenNonce);
+  constructor(sequence: number = 0, created?: BlockNumber) {
+    super(sequence, created);
   }
 }
 
 export class NoteNonce extends Nonce {
-  static readonly MAX_SLOTS = 100;
-
-  constructor(slot: number, sequence: number, created?: BlockNumber) {
-    super(slot, sequence, NoteNonce.MAX_SLOTS, created);
-  }
-
-  /** Increments the nonce array in-place, returns the changed index and previous value. */
-  static increment(nonces: NoteNonce[]): {
-    nonce: NoteNonce;
-    index: number;
-    previous: NoteNonce | undefined;
-  } {
-    return Nonce._increment(nonces, NoteNonce.MAX_SLOTS, NoteNonce);
+  constructor(sequence: number = 0, created?: BlockNumber) {
+    super(sequence, created);
   }
 }
 
@@ -128,17 +56,17 @@ type ChannelKey = bigint;
 /** Channel containing nonces for token and note creation. */
 export class Channel {
   /** @internal */ readonly key: ChannelKey;
-  /** @internal */ readonly nonces: TokenNonce[];
-  /** @internal */ readonly tokens: AddressMap<NoteNonce[]>;
+  /** @internal */ tokenNonce: TokenNonce;
+  /** @internal */ readonly tokens: AddressMap<NoteNonce>;
 
   constructor(
     key: ChannelKey,
-    nonces?: TokenNonce[],
-    tokens?: Iterable<[StarknetAddress, NoteNonce[]]>
+    tokenNonce?: TokenNonce,
+    tokens?: Iterable<[StarknetAddress, NoteNonce]>
   ) {
     this.key = key;
-    this.nonces = nonces ?? [];
-    this.tokens = new AddressMap<NoteNonce[]>(() => []);
+    this.tokenNonce = tokenNonce ?? new TokenNonce();
+    this.tokens = new AddressMap<NoteNonce>(() => new NoteNonce());
     if (tokens) {
       for (const [k, v] of tokens) {
         this.tokens.set(k, v);
@@ -147,14 +75,15 @@ export class Channel {
   }
 
   incrementTokenNonce(): TokenNonce {
-    const { nonce } = TokenNonce.increment(this.nonces);
-    return nonce;
+    const current = this.tokenNonce;
+    this.tokenNonce = current.increment();
+    return current;
   }
 
   incrementNoteNonce(token: StarknetAddress): NoteNonce {
-    const nonces = this.tokens.get(token)!;
-    const { nonce } = NoteNonce.increment(nonces);
-    return nonce;
+    const current = this.tokens.get(token)!;
+    this.tokens.set(token, current.increment());
+    return current;
   }
 }
 
@@ -164,7 +93,7 @@ export const channelSerde: ChannelSerde = {
     const json = jsonStringify({
       v: 1,
       key: channel.key,
-      nonces: channel.nonces,
+      tokenNonce: channel.tokenNonce,
       tokens: Array.from(channel.tokens.entries()),
     });
     return json as Blob<string>;
@@ -175,12 +104,12 @@ export const channelSerde: ChannelSerde = {
     if (parsed === null || typeof parsed !== "object") {
       throw new Error("Invalid channel payload");
     }
-    const { key, nonces, tokens } = parsed as Record<string, unknown>;
+    const { key, tokenNonce, tokens } = parsed as Record<string, unknown>;
     const decodedKey = assertChannelKey(key);
-    const decodedNonces = assertNonces(nonces);
+    const decodedTokenNonce = assertTokenNonce(tokenNonce);
     const decodedTokens = assertTokenEntries(tokens);
 
-    return new Channel(decodedKey, decodedNonces, decodedTokens);
+    return new Channel(decodedKey, decodedTokenNonce, decodedTokens);
   },
 };
 
@@ -211,7 +140,7 @@ export const witnessSerde: WitnessSerde = {
     }
     const { channelKey, nonce } = parsed as Record<string, unknown>;
     const decodedChannelKey = assertChannelKey(channelKey);
-    const decodedNonce = assertChannelNonce(nonce);
+    const decodedNonce = assertNoteNonce(nonce);
 
     return new Witness(decodedChannelKey, decodedNonce);
   },
@@ -227,51 +156,36 @@ function assertChannelKey(value: unknown): ChannelKey {
   throw new Error("Invalid channel key");
 }
 
-function assertChannelNonce(value: unknown): TokenNonce {
+function assertTokenNonce(value: unknown): TokenNonce {
   if (value instanceof TokenNonce) {
     return value;
   }
   assert(value !== null && typeof value === "object", "Invalid nonce: expected object");
-  const { slot, sequence } = value as Record<string, unknown>;
-  assert(
-    isUint(slot) && isUint(sequence),
-    "Invalid nonce: slot and sequence must be non-negative integers"
-  );
-  return new TokenNonce(slot, sequence);
+  const { sequence } = value as Record<string, unknown>;
+  assert(isUint(sequence), "Invalid nonce: sequence must be a non-negative integer");
+  return new TokenNonce(sequence);
 }
 
-function assertTokenNonce(value: unknown): NoteNonce {
+function assertNoteNonce(value: unknown): NoteNonce {
   if (value instanceof NoteNonce) {
     return value;
   }
   assert(value !== null && typeof value === "object", "Invalid nonce: expected object");
-  const { slot, sequence } = value as Record<string, unknown>;
-  assert(
-    isUint(slot) && isUint(sequence),
-    "Invalid nonce: slot and sequence must be non-negative integers"
-  );
-  return new NoteNonce(slot, sequence);
+  const { sequence } = value as Record<string, unknown>;
+  assert(isUint(sequence), "Invalid nonce: sequence must be a non-negative integer");
+  return new NoteNonce(sequence);
 }
 
-function assertNonces(value: unknown): TokenNonce[] {
-  if (Array.isArray(value)) {
-    return value.map((n) => assertChannelNonce(n));
-  }
-  return [assertChannelNonce(value)];
-}
-
-function assertTokenEntries(value: unknown): Map<StarknetAddress, NoteNonce[]> {
+function assertTokenEntries(value: unknown): Map<StarknetAddress, NoteNonce> {
   if (!Array.isArray(value)) {
     throw new Error("Invalid tokens");
   }
-  const entries: [StarknetAddress, NoteNonce[]][] = value.map((entry) => {
+  const entries: [StarknetAddress, NoteNonce][] = value.map((entry) => {
     if (!Array.isArray(entry) || entry.length !== 2) {
       throw new Error("Invalid token entry");
     }
-    const [token, nonces] = entry;
-    const normalized = Array.isArray(nonces) ? nonces : [nonces];
-    const decodedNonces = normalized.map((n) => assertTokenNonce(n));
-    return [token as StarknetAddress, decodedNonces];
+    const [token, nonce] = entry;
+    return [token as StarknetAddress, assertNoteNonce(nonce)];
   });
   return new Map(entries);
 }

--- a/sdk/src/testing/builders.ts
+++ b/sdk/src/testing/builders.ts
@@ -16,7 +16,6 @@ import type {
 } from "../interfaces.js";
 import { Channel } from "../interfaces.js";
 import type { Call } from "starknet";
-import { TokenNonce } from "../internal/index.js";
 import { type PrivateKey } from "../utils/crypto.js";
 import { assert, isOpen, toBigInt } from "../utils/index.js";
 import type { CompositeInput, CompositeOutput, PrivacyPool } from "./pool.js";
@@ -147,8 +146,7 @@ export class MockPrivateTransfersBuilder implements PrivateTransfersBuilder {
     for (const tokenBuilder of this.tokenBuilders.values()) {
       for (const recipient of tokenBuilder.setupCalls) {
         const channel = recipient.context;
-        const { index } = TokenNonce.increment(channel.nonces);
-        const nonce = channel.nonces[index];
+        const nonce = channel.incrementTokenNonce();
         this.pool.setToken(
           this.userAddress,
           recipient.address,

--- a/sdk/src/testing/discovery.ts
+++ b/sdk/src/testing/discovery.ts
@@ -40,29 +40,30 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
       const channel = decryptChannelInfo(encryptedChannel, viewingKey);
       const key = channel.key;
 
-      for (let slot = 0; slot < NoteNonce.MAX_SLOTS; slot++) {
-        let sequence = 0;
-        let token: StarknetAddressBigint | false;
-        while ((token = this.pool.getToken(key, new NoteNonce(slot, sequence++))) !== false) {
-          for (let noteSlot = 0; noteSlot < NoteNonce.MAX_SLOTS; noteSlot++) {
-            let note: { amount: Amount; open: boolean } | false;
-            let nonce = new NoteNonce(noteSlot, 0);
-            while ((note = this.pool.getNote(new Witness(key, nonce), token)) !== false) {
-              if (this.pool.getNullifier(new Witness(key, nonce), token, viewingKey) !== false) {
-                nonce = nonce.increment();
-                continue;
-              }
-
-              result.get(token)!.push({
-                id: hashes.noteId(new Witness(key, nonce), token),
-                amount: note.amount,
-                witness: new Witness(key, nonce),
-                sender: channel.sender,
-                open: note.open,
-              });
-              nonce = nonce.increment();
-            }
+      // Iterate token sequences
+      let tokenSequence = 0;
+      let token: StarknetAddressBigint | false;
+      while ((token = this.pool.getToken(key, new NoteNonce(tokenSequence++))) !== false) {
+        // Iterate note sequences for this token
+        let noteSequence = 0;
+        let note: { amount: Amount; open: boolean } | false;
+        while (
+          (note = this.pool.getNote(new Witness(key, new NoteNonce(noteSequence)), token)) !== false
+        ) {
+          const nonce = new NoteNonce(noteSequence);
+          if (this.pool.getNullifier(new Witness(key, nonce), token, viewingKey) !== false) {
+            noteSequence++;
+            continue;
           }
+
+          result.get(token)!.push({
+            id: hashes.noteId(new Witness(key, nonce), token),
+            amount: note.amount,
+            witness: new Witness(key, nonce),
+            sender: channel.sender,
+            open: note.open,
+          });
+          noteSequence++;
         }
       }
     }
@@ -84,37 +85,24 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
     for (const recipient of recipients) {
       const addr = assertRecipientAddress(recipient);
       const key = hashes.channelKey(address, viewingKey, addr, this.pool.getPublicKey(addr));
-      // TODO: simulate the logarithmic search?
-      const nonces: TokenNonce[] = [];
-      const tokens = new AddressMap<NoteNonce[]>(() => []);
-      for (let slot = 0; slot < TokenNonce.MAX_SLOTS; slot++) {
-        let sequence = 0;
-        let token: StarknetAddress | false;
-        let nonce: TokenNonce;
-        while (
-          ((nonce = new TokenNonce(slot, sequence++)),
-          (token = this.pool.getToken(key, nonce)),
-          token !== false)
-        ) {
-          for (let noteSlot = 0; noteSlot < NoteNonce.MAX_SLOTS; noteSlot++) {
-            let noteSequence = 0;
-            let nonce: NoteNonce;
-            while (
-              ((nonce = new NoteNonce(noteSlot, noteSequence++)),
-              this.pool.getNote(new Witness(key, nonce), token) !== false)
-            ) {
-              // just iterate until no note exists
-            }
-            if (nonce.sequence > 0) {
-              tokens.get(token)!.push(nonce.decrement());
-            }
-          }
+
+      // Find the highest token nonce sequence
+      let tokenSequence = 0;
+      let token: StarknetAddress | false;
+      const tokens = new AddressMap<NoteNonce>();
+
+      while ((token = this.pool.getToken(key, new TokenNonce(tokenSequence))) !== false) {
+        // Find the highest note nonce sequence for this token
+        let noteSequence = 0;
+        while (this.pool.getNote(new Witness(key, new NoteNonce(noteSequence)), token) !== false) {
+          noteSequence++;
         }
-        if (nonce.sequence > 0) {
-          nonces.push(nonce.decrement());
-        }
+        tokens.set(token, new NoteNonce(noteSequence));
+        tokenSequence++;
       }
-      result.set(addr, new Channel(key, nonces, tokens));
+
+      const tokenNonce = new TokenNonce(tokenSequence);
+      result.set(addr, new Channel(key, tokenNonce, tokens));
     }
 
     return { timestamp: this._currentBlock, channels: result };

--- a/sdk/src/testing/pool.ts
+++ b/sdk/src/testing/pool.ts
@@ -12,7 +12,7 @@ import type {
 } from "../interfaces.js";
 import { Witness } from "../interfaces.js";
 import { BigNumberish } from "starknet";
-import { NoteNonce } from "../internal/index.js";
+import { NoteNonce, TokenNonce } from "../internal/index.js";
 import {
   encryptChannelInfo,
   encryptSymmetric,
@@ -118,7 +118,7 @@ export class PrivacyPool {
     to: StarknetAddress,
     channelKey: Hash,
     token: StarknetAddress,
-    nonce: NoteNonce
+    nonce: TokenNonce
   ): void {
     this.assertRegistered(from);
 
@@ -140,7 +140,7 @@ export class PrivacyPool {
     this.subchannelIds.add(hashes.subchannelId(channelKey, to, toPublicKey, token));
   }
 
-  getToken(channelKey: Hash, nonce: NoteNonce): StarknetAddressBigint | false {
+  getToken(channelKey: Hash, nonce: TokenNonce): StarknetAddressBigint | false {
     const subchannelKey = hashes.subchannelKey(channelKey, nonce);
     const encrypted = this.subchannels.get(subchannelKey);
     if (!encrypted) return false;

--- a/sdk/src/utils/hashes.ts
+++ b/sdk/src/utils/hashes.ts
@@ -45,7 +45,7 @@ export const hashes = {
    * Cairo uses (index, 0) where index=slot, 0=sequence
    */
   subchannelKey: (channelKey: Hash, nonce: TokenNonce): Hash =>
-    hash(SUBCHANNEL_KEY_TAG, channelKey, nonce.slot, nonce.sequence),
+    hash(SUBCHANNEL_KEY_TAG, channelKey, nonce.sequence, 0n),
 
   /**
    * Computes the subchannel id given the channel key and token.
@@ -64,7 +64,7 @@ export const hashes = {
    * Cairo uses (index, 0) where index=slot, 0=sequence
    */
   noteId: (witness: Witness, token: StarknetAddress): Hash =>
-    hash(NOTE_ID_TAG, witness.channelKey, token, witness.nonce.slot, witness.nonce.sequence),
+    hash(NOTE_ID_TAG, witness.channelKey, token, witness.nonce.sequence, 0n),
 
   /**
    * Computes the nullifier.
@@ -72,12 +72,5 @@ export const hashes = {
    * Cairo uses (index, 0, privKey) where index=slot, 0=sequence
    */
   nullifier: (witness: Witness, token: StarknetAddress, ownerPrivateKey: PrivateKey): Hash =>
-    hash(
-      NULLIFIER_TAG,
-      witness.channelKey,
-      token,
-      witness.nonce.slot,
-      witness.nonce.sequence,
-      ownerPrivateKey
-    ),
+    hash(NULLIFIER_TAG, witness.channelKey, token, witness.nonce.sequence, 0n, ownerPrivateKey),
 };

--- a/sdk/tests/internal/nonce.test.ts
+++ b/sdk/tests/internal/nonce.test.ts
@@ -1,89 +1,68 @@
 import { describe, expect, it } from "vitest";
 import { TokenNonce, NoteNonce } from "../../src/internal/index.js";
 
-describe("TokenNonce.increment", () => {
-  it("increments the oldest nonce in-place and returns index and previous", () => {
-    const nonces = [
-      Object.assign(new TokenNonce(0, 5), { created: 100 }),
-      Object.assign(new TokenNonce(1, 3), { created: 50 }), // oldest
-      Object.assign(new TokenNonce(2, 8), { created: 200 }),
-    ];
-
-    const result = TokenNonce.increment(nonces);
-
-    expect(result.index).toBe(1);
-    expect(result.previous?.slot).toBe(1);
-    expect(result.previous?.sequence).toBe(3);
-    // Array was mutated
-    expect(nonces[1].slot).toBe(1);
-    expect(nonces[1].sequence).toBe(4); // 3 + 1
+describe("TokenNonce", () => {
+  it("starts at sequence 0 by default", () => {
+    const nonce = new TokenNonce();
+    expect(nonce.sequence).toBe(0);
   });
 
-  it("adds a new slot when no nonces have created block number", () => {
-    const nonces: TokenNonce[] = [];
-
-    const result = TokenNonce.increment(nonces);
-
-    expect(result.index).toBe(0);
-    expect(result.previous).toBeUndefined();
-    expect(nonces.length).toBe(1);
-    expect(nonces[0].slot).toBe(0);
-    expect(nonces[0].sequence).toBe(0);
+  it("can be created with a specific sequence", () => {
+    const nonce = new TokenNonce(5);
+    expect(nonce.sequence).toBe(5);
   });
 
-  it("adds a new slot at the end when existing nonces lack created", () => {
-    const nonces = [new TokenNonce(0, 5), new TokenNonce(1, 3)];
+  it("increment returns a new nonce with sequence + 1", () => {
+    const nonce = new TokenNonce(3);
+    const incremented = nonce.increment();
 
-    const result = TokenNonce.increment(nonces);
-
-    expect(result.index).toBe(2);
-    expect(result.previous).toBeUndefined();
-    expect(nonces.length).toBe(3);
-    expect(nonces[2].slot).toBe(2);
-    expect(nonces[2].sequence).toBe(0);
+    expect(incremented.sequence).toBe(4);
+    expect(nonce.sequence).toBe(3); // original unchanged
   });
 
-  it("throws when max slots reached and no nonces have created", () => {
-    // Create array with MAX_SLOTS nonces, none with created
-    const nonces = Array.from({ length: TokenNonce.MAX_SLOTS }, (_, i) => new TokenNonce(i, 0));
+  it("decrement returns a new nonce with sequence - 1", () => {
+    const nonce = new TokenNonce(3);
+    const decremented = nonce.decrement();
 
-    expect(() => TokenNonce.increment(nonces)).toThrow(
-      `Cannot add new slot: already at max slots (${TokenNonce.MAX_SLOTS})`
-    );
+    expect(decremented.sequence).toBe(2);
+    expect(nonce.sequence).toBe(3); // original unchanged
   });
 
-  it("throws when slots are not sequential", () => {
-    const nonces = [
-      Object.assign(new TokenNonce(0, 1), { created: 100 }),
-      Object.assign(new TokenNonce(2, 1), { created: 200 }), // gap: should be slot 1
-    ];
-
-    expect(() => TokenNonce.increment(nonces)).toThrow(
-      "Invalid nonce array: expected slot 1, got 2"
-    );
+  it("throws when decrementing below 0", () => {
+    const nonce = new TokenNonce(0);
+    expect(() => nonce.decrement()).toThrow("Invalid nonce: cannot decrement below 0");
   });
 });
 
-describe("NoteNonce.increment", () => {
-  it("increments the oldest nonce in-place", () => {
-    const nonces = [
-      Object.assign(new NoteNonce(0, 2), { created: 300 }),
-      Object.assign(new NoteNonce(1, 1), { created: 100 }), // oldest
-    ];
-
-    const result = NoteNonce.increment(nonces);
-
-    expect(result.index).toBe(1);
-    expect(result.previous?.sequence).toBe(1);
-    expect(nonces[1].sequence).toBe(2); // 1 + 1
+describe("NoteNonce", () => {
+  it("starts at sequence 0 by default", () => {
+    const nonce = new NoteNonce();
+    expect(nonce.sequence).toBe(0);
   });
 
-  it("respects NoteNonce.MAX_SLOTS", () => {
-    // Create array with MAX_SLOTS nonces, none with created
-    const nonces = Array.from({ length: NoteNonce.MAX_SLOTS }, (_, i) => new NoteNonce(i, 0));
+  it("can be created with a specific sequence", () => {
+    const nonce = new NoteNonce(10);
+    expect(nonce.sequence).toBe(10);
+  });
 
-    expect(() => NoteNonce.increment(nonces)).toThrow(
-      `Cannot add new slot: already at max slots (${NoteNonce.MAX_SLOTS})`
-    );
+  it("increment returns a new nonce with sequence + 1", () => {
+    const nonce = new NoteNonce(7);
+    const incremented = nonce.increment();
+
+    expect(incremented.sequence).toBe(8);
+    expect(nonce.sequence).toBe(7); // original unchanged
+  });
+
+  it("decrement returns a new nonce with sequence - 1", () => {
+    const nonce = new NoteNonce(5);
+    const decremented = nonce.decrement();
+
+    expect(decremented.sequence).toBe(4);
+    expect(nonce.sequence).toBe(5); // original unchanged
+  });
+
+  it("throws when decrementing below 0", () => {
+    const nonce = new NoteNonce(0);
+    expect(() => nonce.decrement()).toThrow("Invalid nonce: cannot decrement below 0");
   });
 });

--- a/sdk/tests/internal/serde.test.ts
+++ b/sdk/tests/internal/serde.test.ts
@@ -12,18 +12,18 @@ describe("channelSerde", () => {
   it("encodes and decodes a channel round-trip", () => {
     const original = new Channel(
       12345n,
-      [new TokenNonce(0, 1), new TokenNonce(1, 2)],
+      new TokenNonce(5),
       new Map([
-        ["0xabc", [new NoteNonce(0, 10), new NoteNonce(1, 20)]],
-        ["0xdef", [new NoteNonce(0, 30)]],
+        ["0xabc", new NoteNonce(10)],
+        ["0xdef", new NoteNonce(30)],
       ])
     );
 
     const decoded = channelSerde.decode(channelSerde.encode(original));
 
-    // Compare essential data (AdvancedMap instances don't deep-equal well)
+    // Compare essential data (AdvressMap instances don't deep-equal well)
     expect(decoded.key).toEqual(original.key);
-    expect(decoded.nonces).toEqual(original.nonces);
+    expect(decoded.tokenNonce.sequence).toEqual(original.tokenNonce.sequence);
     expect(Array.from(decoded.tokens.entries())).toEqual(Array.from(original.tokens.entries()));
   });
 
@@ -36,11 +36,12 @@ describe("channelSerde", () => {
 
 describe("witnessSerde", () => {
   it("encodes and decodes a witness round-trip", () => {
-    const original = new Witness(42n, new NoteNonce(3, 7));
+    const original = new Witness(42n, new NoteNonce(7));
 
     const decoded = witnessSerde.decode(witnessSerde.encode(original));
 
-    expect(decoded).toEqual(original);
+    expect(decoded.channelKey).toEqual(original.channelKey);
+    expect(decoded.nonce.sequence).toEqual(original.nonce.sequence);
   });
 
   it("throws on invalid payload", () => {


### PR DESCRIPTION
- Remove slot property from Nonce, keep only sequence
- Channel now has single tokenNonce instead of nonces array
- Channel.tokens maps to single NoteNonce instead of array
- Remove array-based increment methods (_increment, static increment)
- Update discovery to iterate sequences without slots
- Update pool setToken/getToken to use TokenNonce
- Update helpers hash functions to exclude slot
- Update tests for new nonce structure

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/156)
<!-- Reviewable:end -->
