### PR TITLE
feat(sdk): add action compiler and registry updater for context resolution and optimistic updates

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -108,6 +108,8 @@ export interface ProveInterface {
   prove(calls: AllowArray<Call>): Promise<Proof>;
 }
 
+// ============ Raw Actions (builder output, no context) ============
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type SetViewingKeyAction = {};
 
@@ -117,16 +119,16 @@ export type OpenChannelAction = {
 
 export type OpenTokenChannelAction = {
   recipient: StarknetAddress;
-  context: Channel;
   token: StarknetAddress;
 };
 
 export type DepositAction = {
-  recipient: StarknetAddress | NoteId;
-  context?: Channel;
   token: StarknetAddress;
   amount: Amount;
-};
+} & (
+  | { recipient: StarknetAddress } // Deposit to address (context resolved from registry)
+  | { noteId: NoteId } // Deposit to open note (no context needed)
+);
 
 export type UseNoteAction = {
   token: StarknetAddress;
@@ -135,7 +137,6 @@ export type UseNoteAction = {
 
 export type CreateNoteAction = {
   recipient: StarknetAddress;
-  context: Channel;
   token: StarknetAddress;
   amount: Amount | Open;
 };
@@ -145,6 +146,82 @@ export type WithdrawAction = {
   token: StarknetAddress;
   amount: Amount;
 };
+
+/** Actions - context comes from registry */
+export type Actions = {
+  setViewingKey?: SetViewingKeyAction;
+  openChannels?: OpenChannelAction[];
+  openTokenChannels?: OpenTokenChannelAction[];
+  deposits?: DepositAction[];
+  useNotes?: UseNoteAction[];
+  createNotes?: CreateNoteAction[];
+  withdraws?: WithdrawAction[];
+};
+
+// ============ Auto-Discovery & Registry Types ============
+
+/**
+ * Discovery level controls when/whether to call the discovery service.
+ * - 'none': Never call discovery. Missing data → error.
+ * - 'explicit': Only discover when data is missing. Trust registry contents.
+ * - 'refresh': Always discover. Use registry as optimization hint.
+ */
+export type DiscoveryLevel = "none" | "explicit" | "refresh";
+
+/**
+ * Options for automatic discovery during execute.
+ */
+export type AutoDiscoveryOptions = {
+  /** Discovery level for notes */
+  notes?: DiscoveryLevel;
+  /** Discovery level for recipient channels (includes self) */
+  recipient?: DiscoveryLevel;
+};
+
+/**
+ * Registry holding the user's private state: channels and notes.
+ * Passed to execute() for context resolution and updated with new state.
+ */
+export type PrivateRegistry = {
+  /** Channels by recipient address */
+  channels: AddressMap<Channel>;
+  /** Notes by token address */
+  notes: AddressMap<Note[]>;
+};
+
+/** Create an empty private registry */
+export function createEmptyRegistry(): PrivateRegistry {
+  return {
+    channels: new AddressMap<Channel>(),
+    notes: new AddressMap<Note[]>(() => []),
+  };
+}
+
+/**
+ * Options for building and executing private transfers.
+ */
+export type ExecuteOptions = {
+  /** Auto-discovery options */
+  autoDiscover?: AutoDiscoveryOptions;
+  /** If true, add OpenChannel/OpenTokenChannel actions implicitly when missing */
+  autoSetup?: boolean;
+  /** If true, auto-select notes from registry when inputs() not called */
+  autoSelectNotes?: boolean;
+  /** Registry for context/notes lookup. Updated during execute unless registryConst is true. */
+  registry?: PrivateRegistry;
+  /** If true, registry is not mutated; a new one is returned instead */
+  registryConst?: boolean;
+};
+
+/**
+ * Result of execute, including the call/proof and updated registry.
+ */
+export type ExecuteResult = {
+  callAndProof: CallAndProof;
+  /** Updated registry (new object if registryConst was true, same object otherwise) */
+  registry: PrivateRegistry;
+};
+
 /**
  * Main interface for clients to use. It is stateless.
  * The methods call the proof provider to generate a proof and prepare a public call to send to Starknet.
@@ -179,7 +256,7 @@ export interface PrivateTransfers {
    * @throws if the account or recipient is not registered
    */
   discoverRequirement(
-    recipient: PrivateRecipient,
+    recipient: StarknetAddress,
     token: StarknetAddress
   ): Promise<SetupRequirement>;
 
@@ -195,20 +272,22 @@ export interface PrivateTransfers {
   /**
    * Discover channels for one or more recipients
    */
-  discoverChannels(...recipients: (StarknetAddress | PrivateRecipient)[]): {
+  discoverChannels(...recipients: StarknetAddress[]): {
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
   };
 
-  execute(actions: {
-    setViewingKey?: SetViewingKeyAction;
-    openChannels?: OpenChannelAction[];
-    openTokenChannels?: OpenTokenChannelAction[];
-    deposits?: DepositAction[];
-    useNotes?: UseNoteAction[];
-    createNotes?: CreateNoteAction[];
-    withdraws?: WithdrawAction[];
-  }): Promise<CallAndProof>;
+  /**
+   * Execute raw actions. The implementation:
+   * 1. Compiles actions (resolves contexts from registry, openChannels, autoSetup, or discovery)
+   * 2. Validates the compiled actions
+   * 3. Executes on the pool
+   * 4. Returns result with updated registry
+   */
+  execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult>;
+
+  /** Create a builder for batching multiple operations */
+  build(options?: ExecuteOptions): PrivateTransfersBuilder;
 }
 
 // ============ Builder Types ============
@@ -216,7 +295,7 @@ export interface PrivateTransfers {
 /**
  * Output specification for transfer/withdraw operations
  */
-export type TransferOutput = { recipient: PrivateRecipient; amount: Amount | Open };
+export type TransferOutput = { recipient: StarknetAddress; amount: Amount | Open };
 export type WithdrawOutput = { recipient?: StarknetAddress; amount: Amount };
 
 /**
@@ -231,28 +310,32 @@ export type WithdrawOutput = { recipient?: StarknetAddress; amount: Amount };
  */
 export interface TokenOperationsBuilder {
   /** Setup this token in recipient's channel */
-  setup(recipient: PrivateRecipient): this;
+  setup(recipient: StarknetAddress): this;
 
-  /** Specify input notes for this token */
+  /** Specify input notes for this token. If not called and autoSelectNotes is enabled, notes are auto-selected. */
   inputs(...notes: Note[]): this;
 
-  /** Deposit this token (to self by default, or to a recipient with an open note already prepared)
-   * @param recipient can be a recipient or a note id for an open note.
+  /**
+   * Deposit this token.
+   * @param recipient Address or NoteId (for open notes). Context resolved from registry or discovery.
    */
-  deposit(amount: Amount, recipient: PrivateRecipient | NoteId): this;
+  deposit(amount: Amount, recipient: StarknetAddress | NoteId): this;
 
   /** Withdraw this token to one or more public addresses */
   withdraw(...outputs: WithdrawOutput[]): this;
 
-  /** Transfer this token privately to one or more recipients */
-  transfer(...outputs: TransferOutput[]): this;
+  /**
+   * Transfer this token privately to one or more recipients.
+   * Context for each recipient is resolved from registry or discovery.
+   */
+  transfer(...outputs: Array<{ recipient: StarknetAddress; amount: Amount | Open }>): this;
 
   /**
    * Set the recipient for any surplus for this token.
    * Overrides the top-level surplusTo for this specific token.
    * If inputs exceed outputs, a CreateNoteAction is automatically added for the difference.
    */
-  surplusTo(recipient: PrivateRecipient | Channel): this;
+  surplusTo(recipient: StarknetAddress | Channel): this;
 
   /** Switch to another token */
   with(token: StarknetAddress): TokenOperationsBuilder;
@@ -261,7 +344,7 @@ export interface TokenOperationsBuilder {
   done(): PrivateTransfersBuilder;
 
   /** Execute all queued operations */
-  execute(): Promise<CallAndProof>;
+  execute(options?: ExecuteOptions): Promise<ExecuteResult>;
 }
 
 /**
@@ -279,13 +362,12 @@ export interface TokenOperationsBuilder {
  *
  * @example Register and setup a new recipient
  * ```ts
- * const alice: PrivateRecipient = { address: ALICE_ADDRESS, context: undefined! };
- * await transfers.build()
+ * await transfers.build({ autoSetup: true })
  *   .register()
- *   .setup(alice)  // alice.context will be populated with the Channel
+ *   .setup(BOB_ADDRESS)
  *   .with(STRK)
- *     .setup(alice)
- *     .deposit(100n, alice)
+ *     .setup(BOB_ADDRESS)
+ *     .deposit(100n, BOB_ADDRESS)
  *   .execute();
  * ```
  *
@@ -341,13 +423,13 @@ export interface PrivateTransfersBuilder {
    * If inputs exceed outputs for a token, a CreateNoteAction is automatically added for the difference.
    * Can be overridden per-token using TokenOperationsBuilder.surplusTo().
    */
-  surplusTo(recipient: PrivateRecipient | Channel): this;
+  surplusTo(recipient: StarknetAddress | Channel): this;
 
   /** Start token-specific operations */
   with(token: StarknetAddress): TokenOperationsBuilder;
 
   /** Execute all queued operations and return the results */
-  execute(): Promise<CallAndProof>;
+  execute(options?: ExecuteOptions): Promise<ExecuteResult>;
 }
 
 ////// The following are more likely to change /////////
@@ -364,8 +446,13 @@ export interface ProofProviderInterface {
 
 export interface DiscoveryProviderInterface {
   /**
+   * Get the public key for a registered address.
+   * This is a contract read operation.
+   */
+  getPublicKey(address: StarknetAddress): BigNumberish;
+
+  /**
    * Discover unspent notes per token
-   *
    */
   discoverNotes(
     address: StarknetAddress,
@@ -382,7 +469,7 @@ export interface DiscoveryProviderInterface {
   discoverChannels(
     address: StarknetAddress,
     viewingKey: ViewingKey,
-    ...recipients: (StarknetAddress | PrivateRecipient)[]
+    ...recipients: StarknetAddress[]
   ): {
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
@@ -396,7 +483,7 @@ export interface DiscoveryProviderInterface {
   discoverRequirement(
     address: StarknetAddress,
     viewingKey: ViewingKey,
-    recipient: PrivateRecipient,
+    recipient: StarknetAddress,
     token: StarknetAddress
   ): Promise<SetupRequirement>;
 }

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -4,18 +4,19 @@
 
 import type {
   Amount,
-  CallAndProof,
   Channel,
   CreateNoteAction,
   DepositAction,
+  ExecuteOptions,
+  ExecuteResult,
   Note,
   NoteId,
   Open,
   OpenChannelAction,
   OpenTokenChannelAction,
-  PrivateRecipient,
   PrivateTransfers,
   PrivateTransfersBuilder,
+  Actions,
   SetViewingKeyAction,
   StarknetAddress,
   TokenOperationsBuilder,
@@ -24,64 +25,51 @@ import type {
 } from "../interfaces.js";
 import type { Call } from "starknet";
 import { AddressMap } from "../utils/maps.js";
-import { calculateSurplus } from "../utils/validation.js";
-import { createMockCallAndProof } from "../testing/helpers.js";
+
+// ============ Internal Types ============
+
+/** Internal representation of surplus recipient */
+type SurplusRecipient = {
+  address: StarknetAddress;
+  channel?: Channel;
+};
+
+const isChannel = (v: unknown): v is Channel => typeof v === "object" && v !== null && "key" in v;
 
 // ============ Token Operations Builder ============
 
-const isPrivateRecipient = (v: unknown): v is PrivateRecipient =>
-  typeof v === "object" && v !== null && "address" in v && "context" in v;
-
 export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
-  // Actions
-  public openTokenChannels: OpenTokenChannelAction[] = [];
+  // Actions stored without context - context resolved during execute
+  public setupRecipients: StarknetAddress[] = [];
   public useNotes: UseNoteAction[] = [];
-  public deposits: DepositAction[] = [];
+  public deposits: Array<{ amount: Amount; recipient: StarknetAddress | NoteId }> = [];
   public withdraws: WithdrawAction[] = [];
-  public createNotes: CreateNoteAction[] = [];
+  public transfers: Array<{ recipient: StarknetAddress; amount: Amount | Open }> = [];
+  public hasExplicitInputs = false;
 
   // Surplus recipient (overrides parent builder's surplus recipient for this token)
-  public surplusRecipient?: PrivateRecipient;
+  public surplusRecipient?: SurplusRecipient;
 
   constructor(
     private parentBuilder: PrivateTransfersBuilderImpl,
     public readonly token: StarknetAddress
   ) {}
 
-  setup(recipient: PrivateRecipient): this {
-    // Use getter for lazy context access (context is populated during execute)
-    this.openTokenChannels.push({
-      recipient: recipient.address,
-      get context() {
-        return recipient.context;
-      },
-      token: this.token,
-    });
+  setup(recipient: StarknetAddress): this {
+    this.setupRecipients.push(recipient);
     return this;
   }
 
   inputs(...notes: Note[]): this {
+    this.hasExplicitInputs = true;
     for (const note of notes) {
       this.useNotes.push({ token: this.token, note });
     }
     return this;
   }
 
-  deposit(amount: Amount, recipient: PrivateRecipient | NoteId): this {
-    if (isPrivateRecipient(recipient)) {
-      // Use getter for lazy context access (context is populated during execute)
-      this.deposits.push({
-        token: this.token,
-        amount,
-        recipient: recipient.address,
-        get context() {
-          return recipient.context;
-        },
-      });
-    } else {
-      // NoteId - no context needed
-      this.deposits.push({ token: this.token, amount, recipient });
-    }
+  deposit(amount: Amount, recipient: StarknetAddress | NoteId): this {
+    this.deposits.push({ amount, recipient });
     return this;
   }
 
@@ -96,26 +84,15 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
     return this;
   }
 
-  transfer(...outputs: Array<{ recipient: PrivateRecipient; amount: Amount | Open }>): this {
-    for (const output of outputs) {
-      const recipient = output.recipient;
-      // Use getter for lazy context access (context is populated during execute)
-      this.createNotes.push({
-        token: this.token,
-        recipient: recipient.address,
-        get context() {
-          return recipient.context;
-        },
-        amount: output.amount,
-      });
-    }
+  transfer(...outputs: Array<{ recipient: StarknetAddress; amount: Amount | Open }>): this {
+    this.transfers.push(...outputs);
     return this;
   }
 
-  surplusTo(recipient: PrivateRecipient | Channel): this {
-    this.surplusRecipient = isPrivateRecipient(recipient)
-      ? recipient
-      : { address: this.parentBuilder.userAddress, context: recipient };
+  surplusTo(recipient: StarknetAddress | Channel): this {
+    this.surplusRecipient = isChannel(recipient)
+      ? { address: this.parentBuilder.userAddress, channel: recipient }
+      : { address: recipient };
     return this;
   }
 
@@ -127,31 +104,18 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
     return this.parentBuilder;
   }
 
-  async execute(): Promise<CallAndProof> {
-    return this.parentBuilder.execute();
+  async execute(options?: ExecuteOptions): Promise<ExecuteResult> {
+    return this.parentBuilder.execute(options);
   }
 
   reset(): void {
-    this.openTokenChannels = [];
+    this.setupRecipients = [];
     this.useNotes = [];
     this.deposits = [];
     this.withdraws = [];
-    this.createNotes = [];
+    this.transfers = [];
+    this.hasExplicitInputs = false;
     this.surplusRecipient = undefined;
-  }
-
-  /**
-   * Calculate the surplus for this token builder.
-   * Returns the surplus amount (inputs - outputs).
-   * @throws Error if outputs exceed inputs
-   */
-  calculateSurplus(): bigint {
-    return calculateSurplus(
-      this.deposits.map((d) => d.amount),
-      this.useNotes.map((u) => u.note.amount),
-      this.createNotes.map((c) => c.amount),
-      this.withdraws.map((w) => w.amount)
-    );
   }
 }
 
@@ -166,12 +130,18 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
   );
 
   // Default surplus recipient for all tokens
-  public defaultSurplusRecipient?: PrivateRecipient;
+  public defaultSurplusRecipient?: SurplusRecipient;
+
+  // Options passed at build time
+  private buildOptions?: ExecuteOptions;
 
   constructor(
     private transfers: PrivateTransfers,
-    public readonly userAddress: StarknetAddress
-  ) {}
+    public readonly userAddress: StarknetAddress,
+    options?: ExecuteOptions
+  ) {
+    this.buildOptions = options;
+  }
 
   register(): this {
     this.setViewingKey = {};
@@ -188,10 +158,10 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     return this;
   }
 
-  surplusTo(recipient: PrivateRecipient | Channel): this {
-    this.defaultSurplusRecipient = isPrivateRecipient(recipient)
-      ? recipient
-      : { address: this.userAddress, context: recipient };
+  surplusTo(recipient: StarknetAddress | Channel): this {
+    this.defaultSurplusRecipient = isChannel(recipient)
+      ? { address: this.userAddress, channel: recipient }
+      : { address: recipient };
     return this;
   }
 
@@ -199,8 +169,19 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     return this.tokenBuilders.get(token)!;
   }
 
-  async execute(): Promise<CallAndProof> {
-    // 1. Collect all actions from token builders
+  async execute(options?: ExecuteOptions): Promise<ExecuteResult> {
+    // Merge build-time options with execute-time options
+    const mergedOptions: ExecuteOptions = {
+      ...this.buildOptions,
+      ...options,
+      autoDiscover: {
+        ...this.buildOptions?.autoDiscover,
+        ...options?.autoDiscover,
+      },
+    };
+
+    // Collect raw actions from token builders
+    // Context resolution will happen in PrivateTransfers.execute via ActionCompiler
     const openTokenChannels: OpenTokenChannelAction[] = [];
     const deposits: DepositAction[] = [];
     const useNotes: UseNoteAction[] = [];
@@ -208,40 +189,73 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     const withdraws: WithdrawAction[] = [];
 
     for (const [token, tokenBuilder] of this.tokenBuilders.entries()) {
-      openTokenChannels.push(...tokenBuilder.openTokenChannels);
-      deposits.push(...tokenBuilder.deposits);
+      // Setup actions (no context - raw action)
+      for (const recipient of tokenBuilder.setupRecipients) {
+        openTokenChannels.push({ recipient, token });
+      }
+
+      // Deposits (no context - raw action)
+      for (const dep of tokenBuilder.deposits) {
+        if (typeof dep.recipient === "bigint" || typeof dep.recipient === "number") {
+          // Deposit to open note
+          deposits.push({ token, amount: dep.amount, noteId: dep.recipient as NoteId });
+        } else {
+          // Deposit to address
+          deposits.push({ token, amount: dep.amount, recipient: dep.recipient });
+        }
+      }
+
+      // Use notes
       useNotes.push(...tokenBuilder.useNotes);
-      createNotes.push(...tokenBuilder.createNotes);
+
+      // Transfers (no context - raw action)
+      for (const transfer of tokenBuilder.transfers) {
+        createNotes.push({
+          token,
+          recipient: transfer.recipient,
+          amount: transfer.amount,
+        });
+      }
+
+      // Withdraws
       withdraws.push(...tokenBuilder.withdraws);
 
-      // 2. Handle surplus for this token
+      // Handle surplus - calculate and add CreateNoteAction if needed
       const surplusRecipient = tokenBuilder.surplusRecipient ?? this.defaultSurplusRecipient;
       if (surplusRecipient) {
-        const surplus = tokenBuilder.calculateSurplus();
+        // Calculate surplus: deposits + useNotes - transfers - withdraws
+        const depositSum = tokenBuilder.deposits.reduce((sum, d) => sum + d.amount, 0n);
+        const useNoteSum = tokenBuilder.useNotes.reduce((sum, u) => sum + u.note.amount, 0n);
+        const transferSum = tokenBuilder.transfers.reduce(
+          (sum, t) => sum + (typeof t.amount === "object" ? 0n : t.amount),
+          0n
+        );
+        const withdrawSum = tokenBuilder.withdraws.reduce((sum, w) => sum + w.amount, 0n);
+
+        const surplus = depositSum + useNoteSum - transferSum - withdrawSum;
         if (surplus > 0n) {
-          // Create a note for the surplus
           createNotes.push({
             token,
             recipient: surplusRecipient.address,
-            context: surplusRecipient.context,
             amount: surplus,
           });
         }
       }
     }
 
-    // 3. Execute everything via single pool.execute call
-    await this.transfers.execute({
+    // Build raw actions (no context - ActionCompiler will resolve)
+    const actions: Actions = {
       setViewingKey: this.setViewingKey,
-      openChannels: this.openChannels,
-      openTokenChannels,
-      deposits,
-      useNotes,
-      createNotes,
-      withdraws,
-    });
+      openChannels: this.openChannels.length > 0 ? this.openChannels : undefined,
+      openTokenChannels: openTokenChannels.length > 0 ? openTokenChannels : undefined,
+      deposits: deposits.length > 0 ? deposits : undefined,
+      useNotes: useNotes.length > 0 ? useNotes : undefined,
+      createNotes: createNotes.length > 0 ? createNotes : undefined,
+      withdraws: withdraws.length > 0 ? withdraws : undefined,
+    };
 
-    return createMockCallAndProof();
+    // Execute via PrivateTransfers - ActionCompiler will resolve contexts
+    return this.transfers.execute(actions, mergedOptions);
   }
 
   reset(): void {

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -1,0 +1,235 @@
+/**
+ * ActionCompiler - Resolves contexts and prepares actions for execution.
+ *
+ * Context resolution order:
+ * 1. Registry (provided via options)
+ * 2. OpenChannelActions in the same batch (compute channel with nonce=0)
+ * 3. AutoSetup (implicitly create OpenChannelAction)
+ * 4. Discovery (call discovery service)
+ *
+ * After compilation:
+ * - Registry is updated with resolved channels and notes
+ * - Actions may have UseNoteActions added (if autoSelectNotes)
+ * - Pool looks up context from registry
+ *
+ * Note: After pool execution, use applyOptimisticUpdate() from registry-updater.ts
+ * to update the registry with the results.
+ */
+
+import type {
+  Actions,
+  DiscoveryProviderInterface,
+  ExecuteOptions,
+  Note,
+  PrivateRegistry,
+  StarknetAddress,
+  UseNoteAction,
+  ViewingKey,
+} from "../interfaces.js";
+import { Channel, createEmptyRegistry } from "../interfaces.js";
+import { AddressMap } from "../utils/maps.js";
+
+export type CompileResult = {
+  actions: Actions;
+  registry: PrivateRegistry;
+};
+
+export class ActionCompiler {
+  constructor(
+    private userAddress: StarknetAddress,
+    private userViewingKey: ViewingKey,
+    private discoveryProvider: DiscoveryProviderInterface
+  ) {}
+
+  /**
+   * Compile actions by resolving contexts and updating the registry.
+   */
+  compile(actions: Actions, options?: ExecuteOptions): CompileResult {
+    // Get or create registry
+    const inputRegistry = options?.registry ?? createEmptyRegistry();
+    const registry = options?.registryConst ? this.cloneRegistry(inputRegistry) : inputRegistry;
+
+    // Phase 1: Resolve recipient channels
+    this.resolveRecipientChannels(actions, options, registry);
+
+    // Phase 2: Resolve notes (discover and/or auto-select)
+    this.resolveNotes(actions, options, registry);
+
+    return { actions, registry };
+  }
+
+  /**
+   * Resolve recipient channels by discovering or using registry.
+   */
+  private resolveRecipientChannels(
+    actions: Actions,
+    options: ExecuteOptions | undefined,
+    registry: PrivateRegistry
+  ): void {
+    // Collect ALL recipients that need a channel (from any action type)
+    const recipientsNeeded = new AddressMap<boolean>();
+
+    // If a channel is to be opened, need to discover the recipient's public key
+    // to calculate the channel key for further actions.
+    if (actions.openChannels) {
+      for (const action of actions.openChannels) {
+        recipientsNeeded.set(action.recipient, true);
+      }
+    }
+
+    if (actions.openTokenChannels) {
+      for (const action of actions.openTokenChannels) {
+        recipientsNeeded.set(action.recipient, true);
+      }
+    }
+
+    if (actions.deposits) {
+      for (const action of actions.deposits) {
+        if ("recipient" in action) {
+          recipientsNeeded.set(action.recipient, true);
+        }
+      }
+    }
+
+    if (actions.createNotes) {
+      for (const action of actions.createNotes) {
+        recipientsNeeded.set(action.recipient, true);
+      }
+    }
+
+    const recipientDiscoveryLevel = options?.autoDiscover?.recipient ?? "none";
+
+    // Determine which recipients to discover based on discovery level
+    let recipientsToDiscover: StarknetAddress[];
+
+    if (recipientDiscoveryLevel === "refresh") {
+      // Refresh: discover ALL recipients to get latest nonces
+      recipientsToDiscover = [...recipientsNeeded.keys()];
+    } else {
+      // None or explicit: only discover missing recipients
+      recipientsToDiscover = [...recipientsNeeded.keys()].filter((r) => !registry.channels.has(r));
+    }
+
+    if (recipientsToDiscover.length === 0) {
+      return;
+    }
+
+    // Check which recipients have explicit OpenChannelActions
+    const openChannelRecipients = new AddressMap<boolean>();
+    for (const action of actions.openChannels ?? []) {
+      openChannelRecipients.set(action.recipient, true);
+    }
+
+    // Recipients that need context but don't have an explicit OpenChannelAction
+    const recipientsWithoutOpenChannel = recipientsToDiscover.filter(
+      (r) => !openChannelRecipients.has(r) && !registry.channels.has(r)
+    );
+
+    // Handle recipients without explicit OpenChannelAction
+    if (recipientsWithoutOpenChannel.length > 0) {
+      if (recipientDiscoveryLevel === "none" && !options?.autoSetup) {
+        // No way to resolve - error
+        const missing = recipientsWithoutOpenChannel.join(", ");
+        throw new Error(
+          `Missing channel context for recipients: ${missing}. ` +
+            `Provide registry, add OpenChannelAction, enable autoSetup, or enable autoDiscover.`
+        );
+      }
+
+      if (options?.autoSetup) {
+        // AutoSetup: implicitly add OpenChannelActions for missing recipients
+        actions.openChannels = actions.openChannels ?? [];
+        for (const recipient of recipientsWithoutOpenChannel) {
+          actions.openChannels.push({ recipient });
+        }
+      }
+    }
+
+    // Discover channels for all recipients that need discovery in a single call
+    // discoverChannels computes channel keys and returns current nonce state
+    const { channels } = this.discoveryProvider.discoverChannels(
+      this.userAddress,
+      this.userViewingKey,
+      ...recipientsToDiscover
+    );
+    for (const [addr, channel] of channels.entries()) {
+      registry.channels.set(addr, channel);
+    }
+  }
+
+  /**
+   * Resolve notes by discovering and/or auto-selecting from registry.
+   */
+  private resolveNotes(
+    actions: Actions,
+    options: ExecuteOptions | undefined,
+    registry: PrivateRegistry
+  ): void {
+    const notesDiscoveryLevel = options?.autoDiscover?.notes ?? "none";
+
+    // Discover notes if requested
+    if (notesDiscoveryLevel !== "none") {
+      const shouldDiscover = notesDiscoveryLevel === "refresh" || registry.notes.size === 0;
+
+      if (shouldDiscover) {
+        const { notes } = this.discoveryProvider.discoverNotes(
+          this.userAddress,
+          this.userViewingKey,
+          { known: registry.notes }
+        );
+
+        // Replace registry notes (don't merge - some may have been spent)
+        registry.notes = notes;
+      }
+    }
+
+    // Auto-select notes if enabled and no useNotes provided
+    if (options?.autoSelectNotes && (!actions.useNotes || actions.useNotes.length === 0)) {
+      // Collect tokens that need notes (from createNotes, withdraws)
+      const tokensNeeded = new AddressMap<boolean>();
+
+      if (actions.createNotes) {
+        for (const action of actions.createNotes) {
+          tokensNeeded.set(action.token, true);
+        }
+      }
+
+      if (actions.withdraws) {
+        for (const action of actions.withdraws) {
+          tokensNeeded.set(action.token, true);
+        }
+      }
+
+      // Select all available notes for needed tokens
+      const useNotes: UseNoteAction[] = [];
+      for (const token of tokensNeeded.keys()) {
+        const tokenNotes = registry.notes.get(token);
+        if (tokenNotes) {
+          for (const note of tokenNotes) {
+            useNotes.push({ token, note });
+          }
+        }
+      }
+
+      if (useNotes.length > 0) {
+        actions.useNotes = useNotes;
+      }
+    }
+  }
+
+  private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {
+    // Clone channels
+    const clonedChannels = new AddressMap<Channel>();
+    for (const [addr, channel] of registry.channels.entries()) {
+      clonedChannels.set(addr, channel);
+    }
+
+    // Clone notes
+    const clonedNotes = new AddressMap<Note[]>(() => []);
+    for (const [addr, notes] of registry.notes.entries()) {
+      clonedNotes.set(addr, [...notes]);
+    }
+
+    return { channels: clonedChannels, notes: clonedNotes };
+  }
+}

--- a/sdk/src/internal/index.ts
+++ b/sdk/src/internal/index.ts
@@ -85,6 +85,11 @@ export class Channel {
     this.tokens.set(token, current.increment());
     return current;
   }
+
+  /** Create a deep clone of this channel */
+  clone(): Channel {
+    return new Channel(this.key, this.tokenNonce, this.tokens.entries());
+  }
 }
 
 export const channelSerde: ChannelSerde = {
@@ -190,5 +195,7 @@ function assertTokenEntries(value: unknown): Map<StarknetAddress, NoteNonce> {
   return new Map(entries);
 }
 
-// Re-export builders
+// Re-export builders, compiler, and registry updater
 export { TokenOperationsBuilderImpl, PrivateTransfersBuilderImpl } from "./builders.js";
+export { ActionCompiler } from "./compiler.js";
+export { applyOptimisticUpdate } from "./registry-updater.js";

--- a/sdk/src/internal/registry-updater.ts
+++ b/sdk/src/internal/registry-updater.ts
@@ -1,0 +1,75 @@
+/**
+ * RegistryUpdater - Applies optimistic updates to the registry after pool execution.
+ *
+ * After executing actions on the pool, the registry needs to be updated to reflect
+ * the new state. This is an "optimistic" update because in real-world scenarios,
+ * the transaction hasn't been confirmed on-chain yet.
+ *
+ * Updates:
+ * - Channel nonces (tokenNonce from openTokenChannels, noteNonces from deposits/createNotes)
+ * - Removes spent notes (from useNotes actions)
+ *
+ * Note: Created notes (from deposits/createNotes) are NOT added to the sender's registry
+ * - those notes belong to the recipients.
+ *
+ * Note: openChannels actions don't need handling here - the channel is already in the
+ * registry from the compile phase (via discoverChannels) with initial nonces.
+ */
+
+import type { Actions, PrivateRegistry } from "../interfaces.js";
+
+/**
+ * Apply optimistic updates to the registry after pool execution.
+ *
+ * @param actions - The compiled actions that were executed
+ * @param registry - The registry to update
+ */
+export function applyOptimisticUpdate(actions: Actions, registry: PrivateRegistry): void {
+  // 1. Update channel token nonces (from openTokenChannels)
+  if (actions.openTokenChannels) {
+    for (const action of actions.openTokenChannels) {
+      const channel = registry.channels.get(action.recipient);
+      if (channel) {
+        channel.incrementTokenNonce();
+      }
+    }
+  }
+
+  // 2. Update channel note nonces (from deposits and createNotes)
+  if (actions.deposits) {
+    for (const action of actions.deposits) {
+      if ("recipient" in action) {
+        const channel = registry.channels.get(action.recipient);
+        if (channel) {
+          channel.incrementNoteNonce(action.token);
+        }
+      }
+    }
+  }
+
+  if (actions.createNotes) {
+    for (const action of actions.createNotes) {
+      const channel = registry.channels.get(action.recipient);
+      if (channel) {
+        channel.incrementNoteNonce(action.token);
+      }
+    }
+  }
+
+  // 3. Remove spent notes
+  if (actions.useNotes) {
+    for (const action of actions.useNotes) {
+      const noteId = action.note.id;
+      // Search all tokens for this note
+      for (const [, tokenNotes] of registry.notes.entries()) {
+        const index = tokenNotes.findIndex(
+          (n) => BigInt(n.id as bigint) === BigInt(noteId as bigint)
+        );
+        if (index !== -1) {
+          tokenNotes.splice(index, 1);
+          break;
+        }
+      }
+    }
+  }
+}

--- a/sdk/src/testing/discovery.ts
+++ b/sdk/src/testing/discovery.ts
@@ -6,7 +6,6 @@ import type {
   Amount,
   DiscoveryProviderInterface,
   Note,
-  PrivateRecipient,
   StarknetAddress,
   StarknetAddressBigint,
   ViewingKey,
@@ -23,6 +22,10 @@ import { hashes } from "../utils/hashes.js";
 export class MockDiscoveryProvider implements DiscoveryProviderInterface {
   private _currentBlock: BlockIdentifier = 0; // TODO: allow block advancement
   constructor(private pool: PrivacyPool) {}
+
+  getPublicKey(address: StarknetAddress) {
+    return this.pool.getPublicKey(address);
+  }
 
   discoverNotes(
     address: StarknetAddress,
@@ -77,7 +80,7 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
   discoverChannels(
     address: StarknetAddress,
     viewingKey: ViewingKey,
-    ...recipients: (StarknetAddress | PrivateRecipient)[]
+    ...recipients: StarknetAddress[]
   ): { timestamp: BlockIdentifier; channels: AddressMap<Channel> } {
     assertViewingKey(viewingKey);
 
@@ -111,7 +114,7 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
   async discoverRequirement(
     address: StarknetAddress,
     viewingKey: ViewingKey,
-    recipient: PrivateRecipient,
+    recipient: StarknetAddress,
     token: StarknetAddress
   ): Promise<SetupRequirement> {
     assertViewingKey(viewingKey);

--- a/sdk/src/testing/pool.ts
+++ b/sdk/src/testing/pool.ts
@@ -3,21 +3,16 @@
  */
 
 import type {
+  Actions,
   Amount,
-  CreateNoteAction,
-  DepositAction,
   Note,
   NoteId,
   Open,
-  OpenChannelAction,
-  OpenTokenChannelAction,
-  SetViewingKeyAction,
+  PrivateRegistry,
   StarknetAddress,
   StarknetAddressBigint,
-  UseNoteAction,
-  WithdrawAction,
 } from "../interfaces.js";
-import { Witness } from "../interfaces.js";
+import { Witness, Channel } from "../interfaces.js";
 import { BigNumberish } from "starknet";
 import { NoteNonce, TokenNonce } from "../internal/index.js";
 import {
@@ -123,18 +118,25 @@ export class PrivacyPool {
   execute(
     sender: StarknetAddress,
     senderViewingKey: ViewingKey,
-    actions: {
-      setViewingKey?: SetViewingKeyAction;
-      openChannels?: OpenChannelAction[];
-      openTokenChannels?: OpenTokenChannelAction[];
-      deposits?: DepositAction[];
-      useNotes?: UseNoteAction[];
-      createNotes?: CreateNoteAction[];
-      withdraws?: WithdrawAction[];
-    }
+    actions: Actions,
+    registry: PrivateRegistry
   ) {
+    // Clone channels to avoid mutating the registry (simulates real contract behavior)
+    // The real Starknet contract doesn't have access to our local registry objects
+    const clonedChannels = new AddressMap<Channel>();
+    for (const [addr, channel] of registry.channels.entries()) {
+      clonedChannels.set(addr, channel.clone());
+    }
+
+    // Helper to get cloned channel
+    const getChannel = (recipient: StarknetAddress) => {
+      const channel = clonedChannels.get(recipient);
+      assert(channel, `No channel found for recipient ${recipient} in registry`);
+      return channel;
+    };
+
     // Validate before mutating any state
-    this.validateTokenTotals(actions);
+    this.validateTokenTotals(actions, registry);
 
     // 1. Register user if setViewingKey is requested
     if (actions.setViewingKey) {
@@ -148,10 +150,10 @@ export class PrivacyPool {
       }
     }
 
-    // 3. Open token channels
+    // 3. Open token channels - use cloned channel
     if (actions.openTokenChannels) {
       for (const action of actions.openTokenChannels) {
-        const channel = action.context;
+        const channel = getChannel(action.recipient);
         const nonce = channel.incrementTokenNonce();
         this.setToken(sender, action.recipient, channel.key, action.token, nonce);
       }
@@ -164,9 +166,13 @@ export class PrivacyPool {
       for (const action of actions.deposits) {
         this.deposit(sender, action.token, action.amount);
 
-        if (action.context) {
-          // Normal deposit: create a new note
-          const nonce = action.context.incrementNoteNonce(action.token);
+        if ("noteId" in action) {
+          // Deposit to existing open note
+          this.fillOpenNote(action.noteId, action.token, action.amount);
+        } else {
+          // Normal deposit: create a new note - use cloned channel
+          const channel = getChannel(action.recipient);
+          const nonce = channel.incrementNoteNonce(action.token);
           this.createNote(
             sender,
             senderViewingKey,
@@ -175,9 +181,6 @@ export class PrivacyPool {
             nonce,
             action.amount
           );
-        } else {
-          // Deposit to existing open note
-          this.fillOpenNote(action.recipient as NoteId, action.token, action.amount);
         }
       }
     }
@@ -189,10 +192,11 @@ export class PrivacyPool {
       }
     }
 
-    // Process createNotes: create new notes for recipients
+    // Process createNotes: create new notes for recipients - use cloned channel
     if (actions.createNotes) {
       for (const action of actions.createNotes) {
-        const nonce = action.context.incrementNoteNonce(action.token);
+        const channel = getChannel(action.recipient);
+        const nonce = channel.incrementNoteNonce(action.token);
         this.createNote(
           sender,
           senderViewingKey,
@@ -346,12 +350,7 @@ export class PrivacyPool {
     note.amount = amount;
   }
 
-  private validateTokenTotals(actions: {
-    deposits?: DepositAction[];
-    useNotes?: UseNoteAction[];
-    createNotes?: CreateNoteAction[];
-    withdraws?: WithdrawAction[];
-  }): void {
+  private validateTokenTotals(actions: Actions, _registry: PrivateRegistry): void {
     // 1. Validate all amounts are non-negative
     if (actions.deposits) {
       for (const deposit of actions.deposits) {

--- a/sdk/src/testing/transfers.ts
+++ b/sdk/src/testing/transfers.ts
@@ -3,33 +3,24 @@
  */
 
 import type {
-  Amount,
-  CallAndProof,
-  CreateNoteAction,
-  DepositAction,
+  Actions,
+  ExecuteOptions,
+  ExecuteResult,
   Note,
-  NoteId,
-  Open,
-  OpenChannelAction,
-  OpenTokenChannelAction,
-  PrivateInvocationResult,
-  PrivateRecipient,
   PrivateTransfers,
   PrivateTransfersBuilder,
-  SetViewingKeyAction,
   StarknetAddress,
-  UseNoteAction,
-  WithdrawAction,
 } from "../interfaces.js";
 import { Channel, SetupRequirement } from "../interfaces.js";
 import type { BlockIdentifier } from "starknet";
 import type { PrivateKey } from "../utils/crypto.js";
-import { hashes } from "../utils/hashes.js";
 import { AddressMap } from "../utils/maps.js";
 import { createMockCallAndProof } from "./helpers.js";
 import type { PrivacyPool } from "./pool.js";
 import { MockDiscoveryProvider } from "./discovery.js";
 import { PrivateTransfersBuilderImpl } from "../internal/builders.js";
+import { ActionCompiler } from "../internal/compiler.js";
+import { applyOptimisticUpdate } from "../internal/registry-updater.js";
 
 export class MockPrivateTransfers implements PrivateTransfers {
   private pool: PrivacyPool;
@@ -39,16 +30,18 @@ export class MockPrivateTransfers implements PrivateTransfers {
   private userAddress: StarknetAddress = "0x0";
   private userViewingKey: PrivateKey = 0n;
   private discoveryProvider: MockDiscoveryProvider;
+  private compiler: ActionCompiler;
 
   constructor(pool: PrivacyPool, userAddress: StarknetAddress, userPrivateKey: PrivateKey) {
     this.pool = pool;
     this.discoveryProvider = new MockDiscoveryProvider(pool);
     this.userAddress = userAddress;
     this.userViewingKey = userPrivateKey;
+    this.compiler = new ActionCompiler(userAddress, userPrivateKey, this.discoveryProvider);
   }
 
   async discoverRequirement(
-    recipient: PrivateRecipient,
+    recipient: StarknetAddress,
     token: StarknetAddress
   ): Promise<SetupRequirement> {
     return this.discoveryProvider.discoverRequirement(
@@ -59,131 +52,24 @@ export class MockPrivateTransfers implements PrivateTransfers {
     );
   }
 
-  async register(): Promise<CallAndProof> {
-    return this.build().register().execute();
+  async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
+    // 1. Compile actions - resolves contexts and updates registry
+    const { actions: compiledActions, registry } = this.compiler.compile(actions, options);
+
+    // 2. Execute actions on the pool - pass registry for context lookup
+    await this.pool.execute(this.userAddress, this.userViewingKey, compiledActions, registry);
+
+    // 3. Apply optimistic updates - update channel nonces, remove spent notes
+    applyOptimisticUpdate(compiledActions, registry);
+
+    return {
+      callAndProof: createMockCallAndProof(),
+      registry,
+    };
   }
 
-  async setupChannel(
-    recipient: StarknetAddress
-  ): Promise<{ invocationData: CallAndProof; channel: Channel }> {
-    const invocationData = await this.build().setup(recipient).execute();
-    // Compute the channel key
-    const recipientPublicKey = this.pool.getPublicKey(recipient);
-    const channelKey = hashes.channelKey(
-      this.userAddress,
-      this.userViewingKey,
-      recipient,
-      recipientPublicKey
-    );
-    return { invocationData, channel: new Channel(channelKey) };
-  }
-
-  async setupToken(
-    recipient: PrivateRecipient,
-    token: StarknetAddress
-  ): Promise<{ invocationData: CallAndProof; channel: Channel }> {
-    const channel = recipient.context;
-    const invocationData = await this.build().with(token).setup(recipient).execute();
-    return { invocationData, channel };
-  }
-
-  async deposit(params: {
-    token: StarknetAddress;
-    amount: Amount;
-    recipient: PrivateRecipient | NoteId;
-  }): Promise<PrivateInvocationResult> {
-    const invocationData = await this.build()
-      .with(params.token)
-      .deposit(params.amount, params.recipient)
-      .execute();
-    return { invocationData };
-  }
-
-  private async withdrawOrTransfer(params: {
-    token: StarknetAddress;
-    inputs: Note[];
-    recipientAddress?: StarknetAddress;
-    recipientPrivate?: PrivateRecipient;
-    amount?: Amount;
-    selfChannel?: Channel;
-    isWithdraw: boolean;
-  }): Promise<PrivateInvocationResult> {
-    const builder = this.build()
-      .with(params.token)
-      .inputs(...params.inputs);
-
-    // Compute amount and handle change
-    const availableAmount = this.availableAmount(params.inputs);
-    const amount = params.amount ?? availableAmount;
-
-    // Add main output (withdraw or transfer)
-    if (params.isWithdraw) {
-      builder.withdraw({ recipient: params.recipientAddress, amount });
-    } else {
-      builder.transfer({ recipient: params.recipientPrivate!, amount });
-    }
-
-    // If there's change, transfer it back to self
-    if (amount < availableAmount && params.selfChannel) {
-      builder.transfer({
-        recipient: { address: this.userAddress, context: params.selfChannel },
-        amount: availableAmount - amount,
-      });
-    }
-
-    const invocationData = await builder.execute();
-    return { invocationData };
-  }
-
-  async withdraw(params: {
-    token: StarknetAddress;
-    inputs: Note[];
-    recipient?: StarknetAddress;
-    amount?: Amount;
-    selfChannel?: Channel;
-  }): Promise<PrivateInvocationResult> {
-    return this.withdrawOrTransfer({
-      token: params.token,
-      inputs: params.inputs,
-      recipientAddress: params.recipient,
-      amount: params.amount,
-      selfChannel: params.selfChannel,
-      isWithdraw: true,
-    });
-  }
-
-  async transfer(params: {
-    token: StarknetAddress;
-    inputs: Note[];
-    recipient: PrivateRecipient;
-    amount?: Amount | Open;
-    selfChannel?: Channel;
-  }): Promise<PrivateInvocationResult> {
-    return this.withdrawOrTransfer({
-      token: params.token,
-      inputs: params.inputs,
-      recipientPrivate: params.recipient,
-      amount: params.amount as Amount | undefined,
-      selfChannel: params.selfChannel,
-      isWithdraw: false,
-    });
-  }
-
-  async execute(actions: {
-    setViewingKey?: SetViewingKeyAction;
-    openChannels?: OpenChannelAction[];
-    openTokenChannels?: OpenTokenChannelAction[];
-    deposits?: DepositAction[];
-    useNotes?: UseNoteAction[];
-    createNotes?: CreateNoteAction[];
-    withdraws?: WithdrawAction[];
-  }): Promise<CallAndProof> {
-    this.pool.execute(this.userAddress, this.userViewingKey, actions);
-    return createMockCallAndProof();
-  }
-
-  build(): PrivateTransfersBuilder {
-    return new PrivateTransfersBuilderImpl(this, this.userAddress);
+  build(options?: ExecuteOptions): PrivateTransfersBuilder {
+    return new PrivateTransfersBuilderImpl(this, this.userAddress, options);
   }
 
   discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> } = {}): {
@@ -193,23 +79,14 @@ export class MockPrivateTransfers implements PrivateTransfers {
     return this.discoveryProvider.discoverNotes(this.userAddress, this.userViewingKey, params);
   }
 
-  discoverChannels(..._recipients: (StarknetAddress | PrivateRecipient)[]): {
+  discoverChannels(...recipients: StarknetAddress[]): {
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
   } {
     return this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      ..._recipients
+      ...recipients
     );
-  }
-
-  /** Access the underlying PrivacyPool for advanced testing */
-  getPool(): PrivacyPool {
-    return this.pool;
-  }
-
-  availableAmount(inputs: Note[]): bigint {
-    return inputs.reduce((acc, input) => acc + input.amount, 0n);
   }
 }

--- a/sdk/tests/internal/builders.test.ts
+++ b/sdk/tests/internal/builders.test.ts
@@ -5,10 +5,8 @@ import {
   consoleLogCallback,
   debugHint,
   isDebugEnabled,
-  hashes,
 } from "../../src/utils/index.js";
-import type { PrivateRecipient } from "../../src/interfaces.js";
-import { Channel, open, SetupRequirement } from "../../src/interfaces.js";
+import { Channel, createEmptyRegistry, open, SetupRequirement } from "../../src/interfaces.js";
 
 // Test addresses and keys (must be valid hex addresses convertible to BigInt)
 const POOL_ADDRESS = "0x1";
@@ -21,21 +19,22 @@ const ALICE_PRIVATE_KEY = 12345n;
 const BOB_ADDRESS = "0xB0B";
 const BOB_PRIVATE_KEY = 67890n;
 
+// Default options for auto-discovery and auto-setup
+const AUTO_OPTIONS = {
+  autoDiscover: { recipient: "refresh" as const },
+  autoSetup: true,
+};
+
 describe("PrivateTransfersBuilder", () => {
   let erc20s: ERC20s;
   let pool: PrivacyPool;
   let alice: MockPrivateTransfers;
   let bob: MockPrivateTransfers;
 
-  // Helper to compute channel and set context on a PrivateRecipient
-  const setContext = (
-    from: { address: string; key: bigint },
-    recipient: PrivateRecipient
-  ): void => {
-    const toPublicKey = pool.getPublicKey(recipient.address);
-    const channelKey = hashes.channelKey(from.address, from.key, recipient.address, toPublicKey);
-    recipient.context = new Channel(channelKey);
-  };
+  // Store channels for context
+  let aliceSelfChannel: Channel;
+  let aliceToBobChannel: Channel;
+  let bobSelfChannel: Channel;
 
   // Show debug hint after tests complete (only if debug is disabled)
   afterAll(() => {
@@ -60,34 +59,25 @@ describe("PrivateTransfersBuilder", () => {
   });
 
   it("example: register and setup a new recipient", async () => {
-    // From interface docs:
-    // const alice: PrivateRecipient = { address: ALICE_ADDRESS, context: undefined! };
-    // await transfers.build()
-    //   .register()
-    //   .setup(alice)  // alice.context will be populated with the Channel
-    //   .with(STRK)
-    //     .setup(alice)
-    //     .deposit(100n, alice)
-    //   .execute();
-
     // First Bob needs to register so Alice can set up channel to him
-    await bob.register();
+    await bob.build().register().execute();
 
-    // Alice registers first so she can compute channels
-    await alice.register();
+    // Alice registers and sets up channel to Bob
+    await alice.build().register().execute();
+    await alice.build().setup(BOB_ADDRESS).execute();
+    aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
 
-    // Create recipient and compute context (both users must be registered)
-    const bobRecipient: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-    setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, bobRecipient);
+    // Setup token
+    const registry = createEmptyRegistry();
+    registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+    await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
 
-    // Use builder to setup channel, setup token, and deposit
+    // Use builder to deposit
     // prettier-ignore
     await alice
-      .build()
-      .setup(BOB_ADDRESS)
+      .build(AUTO_OPTIONS)
       .with(STRK)
-        .setup(bobRecipient)
-        .deposit(100n, bobRecipient)
+        .deposit(100n, BOB_ADDRESS)
       .execute();
 
     // Bob should have a note
@@ -97,40 +87,38 @@ describe("PrivateTransfersBuilder", () => {
   });
 
   it("example: transfer to multiple recipients with multiple tokens", async () => {
-    // From interface docs:
-    // await transfers.build()
-    //   .with(STRK)
-    //     .inputs(strkNote)
-    //     .transfer({ recipient: alice, amount: 10n })
-    //   .with(ETH)
-    //     .inputs(ethNote1, ethNote2)
-    //     .transfer({ recipient: bob, amount: 20n })
-    //   .execute();
-
     // Both users register first
-    await bob.register();
-    await alice.register();
+    await bob.build().register().execute();
+    await alice.build().register().execute();
 
-    // Create recipients and compute contexts
-    const aliceSelf: PrivateRecipient = { address: ALICE_ADDRESS, context: undefined! };
-    const bobRecipient: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-    setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceSelf);
-    setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, bobRecipient);
+    // Alice sets up channels
+    await alice.build().setup(ALICE_ADDRESS).setup(BOB_ADDRESS).execute();
+    aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+    aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
 
-    // Alice sets up channels, tokens, and deposits - all via builder
+    // Setup tokens
+    const registry = createEmptyRegistry();
+    registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+    registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+
+    await alice
+      .build({ registry })
+      .with(STRK)
+      .setup(ALICE_ADDRESS)
+      .setup(BOB_ADDRESS)
+      .with(ETH)
+      .setup(ALICE_ADDRESS)
+      .setup(BOB_ADDRESS)
+      .execute();
+
+    // Deposit to self
     // prettier-ignore
     await alice
-      .build()
-      .setup(ALICE_ADDRESS) // channel to self for deposits
-      .setup(BOB_ADDRESS) // channel to Bob for transfers
+      .build(AUTO_OPTIONS)
       .with(STRK)
-        .setup(aliceSelf)
-        .setup(bobRecipient)
-        .deposit(100n, aliceSelf)
+        .deposit(100n, ALICE_ADDRESS)
       .with(ETH)
-        .setup(aliceSelf)
-        .setup(bobRecipient)
-        .deposit(50n, aliceSelf)
+        .deposit(50n, ALICE_ADDRESS)
       .execute();
 
     // Alice discovers her notes
@@ -141,16 +129,16 @@ describe("PrivateTransfersBuilder", () => {
     expect(strkNote).toBeDefined();
     expect(ethNote).toBeDefined();
 
-    // Now use builder to transfer to Bob (must use full amounts - no change support yet)
+    // Now use builder to transfer to Bob (must use full amounts)
     // prettier-ignore
     await alice
-      .build()
+      .build(AUTO_OPTIONS)
       .with(STRK)
         .inputs(strkNote)
-        .transfer({ recipient: bobRecipient, amount: 100n }) // Full amount
+        .transfer({ recipient: BOB_ADDRESS, amount: 100n })
       .with(ETH)
         .inputs(ethNote)
-        .transfer({ recipient: bobRecipient, amount: 50n }) // Full amount
+        .transfer({ recipient: BOB_ADDRESS, amount: 50n })
       .execute();
 
     // Bob should have notes
@@ -166,17 +154,16 @@ describe("PrivateTransfersBuilder", () => {
 
   it("builder fails when input/output amounts don't match", async () => {
     // Setup: Alice registers and deposits 100n STRK to herself
-    await alice.register();
-    const aliceSelf: PrivateRecipient = { address: ALICE_ADDRESS, context: undefined! };
-    setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceSelf);
+    await alice.build().register().execute();
 
-    await alice
-      .build()
-      .setup(ALICE_ADDRESS)
-      .with(STRK)
-      .setup(aliceSelf)
-      .deposit(100n, aliceSelf)
-      .execute();
+    await alice.build().setup(ALICE_ADDRESS).execute();
+    aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+    const registry = createEmptyRegistry();
+    registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+    await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+    await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
 
     // Get Alice's note
     const strkNote = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
@@ -185,23 +172,20 @@ describe("PrivateTransfersBuilder", () => {
     // Try to transfer only 50n (leaving 50n unaccounted for) - should fail
     // Pool validates that final total per token is 0 (input 100n - output 50n = 50n != 0)
     await expect(
-      alice.build().with(STRK).inputs(strkNote).withdraw({ amount: 50n }).execute()
+      alice.build(AUTO_OPTIONS).with(STRK).inputs(strkNote).withdraw({ amount: 50n }).execute()
     ).rejects.toThrow(/Final total for token.*is 50.*expected 0/);
   });
 
   it("builder: register, setup channel, and deposit in one batch", async () => {
     // Bob needs to be registered first
-    await bob.register();
+    await bob.build().register().execute();
 
     // Alice does everything in one builder call
     const result = await alice.build().register().setup(BOB_ADDRESS).execute();
 
     expect(result).toBeDefined();
     // Verify Alice is registered (not requiring Register)
-    const aliceReq = await alice.discoverRequirement(
-      { address: ALICE_ADDRESS, context: undefined! },
-      "0x0"
-    );
+    const aliceReq = await alice.discoverRequirement(ALICE_ADDRESS, "0x0");
     expect(aliceReq).not.toBe(SetupRequirement.Register);
 
     // Verify channel was set up by discovering it
@@ -211,37 +195,31 @@ describe("PrivateTransfersBuilder", () => {
 
   it("open notes: Bob creates open note, Alice deposits into it", async () => {
     // Both users register
-    await bob.register();
-    await alice.register();
+    await bob.build().register().execute();
+    await alice.build().register().execute();
 
-    // Create recipients and compute contexts
-    const bobSelf: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-    const aliceToBob: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-    setContext({ address: BOB_ADDRESS, key: BOB_PRIVATE_KEY }, bobSelf);
-    setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceToBob);
+    // Setup Bob's self channel
+    await bob.build().setup(BOB_ADDRESS).execute();
+    bobSelfChannel = bob.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
 
-    // prettier-ignore
-    await bob
-      .build()
-      .setup(BOB_ADDRESS) // channel to self
-      .with(STRK)
-        .setup(bobSelf)
-      .execute();
+    const bobRegistry = createEmptyRegistry();
+    bobRegistry.channels.set(BOB_ADDRESS, bobSelfChannel);
+    await bob.build({ registry: bobRegistry }).with(STRK).setup(BOB_ADDRESS).execute();
 
-    // prettier-ignore
-    await alice
-      .build()
-      .setup(BOB_ADDRESS) // channel to Bob
-      .with(STRK)
-        .setup(aliceToBob)
-      .execute();
+    // Setup Alice -> Bob channel
+    await alice.build().setup(BOB_ADDRESS).execute();
+    aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+    const aliceRegistry = createEmptyRegistry();
+    aliceRegistry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+    await alice.build({ registry: aliceRegistry }).with(STRK).setup(BOB_ADDRESS).execute();
 
     // Step 1: Bob creates an open note for himself
     // prettier-ignore
     await bob
-      .build()
+      .build(AUTO_OPTIONS)
       .with(STRK)
-        .transfer({ recipient: bobSelf, amount: open })
+        .transfer({ recipient: BOB_ADDRESS, amount: open })
       .execute();
 
     // Bob discovers his open note
@@ -257,7 +235,7 @@ describe("PrivateTransfersBuilder", () => {
 
     // prettier-ignore
     await alice
-      .build()
+      .build(AUTO_OPTIONS)
       .with(STRK)
         .deposit(100n, openNoteId) // deposit into the open note by ID
       .execute();
@@ -269,23 +247,21 @@ describe("PrivateTransfersBuilder", () => {
   });
 
   describe("surplusTo", () => {
-    let aliceSelf: PrivateRecipient;
-
     beforeEach(async () => {
       // Setup: register Alice and set up channel to self
-      await alice.register();
+      await alice.build().register().execute();
 
-      aliceSelf = { address: ALICE_ADDRESS, context: undefined! };
-      setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceSelf);
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
 
-      // prettier-ignore
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
       await alice
-        .build()
-        .setup(ALICE_ADDRESS)
+        .build({ registry })
         .with(STRK)
-          .setup(aliceSelf)
+        .setup(ALICE_ADDRESS)
         .with(ETH)
-          .setup(aliceSelf)
+        .setup(ALICE_ADDRESS)
         .execute();
     });
 
@@ -293,9 +269,9 @@ describe("PrivateTransfersBuilder", () => {
       // Deposit 100 STRK to Alice (she starts with 1000n public)
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .deposit(100n, aliceSelf)
+          .deposit(100n, ALICE_ADDRESS)
         .execute();
 
       // After deposit: 900n public, 100n private
@@ -306,8 +282,8 @@ describe("PrivateTransfersBuilder", () => {
       // Use the 100n note but only withdraw 30n - surplus of 70n should go to self
       // prettier-ignore
       await alice
-        .build()
-        .surplusTo(aliceSelf)
+        .build(AUTO_OPTIONS)
+        .surplusTo(ALICE_ADDRESS)
         .with(STRK)
           .inputs(note)
           .withdraw({ amount: 30n })
@@ -327,11 +303,11 @@ describe("PrivateTransfersBuilder", () => {
       // Deposit to self for both tokens
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .deposit(100n, aliceSelf)
+          .deposit(100n, ALICE_ADDRESS)
         .with(ETH)
-          .deposit(50n, aliceSelf)
+          .deposit(50n, ALICE_ADDRESS)
         .execute();
 
       // After deposits: STRK 900n public, ETH 450n public
@@ -343,9 +319,9 @@ describe("PrivateTransfersBuilder", () => {
       // ETH: 50n in, 50n out -> no surplus (exact match)
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .surplusTo(aliceSelf)
+          .surplusTo(ALICE_ADDRESS)
           .inputs(strkNote)
           .withdraw({ amount: 30n })
         .with(ETH)
@@ -367,37 +343,29 @@ describe("PrivateTransfersBuilder", () => {
 
     it("token-level surplusTo overrides root-level surplusTo", async () => {
       // Register Bob too for cross-user transfer
-      await bob.register();
-      const bobSelf: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-      setContext({ address: BOB_ADDRESS, key: BOB_PRIVATE_KEY }, bobSelf);
+      await bob.build().register().execute();
+
+      await bob.build().setup(BOB_ADDRESS).execute();
+      bobSelfChannel = bob.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const bobRegistry = createEmptyRegistry();
+      bobRegistry.channels.set(BOB_ADDRESS, bobSelfChannel);
+      await bob.build({ registry: bobRegistry }).with(STRK).setup(BOB_ADDRESS).execute();
 
       // Alice sets up channel to Bob
-      const aliceToBob: PrivateRecipient = { address: BOB_ADDRESS, context: undefined! };
-      setContext({ address: ALICE_ADDRESS, key: ALICE_PRIVATE_KEY }, aliceToBob);
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
 
-      // prettier-ignore
-      await alice
-        .build()
-        .setup(BOB_ADDRESS)
-        .with(STRK)
-          .setup(aliceToBob)
-        .execute();
-
-      // Bob sets up channel to self for STRK
-      // prettier-ignore
-      await bob
-        .build()
-        .setup(BOB_ADDRESS)
-        .with(STRK)
-          .setup(bobSelf)
-        .execute();
+      const aliceRegistry = createEmptyRegistry();
+      aliceRegistry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry: aliceRegistry }).with(STRK).setup(BOB_ADDRESS).execute();
 
       // Deposit to Alice (she starts with 1000n)
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .deposit(100n, aliceSelf)
+          .deposit(100n, ALICE_ADDRESS)
         .execute();
 
       // After: 900n public, 100n private
@@ -407,10 +375,10 @@ describe("PrivateTransfersBuilder", () => {
       // 100n in, 30n withdrawn -> 70n surplus goes to Bob (not Alice)
       // prettier-ignore
       await alice
-        .build()
-        .surplusTo(aliceSelf) // default: surplus to Alice
+        .build(AUTO_OPTIONS)
+        .surplusTo(ALICE_ADDRESS) // default: surplus to Alice
         .with(STRK)
-          .surplusTo(aliceToBob) // override: surplus to Bob for STRK
+          .surplusTo(BOB_ADDRESS) // override: surplus to Bob for STRK
           .inputs(note)
           .withdraw({ amount: 30n })
         .execute();
@@ -430,9 +398,9 @@ describe("PrivateTransfersBuilder", () => {
       // Alice starts with 1000n
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .deposit(100n, aliceSelf)
+          .deposit(100n, ALICE_ADDRESS)
         .execute();
 
       // After: 900n public, 100n private
@@ -441,8 +409,8 @@ describe("PrivateTransfersBuilder", () => {
       // 100n in, 100n out -> no surplus even with surplusTo set
       // prettier-ignore
       await alice
-        .build()
-        .surplusTo(aliceSelf)
+        .build(AUTO_OPTIONS)
+        .surplusTo(ALICE_ADDRESS)
         .with(STRK)
           .inputs(note)
           .withdraw({ amount: 100n })
@@ -457,16 +425,16 @@ describe("PrivateTransfersBuilder", () => {
     it("without surplusTo, unbalanced amounts still fail", async () => {
       // prettier-ignore
       await alice
-        .build()
+        .build(AUTO_OPTIONS)
         .with(STRK)
-          .deposit(100n, aliceSelf)
+          .deposit(100n, ALICE_ADDRESS)
         .execute();
 
       const note = (alice.discoverNotes().notes.get(STRK) ?? [])[0];
 
       // 100n in, 50n out, no surplusTo -> should fail validation
       await expect(
-        alice.build().with(STRK).inputs(note).withdraw({ amount: 50n }).execute()
+        alice.build(AUTO_OPTIONS).with(STRK).inputs(note).withdraw({ amount: 50n }).execute()
       ).rejects.toThrow(/Final total for token.*is 50.*expected 0/);
     });
   });

--- a/sdk/tests/internal/compiler.test.ts
+++ b/sdk/tests/internal/compiler.test.ts
@@ -1,0 +1,922 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { ERC20s, PrivacyPool, MockPrivateTransfers } from "../../src/testing/index.js";
+import { Channel, createEmptyRegistry } from "../../src/interfaces.js";
+
+// Test addresses (must be valid hex)
+const POOL_ADDRESS = "0x1";
+const ALICE_ADDRESS = "0xA11CE";
+const ALICE_PRIVATE_KEY = 12345n;
+const BOB_ADDRESS = "0xB0B";
+const BOB_PRIVATE_KEY = 67890n;
+const CAROL_ADDRESS = "0xCA201";
+const STRK = "0x534752";
+const ETH = "0x455448";
+
+// Default options for auto-discovery, auto-setup, and auto-select notes
+const AUTO_OPTIONS = {
+  autoDiscover: { recipient: "refresh" as const, notes: "refresh" as const },
+  autoSetup: true,
+  autoSelectNotes: true,
+};
+
+describe("ActionCompiler (via builder)", () => {
+  let erc20s: ERC20s;
+  let pool: PrivacyPool;
+  let alice: MockPrivateTransfers;
+  let bob: MockPrivateTransfers;
+
+  // Store channels for context
+  let aliceToBobChannel: Channel;
+  let aliceSelfChannel: Channel;
+
+  beforeEach(() => {
+    erc20s = new ERC20s();
+    pool = new PrivacyPool(POOL_ADDRESS, erc20s);
+    alice = new MockPrivateTransfers(pool, ALICE_ADDRESS, ALICE_PRIVATE_KEY);
+    bob = new MockPrivateTransfers(pool, BOB_ADDRESS, BOB_PRIVATE_KEY);
+
+    // Give Alice some tokens
+    erc20s.get(STRK).setBalance(ALICE_ADDRESS, 1000n);
+    erc20s.get(ETH).setBalance(ALICE_ADDRESS, 500n);
+  });
+
+  describe("autoDiscover.recipient", () => {
+    beforeEach(async () => {
+      // Register both users
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup channel and token in the pool (so it exists for discovery)
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+    });
+
+    it("none: throws error when channel missing from registry", async () => {
+      // Empty registry - no channel for Bob
+      const emptyRegistry = createEmptyRegistry();
+
+      await expect(
+        alice
+          .build({ registry: emptyRegistry, autoDiscover: { recipient: "none" }, autoSetup: false })
+          .with(STRK)
+          .deposit(100n, BOB_ADDRESS)
+          .execute()
+      ).rejects.toThrow(/Missing channel context for recipients/);
+    });
+
+    it("none: succeeds when channel exists in registry", async () => {
+      // Registry with Bob's channel (and correct nonces from discovery)
+      const registry = createEmptyRegistry();
+      const discovered = alice.discoverChannels(BOB_ADDRESS);
+      registry.channels.set(BOB_ADDRESS, discovered.channels.get(BOB_ADDRESS)!);
+
+      // Should succeed using registry data
+      await alice
+        .build({ registry, autoDiscover: { recipient: "none" } })
+        .with(STRK)
+        .deposit(100n, BOB_ADDRESS)
+        .execute();
+
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+      expect(bobNotes[0].amount).toBe(100n);
+    });
+
+    it("explicit: discovers only missing channels, updates registry", async () => {
+      // Registry with Bob but not Carol
+      const registry = createEmptyRegistry();
+      const bobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+      registry.channels.set(BOB_ADDRESS, bobChannel);
+
+      // Carol registers so we can set up channel
+      const carol = new MockPrivateTransfers(pool, CAROL_ADDRESS, 99999n);
+      await carol.build().register().execute();
+
+      // Setup Carol's channel in pool
+      await alice.build().setup(CAROL_ADDRESS).execute();
+      const carolChannel = alice.discoverChannels(CAROL_ADDRESS).channels.get(CAROL_ADDRESS)!;
+      const carolRegistry = createEmptyRegistry();
+      carolRegistry.channels.set(CAROL_ADDRESS, carolChannel);
+      await alice.build({ registry: carolRegistry }).with(STRK).setup(CAROL_ADDRESS).execute();
+
+      // explicit: should discover Carol (missing) but use registry for Bob
+      const result = await alice
+        .build({ registry, autoDiscover: { recipient: "explicit" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .deposit(50n, CAROL_ADDRESS)
+        .execute();
+
+      // Both should be in registry now
+      expect(result.registry.channels.has(BOB_ADDRESS)).toBe(true);
+      expect(result.registry.channels.has(CAROL_ADDRESS)).toBe(true);
+
+      // Verify deposits worked
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+      const carolNotes = carol.discoverNotes().notes.get(STRK) ?? [];
+      expect(carolNotes.length).toBe(1);
+    });
+
+    it("refresh: discovers all recipients, updates registry with fresh nonces", async () => {
+      // Start with an outdated registry (nonces at 0)
+      const staleRegistry = createEmptyRegistry();
+      const staleChannel = new Channel(aliceToBobChannel.key); // fresh channel with nonce 0
+      staleRegistry.channels.set(BOB_ADDRESS, staleChannel);
+
+      // Do first deposit - this advances nonces in the pool
+      await alice
+        .build({ registry: staleRegistry, autoDiscover: { recipient: "refresh" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .execute();
+
+      // Do second deposit - refresh should get the updated nonces
+      await alice
+        .build({ registry: staleRegistry, autoDiscover: { recipient: "refresh" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .execute();
+
+      // Should have 2 notes (correct nonces used)
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(2);
+    });
+  });
+
+  describe("autoDiscover.notes", () => {
+    beforeEach(async () => {
+      // Register and setup Alice's self channel
+      await alice.build().register().execute();
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to create a note
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+    });
+
+    it("none: does not discover notes, uses only registry notes", async () => {
+      // Empty registry - no notes
+      const emptyRegistry = createEmptyRegistry();
+      emptyRegistry.channels.set(
+        ALICE_ADDRESS,
+        alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!
+      );
+
+      // With no notes in registry and no auto-select, withdraw should fail due to unbalanced
+      await expect(
+        alice
+          .build({
+            registry: emptyRegistry,
+            autoDiscover: { notes: "none", recipient: "refresh" },
+            autoSelectNotes: true,
+          })
+          .with(STRK)
+          .withdraw({ amount: 50n })
+          .execute()
+      ).rejects.toThrow(/Running total for token.*went negative/);
+    });
+
+    it("none: succeeds when notes exist in registry", async () => {
+      // Get fresh notes from discovery
+      const discoveredNotes = alice.discoverNotes().notes;
+      const registry = createEmptyRegistry();
+      registry.channels.set(
+        ALICE_ADDRESS,
+        alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!
+      );
+      registry.notes.set(STRK, discoveredNotes.get(STRK) ?? []);
+
+      // With notes in registry, withdraw should work
+      await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "none", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // Alice should have public balance
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n); // 900 + 100 back
+    });
+
+    it("explicit: discovers notes only when registry is empty", async () => {
+      // Empty registry - notes will be discovered
+      const registry = createEmptyRegistry();
+      registry.channels.set(
+        ALICE_ADDRESS,
+        alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!
+      );
+
+      // Should discover notes since registry is empty
+      await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "explicit", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // Registry was populated with discovered notes (before they were used)
+      // Note: the registry keeps track of discovered notes, not spent status
+      expect(registry.notes.has(STRK)).toBe(true);
+
+      // Alice should have public balance
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+    });
+
+    it("explicit: uses existing registry notes, does not rediscover", async () => {
+      // Registry with old note data (won't be refreshed)
+      const existingNote = alice.discoverNotes().notes.get(STRK)![0];
+      const registry = createEmptyRegistry();
+      registry.channels.set(
+        ALICE_ADDRESS,
+        alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!
+      );
+      registry.notes.set(STRK, [existingNote]);
+
+      // Uses the existing note from registry
+      await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "explicit", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+    });
+
+    it("refresh: discovers fresh notes even when registry has stale data", async () => {
+      // Registry is empty (no notes) but pool has a note
+      const registry = createEmptyRegistry();
+      registry.channels.set(
+        ALICE_ADDRESS,
+        alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!
+      );
+      // Registry has NO notes, but pool has the note from beforeEach deposit
+
+      // With refresh, it should discover the note and use it for withdraw
+      await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "refresh", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // Withdraw succeeded (note was discovered from pool, not registry)
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+
+      // After spending the note, a fresh discovery should show no notes
+      const freshNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(freshNotes.length).toBe(0);
+    });
+  });
+
+  describe("autoSetup", () => {
+    beforeEach(async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+    });
+
+    it("true: adds OpenChannelAction when deposit recipient has no channel setup", async () => {
+      // First set up token channel in pool (but not in our builder call)
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Deposit without explicit setup() - autoSetup should add OpenChannelAction
+      const result = await alice
+        .build({ autoSetup: true, autoDiscover: { recipient: "refresh" } })
+        .with(STRK)
+        .deposit(100n, BOB_ADDRESS)
+        .execute();
+
+      // Channel should be in registry
+      expect(result.registry.channels.has(BOB_ADDRESS)).toBe(true);
+
+      // Bob should have the note
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+    });
+
+    it("true: adds OpenChannelAction when createNotes recipient has no channel", async () => {
+      // Setup for Alice first
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      let registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to self first
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+
+      // Setup Bob's channel and token in pool
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+      registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Transfer to Bob without explicit setup - autoSetup should add OpenChannelAction
+      const result = await alice
+        .build({
+          autoSetup: true,
+          autoDiscover: { recipient: "refresh", notes: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .transfer({ recipient: BOB_ADDRESS, amount: 100n })
+        .execute();
+
+      expect(result.registry.channels.has(BOB_ADDRESS)).toBe(true);
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+    });
+
+    it("false: throws error when channel not in registry and no explicit setup", async () => {
+      await expect(
+        alice
+          .build({ autoSetup: false, autoDiscover: { recipient: "none" } })
+          .with(STRK)
+          .deposit(100n, BOB_ADDRESS)
+          .execute()
+      ).rejects.toThrow(/Missing channel context for recipients/);
+    });
+
+    it("false: succeeds when explicit setup() is called", async () => {
+      // With autoSetup=false but explicit setup(), should work
+      await alice.build({ autoSetup: false }).setup(BOB_ADDRESS).execute();
+
+      const channels = alice.discoverChannels(BOB_ADDRESS);
+      expect(channels.channels.has(BOB_ADDRESS)).toBe(true);
+    });
+  });
+
+  describe("autoSelectNotes", () => {
+    beforeEach(async () => {
+      await alice.build().register().execute();
+
+      // Setup self channel and token
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to create notes
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+    });
+
+    it("true: auto-selects notes from registry when no inputs() called", async () => {
+      // Withdraw without calling inputs() - should auto-select
+      await alice
+        .build({
+          autoDiscover: { notes: "refresh", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // Should have withdrawn (note auto-selected)
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+      const notes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(notes.length).toBe(0);
+    });
+
+    it("true: uses provided inputs() without auto-selection", async () => {
+      // Get the note manually
+      const note = alice.discoverNotes().notes.get(STRK)![0];
+
+      // Provide inputs explicitly
+      await alice
+        .build({
+          autoDiscover: { notes: "refresh", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .inputs(note)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+    });
+
+    it("false: does not auto-select, fails when inputs not provided", async () => {
+      // No inputs, no auto-select - should fail with unbalanced amounts
+      await expect(
+        alice
+          .build({
+            autoDiscover: { notes: "refresh", recipient: "refresh" },
+            autoSelectNotes: false,
+          })
+          .with(STRK)
+          .withdraw({ amount: 100n })
+          .execute()
+      ).rejects.toThrow(/Running total for token.*went negative/);
+    });
+
+    it("false: succeeds when inputs() explicitly provided", async () => {
+      const note = alice.discoverNotes().notes.get(STRK)![0];
+
+      await alice
+        .build({
+          autoDiscover: { notes: "refresh", recipient: "refresh" },
+          autoSelectNotes: false,
+        })
+        .with(STRK)
+        .inputs(note)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+    });
+  });
+
+  describe("registry updates", () => {
+    it("channel nonces are updated after each operation", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // First deposit
+      const result1 = await alice
+        .build({ registry, autoDiscover: { recipient: "refresh" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .execute();
+
+      const channelAfter1 = result1.registry.channels.get(BOB_ADDRESS)!;
+      const nonce1 = channelAfter1.tokens.get(STRK)!;
+
+      // Second deposit
+      const result2 = await alice
+        .build({ registry, autoDiscover: { recipient: "refresh" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .execute();
+
+      const channelAfter2 = result2.registry.channels.get(BOB_ADDRESS)!;
+      const nonce2 = channelAfter2.tokens.get(STRK)!;
+
+      // Nonces should have advanced
+      expect(nonce2.sequence).toBeGreaterThan(nonce1.sequence);
+
+      // Both notes should exist
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(2);
+    });
+
+    it("discovery refreshes registry notes before execution", async () => {
+      await alice.build().register().execute();
+
+      // Setup self channel
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to create notes
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+
+      // Start with empty notes in registry
+      expect(registry.notes.get(STRK)?.length ?? 0).toBe(0);
+
+      // Withdraw using notes - discovery should populate registry
+      await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "refresh", recipient: "refresh" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // After optimistic update, spent notes are removed from registry
+      expect(registry.notes.get(STRK)?.length ?? 0).toBe(0);
+
+      // Verify withdraw succeeded
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(1000n);
+
+      // Fresh discovery confirms notes are gone in pool too
+      const freshNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(freshNotes.length).toBe(0);
+    });
+  });
+
+  describe("optimistic registry updates", () => {
+    it("channel note nonces are updated after deposit", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup channel and token
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Record initial note nonce
+      const initialNonce = registry.channels.get(BOB_ADDRESS)!.tokens.get(STRK)!.sequence;
+
+      // Deposit to Bob
+      await alice
+        .build({ registry, autoDiscover: { recipient: "none" } })
+        .with(STRK)
+        .deposit(100n, BOB_ADDRESS)
+        .execute();
+
+      // Channel note nonce should be incremented
+      const updatedNonce = registry.channels.get(BOB_ADDRESS)!.tokens.get(STRK)!.sequence;
+      expect(updatedNonce).toBe(initialNonce + 1);
+
+      // Registry channel should match discovery
+      const discoveredChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+      expect(updatedNonce).toBe(discoveredChannel.tokens.get(STRK)!.sequence);
+    });
+
+    it("spent notes are removed from registry after use", async () => {
+      await alice.build().register().execute();
+
+      // Setup self channel
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to create a note
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+
+      // Discover notes and put them in registry
+      const discovered = alice.discoverNotes().notes;
+      registry.notes.set(STRK, discovered.get(STRK) ?? []);
+      expect(registry.notes.get(STRK)?.length).toBe(1);
+
+      // Use the note in a withdraw
+      const result = await alice
+        .build({
+          registry,
+          autoDiscover: { notes: "none", recipient: "none" },
+          autoSelectNotes: true,
+        })
+        .with(STRK)
+        .withdraw({ amount: 100n })
+        .execute();
+
+      // Registry should have no notes (spent note removed)
+      expect(result.registry.notes.get(STRK)?.length ?? 0).toBe(0);
+    });
+
+    it("multiple deposits update channel note nonce correctly", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup channel and token
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Record initial note nonce
+      const initialNonce = registry.channels.get(BOB_ADDRESS)!.tokens.get(STRK)!.sequence;
+
+      // Two deposits in one execute
+      await alice
+        .build({ registry, autoDiscover: { recipient: "none" } })
+        .with(STRK)
+        .deposit(50n, BOB_ADDRESS)
+        .deposit(30n, BOB_ADDRESS)
+        .execute();
+
+      // Channel note nonce should be incremented by 2
+      const updatedNonce = registry.channels.get(BOB_ADDRESS)!.tokens.get(STRK)!.sequence;
+      expect(updatedNonce).toBe(initialNonce + 2);
+
+      // Bob should have 2 notes via discovery
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(2);
+    });
+
+    it("partial spend removes used note, remainder needs discovery", async () => {
+      await alice.build().register().execute();
+
+      // Setup self channel
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Create two notes
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(50n, ALICE_ADDRESS).execute();
+
+      // Refresh registry with current state (notes + updated channel nonces)
+      const discovered = alice.discoverNotes().notes;
+      registry.notes.set(STRK, [...(discovered.get(STRK) ?? [])]);
+      expect(registry.notes.get(STRK)?.length).toBe(2);
+
+      // Also refresh channel to get updated nonces
+      const refreshedChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+      registry.channels.set(ALICE_ADDRESS, refreshedChannel);
+
+      // Use one note in a withdrawal, create remainder
+      const notes = registry.notes.get(STRK)!;
+      const note100 = notes.find((n) => n.amount === 100n)!;
+
+      const result = await alice
+        .build({ registry, autoDiscover: { notes: "none", recipient: "none" } })
+        .with(STRK)
+        .inputs(note100)
+        .withdraw({ amount: 70n })
+        .transfer({ recipient: ALICE_ADDRESS, amount: 30n }) // remainder
+        .execute();
+
+      // Registry should have only the unused 50n note (spent note removed, remainder not added)
+      const updatedNotes = result.registry.notes.get(STRK) ?? [];
+      expect(updatedNotes.length).toBe(1);
+      expect(updatedNotes[0].amount).toBe(50n);
+
+      // After discovery, Alice should have both the 50n and the 30n remainder
+      const freshNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(freshNotes.length).toBe(2);
+      expect(freshNotes.map((n) => n.amount).sort()).toEqual([30n, 50n]);
+    });
+
+    it("token nonce is updated after openTokenChannel", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup channel
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+
+      // Record initial token nonce
+      const initialTokenNonce = registry.channels.get(BOB_ADDRESS)!.tokenNonce.sequence;
+
+      // Setup token channel
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Token nonce should be incremented
+      const updatedTokenNonce = registry.channels.get(BOB_ADDRESS)!.tokenNonce.sequence;
+      expect(updatedTokenNonce).toBe(initialTokenNonce + 1);
+
+      // Registry should match discovery
+      const discoveredChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+      expect(updatedTokenNonce).toBe(discoveredChannel.tokenNonce.sequence);
+    });
+
+    it("registry channel matches discovery after multiple operations", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup channel
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+
+      // Setup two tokens
+      await alice
+        .build({ registry })
+        .with(STRK)
+        .setup(BOB_ADDRESS)
+        .with(ETH)
+        .setup(BOB_ADDRESS)
+        .execute();
+
+      // Multiple deposits to both tokens
+      await alice
+        .build({ registry, autoDiscover: { recipient: "none" } })
+        .with(STRK)
+        .deposit(100n, BOB_ADDRESS)
+        .deposit(50n, BOB_ADDRESS)
+        .with(ETH)
+        .deposit(200n, BOB_ADDRESS)
+        .execute();
+
+      // Registry channel should exactly match discovery
+      const registryChannel = registry.channels.get(BOB_ADDRESS)!;
+      const discoveredChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      // Compare channel key
+      expect(registryChannel.key).toBe(discoveredChannel.key);
+
+      // Compare token nonce
+      expect(registryChannel.tokenNonce.sequence).toBe(discoveredChannel.tokenNonce.sequence);
+
+      // Compare note nonces for each token
+      expect(registryChannel.tokens.get(STRK)!.sequence).toBe(
+        discoveredChannel.tokens.get(STRK)!.sequence
+      );
+      expect(registryChannel.tokens.get(ETH)!.sequence).toBe(
+        discoveredChannel.tokens.get(ETH)!.sequence
+      );
+    });
+
+    it("registry notes match discovery after spending", async () => {
+      await alice.build().register().execute();
+
+      // Setup self channel
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Create three notes
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(50n, ALICE_ADDRESS).execute();
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(25n, ALICE_ADDRESS).execute();
+
+      // Sync registry with discovery
+      registry.notes = alice.discoverNotes().notes;
+      const refreshedChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+      registry.channels.set(ALICE_ADDRESS, refreshedChannel);
+
+      expect(registry.notes.get(STRK)?.length).toBe(3);
+
+      // Spend one note (the 50n one)
+      const notes = registry.notes.get(STRK)!;
+      const note50 = notes.find((n) => n.amount === 50n)!;
+
+      await alice
+        .build({ registry, autoDiscover: { notes: "none", recipient: "none" } })
+        .with(STRK)
+        .inputs(note50)
+        .withdraw({ amount: 50n })
+        .execute();
+
+      // Registry should have 2 notes
+      const registryNotes = registry.notes.get(STRK) ?? [];
+      expect(registryNotes.length).toBe(2);
+      const sortBigint = (a: bigint, b: bigint) => (a < b ? -1 : a > b ? 1 : 0);
+      expect(registryNotes.map((n) => n.amount).sort(sortBigint)).toEqual([25n, 100n]);
+
+      // Discovery should also return 2 notes with same amounts
+      const discoveredNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(discoveredNotes.length).toBe(2);
+      expect(discoveredNotes.map((n) => n.amount).sort(sortBigint)).toEqual([25n, 100n]);
+
+      // Note IDs should match
+      const registryIds = new Set(registryNotes.map((n) => BigInt(n.id as bigint)));
+      const discoveredIds = new Set(discoveredNotes.map((n) => BigInt(n.id as bigint)));
+      expect(registryIds).toEqual(discoveredIds);
+    });
+  });
+
+  describe("deposit and note creation", () => {
+    it("deposit creates note for recipient", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Set up channel and token
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Deposit using builder
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, BOB_ADDRESS).execute();
+
+      // Bob should have a note
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+      expect(bobNotes[0].amount).toBe(100n);
+
+      // Alice's public balance should decrease
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(900n);
+    });
+
+    it("transfer creates notes using input notes", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Setup self channel for Alice
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      aliceSelfChannel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, aliceSelfChannel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+      // Deposit to self using builder
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, ALICE_ADDRESS).execute();
+
+      // Alice should have a note
+      let aliceNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(aliceNotes.length).toBe(1);
+
+      // Setup channel to Bob
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+      // Transfer to Bob using builder
+      await alice
+        .build(AUTO_OPTIONS)
+        .with(STRK)
+        .transfer({ recipient: BOB_ADDRESS, amount: 100n })
+        .execute();
+
+      // Alice should have no notes (used the input via auto-select)
+      aliceNotes = alice.discoverNotes().notes.get(STRK) ?? [];
+      expect(aliceNotes.length).toBe(0);
+
+      // Bob should have the note
+      const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      expect(bobNotes.length).toBe(1);
+      expect(bobNotes[0].amount).toBe(100n);
+    });
+  });
+
+  describe("multi-token operations", () => {
+    it("handles multiple tokens in one execute", async () => {
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+
+      // Set up channel and tokens
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceToBobChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceToBobChannel);
+      await alice
+        .build({ registry })
+        .with(STRK)
+        .setup(BOB_ADDRESS)
+        .with(ETH)
+        .setup(BOB_ADDRESS)
+        .execute();
+
+      // Deposit multiple tokens using builder
+      await alice
+        .build(AUTO_OPTIONS)
+        .with(STRK)
+        .deposit(100n, BOB_ADDRESS)
+        .with(ETH)
+        .deposit(50n, BOB_ADDRESS)
+        .execute();
+
+      // Bob should have notes for both tokens
+      const bobStrkNotes = bob.discoverNotes().notes.get(STRK) ?? [];
+      const bobEthNotes = bob.discoverNotes().notes.get(ETH) ?? [];
+
+      expect(bobStrkNotes.length).toBe(1);
+      expect(bobStrkNotes[0].amount).toBe(100n);
+      expect(bobEthNotes.length).toBe(1);
+      expect(bobEthNotes[0].amount).toBe(50n);
+
+      // Alice's balances should decrease
+      expect(erc20s.get(STRK).balanceOf(ALICE_ADDRESS)).toBe(900n);
+      expect(erc20s.get(ETH).balanceOf(ALICE_ADDRESS)).toBe(450n);
+    });
+  });
+});

--- a/sdk/tests/testing/mock-private-transfers.test.ts
+++ b/sdk/tests/testing/mock-private-transfers.test.ts
@@ -6,8 +6,7 @@ import {
   debugHint,
   isDebugEnabled,
 } from "../../src/utils/index.js";
-import type { PrivateRecipient } from "../../src/interfaces.js";
-import { Channel, SetupRequirement } from "../../src/interfaces.js";
+import { Channel, createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
 
 // Test addresses and keys (must be valid hex addresses convertible to BigInt)
 const POOL_ADDRESS = "0x1";
@@ -19,6 +18,12 @@ const ALICE_PRIVATE_KEY = 12345n;
 
 const BOB_ADDRESS = "0xB0B";
 const BOB_PRIVATE_KEY = 67890n;
+
+// Default options for auto-discovery and auto-setup
+const AUTO_OPTIONS = {
+  autoDiscover: { recipient: "refresh" as const },
+  autoSetup: true,
+};
 
 describe("MockPrivateTransfers", () => {
   let erc20s: ERC20s;
@@ -45,87 +50,88 @@ describe("MockPrivateTransfers", () => {
   });
 
   describe("discoverRequirement", () => {
-    // Helper to create a PrivateRecipient
-    const recipient = (address: string): PrivateRecipient => ({
-      address,
-      context: undefined!,
-    });
-
     describe("discovering requirements for self", () => {
       it("returns Register when user is not registered", async () => {
-        const req = await alice.discoverRequirement(recipient(ALICE_ADDRESS), STRK);
+        const req = await alice.discoverRequirement(ALICE_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.Register);
       });
 
       it("returns SetupChannel after registration (no channel to self)", async () => {
-        await alice.register();
-        const req = await alice.discoverRequirement(recipient(ALICE_ADDRESS), STRK);
+        await alice.build().register().execute();
+        const req = await alice.discoverRequirement(ALICE_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.SetupChannel);
       });
 
       it("returns SetupToken after channel setup (no token)", async () => {
-        await alice.register();
-        await alice.setupChannel(ALICE_ADDRESS);
-        const req = await alice.discoverRequirement(recipient(ALICE_ADDRESS), STRK);
+        await alice.build().register().execute();
+        await alice.build().setup(ALICE_ADDRESS).execute();
+        const req = await alice.discoverRequirement(ALICE_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.SetupToken);
       });
 
       it("returns Ready after token setup", async () => {
-        await alice.register();
-        const { channel } = await alice.setupChannel(ALICE_ADDRESS);
-        const aliceRecipient: PrivateRecipient = { address: ALICE_ADDRESS, context: channel };
-        await alice.setupToken(aliceRecipient, STRK);
-        const req = await alice.discoverRequirement(recipient(ALICE_ADDRESS), STRK);
+        await alice.build().register().execute();
+        await alice.build().setup(ALICE_ADDRESS).execute();
+        const channel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+        const registry = createEmptyRegistry();
+        registry.channels.set(ALICE_ADDRESS, channel);
+        await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
+
+        const req = await alice.discoverRequirement(ALICE_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.Ready);
       });
     });
 
     describe("discovering requirements for another user", () => {
       it("returns Register when recipient is not registered", async () => {
-        await alice.register();
-        const req = await alice.discoverRequirement(recipient(BOB_ADDRESS), STRK);
+        await alice.build().register().execute();
+        const req = await alice.discoverRequirement(BOB_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.Register);
       });
 
       it("returns SetupChannel when recipient is registered but no channel", async () => {
-        await alice.register();
-        await bob.register();
-        const req = await alice.discoverRequirement(recipient(BOB_ADDRESS), STRK);
+        await alice.build().register().execute();
+        await bob.build().register().execute();
+        const req = await alice.discoverRequirement(BOB_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.SetupChannel);
       });
 
       it("returns SetupToken when channel exists but token not set up", async () => {
-        await alice.register();
-        await bob.register();
-        await alice.setupChannel(BOB_ADDRESS);
-        const req = await alice.discoverRequirement(recipient(BOB_ADDRESS), STRK);
+        await alice.build().register().execute();
+        await bob.build().register().execute();
+        await alice.build().setup(BOB_ADDRESS).execute();
+        const req = await alice.discoverRequirement(BOB_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.SetupToken);
       });
 
       it("returns Ready when fully set up", async () => {
-        await alice.register();
-        await bob.register();
-        const { channel } = await alice.setupChannel(BOB_ADDRESS);
-        const bobRecipient: PrivateRecipient = { address: BOB_ADDRESS, context: channel };
-        await alice.setupToken(bobRecipient, STRK);
-        const req = await alice.discoverRequirement(recipient(BOB_ADDRESS), STRK);
+        await alice.build().register().execute();
+        await bob.build().register().execute();
+        await alice.build().setup(BOB_ADDRESS).execute();
+        const channel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+        const registry = createEmptyRegistry();
+        registry.channels.set(BOB_ADDRESS, channel);
+        await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
+
+        const req = await alice.discoverRequirement(BOB_ADDRESS, STRK);
         expect(req).toBe(SetupRequirement.Ready);
       });
 
       it("different tokens require separate setup", async () => {
-        await alice.register();
-        await bob.register();
-        const { channel } = await alice.setupChannel(BOB_ADDRESS);
-        const bobRecipient: PrivateRecipient = { address: BOB_ADDRESS, context: channel };
-        await alice.setupToken(bobRecipient, STRK);
+        await alice.build().register().execute();
+        await bob.build().register().execute();
+        await alice.build().setup(BOB_ADDRESS).execute();
+        const channel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+        const registry = createEmptyRegistry();
+        registry.channels.set(BOB_ADDRESS, channel);
+        await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
 
         // STRK is ready, but ETH still needs setup
-        expect(await alice.discoverRequirement(recipient(BOB_ADDRESS), STRK)).toBe(
-          SetupRequirement.Ready
-        );
-        expect(await alice.discoverRequirement(recipient(BOB_ADDRESS), ETH)).toBe(
-          SetupRequirement.SetupToken
-        );
+        expect(await alice.discoverRequirement(BOB_ADDRESS, STRK)).toBe(SetupRequirement.Ready);
+        expect(await alice.discoverRequirement(BOB_ADDRESS, ETH)).toBe(SetupRequirement.SetupToken);
       });
     });
 
@@ -138,37 +144,29 @@ describe("MockPrivateTransfers", () => {
     });
   });
 
-  describe("direct methods", () => {
+  describe("builder operations", () => {
     let aliceChannel: Channel;
-    let bobRecipient: PrivateRecipient;
 
     beforeEach(async () => {
       // Register both users
-      await alice.register();
-      await bob.register();
+      await alice.build().register().execute();
+      await bob.build().register().execute();
 
       // Alice sets up channel to Bob
-      const setupResult = await alice.setupChannel(BOB_ADDRESS);
-      aliceChannel = setupResult.channel;
-
-      bobRecipient = {
-        address: BOB_ADDRESS,
-        context: aliceChannel,
-      };
+      await alice.build().setup(BOB_ADDRESS).execute();
+      aliceChannel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
 
       // Setup token for Bob
-      await alice.setupToken(bobRecipient, STRK);
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, aliceChannel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
 
       // Give Alice some public STRK to deposit
       erc20s.get(STRK).setBalance(ALICE_ADDRESS, 1000n);
     });
 
     it("deposit creates a note for the recipient", async () => {
-      await alice.deposit({
-        token: STRK,
-        amount: 100n,
-        recipient: bobRecipient,
-      });
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, BOB_ADDRESS).execute();
 
       // Bob should be able to discover the note
       const discovered = bob.discoverNotes();
@@ -179,11 +177,7 @@ describe("MockPrivateTransfers", () => {
 
     it("withdraw converts private note back to public balance", async () => {
       // First deposit
-      await alice.deposit({
-        token: STRK,
-        amount: 100n,
-        recipient: bobRecipient,
-      });
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, BOB_ADDRESS).execute();
 
       // Bob discovers his notes
       const discovered = bob.discoverNotes();
@@ -191,12 +185,12 @@ describe("MockPrivateTransfers", () => {
       expect(notes.length).toBe(1);
 
       // Bob withdraws
-      await bob.withdraw({
-        token: STRK,
-        inputs: notes,
-        recipient: BOB_ADDRESS,
-        amount: 100n,
-      });
+      await bob
+        .build(AUTO_OPTIONS)
+        .with(STRK)
+        .inputs(...notes)
+        .withdraw({ recipient: BOB_ADDRESS, amount: 100n })
+        .execute();
 
       // Bob should have public balance now
       expect(erc20s.get(STRK).balanceOf(BOB_ADDRESS)).toBe(100n);
@@ -204,32 +198,27 @@ describe("MockPrivateTransfers", () => {
 
     it("transfer moves note from one user to another", async () => {
       // Setup: Alice deposits to Bob
-      await alice.deposit({
-        token: STRK,
-        amount: 100n,
-        recipient: bobRecipient,
-      });
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, BOB_ADDRESS).execute();
 
       // Bob discovers his notes
       const bobNotes = bob.discoverNotes().notes.get(STRK) ?? [];
       expect(bobNotes.length).toBe(1);
 
       // Bob needs to set up channel to Alice for transfer
-      const bobToAliceSetup = await bob.setupChannel(ALICE_ADDRESS);
-      const bobToAliceChannel = bobToAliceSetup.channel;
-      const aliceRecipient: PrivateRecipient = {
-        address: ALICE_ADDRESS,
-        context: bobToAliceChannel,
-      };
-      await bob.setupToken(aliceRecipient, STRK);
+      await bob.build().setup(ALICE_ADDRESS).execute();
+      const bobToAliceChannel = bob.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const bobRegistry = createEmptyRegistry();
+      bobRegistry.channels.set(ALICE_ADDRESS, bobToAliceChannel);
+      await bob.build({ registry: bobRegistry }).with(STRK).setup(ALICE_ADDRESS).execute();
 
       // Bob transfers to Alice
-      await bob.transfer({
-        token: STRK,
-        inputs: bobNotes,
-        recipient: aliceRecipient,
-        amount: 100n,
-      });
+      await bob
+        .build(AUTO_OPTIONS)
+        .with(STRK)
+        .inputs(...bobNotes)
+        .transfer({ recipient: ALICE_ADDRESS, amount: 100n })
+        .execute();
 
       // Alice should now have the note
       const aliceNotes = alice.discoverNotes().notes.get(STRK) ?? [];
@@ -244,32 +233,43 @@ describe("MockPrivateTransfers", () => {
 
   describe("validation", () => {
     it("rejects negative deposit amounts", async () => {
-      await alice.register();
-      const { channel } = await alice.setupChannel(ALICE_ADDRESS);
-      const aliceSelf = { address: ALICE_ADDRESS, context: channel };
-      await alice.setupToken(aliceSelf, STRK);
+      await alice.build().register().execute();
+      await alice.build().setup(ALICE_ADDRESS).execute();
+      const channel = alice.discoverChannels(ALICE_ADDRESS).channels.get(ALICE_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(ALICE_ADDRESS, channel);
+      await alice.build({ registry }).with(STRK).setup(ALICE_ADDRESS).execute();
 
       await expect(
-        alice.deposit({ token: STRK, amount: -100n, recipient: aliceSelf })
+        alice.build(AUTO_OPTIONS).with(STRK).deposit(-100n, ALICE_ADDRESS).execute()
       ).rejects.toThrow(/Deposit amount must be non-negative/);
     });
 
     it("rejects negative withdraw amounts", async () => {
-      await alice.register();
-      await bob.register();
-      const { channel } = await alice.setupChannel(BOB_ADDRESS);
-      const bobRecipient = { address: BOB_ADDRESS, context: channel };
-      await alice.setupToken(bobRecipient, STRK);
+      await alice.build().register().execute();
+      await bob.build().register().execute();
+      await alice.build().setup(BOB_ADDRESS).execute();
+      const channel = alice.discoverChannels(BOB_ADDRESS).channels.get(BOB_ADDRESS)!;
+
+      const registry = createEmptyRegistry();
+      registry.channels.set(BOB_ADDRESS, channel);
+      await alice.build({ registry }).with(STRK).setup(BOB_ADDRESS).execute();
 
       erc20s.get(STRK).setBalance(ALICE_ADDRESS, 1000n);
-      await alice.deposit({ token: STRK, amount: 100n, recipient: bobRecipient });
+      await alice.build(AUTO_OPTIONS).with(STRK).deposit(100n, BOB_ADDRESS).execute();
 
       const notes = bob.discoverNotes().notes.get(STRK) ?? [];
       expect(notes.length).toBe(1);
 
-      await expect(bob.withdraw({ token: STRK, inputs: notes, amount: -50n })).rejects.toThrow(
-        /Withdraw amount must be non-negative/
-      );
+      await expect(
+        bob
+          .build(AUTO_OPTIONS)
+          .with(STRK)
+          .inputs(...notes)
+          .withdraw({ amount: -50n })
+          .execute()
+      ).rejects.toThrow(/Withdraw amount must be non-negative/);
     });
   });
 });


### PR DESCRIPTION
Added auto discovery if the client doesn't create all necessary actions or pass in the necessary context. This applies to both channel (recipient) discovery as well as notes discovery and the automatic selection of notes. 

Removed PrivateRecipient and moved the context to a separate registry object. That way clients don't need to create wrappers and it's easier to see what's missing and update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/170)
<!-- Reviewable:end -->
