### PR TITLE
feat(indexer): add api server with health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +630,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "backoff",
  "clap",
  "discovery-core",
@@ -1092,6 +1145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1164,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1542,6 +1602,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2443,6 +2509,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -28,11 +28,15 @@ starknet-tokio-tungstenite = "0.3"
 url = "2"
 
 # HTTP
+axum = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 tower = { version = "0.5", features = ["limit"] }
 
 # Storage
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
 
 # Error handling
 thiserror = "2"
@@ -50,6 +54,5 @@ expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"
 nix = { version = "0.29", features = ["signal"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"

--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -1,0 +1,198 @@
+//! API server with health endpoint for Docker health checks.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Serialize;
+use thiserror::Error;
+use tokio::sync::broadcast;
+use tracing::{error, info};
+
+use crate::store::{Head, SqliteStore, Store, StoreError};
+
+/// Default maximum lag threshold for health check (5 seconds).
+const DEFAULT_HEALTH_MAX_LAG_SECS: u64 = 5;
+
+/// Default API server bind address.
+const DEFAULT_API_HOST: &str = "127.0.0.1:8080";
+
+/// Errors that can occur during API server operation.
+#[derive(Debug, Error)]
+pub enum ApiServerError {
+    /// Failed to open database.
+    #[error("Failed to open database: {0}")]
+    Database(#[from] StoreError),
+    /// Failed to bind to address.
+    #[error("Failed to bind to {0}: {1}")]
+    Bind(String, std::io::Error),
+    /// Server error.
+    #[error("Server error: {0}")]
+    Server(#[from] std::io::Error),
+}
+
+/// API server configuration.
+pub struct ApiServerConfig {
+    /// Address to bind the HTTP server to (e.g., "127.0.0.1:8080").
+    pub api_host: String,
+    /// Maximum acceptable lag in seconds for health check.
+    pub health_max_lag_secs: u64,
+}
+
+impl Default for ApiServerConfig {
+    fn default() -> Self {
+        Self {
+            api_host: DEFAULT_API_HOST.to_string(),
+            health_max_lag_secs: DEFAULT_HEALTH_MAX_LAG_SECS,
+        }
+    }
+}
+
+/// Shared application state for request handlers.
+struct AppState {
+    store: SqliteStore,
+    config: ApiServerConfig,
+}
+
+/// Health check response.
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    chain_head: Option<Head>,
+    lag_secs: u64,
+}
+
+/// API server that exposes health endpoint.
+pub struct ApiServer {
+    config: ApiServerConfig,
+    db_path: String,
+    rx_shutdown: broadcast::Receiver<()>,
+}
+
+impl ApiServer {
+    /// Create a new API server instance.
+    pub fn new(
+        config: ApiServerConfig,
+        db_path: String,
+        rx_shutdown: broadcast::Receiver<()>,
+    ) -> Self {
+        Self {
+            config,
+            db_path,
+            rx_shutdown,
+        }
+    }
+
+    /// Run the API server until shutdown signal is received.
+    pub async fn run(self) -> Result<(), ()> {
+        self.run_inner().await.map_err(|e| {
+            error!("API server error: {}", e);
+        })
+    }
+
+    async fn run_inner(mut self) -> Result<(), ApiServerError> {
+        let api_host = self.config.api_host.clone();
+        info!("API server starting on {}", api_host);
+
+        let store = SqliteStore::reader(&self.db_path).await?;
+
+        let state = Arc::new(AppState {
+            store,
+            config: self.config,
+        });
+
+        let app = Router::new()
+            .route("/health", get(health))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind(&api_host)
+            .await
+            .map_err(|e| ApiServerError::Bind(api_host.clone(), e))?;
+
+        info!("API server listening on {}", api_host);
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = self.rx_shutdown.recv().await;
+                info!("API server received shutdown signal");
+            })
+            .await?;
+
+        info!("API server stopped");
+        Ok(())
+    }
+}
+
+/// Health endpoint handler.
+async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+
+    let mut conn = match state.store.acquire().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            error!(
+                "Failed to acquire database connection for health check: {}",
+                e
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(HealthResponse {
+                    status: "UNHEALTHY",
+                    chain_head: None,
+                    lag_secs: 0,
+                }),
+            );
+        }
+    };
+
+    let head = match conn.get_head().await {
+        Ok(head) => head,
+        Err(e) => {
+            error!("Failed to get head for health check: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(HealthResponse {
+                    status: "UNHEALTHY",
+                    chain_head: None,
+                    lag_secs: 0,
+                }),
+            );
+        }
+    };
+
+    let (status, lag_secs) = match &head {
+        Some(h) => {
+            let lag = now_secs.saturating_sub(h.timestamp);
+            let status = if lag <= state.config.health_max_lag_secs {
+                "OK"
+            } else {
+                "UNHEALTHY"
+            };
+            (status, lag)
+        }
+        // No head yet means service is still initializing
+        None => ("UNHEALTHY", now_secs),
+    };
+
+    let status_code = if status == "OK" {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (
+        status_code,
+        Json(HealthResponse {
+            status,
+            chain_head: head,
+            lag_secs,
+        }),
+    )
+}

