### PR TITLE
chore: make husky hooks conditional on sdk files

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,4 @@
-cd sdk && npx commitlint --edit "$1"
-
+# Only run sdk commitlint if sdk files are being committed
+if git diff --cached --name-only | grep -q "^sdk/"; then
+  cd sdk && npx commitlint --edit "$1"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
-cd sdk && npx lint-staged
-
+# Only run sdk lint-staged if sdk files are being committed
+if git diff --cached --name-only | grep -q "^sdk/"; then
+  cd sdk && npx lint-staged
+fi


### PR DESCRIPTION
Only run lint-staged and commitlint when files in sdk/ are being committed.
This allows commits to other parts of the monorepo without triggering sdk hooks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/172)
<!-- Reviewable:end -->
