### PR TITLE
refactor(sdk): include recipient public key in channel, remove getpublickey from discovery

### DIFF
--- a/sdk/src/client-actions.ts
+++ b/sdk/src/client-actions.ts
@@ -1,0 +1,122 @@
+/**
+ * Client action input types - TypeScript equivalents of Cairo ClientAction inputs.
+ * These are the "unwrapped" action types that contain all information needed
+ * for proof generation and on-chain execution.
+ *
+ * See packages/privacy/src/actions.cairo for the Cairo definitions.
+ */
+
+import type { Amount, StarknetAddress, ViewingKey } from "./interfaces.js";
+
+/**
+ * Input for the SetViewingKey action.
+ */
+export type SetViewingKeyInput = {
+  /** The viewing key (private key) to set */
+  privateKey: ViewingKey;
+  /** Random value used to encrypt the private key for compliance */
+  random: bigint;
+};
+
+/**
+ * Input for the OpenChannel action.
+ */
+export type OpenChannelInput = {
+  /** The sender's private key (viewing key) */
+  senderPrivateKey: ViewingKey;
+  /** The recipient's address */
+  recipientAddr: StarknetAddress;
+  /** The recipient's public key */
+  recipientPublicKey: bigint;
+  /** Random value used to encrypt the channel info for the recipient */
+  random: bigint;
+};
+
+/**
+ * Input for the OpenSubchannel (token channel) action.
+ */
+export type OpenSubchannelInput = {
+  /** The recipient's address */
+  recipientAddr: StarknetAddress;
+  /** The recipient's public key */
+  recipientPublicKey: bigint;
+  /** The channel key of the subchannel */
+  channelKey: bigint;
+  /** The index of the subchannel within the channel (token nonce) */
+  index: number;
+  /** The token address */
+  token: StarknetAddress;
+  /** Random value used to encrypt the subchannel token */
+  random: bigint;
+};
+
+/**
+ * Input for the CreateNote action.
+ */
+export type CreateNoteInput = {
+  /** The sender's private key (viewing key) */
+  senderPrivateKey: ViewingKey;
+  /** The recipient's address */
+  recipientAddr: StarknetAddress;
+  /** The recipient's public key */
+  recipientPublicKey: bigint;
+  /** The token's address */
+  token: StarknetAddress;
+  /** The amount the note represents */
+  amount: Amount;
+  /** The index of the note within the channel (note nonce) */
+  index: number;
+  /** Random value used to encrypt the note amount (must be 120 bits) */
+  random: bigint;
+};
+
+/**
+ * Input for the Deposit action.
+ */
+export type DepositInput = {
+  /** The token's address */
+  token: StarknetAddress;
+  /** The amount to deposit */
+  amount: Amount;
+  /** Optional: If depositing to fill an open note, the note's ID */
+  noteId?: bigint;
+};
+
+/**
+ * Input for the UseNote action.
+ */
+export type UseNoteInput = {
+  /** The owner's private key (viewing key) */
+  ownerPrivateKey: ViewingKey;
+  /** The channel key of the note's channel */
+  channelKey: bigint;
+  /** The note's token address */
+  token: StarknetAddress;
+  /** The index of the note within the channel (note nonce) */
+  noteIndex: number;
+};
+
+/**
+ * Input for the Withdraw action.
+ */
+export type WithdrawInput = {
+  /** The target of the withdrawal */
+  withdrawalTarget: StarknetAddress;
+  /** The token's address */
+  token: StarknetAddress;
+  /** The amount to withdraw */
+  amount: Amount;
+};
+
+/**
+ * Union type representing all possible client action inputs.
+ * Matches Cairo's ClientAction enum.
+ */
+export type ClientAction =
+  | { type: "SetViewingKey"; input: SetViewingKeyInput }
+  | { type: "OpenChannel"; input: OpenChannelInput }
+  | { type: "OpenSubchannel"; input: OpenSubchannelInput }
+  | { type: "CreateNote"; input: CreateNoteInput }
+  | { type: "Deposit"; input: DepositInput }
+  | { type: "UseNote"; input: UseNoteInput }
+  | { type: "Withdraw"; input: WithdrawInput };

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -446,12 +446,6 @@ export interface ProofProviderInterface {
 
 export interface DiscoveryProviderInterface {
   /**
-   * Get the public key for a registered address.
-   * This is a contract read operation.
-   */
-  getPublicKey(address: StarknetAddress): BigNumberish;
-
-  /**
    * Discover unspent notes per token
    */
   discoverNotes(

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -10,7 +10,7 @@
  * After compilation:
  * - Registry is updated with resolved channels and notes
  * - Actions may have UseNoteActions added (if autoSelectNotes)
- * - Pool looks up context from registry
+ * - ClientAction[] is produced with all context "unwrapped"
  *
  * Note: After pool execution, use applyOptimisticUpdate() from registry-updater.ts
  * to update the registry with the results.
@@ -28,11 +28,38 @@ import type {
 } from "../interfaces.js";
 import { Channel, createEmptyRegistry } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
+import { isOpen } from "../utils/validation.js";
+import type { ClientAction } from "../client-actions.js";
 
 export type CompileResult = {
-  actions: Actions;
+  clientActions: ClientAction[];
   registry: PrivateRegistry;
 };
+
+/** Generate a random bigint for use in encryption */
+function generateRandom(): bigint {
+  // Generate a 252-bit random value (valid felt252)
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  // Clear top 4 bits to ensure < 2^252
+  bytes[0] &= 0x0f;
+  let result = 0n;
+  for (const byte of bytes) {
+    result = (result << 8n) | BigInt(byte);
+  }
+  return result;
+}
+
+/** Generate a 120-bit random value for note encryption */
+function generateRandom120(): bigint {
+  const bytes = new Uint8Array(15); // 15 bytes = 120 bits
+  crypto.getRandomValues(bytes);
+  let result = 0n;
+  for (const byte of bytes) {
+    result = (result << 8n) | BigInt(byte);
+  }
+  return result;
+}
 
 export class ActionCompiler {
   constructor(
@@ -42,7 +69,7 @@ export class ActionCompiler {
   ) {}
 
   /**
-   * Compile actions by resolving contexts and updating the registry.
+   * Compile actions by resolving contexts, updating the registry, and producing ClientAction[].
    */
   compile(actions: Actions, options?: ExecuteOptions): CompileResult {
     // Get or create registry
@@ -55,7 +82,194 @@ export class ActionCompiler {
     // Phase 2: Resolve notes (discover and/or auto-select)
     this.resolveNotes(actions, options, registry);
 
-    return { actions, registry };
+    // Phase 3: Transform Actions to ClientAction[]
+    const clientActions = this.transformToClientActions(actions, registry);
+
+    return { clientActions, registry };
+  }
+
+  /**
+   * Transform high-level Actions to low-level ClientAction[] using registry context.
+   */
+  private transformToClientActions(actions: Actions, registry: PrivateRegistry): ClientAction[] {
+    const clientActions: ClientAction[] = [];
+
+    // Track nonces locally to handle multiple actions to the same recipient in one batch
+    const tokenNonceDeltas = new AddressMap<number>(() => 0);
+    const noteNonceDeltas = new AddressMap<AddressMap<number>>(
+      () => new AddressMap<number>(() => 0)
+    );
+
+    // Helper to get channel and validate it exists
+    const getChannel = (recipient: StarknetAddress): Channel => {
+      const channel = registry.channels.get(recipient);
+      if (!channel) {
+        throw new Error(`No channel found for recipient ${recipient} in registry`);
+      }
+      return channel;
+    };
+
+    // 1. SetViewingKey
+    if (actions.setViewingKey) {
+      clientActions.push({
+        type: "SetViewingKey",
+        input: {
+          privateKey: this.userViewingKey,
+          random: generateRandom(),
+        },
+      });
+    }
+
+    // 2. OpenChannel
+    if (actions.openChannels) {
+      for (const action of actions.openChannels) {
+        const channel = getChannel(action.recipient);
+        clientActions.push({
+          type: "OpenChannel",
+          input: {
+            senderPrivateKey: this.userViewingKey,
+            recipientAddr: action.recipient,
+            recipientPublicKey: channel.recipientPublicKey,
+            random: generateRandom(),
+          },
+        });
+      }
+    }
+
+    // 3. OpenSubchannel (OpenTokenChannel)
+    if (actions.openTokenChannels) {
+      for (const action of actions.openTokenChannels) {
+        const channel = getChannel(action.recipient);
+        const currentDelta = tokenNonceDeltas.get(action.recipient)!;
+        const index = channel.tokenNonce.sequence + currentDelta;
+        tokenNonceDeltas.set(action.recipient, currentDelta + 1);
+
+        clientActions.push({
+          type: "OpenSubchannel",
+          input: {
+            recipientAddr: action.recipient,
+            recipientPublicKey: channel.recipientPublicKey,
+            channelKey: channel.key,
+            index,
+            token: action.token,
+            random: generateRandom(),
+          },
+        });
+      }
+    }
+
+    // 4. Deposit (token transfer + optional note creation)
+    if (actions.deposits) {
+      for (const action of actions.deposits) {
+        // If deposit has a noteId (deposit to open note), include it
+        const noteId = "noteId" in action ? BigInt(action.noteId) : undefined;
+
+        clientActions.push({
+          type: "Deposit",
+          input: {
+            token: action.token,
+            amount: action.amount,
+            noteId,
+          },
+        });
+
+        // If deposit has a recipient (not noteId), also create a note
+        if ("recipient" in action) {
+          const channel = getChannel(action.recipient);
+
+          // Get note nonce delta map for this recipient
+          let recipientDeltas = noteNonceDeltas.get(action.recipient);
+          if (!recipientDeltas) {
+            recipientDeltas = new AddressMap<number>(() => 0);
+            noteNonceDeltas.set(action.recipient, recipientDeltas);
+          }
+
+          const currentDelta = recipientDeltas.get(action.token)!;
+          const noteNonce = channel.tokens.get(action.token);
+          const index = (noteNonce?.sequence ?? 0) + currentDelta;
+          recipientDeltas.set(action.token, currentDelta + 1);
+
+          clientActions.push({
+            type: "CreateNote",
+            input: {
+              senderPrivateKey: this.userViewingKey,
+              recipientAddr: action.recipient,
+              recipientPublicKey: channel.recipientPublicKey,
+              token: action.token,
+              amount: action.amount,
+              index,
+              random: generateRandom120(),
+            },
+          });
+        }
+      }
+    }
+
+    // 5. UseNote
+    if (actions.useNotes) {
+      for (const action of actions.useNotes) {
+        clientActions.push({
+          type: "UseNote",
+          input: {
+            ownerPrivateKey: this.userViewingKey,
+            channelKey: action.note.witness.channelKey,
+            token: action.token,
+            noteIndex: action.note.witness.nonce.sequence,
+          },
+        });
+      }
+    }
+
+    // 6. CreateNote (non-deposit notes)
+    if (actions.createNotes) {
+      for (const action of actions.createNotes) {
+        const channel = getChannel(action.recipient);
+
+        // Get note nonce delta map for this recipient
+        let recipientDeltas = noteNonceDeltas.get(action.recipient);
+        if (!recipientDeltas) {
+          recipientDeltas = new AddressMap<number>(() => 0);
+          noteNonceDeltas.set(action.recipient, recipientDeltas);
+        }
+
+        const currentDelta = recipientDeltas.get(action.token)!;
+        const noteNonce = channel.tokens.get(action.token);
+        const index = (noteNonce?.sequence ?? 0) + currentDelta;
+        recipientDeltas.set(action.token, currentDelta + 1);
+
+        // For open notes, use 0 as amount (will be filled by deposit)
+        const amount = isOpen(action.amount) ? 0n : action.amount;
+
+        clientActions.push({
+          type: "CreateNote",
+          input: {
+            senderPrivateKey: this.userViewingKey,
+            recipientAddr: action.recipient,
+            recipientPublicKey: channel.recipientPublicKey,
+            token: action.token,
+            amount,
+            index,
+            random: generateRandom120(),
+          },
+        });
+      }
+    }
+
+    // 7. Withdraw
+    if (actions.withdraws) {
+      for (const action of actions.withdraws) {
+        clientActions.push({
+          type: "Withdraw",
+          input: {
+            withdrawalTarget: action.recipient,
+            token: action.token,
+            amount: action.amount,
+          },
+        });
+      }
+    }
+
+    return clientActions;
   }
 
   /**

--- a/sdk/src/internal/index.ts
+++ b/sdk/src/internal/index.ts
@@ -56,15 +56,19 @@ type ChannelKey = bigint;
 /** Channel containing nonces for token and note creation. */
 export class Channel {
   /** @internal */ readonly key: ChannelKey;
+  /** Recipient's public key (needed for creating notes) */
+  readonly recipientPublicKey: bigint;
   /** @internal */ tokenNonce: TokenNonce;
   /** @internal */ readonly tokens: AddressMap<NoteNonce>;
 
   constructor(
     key: ChannelKey,
+    recipientPublicKey: bigint,
     tokenNonce?: TokenNonce,
     tokens?: Iterable<[StarknetAddress, NoteNonce]>
   ) {
     this.key = key;
+    this.recipientPublicKey = recipientPublicKey;
     this.tokenNonce = tokenNonce ?? new TokenNonce();
     this.tokens = new AddressMap<NoteNonce>(() => new NoteNonce());
     if (tokens) {
@@ -88,7 +92,7 @@ export class Channel {
 
   /** Create a deep clone of this channel */
   clone(): Channel {
-    return new Channel(this.key, this.tokenNonce, this.tokens.entries());
+    return new Channel(this.key, this.recipientPublicKey, this.tokenNonce, this.tokens.entries());
   }
 }
 
@@ -98,6 +102,7 @@ export const channelSerde: ChannelSerde = {
     const json = jsonStringify({
       v: 1,
       key: channel.key,
+      recipientPublicKey: channel.recipientPublicKey,
       tokenNonce: channel.tokenNonce,
       tokens: Array.from(channel.tokens.entries()),
     });
@@ -109,12 +114,13 @@ export const channelSerde: ChannelSerde = {
     if (parsed === null || typeof parsed !== "object") {
       throw new Error("Invalid channel payload");
     }
-    const { key, tokenNonce, tokens } = parsed as Record<string, unknown>;
+    const { key, recipientPublicKey, tokenNonce, tokens } = parsed as Record<string, unknown>;
     const decodedKey = assertChannelKey(key);
+    const decodedPublicKey = assertChannelKey(recipientPublicKey); // same format as key
     const decodedTokenNonce = assertTokenNonce(tokenNonce);
     const decodedTokens = assertTokenEntries(tokens);
 
-    return new Channel(decodedKey, decodedTokenNonce, decodedTokens);
+    return new Channel(decodedKey, decodedPublicKey, decodedTokenNonce, decodedTokens);
   },
 };
 

--- a/sdk/src/internal/registry-updater.ts
+++ b/sdk/src/internal/registry-updater.ts
@@ -6,70 +6,72 @@
  * the transaction hasn't been confirmed on-chain yet.
  *
  * Updates:
- * - Channel nonces (tokenNonce from openTokenChannels, noteNonces from deposits/createNotes)
- * - Removes spent notes (from useNotes actions)
+ * - Channel nonces (tokenNonce from OpenSubchannel, noteNonces from CreateNote)
+ * - Removes spent notes (from UseNote actions)
  *
- * Note: Created notes (from deposits/createNotes) are NOT added to the sender's registry
+ * Note: Created notes are NOT added to the sender's registry
  * - those notes belong to the recipients.
  *
- * Note: openChannels actions don't need handling here - the channel is already in the
+ * Note: OpenChannel actions don't need handling here - the channel is already in the
  * registry from the compile phase (via discoverChannels) with initial nonces.
  */
 
-import type { Actions, PrivateRegistry } from "../interfaces.js";
+import type { PrivateRegistry } from "../interfaces.js";
+import { Witness } from "../interfaces.js";
+import { NoteNonce } from "./index.js";
+import type { ClientAction } from "../client-actions.js";
+import { hashes } from "../utils/hashes.js";
 
 /**
  * Apply optimistic updates to the registry after pool execution.
  *
- * @param actions - The compiled actions that were executed
+ * @param clientActions - The client actions that were executed
  * @param registry - The registry to update
  */
-export function applyOptimisticUpdate(actions: Actions, registry: PrivateRegistry): void {
-  // 1. Update channel token nonces (from openTokenChannels)
-  if (actions.openTokenChannels) {
-    for (const action of actions.openTokenChannels) {
-      const channel = registry.channels.get(action.recipient);
-      if (channel) {
-        channel.incrementTokenNonce();
-      }
-    }
-  }
-
-  // 2. Update channel note nonces (from deposits and createNotes)
-  if (actions.deposits) {
-    for (const action of actions.deposits) {
-      if ("recipient" in action) {
-        const channel = registry.channels.get(action.recipient);
+export function applyOptimisticUpdate(
+  clientActions: ClientAction[],
+  registry: PrivateRegistry
+): void {
+  for (const action of clientActions) {
+    switch (action.type) {
+      case "OpenSubchannel": {
+        // Increment token nonce for the channel to this recipient
+        const channel = registry.channels.get(action.input.recipientAddr);
         if (channel) {
-          channel.incrementNoteNonce(action.token);
+          channel.incrementTokenNonce();
         }
+        break;
       }
-    }
-  }
 
-  if (actions.createNotes) {
-    for (const action of actions.createNotes) {
-      const channel = registry.channels.get(action.recipient);
-      if (channel) {
-        channel.incrementNoteNonce(action.token);
-      }
-    }
-  }
-
-  // 3. Remove spent notes
-  if (actions.useNotes) {
-    for (const action of actions.useNotes) {
-      const noteId = action.note.id;
-      // Search all tokens for this note
-      for (const [, tokenNotes] of registry.notes.entries()) {
-        const index = tokenNotes.findIndex(
-          (n) => BigInt(n.id as bigint) === BigInt(noteId as bigint)
-        );
-        if (index !== -1) {
-          tokenNotes.splice(index, 1);
-          break;
+      case "CreateNote": {
+        // Increment note nonce for the channel/token
+        const channel = registry.channels.get(action.input.recipientAddr);
+        if (channel) {
+          channel.incrementNoteNonce(action.input.token);
         }
+        break;
       }
+
+      case "UseNote": {
+        // Compute the note ID and remove from registry
+        const nonce = new NoteNonce(action.input.noteIndex);
+        const witness = new Witness(action.input.channelKey, nonce);
+        const noteId = hashes.noteId(witness, action.input.token);
+
+        // Search all tokens for this note and remove it
+        for (const [, tokenNotes] of registry.notes.entries()) {
+          const index = tokenNotes.findIndex((n) => BigInt(n.id as bigint) === BigInt(noteId));
+          if (index !== -1) {
+            tokenNotes.splice(index, 1);
+            break;
+          }
+        }
+        break;
+      }
+
+      // Other action types don't affect the registry optimistically
+      default:
+        break;
     }
   }
 }

--- a/sdk/src/testing/discovery.ts
+++ b/sdk/src/testing/discovery.ts
@@ -13,7 +13,7 @@ import type {
 import { Channel, SetupRequirement, Witness } from "../interfaces.js";
 import type { BlockIdentifier } from "starknet";
 import { NoteNonce, TokenNonce } from "../internal/index.js";
-import { decryptChannelInfo } from "../utils/crypto.js";
+import { decryptChannelInfo, toBigInt } from "../utils/crypto.js";
 import { AddressMap } from "../utils/maps.js";
 import { assertRecipientAddress, assertViewingKey } from "../utils/validation.js";
 import type { PrivacyPool } from "./pool.js";
@@ -22,10 +22,6 @@ import { hashes } from "../utils/hashes.js";
 export class MockDiscoveryProvider implements DiscoveryProviderInterface {
   private _currentBlock: BlockIdentifier = 0; // TODO: allow block advancement
   constructor(private pool: PrivacyPool) {}
-
-  getPublicKey(address: StarknetAddress) {
-    return this.pool.getPublicKey(address);
-  }
 
   discoverNotes(
     address: StarknetAddress,
@@ -87,7 +83,8 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
     const result = new AddressMap<Channel>();
     for (const recipient of recipients) {
       const addr = assertRecipientAddress(recipient);
-      const key = hashes.channelKey(address, viewingKey, addr, this.pool.getPublicKey(addr));
+      const recipientPublicKey = toBigInt(this.pool.getPublicKey(addr));
+      const key = hashes.channelKey(address, viewingKey, addr, recipientPublicKey);
 
       // Find the highest token nonce sequence
       let tokenSequence = 0;
@@ -105,7 +102,7 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
       }
 
       const tokenNonce = new TokenNonce(tokenSequence);
-      result.set(addr, new Channel(key, tokenNonce, tokens));
+      result.set(addr, new Channel(key, recipientPublicKey, tokenNonce, tokens));
     }
 
     return { timestamp: this._currentBlock, channels: result };

--- a/sdk/src/testing/pool.ts
+++ b/sdk/src/testing/pool.ts
@@ -1,18 +1,16 @@
 /**
  * Mock PrivacyPool implementation for testing.
+ * Consumes ClientAction[] (the unwrapped action inputs from the compiler).
  */
 
 import type {
-  Actions,
   Amount,
   Note,
   NoteId,
-  Open,
-  PrivateRegistry,
   StarknetAddress,
   StarknetAddressBigint,
 } from "../interfaces.js";
-import { Witness, Channel } from "../interfaces.js";
+import { Witness } from "../interfaces.js";
 import { BigNumberish } from "starknet";
 import { NoteNonce, TokenNonce } from "../internal/index.js";
 import {
@@ -29,9 +27,10 @@ import {
   derivePublicKey,
 } from "../utils/crypto.js";
 import { AdvancedMap, AddressMap } from "../utils/maps.js";
-import { assert, isOpen } from "../utils/validation.js";
+import { assert } from "../utils/validation.js";
 import type { ERC20s } from "./erc20.js";
 import { hashes } from "../utils/hashes.js";
+import type { ClientAction } from "../client-actions.js";
 
 type OpenNote = {
   r: bigint;
@@ -115,103 +114,82 @@ export class PrivacyPool {
     return this.nullifiers.has(hashes.nullifier(witness, token, ownerPrivateKey));
   }
 
-  execute(
-    sender: StarknetAddress,
-    senderViewingKey: ViewingKey,
-    actions: Actions,
-    registry: PrivateRegistry
-  ) {
-    // Clone channels to avoid mutating the registry (simulates real contract behavior)
-    // The real Starknet contract doesn't have access to our local registry objects
-    const clonedChannels = new AddressMap<Channel>();
-    for (const [addr, channel] of registry.channels.entries()) {
-      clonedChannels.set(addr, channel.clone());
-    }
+  /**
+   * Execute client actions. Actions must be in the correct order:
+   * 1. SetViewingKey (optional, at most 1)
+   * 2. OpenChannel (any number)
+   * 3. OpenSubchannel (any number)
+   * 4. Deposit (any number)
+   * 5. UseNote (any number)
+   * 6. CreateNote (any number)
+   * 7. Withdraw (any number)
+   *
+   * @param sender The sender's address
+   * @param clientActions The array of client action inputs from the compiler
+   */
+  execute(sender: StarknetAddress, clientActions: ClientAction[]): void {
+    // Validate token totals before mutating state
+    this.validateTokenTotals(sender, clientActions);
 
-    // Helper to get cloned channel
-    const getChannel = (recipient: StarknetAddress) => {
-      const channel = clonedChannels.get(recipient);
-      assert(channel, `No channel found for recipient ${recipient} in registry`);
-      return channel;
-    };
+    // Process actions in order
+    for (const action of clientActions) {
+      switch (action.type) {
+        case "SetViewingKey":
+          this.register(sender, action.input.privateKey);
+          break;
 
-    // Validate before mutating any state
-    this.validateTokenTotals(actions, registry);
-
-    // 1. Register user if setViewingKey is requested
-    if (actions.setViewingKey) {
-      this.register(sender, senderViewingKey);
-    }
-
-    // 2. Open channels for recipients
-    if (actions.openChannels) {
-      for (const action of actions.openChannels) {
-        this.setChannel(sender, senderViewingKey, action.recipient);
-      }
-    }
-
-    // 3. Open token channels - use cloned channel
-    if (actions.openTokenChannels) {
-      for (const action of actions.openTokenChannels) {
-        const channel = getChannel(action.recipient);
-        const nonce = channel.incrementTokenNonce();
-        this.setToken(sender, action.recipient, channel.key, action.token, nonce);
-      }
-    }
-
-    // 4. Execute operations directly
-
-    // Process deposits: transfer to pool, then create note or fill open note
-    if (actions.deposits) {
-      for (const action of actions.deposits) {
-        this.deposit(sender, action.token, action.amount);
-
-        if ("noteId" in action) {
-          // Deposit to existing open note
-          this.fillOpenNote(action.noteId, action.token, action.amount);
-        } else {
-          // Normal deposit: create a new note - use cloned channel
-          const channel = getChannel(action.recipient);
-          const nonce = channel.incrementNoteNonce(action.token);
-          this.createNote(
+        case "OpenChannel":
+          this.setChannel(
             sender,
-            senderViewingKey,
-            action.recipient,
-            action.token,
-            nonce,
-            action.amount
+            action.input.senderPrivateKey,
+            action.input.recipientAddr,
+            action.input.recipientPublicKey
           );
-        }
-      }
-    }
+          break;
 
-    // Process useNotes: spend notes (marks nullifier)
-    if (actions.useNotes) {
-      for (const action of actions.useNotes) {
-        this.useNote(sender, senderViewingKey, action.token, action.note.witness);
-      }
-    }
+        case "OpenSubchannel":
+          this.setToken(
+            sender,
+            action.input.recipientAddr,
+            action.input.recipientPublicKey,
+            action.input.channelKey,
+            action.input.token,
+            action.input.index
+          );
+          break;
 
-    // Process createNotes: create new notes for recipients - use cloned channel
-    if (actions.createNotes) {
-      for (const action of actions.createNotes) {
-        const channel = getChannel(action.recipient);
-        const nonce = channel.incrementNoteNonce(action.token);
-        this.createNote(
-          sender,
-          senderViewingKey,
-          action.recipient,
-          action.token,
-          nonce,
-          action.amount
-        );
-      }
-    }
+        case "Deposit":
+          this.deposit(sender, action.input.token, action.input.amount);
+          // If depositing to an open note, fill it
+          if (action.input.noteId) {
+            this.fillOpenNote(action.input.noteId, action.input.token, action.input.amount);
+          }
+          break;
 
-    // Process withdraws: transfer from pool to recipient
-    if (actions.withdraws) {
-      for (const action of actions.withdraws) {
-        this.withdraw(action.token, action.recipient, action.amount);
+        case "UseNote":
+          this.useNote(
+            sender,
+            action.input.ownerPrivateKey,
+            action.input.token,
+            action.input.channelKey,
+            action.input.noteIndex
+          );
+          break;
+
+        case "CreateNote":
+          this.createNote(
+            action.input.senderPrivateKey,
+            action.input.recipientAddr,
+            action.input.recipientPublicKey,
+            action.input.token,
+            action.input.index,
+            action.input.amount
+          );
+          break;
+
+        case "Withdraw":
+          this.withdraw(action.input.token, action.input.withdrawalTarget, action.input.amount);
+          break;
       }
     }
   }
@@ -231,10 +209,10 @@ export class PrivacyPool {
   private setChannel(
     from: StarknetAddress,
     fromPrivateKey: ViewingKey,
-    to: StarknetAddress
+    to: StarknetAddress,
+    toPublicKey: PublicKey
   ): ChannelKey {
     this.assertRegistered(from);
-    const toPublicKey = this.getPublicKey(to);
     const channelKey = hashes.channelKey(from, fromPrivateKey, to, toPublicKey);
     const channelInfo = encryptChannelInfo(toPublicKey, channelKey, from);
     this.channels.get({ address: to, publicKey: toPublicKey })!.push(channelInfo);
@@ -245,22 +223,24 @@ export class PrivacyPool {
   private setToken(
     from: StarknetAddress,
     to: StarknetAddress,
+    toPublicKey: PublicKey,
     channelKey: Hash,
     token: StarknetAddress,
-    nonce: TokenNonce
+    index: number
   ): void {
     this.assertRegistered(from);
 
     assert(
-      this.channelIds.has(hashes.channelId(channelKey, from, to, this.getPublicKey(to))),
+      this.channelIds.has(hashes.channelId(channelKey, from, to, toPublicKey)),
       `Channel does not exist between ${from} and ${to}`
     );
+
+    const nonce = new TokenNonce(index);
     assert(
       nonce.sequence == 0 ||
         this.subchannels.has(hashes.subchannelKey(channelKey, nonce.decrement())),
-      `Nonce ${nonce} is not sequential`
+      `Nonce ${nonce.sequence} is not sequential`
     );
-    const toPublicKey = this.getPublicKey(to);
 
     const subchannelKey = hashes.subchannelKey(channelKey, nonce);
     assert(!this.subchannels.has(subchannelKey), `Token ${token} already exists`);
@@ -273,20 +253,24 @@ export class PrivacyPool {
     owner: StarknetAddress,
     ownerPrivateKey: ViewingKey,
     token: StarknetAddress,
-    witness: Witness
+    channelKey: Hash,
+    noteIndex: number
   ): bigint {
     const ownerPublicKey = this.getPublicKey(owner);
     assert(
-      this.subchannelIds.has(hashes.subchannelId(witness.channelKey, owner, ownerPublicKey, token)),
+      this.subchannelIds.has(hashes.subchannelId(channelKey, owner, ownerPublicKey, token)),
       `Token ${token} does not exist`
     );
+
+    const nonce = new NoteNonce(noteIndex);
+    const witness = new Witness(channelKey, nonce);
     const noteId = hashes.noteId(witness, token);
     const note = this.notes.get(noteId)!;
     if (note.r == 1n) {
       // note is open, get amount as is
       return (note as OpenNote).amount;
     }
-    const amount = decryptSymmetric(note as SymmetricEncryption, witness.channelKey);
+    const amount = decryptSymmetric(note as SymmetricEncryption, channelKey);
     assert(amount == amount, `Note amount does not match`);
 
     const nullifier = hashes.nullifier(witness, token, ownerPrivateKey);
@@ -298,38 +282,61 @@ export class PrivacyPool {
   }
 
   private createNote(
-    from: StarknetAddress,
-    fromPrivateKey: ViewingKey,
+    senderPrivateKey: ViewingKey,
     to: StarknetAddress,
+    toPublicKey: PublicKey,
     token: StarknetAddress,
-    nonce: NoteNonce,
-    amount: Amount | Open
+    index: number,
+    amount: Amount
   ): Note {
-    const channelKey = hashes.channelKey(from, fromPrivateKey, to, this.getPublicKey(to));
-    const subchannelId = hashes.subchannelId(channelKey, to, this.getPublicKey(to), token);
+    // Derive sender address from private key (not needed for note creation, but for validation)
+    const senderPublicKey = derivePublicKey(senderPrivateKey);
+
+    // Compute channel key using sender's private key and recipient's public key
+    // Note: We need the sender address, which we can derive from the registration
+    // For now, we compute channelKey directly from the provided keys
+    // In a real contract, this would be verified
+
+    // Find the sender address from the public key
+    let senderAddr: StarknetAddress | undefined;
+    for (const [addr, pubKey] of this.publicKeys.entries()) {
+      if (pubKey === senderPublicKey) {
+        senderAddr = addr;
+        break;
+      }
+    }
+    assert(senderAddr !== undefined, "Sender not registered");
+
+    const channelKey = hashes.channelKey(senderAddr!, senderPrivateKey, to, toPublicKey);
+    const subchannelId = hashes.subchannelId(channelKey, to, toPublicKey, token);
     assert(this.subchannelIds.has(subchannelId), `Token ${token} does not exist`);
+
+    const nonce = new NoteNonce(index);
     assert(
       nonce.sequence == 0 ||
         this.notes.has(hashes.noteId(new Witness(channelKey, nonce.decrement()), token)),
-      `Nonce ${nonce} is not sequential`
+      `Nonce ${nonce.sequence} is not sequential`
     );
 
     const witness = new Witness(channelKey, nonce);
     const noteId = hashes.noteId(witness, token);
 
     assert(!this.notes.has(noteId), `Note ${noteId} already exists`);
-    const note = isOpen(amount)
+
+    // Amount of 0 indicates an open note
+    const isOpenNote = amount === 0n;
+    const noteData = isOpenNote
       ? { r: 1n, amount: 0n, token: toBigInt(token) }
       : encryptSymmetric(channelKey, amount);
 
-    this.notes.set(noteId, note);
+    this.notes.set(noteId, noteData);
 
     return {
       id: noteId,
-      amount: isOpen(amount) ? 0n : amount,
+      amount: amount,
       witness,
-      sender: from,
-      open: isOpen(amount),
+      sender: senderAddr!,
+      open: isOpenNote,
     };
   }
 
@@ -341,7 +348,10 @@ export class PrivacyPool {
     this.erc20s.get(token).transfer(this.poolAddress, recipient, amount);
   }
 
-  private fillOpenNote(noteId: NoteId, token: StarknetAddress, amount: Amount): void {
+  /**
+   * Fill an open note with an amount (for deposits to open notes).
+   */
+  fillOpenNote(noteId: NoteId, token: StarknetAddress, amount: Amount): void {
     const note = this.notes.get(toBigInt(noteId))! as OpenNote;
     assert(note, `Note ${noteId} does not exist`);
     assert(note.r == 1n, `Note ${noteId} is not open`);
@@ -350,27 +360,7 @@ export class PrivacyPool {
     note.amount = amount;
   }
 
-  private validateTokenTotals(actions: Actions, _registry: PrivateRegistry): void {
-    // 1. Validate all amounts are non-negative
-    if (actions.deposits) {
-      for (const deposit of actions.deposits) {
-        assert(deposit.amount >= 0n, `Deposit amount must be non-negative: ${deposit.amount}`);
-      }
-    }
-    if (actions.createNotes) {
-      for (const create of actions.createNotes) {
-        if (!isOpen(create.amount)) {
-          assert(create.amount >= 0n, `CreateNote amount must be non-negative: ${create.amount}`);
-        }
-      }
-    }
-    if (actions.withdraws) {
-      for (const withdraw of actions.withdraws) {
-        assert(withdraw.amount >= 0n, `Withdraw amount must be non-negative: ${withdraw.amount}`);
-      }
-    }
-
-    // 2. Validate running totals stay non-negative and end at 0
+  private validateTokenTotals(sender: StarknetAddress, clientActions: ClientAction[]): void {
     const runningTotals = new Map<string, bigint>();
 
     const updateTotal = (token: StarknetAddress, delta: bigint) => {
@@ -381,31 +371,54 @@ export class PrivacyPool {
       runningTotals.set(tokenKey, updated);
     };
 
-    // Deposits are balanced: money in, then note created (net 0)
-    // No validation needed for deposits - they're self-balancing
+    for (const action of clientActions) {
+      switch (action.type) {
+        case "Deposit":
+          // Validate amount is non-negative
+          assert(
+            action.input.amount >= 0n,
+            `Deposit amount must be non-negative: ${action.input.amount}`
+          );
+          // Regular deposits add to available balance (consumed by CreateNote)
+          // Deposits to open notes (with noteId) fill an existing note - balanced internally
+          if (!action.input.noteId) {
+            updateTotal(action.input.token, action.input.amount);
+          }
+          break;
 
-    // Using notes increases total
-    if (actions.useNotes) {
-      for (const use of actions.useNotes) {
-        const noteData = this.getNote(use.note.witness, use.token);
-        assert(noteData, `Note not found`);
-        assert(!noteData.open, `Cannot use open note as input`);
-        updateTotal(use.token, noteData.amount);
-      }
-    }
+        case "UseNote": {
+          // Using a note increases available balance
+          const nonce = new NoteNonce(action.input.noteIndex);
+          const witness = new Witness(action.input.channelKey, nonce);
+          const noteData = this.getNote(witness, action.input.token);
+          assert(noteData, `Note not found`);
+          assert(!noteData.open, `Cannot use open note as input`);
+          updateTotal(action.input.token, noteData.amount);
+          break;
+        }
 
-    // Creating notes decreases total (open notes count as 0)
-    if (actions.createNotes) {
-      for (const create of actions.createNotes) {
-        const amount = isOpen(create.amount) ? 0n : create.amount;
-        updateTotal(create.token, -amount);
-      }
-    }
+        case "CreateNote": {
+          // Creating a note decreases available balance (0 for open notes)
+          const amount = action.input.amount;
+          if (amount > 0n) {
+            updateTotal(action.input.token, -amount);
+          }
+          break;
+        }
 
-    // Withdrawals decrease total
-    if (actions.withdraws) {
-      for (const withdraw of actions.withdraws) {
-        updateTotal(withdraw.token, -withdraw.amount);
+        case "Withdraw":
+          // Validate amount is non-negative
+          assert(
+            action.input.amount >= 0n,
+            `Withdraw amount must be non-negative: ${action.input.amount}`
+          );
+          // Withdrawals decrease available balance
+          updateTotal(action.input.token, -action.input.amount);
+          break;
+
+        default:
+          // Other actions don't affect token totals
+          break;
       }
     }
 

--- a/sdk/src/testing/transfers.ts
+++ b/sdk/src/testing/transfers.ts
@@ -53,14 +53,14 @@ export class MockPrivateTransfers implements PrivateTransfers {
   }
 
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
-    // 1. Compile actions - resolves contexts and updates registry
-    const { actions: compiledActions, registry } = this.compiler.compile(actions, options);
+    // 1. Compile actions - resolves contexts and produces clientActions
+    const { clientActions, registry } = this.compiler.compile(actions, options);
 
-    // 2. Execute actions on the pool - pass registry for context lookup
-    await this.pool.execute(this.userAddress, this.userViewingKey, compiledActions, registry);
+    // 2. Execute client actions on the pool
+    this.pool.execute(this.userAddress, clientActions);
 
     // 3. Apply optimistic updates - update channel nonces, remove spent notes
-    applyOptimisticUpdate(compiledActions, registry);
+    applyOptimisticUpdate(clientActions, registry);
 
     return {
       callAndProof: createMockCallAndProof(),

--- a/sdk/tests/internal/compiler.test.ts
+++ b/sdk/tests/internal/compiler.test.ts
@@ -125,7 +125,7 @@ describe("ActionCompiler (via builder)", () => {
     it("refresh: discovers all recipients, updates registry with fresh nonces", async () => {
       // Start with an outdated registry (nonces at 0)
       const staleRegistry = createEmptyRegistry();
-      const staleChannel = new Channel(aliceToBobChannel.key); // fresh channel with nonce 0
+      const staleChannel = new Channel(aliceToBobChannel.key, aliceToBobChannel.recipientPublicKey); // fresh channel with nonce 0
       staleRegistry.channels.set(BOB_ADDRESS, staleChannel);
 
       // Do first deposit - this advances nonces in the pool

--- a/sdk/tests/internal/serde.test.ts
+++ b/sdk/tests/internal/serde.test.ts
@@ -12,6 +12,7 @@ describe("channelSerde", () => {
   it("encodes and decodes a channel round-trip", () => {
     const original = new Channel(
       12345n,
+      67890n, // recipientPublicKey
       new TokenNonce(5),
       new Map([
         ["0xabc", new NoteNonce(10)],
@@ -23,6 +24,7 @@ describe("channelSerde", () => {
 
     // Compare essential data (AdvressMap instances don't deep-equal well)
     expect(decoded.key).toEqual(original.key);
+    expect(decoded.recipientPublicKey).toEqual(original.recipientPublicKey);
     expect(decoded.tokenNonce.sequence).toEqual(original.tokenNonce.sequence);
     expect(Array.from(decoded.tokens.entries())).toEqual(Array.from(original.tokens.entries()));
   });


### PR DESCRIPTION
refactor(sdk): include recipient public key in channel, remove getpublickey from discovery

- add recipientPublicKey field to Channel class
- discoverChannels now stores recipient's public key in the Channel
- remove getPublicKey method from DiscoveryProviderInterface
- update channelSerde to include recipientPublicKey
- compiler can now get public key from registry.channels.get(recipient).recipientPublicKey

feat(sdk): compile actions to client action inputs

- Add client-actions.ts with TypeScript types matching Cairo ClientAction inputs
  (SetViewingKeyInput, OpenChannelInput, OpenSubchannelInput, CreateNoteInput,
  DepositInput, UseNoteInput, WithdrawInput)

- Update ActionCompiler to produce clientActions[] with all context unwrapped:
  - Recipient public keys and channel keys from registry
  - Nonce indices for tokens and notes
  - Random values generated for encryption

- Update PrivacyPool to consume ClientAction[] instead of Actions + registry
  - All context is now in the action inputs
  - Validation updated to track deposits and handle open notes correctly

- Update MockPrivateTransfers to pass clientActions to pool

refactor(sdk): update registry updater to use client actions

- Update applyOptimisticUpdate to work with ClientAction[] directly
  - OpenSubchannel increments channel tokenNonce
  - CreateNote increments channel noteNonce for token
  - UseNote computes noteId from channelKey/token/noteIndex and removes note

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/171)
<!-- Reviewable:end -->