--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -161,7 +161,7 @@ impl Indexer {
                             info!("New block #{}: {:#064x}", head.block_number, head.block_hash);
                             let mut tx = store.begin().await?;
                             tx.store_block(head.block_number, head.block_hash).await?;
-                            tx.set_head(head.block_number, head.block_hash).await?;
+                            tx.set_head(head.block_number, head.block_hash, head.timestamp).await?;
                             tx.commit().await?;
                         }
                         NewHeadsUpdate::Reorg(reorg) => {

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -4,6 +4,7 @@
 //! - RPC-based storage backend for reading privacy contract state
 //! - Indexer for Starknet new heads subscription
 
+pub mod api_server;
 pub mod indexer;
 pub mod rpc_backend;
 pub mod shutdown;

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -1,8 +1,10 @@
 #![doc = include_str!("../README.md")]
 
 use clap::Parser;
+use discovery_service::api_server::{ApiServer, ApiServerConfig};
 use discovery_service::indexer::{Indexer, IndexerConfig};
 use discovery_service::shutdown::Shutdown;
+use discovery_service::store::SqliteStore;
 use tokio::task::JoinHandle;
 use tracing::{error, info, subscriber::set_global_default};
 use tracing_subscriber::filter::EnvFilter;
@@ -53,6 +55,19 @@ async fn main() {
     if let Ok(db_path) = std::env::var("DB_PATH") {
         indexer_config.db_path = db_path;
     }
+    let db_path = indexer_config.db_path.clone();
+
+    let mut api_config = ApiServerConfig::default();
+    if let Ok(api_host) = std::env::var("API_HOST") {
+        api_config.api_host = api_host;
+    }
+
+    // Initialize database before starting services
+    info!("Initializing database at {}", db_path);
+    if let Err(e) = SqliteStore::writer(&db_path).await {
+        error!("Failed to initialize database: {}", e);
+        std::process::exit(1);
+    }
 
     if cli.reindex {
         let db_path = std::path::Path::new(&indexer_config.db_path);
@@ -66,11 +81,17 @@ async fn main() {
     }
 
     let mut indexer = Indexer::new(indexer_config, shutdown.subscribe());
+    let api_server = ApiServer::new(api_config, db_path, shutdown.subscribe());
 
     let indexer_handle = tokio::spawn(async move { indexer.run().await });
+    let api_handle = tokio::spawn(async move { api_server.run().await });
     let shutdown_handle = tokio::spawn(async move { shutdown.run().await });
 
-    match tokio::try_join!(flatten(indexer_handle), flatten(shutdown_handle)) {
+    match tokio::try_join!(
+        flatten(indexer_handle),
+        flatten(api_handle),
+        flatten(shutdown_handle)
+    ) {
         Ok(_) => {
             info!("Discovery service has shut down");
             std::process::exit(0);

--- a/crates/discovery-service/src/store.rs
+++ b/crates/discovery-service/src/store.rs
@@ -1,11 +1,12 @@
 //! Storage layer with multi-reader, single-writer SQLite backend.
 
+use serde::Serialize;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
     SqliteTransactionManager,
 };
-use sqlx::{Pool, Sqlite, TransactionManager};
+use sqlx::{Pool, Row, Sqlite, TransactionManager};
 use starknet::core::types::Felt;
 use std::ops::DerefMut;
 use std::path::Path;
@@ -29,14 +30,26 @@ pub enum StoreError {
     Transaction(String),
 }
 
+/// Current indexed head information.
+#[derive(Debug, Clone, Serialize)]
+pub struct Head {
+    pub block_number: u64,
+    pub block_hash: String,
+    pub timestamp: u64,
+}
+
 /// Storage operations for the discovery service.
 #[async_trait::async_trait]
 pub trait Store: Send + Sync {
     /// Store a block.
     async fn store_block(&mut self, height: u64, hash: Felt) -> Result<(), StoreError>;
 
-    /// Update the head.
-    async fn set_head(&mut self, height: u64, hash: Felt) -> Result<(), StoreError>;
+    /// Update the head with height, hash, and timestamp (Unix seconds).
+    async fn set_head(&mut self, height: u64, hash: Felt, timestamp: u64) -> Result<(), StoreError>;
+
+    /// Get current head information.
+    /// Returns None if no head has been set yet.
+    async fn get_head(&mut self) -> Result<Option<Head>, StoreError>;
 
     /// Commit changes.
     async fn commit(&mut self) -> Result<(), StoreError>;
@@ -85,6 +98,11 @@ impl SqliteStore {
             .await?;
 
         Ok(Self { pool })
+    }
+
+    /// Acquire a connection from the pool.
+    pub async fn acquire(&self) -> Result<PoolConnection<Sqlite>, StoreError> {
+        self.pool.acquire().await.map_err(StoreError::from)
     }
 
     /// Initialize database schema.
@@ -141,16 +159,53 @@ impl Store for PoolConnection<Sqlite> {
         Ok(())
     }
 
-    async fn set_head(&mut self, height: u64, hash: Felt) -> Result<(), StoreError> {
+    async fn set_head(&mut self, height: u64, hash: Felt, timestamp: u64) -> Result<(), StoreError> {
         sqlx::query(
             "INSERT OR REPLACE INTO meta (key, value) \
-            VALUES ('head_height', ?), ('head_hash', ?)",
+            VALUES ('head_height', ?), ('head_hash', ?), ('head_timestamp', ?)",
         )
         .bind(height.to_string())
         .bind(format!("{:#066x}", hash))
+        .bind(timestamp.to_string())
         .execute(self.deref_mut())
         .await?;
         Ok(())
+    }
+
+    async fn get_head(&mut self) -> Result<Option<Head>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT key, value FROM meta WHERE key IN ('head_height', 'head_hash', 'head_timestamp')",
+        )
+        .fetch_all(self.deref_mut())
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let mut height: Option<u64> = None;
+        let mut hash: Option<String> = None;
+        let mut timestamp: Option<u64> = None;
+
+        for row in rows {
+            let key: String = row.get("key");
+            let value: String = row.get("value");
+            match key.as_str() {
+                "head_height" => height = value.parse().ok(),
+                "head_hash" => hash = Some(value),
+                "head_timestamp" => timestamp = value.parse().ok(),
+                _ => {}
+            }
+        }
+
+        match (height, hash, timestamp) {
+            (Some(block_number), Some(block_hash), Some(timestamp)) => Ok(Some(Head {
+                block_number,
+                block_hash,
+                timestamp,
+            })),
+            _ => Ok(None),
+        }
     }
 
     async fn commit(&mut self) -> Result<(), StoreError> {

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -18,10 +18,16 @@ pub struct IndexerClient {
 }
 
 impl IndexerClient {
-    pub async fn spawn_with_binary(binary: &str, ws_url: &str, db_path: &str) -> Result<Self> {
+    pub async fn spawn_with_binary(
+        binary: &str,
+        ws_url: &str,
+        db_path: &str,
+        api_host: &str,
+    ) -> Result<Self> {
         let mut process = Command::new(binary)
             .env("WS_URL", ws_url)
             .env("DB_PATH", db_path)
+            .env("API_HOST", api_host)
             .stderr(std::process::Stdio::piped())
             .spawn()?;
 

--- a/crates/discovery-service/tests/integration.rs
+++ b/crates/discovery-service/tests/integration.rs
@@ -15,12 +15,14 @@
 
 mod common;
 
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
 use common::{DevnetClient, DevnetConfig, IndexerClient};
 use discovery_core::storage::{IViews, StorageBackend};
 use discovery_service::rpc_backend::{RpcBackend, RpcConfig};
 use expect_test::expect;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{Row, SqlitePool};
@@ -92,6 +94,15 @@ async fn test_public_key_lookup() {
 
 // === Indexer Tests ===
 
+/// Counter for generating unique API server ports across tests.
+static API_PORT_COUNTER: AtomicU16 = AtomicU16::new(19000);
+
+/// Generate a unique API host address for tests.
+fn test_api_host() -> String {
+    let port = API_PORT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("127.0.0.1:{}", port)
+}
+
 struct TempDb {
     _dir: TempDir,
     path: String,
@@ -117,9 +128,10 @@ async fn test_startup_and_shutdown() {
     let devnet = DevnetClient::spawn(DevnetConfig::default())
         .await
         .expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &test_api_host())
+            .await
+            .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_log("Indexer started", Duration::from_secs(10))
@@ -141,9 +153,10 @@ async fn test_new_block_notification() {
     let devnet = DevnetClient::spawn(DevnetConfig::default())
         .await
         .expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &test_api_host())
+            .await
+            .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
@@ -167,9 +180,10 @@ async fn test_reorg_notification() {
     let devnet = DevnetClient::spawn(DevnetConfig::default())
         .await
         .expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &test_api_host())
+            .await
+            .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
@@ -206,9 +220,10 @@ async fn test_reconnection_on_devnet_restart() {
     let devnet = DevnetClient::spawn(DevnetConfig::default())
         .await
         .expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &test_api_host())
+            .await
+            .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
@@ -241,9 +256,10 @@ async fn test_blocks_persisted_and_head_matches_latest() {
     let devnet = DevnetClient::spawn(DevnetConfig::default())
         .await
         .expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &test_api_host())
+            .await
+            .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
@@ -305,4 +321,67 @@ async fn test_blocks_persisted_and_head_matches_latest() {
         let normalized = format!("{:#066x}", Felt::from_hex(&hash).unwrap());
         assert!(stored_hashes.contains(&normalized));
     }
+}
+
+// === API Tests ===
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct HealthResponse {
+    status: String,
+    chain_head: Option<ChainHead>,
+    lag_secs: u64,
+}
+
+#[derive(Deserialize)]
+struct ChainHead {
+    block_number: u64,
+    block_hash: String,
+    timestamp: u64,
+}
+
+#[tokio::test]
+async fn test_health_endpoint_returns_ok() {
+    let temp_db = temp_db("health_endpoint");
+    let api_host = test_api_host();
+    let devnet = DevnetClient::spawn(DevnetConfig::default())
+        .await
+        .expect("Failed to spawn devnet");
+    let mut indexer =
+        IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), &temp_db.path, &api_host)
+            .await
+            .expect("Failed to spawn indexer");
+
+    indexer
+        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    // Create a block so we have a chain head
+    devnet.create_block().await.unwrap();
+    indexer
+        .wait_for_log("New block #", Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    // Call health endpoint
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/health", api_host))
+        .send()
+        .await
+        .expect("Failed to call health endpoint");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let health: HealthResponse = resp.json().await.expect("Failed to parse health response");
+    assert_eq!(health.status, "OK");
+    assert!(health.chain_head.is_some());
+    let chain_head = health.chain_head.unwrap();
+    assert!(chain_head.block_number > 0);
+    assert!(chain_head.block_hash.starts_with("0x"));
+    assert!(chain_head.timestamp > 0);
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
 }


### PR DESCRIPTION
### TL;DR

Added a health check API server to the discovery service for Docker health checks and monitoring.

### What changed?

- Added a new API server module with a `/health` endpoint that reports the current chain head and lag
- Implemented health check logic that returns HTTP 200 when the chain head is recent, and HTTP 503 when lagging
- Added Axum as a dependency for the HTTP server implementation
- Enhanced the `Head` struct to include timestamp information for lag calculation
- Updated the `set_head` method to store timestamp information
- Added integration tests for the health endpoint
- Updated `.gitignore` to exclude `.claude` files

### How to test?

1. Start the discovery service with optional environment variables:
   - `API_HOST`: Address to bind the API server (default: 127.0.0.1:8080)
   - `DB_PATH`: Path to the SQLite database
   
2. Check the health endpoint:
   ```
   curl http://127.0.0.1:8080/health
   ```
   
3. The response will include:
   - `status`: "OK" or "UNHEALTHY"
   - `chain_head`: Current head information (block number, hash, timestamp)
   - `lag_secs`: How many seconds behind the chain is

### Why make this change?

This change enables Docker health checks and monitoring for the discovery service. The health endpoint provides visibility into the service's state, allowing automated systems to detect when the service is lagging behind the chain or experiencing issues. This is particularly important for production deployments where automatic recovery from failures is needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/195)
<!-- Reviewable:end -->
