### PR TITLE
feat(sdk): add surplus handling to builders

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -247,6 +247,13 @@ export interface TokenOperationsBuilder {
   /** Transfer this token privately to one or more recipients */
   transfer(...outputs: TransferOutput[]): this;
 
+  /**
+   * Set the recipient for any surplus for this token.
+   * Overrides the top-level surplusTo for this specific token.
+   * If inputs exceed outputs, a CreateNoteAction is automatically added for the difference.
+   */
+  surplusTo(recipient: PrivateRecipient | Channel): this;
+
   /** Switch to another token */
   with(token: StarknetAddress): TokenOperationsBuilder;
 
@@ -328,6 +335,13 @@ export interface PrivateTransfersBuilder {
 
   /** Add an arbitrary Starknet call that will run on starknet after the private operations are executed */
   call(call: Call): this;
+
+  /**
+   * Set the default recipient for any surplus across all tokens.
+   * If inputs exceed outputs for a token, a CreateNoteAction is automatically added for the difference.
+   * Can be overridden per-token using TokenOperationsBuilder.surplusTo().
+   */
+  surplusTo(recipient: PrivateRecipient | Channel): this;
 
   /** Start token-specific operations */
   with(token: StarknetAddress): TokenOperationsBuilder;

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -5,6 +5,7 @@
 import type {
   Amount,
   CallAndProof,
+  Channel,
   CreateNoteAction,
   DepositAction,
   Note,
@@ -23,6 +24,7 @@ import type {
 } from "../interfaces.js";
 import type { Call } from "starknet";
 import { AddressMap } from "../utils/maps.js";
+import { calculateSurplus } from "../utils/validation.js";
 import { createMockCallAndProof } from "../testing/helpers.js";
 
 // ============ Token Operations Builder ============
@@ -37,6 +39,9 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
   public deposits: DepositAction[] = [];
   public withdraws: WithdrawAction[] = [];
   public createNotes: CreateNoteAction[] = [];
+
+  // Surplus recipient (overrides parent builder's surplus recipient for this token)
+  public surplusRecipient?: PrivateRecipient;
 
   constructor(
     private parentBuilder: PrivateTransfersBuilderImpl,
@@ -107,6 +112,13 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
     return this;
   }
 
+  surplusTo(recipient: PrivateRecipient | Channel): this {
+    this.surplusRecipient = isPrivateRecipient(recipient)
+      ? recipient
+      : { address: this.parentBuilder.userAddress, context: recipient };
+    return this;
+  }
+
   with(token: StarknetAddress): TokenOperationsBuilder {
     return this.parentBuilder.with(token);
   }
@@ -125,6 +137,21 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
     this.deposits = [];
     this.withdraws = [];
     this.createNotes = [];
+    this.surplusRecipient = undefined;
+  }
+
+  /**
+   * Calculate the surplus for this token builder.
+   * Returns the surplus amount (inputs - outputs).
+   * @throws Error if outputs exceed inputs
+   */
+  calculateSurplus(): bigint {
+    return calculateSurplus(
+      this.deposits.map((d) => d.amount),
+      this.useNotes.map((u) => u.note.amount),
+      this.createNotes.map((c) => c.amount),
+      this.withdraws.map((w) => w.amount)
+    );
   }
 }
 
@@ -137,6 +164,9 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
   public tokenBuilders = new AddressMap<TokenOperationsBuilderImpl>(
     (token) => new TokenOperationsBuilderImpl(this, token)
   );
+
+  // Default surplus recipient for all tokens
+  public defaultSurplusRecipient?: PrivateRecipient;
 
   constructor(
     private transfers: PrivateTransfers,
@@ -158,6 +188,13 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     return this;
   }
 
+  surplusTo(recipient: PrivateRecipient | Channel): this {
+    this.defaultSurplusRecipient = isPrivateRecipient(recipient)
+      ? recipient
+      : { address: this.userAddress, context: recipient };
+    return this;
+  }
+
   with(token: StarknetAddress): TokenOperationsBuilder {
     return this.tokenBuilders.get(token)!;
   }
@@ -170,15 +207,30 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     const createNotes: CreateNoteAction[] = [];
     const withdraws: WithdrawAction[] = [];
 
-    for (const tokenBuilder of this.tokenBuilders.values()) {
+    for (const [token, tokenBuilder] of this.tokenBuilders.entries()) {
       openTokenChannels.push(...tokenBuilder.openTokenChannels);
       deposits.push(...tokenBuilder.deposits);
       useNotes.push(...tokenBuilder.useNotes);
       createNotes.push(...tokenBuilder.createNotes);
       withdraws.push(...tokenBuilder.withdraws);
+
+      // 2. Handle surplus for this token
+      const surplusRecipient = tokenBuilder.surplusRecipient ?? this.defaultSurplusRecipient;
+      if (surplusRecipient) {
+        const surplus = tokenBuilder.calculateSurplus();
+        if (surplus > 0n) {
+          // Create a note for the surplus
+          createNotes.push({
+            token,
+            recipient: surplusRecipient.address,
+            context: surplusRecipient.context,
+            amount: surplus,
+          });
+        }
+      }
     }
 
-    // 2. Execute everything via single pool.execute call
+    // 3. Execute everything via single pool.execute call
     await this.transfers.execute({
       setViewingKey: this.setViewingKey,
       openChannels: this.openChannels,
@@ -197,5 +249,6 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     this.openChannels = [];
     this.callCalls = [];
     this.tokenBuilders.clear();
+    this.defaultSurplusRecipient = undefined;
   }
 }

--- a/sdk/src/utils/index.ts
+++ b/sdk/src/utils/index.ts
@@ -11,7 +11,13 @@ export {
   type LogCallback,
 } from "./logging.js";
 export { AdvancedMap, AddressMap } from "./maps.js";
-export { assert, assertViewingKey, assertRecipientAddress, isOpen } from "./validation.js";
+export {
+  assert,
+  assertViewingKey,
+  assertRecipientAddress,
+  isOpen,
+  calculateSurplus,
+} from "./validation.js";
 export {
   hash,
   shortStringToFelt,

--- a/sdk/src/utils/validation.ts
+++ b/sdk/src/utils/validation.ts
@@ -50,3 +50,31 @@ export function assertRecipientAddress(
 export function isOpen(value: Amount | Open): value is Open {
   return typeof value !== "bigint";
 }
+
+/**
+ * Calculates the surplus for a token given inputs and outputs.
+ * Surplus = (deposits + useNotes) - (createNotes + withdraws)
+ * Open amounts in createNotes are treated as 0.
+ *
+ * @param deposits - Array of deposit amounts
+ * @param useNotes - Array of input note amounts
+ * @param createNotes - Array of output note amounts (can include Open markers)
+ * @param withdraws - Array of withdrawal amounts
+ * @returns The surplus amount (must be non-negative)
+ * @throws Error if the total is negative (outputs exceed inputs)
+ */
+export function calculateSurplus(
+  deposits: Amount[],
+  useNotes: Amount[],
+  createNotes: (Amount | Open)[],
+  withdraws: Amount[]
+): bigint {
+  const sumDeposits = deposits.reduce((sum, a) => sum + a, 0n);
+  const sumUseNotes = useNotes.reduce((sum, a) => sum + a, 0n);
+  const sumCreateNotes = createNotes.reduce<bigint>((sum, a) => sum + (isOpen(a) ? 0n : a), 0n);
+  const sumWithdraws = withdraws.reduce((sum, a) => sum + a, 0n);
+
+  const total = sumDeposits + sumUseNotes - sumCreateNotes - sumWithdraws;
+  assert(total >= 0n, `Outputs exceed inputs: deficit of ${-total}`);
+  return total;
+}

--- a/sdk/tests/internal/builders.test.ts
+++ b/sdk/tests/internal/builders.test.ts
@@ -267,4 +267,207 @@ describe("PrivateTransfersBuilder", () => {
     const filledNotes = (bobNotesAfter.notes.get(STRK) ?? []).filter((n) => n.open);
     expect(filledNotes[0].amount).toBe(100n);
   });
+
+  describe("surplusTo", () => {
+    let aliceSelf: PrivateRecipient;
+
+    beforeEach(async () => {
+      // Setup: register Alice and set up channel to self
+      await alice.register();
+
+      aliceSelf = { address: ALICE_ADDRESS, context: undefined! };
+      setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceSelf);
+
+      // prettier-ignore
+      await alice
+        .build()
+        .setup(ALICE_ADDRESS)
+        .with(STRK)
+          .setup(aliceSelf)
+        .with(ETH)
+          .setup(aliceSelf)
+        .execute();
+    });
+
+    it("surplusTo on root builder: creates surplus note for all tokens", async () => {
+      // Deposit 100 STRK to Alice (she starts with 1000n public)
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .deposit(100n, aliceSelf)
+        .execute();
+
+      // After deposit: 900n public, 100n private
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(900n);
+      const note = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
+      expect(note.amount).toBe(100n);
+
+      // Use the 100n note but only withdraw 30n - surplus of 70n should go to self
+      // prettier-ignore
+      await alice
+        .build()
+        .surplusTo(aliceSelf)
+        .with(STRK)
+          .inputs(note)
+          .withdraw({ amount: 30n })
+        .execute();
+
+      // After: 930n public (900 + 30), 70n private (surplus note)
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(930n);
+
+      // Alice should have a new note with 70n (the surplus)
+      const notesAfter = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(notesAfter.length).toBe(1); // old note used, new surplus note created
+      expect(notesAfter[0].amount).toBe(70n);
+    });
+
+    it("surplusTo on token builder: creates surplus note for that token only", async () => {
+      // Alice starts with 1000n STRK, 500n ETH
+      // Deposit to self for both tokens
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .deposit(100n, aliceSelf)
+        .with(ETH)
+          .deposit(50n, aliceSelf)
+        .execute();
+
+      // After deposits: STRK 900n public, ETH 450n public
+      const strkNote = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
+      const ethNote = (alice.discoverNotes().notes.get(ETH) ?? [])[0];
+
+      // Use STRK with surplus, ETH without surplus
+      // STRK: 100n in, 30n out -> 70n surplus
+      // ETH: 50n in, 50n out -> no surplus (exact match)
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .surplusTo(aliceSelf)
+          .inputs(strkNote)
+          .withdraw({ amount: 30n })
+        .with(ETH)
+          .inputs(ethNote)
+          .withdraw({ amount: 50n })
+        .execute();
+
+      // STRK: 930n public (900 + 30), 70n private surplus
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(930n);
+      const strkNotesAfter = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(strkNotesAfter.length).toBe(1);
+      expect(strkNotesAfter[0].amount).toBe(70n);
+
+      // ETH: 500n public (450 + 50), no private notes
+      expect(erc20s.get(ETH).balanceOf(ALICE_ADDRESS)).toBe(500n);
+      const ethNotesAfter = alice.discoverNotes().notes.get(ETH) ?? [];
+      expect(ethNotesAfter.length).toBe(0);
+    });
+
+    it("token-level surplusTo overrides root-level surplusTo", async () => {
+      // Register Bob too for cross-user transfer
+      await bob.register();
+      const bobSelf: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
+      setContext({ address: BOB_ADDRESS, key: BOB_PRIVATE_KEY }, bobSelf);
+
+      // Alice sets up channel to Bob
+      const aliceToBob: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
+      setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceToBob);
+
+      // prettier-ignore
+      await alice
+        .build()
+        .setup(BOB_ADDRESS)
+        .with(STRK)
+          .setup(aliceToBob)
+        .execute();
+
+      // Bob sets up channel to self for STRK
+      // prettier-ignore
+      await bob
+        .build()
+        .setup(BOB_ADDRESS)
+        .with(STRK)
+          .setup(bobSelf)
+        .execute();
+
+      // Deposit to Alice (she starts with 1000n)
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .deposit(100n, aliceSelf)
+        .execute();
+
+      // After: 900n public, 100n private
+      const note = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
+
+      // Root: surplus to self (Alice), but STRK override: surplus to Bob
+      // 100n in, 30n withdrawn -> 70n surplus goes to Bob (not Alice)
+      // prettier-ignore
+      await alice
+        .build()
+        .surplusTo(aliceSelf) // default: surplus to Alice
+        .with(STRK)
+          .surplusTo(aliceToBob) // override: surplus to Bob for STRK
+          .inputs(note)
+          .withdraw({ amount: 30n })
+        .execute();
+
+      // Alice has 930n public STRK (900 + 30), no private notes
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(930n);
+      const aliceNotesAfter = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(aliceNotesAfter.length).toBe(0);
+
+      // Bob has 70n private STRK (the surplus)
+      const bobNotesAfter = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotesAfter.length).toBe(1);
+      expect(bobNotesAfter[0].amount).toBe(70n);
+    });
+
+    it("no surplus note created when amounts are exactly balanced", async () => {
+      // Alice starts with 1000n
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .deposit(100n, aliceSelf)
+        .execute();
+
+      // After: 900n public, 100n private
+      const note = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
+
+      // 100n in, 100n out -> no surplus even with surplusTo set
+      // prettier-ignore
+      await alice
+        .build()
+        .surplusTo(aliceSelf)
+        .with(STRK)
+          .inputs(note)
+          .withdraw({ amount: 100n })
+        .execute();
+
+      // Alice has 1000n public (900 + 100), no private notes
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+      const notesAfter = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(notesAfter.length).toBe(0);
+    });
+
+    it("without surplusTo, unbalanced amounts still fail", async () => {
+      // prettier-ignore
+      await alice
+        .build()
+        .with(STRK)
+          .deposit(100n, aliceSelf)
+        .execute();
+
+      const note = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
+
+      // 100n in, 50n out, no surplusTo -> should fail validation
+      await expect(
+        alice.build().with(STRK).inputs(note).withdraw({ amount: 50n }).execute()
+      ).rejects.toThrow(/Final total for token.*is 50.*expected 0/);
+    });
+  });
 });


### PR DESCRIPTION
Add surplusTo(recipient: PrivateRecipient | Channel) to both builders. It adds a CreateNoteAction for remaining surplus after all other actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/165)
<!-- Reviewable:end -->
