### PR TITLE
feat(indexer): sync storage diffs

### DIFF
--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::{error, info};
 
-use crate::store::{Head, SqliteStore, Store, StoreError};
+use crate::store::{SqliteStore, Store};
 
 /// Default maximum lag threshold for health check (5 seconds).
 const DEFAULT_HEALTH_MAX_LAG_SECS: u64 = 5;
@@ -24,9 +24,6 @@ const DEFAULT_API_HOST: &str = "127.0.0.1:8080";
 /// Errors that can occur during API server operation.
 #[derive(Debug, Error)]
 pub enum ApiServerError {
-    /// Failed to open database.
-    #[error("Failed to open database: {0}")]
-    Database(#[from] StoreError),
     /// Failed to bind to address.
     #[error("Failed to bind to {0}: {1}")]
     Bind(String, std::io::Error),
@@ -62,8 +59,24 @@ struct AppState {
 #[derive(Serialize)]
 struct HealthResponse {
     status: &'static str,
-    chain_head: Option<Head>,
+    chain_head: Option<ChainHead>,
+    indexed_state: Option<IndexedStateInfo>,
     lag_secs: u64,
+}
+
+/// Chain head info.
+#[derive(Serialize)]
+struct ChainHead {
+    block_number: u64,
+    block_hash: String,
+    timestamp: u64,
+}
+
+/// Indexed state info.
+#[derive(Serialize)]
+struct IndexedStateInfo {
+    block_number: u64,
+    block_hash: String,
 }
 
 /// API server that exposes health endpoint.
@@ -98,8 +111,7 @@ impl ApiServer {
         let api_host = self.config.api_host.clone();
         info!("API server starting on {}", api_host);
 
-        let store = SqliteStore::reader(&self.db_path).await?;
-
+        let store = SqliteStore::reader(&self.db_path);
         let state = Arc::new(AppState {
             store,
             config: self.config,
@@ -146,6 +158,7 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                 Json(HealthResponse {
                     status: "UNHEALTHY",
                     chain_head: None,
+                    indexed_state: None,
                     lag_secs: 0,
                 }),
             );
@@ -161,13 +174,25 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
                 Json(HealthResponse {
                     status: "UNHEALTHY",
                     chain_head: None,
+                    indexed_state: None,
                     lag_secs: 0,
                 }),
             );
         }
     };
 
-    let (status, lag_secs) = match &head {
+    let indexed_state = match conn.get_indexed_state().await {
+        Ok(state) => state.map(|s| IndexedStateInfo {
+            block_number: s.block_height,
+            block_hash: format!("{:#066x}", s.block_hash),
+        }),
+        Err(e) => {
+            error!("Failed to get indexed state for health check: {}", e);
+            None
+        }
+    };
+
+    let (status, lag_secs, chain_head) = match head {
         Some(h) => {
             let lag = now_secs.saturating_sub(h.timestamp);
             let status = if lag <= state.config.health_max_lag_secs {
@@ -175,10 +200,15 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             } else {
                 "UNHEALTHY"
             };
-            (status, lag)
+            let chain_head = ChainHead {
+                block_number: h.block_number,
+                block_hash: h.block_hash,
+                timestamp: h.timestamp,
+            };
+            (status, lag, Some(chain_head))
         }
         // No head yet means service is still initializing
-        None => ("UNHEALTHY", now_secs),
+        None => ("UNHEALTHY", now_secs, None),
     };
 
     let status_code = if status == "OK" {
@@ -191,7 +221,8 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         status_code,
         Json(HealthResponse {
             status,
-            chain_head: head,
+            chain_head,
+            indexed_state,
             lag_secs,
         }),
     )

--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -1,18 +1,25 @@
-//! Indexer that subscribes to Starknet new heads via WebSocket.
+//! Indexer that subscribes to Starknet new heads via WebSocket and indexes state diffs.
 
 use std::time::Duration;
 
 use backoff::ExponentialBackoffBuilder;
 use backoff::{backoff::Backoff, ExponentialBackoff};
-use starknet::core::types::ConfirmedBlockId;
+use starknet::core::types::{
+    BlockHeader, BlockId, BlockTag, ConfirmedBlockId, Felt, MaybePreConfirmedBlockWithTxHashes,
+    MaybePreConfirmedStateUpdate,
+};
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Provider};
 use starknet_tokio_tungstenite::{NewHeadsUpdate, TungsteniteStream};
 use thiserror::Error;
 use tokio::sync::broadcast;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
+use url::Url;
 
-use crate::store::{SqliteStore, Store, StoreError};
+use crate::store::{IndexedState, SqliteStore, Store, StoreError};
 
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:5050/ws";
+const DEFAULT_RPC_URL: &str = "http://127.0.0.1:5050/rpc";
 const DEFAULT_DB_PATH: &str = "data/discovery.db";
 
 /// Errors that can occur during indexer operation.
@@ -33,6 +40,12 @@ pub enum IndexerError {
     /// Error closing WebSocket connection.
     #[error("WebSocket close error: {0}")]
     Close(#[from] starknet_tokio_tungstenite::CloseError),
+    /// RPC provider error (retriable).
+    #[error("RPC error: {0}")]
+    Rpc(#[from] starknet::providers::ProviderError),
+    /// Unexpected response from provider (retriable).
+    #[error("Unexpected response: {0}")]
+    UnexpectedResponse(String),
     /// Storage error (fatal).
     #[error("Storage error: {0}")]
     Store(#[from] StoreError),
@@ -48,13 +61,18 @@ impl IndexerError {
                 | IndexerError::Receive(_)
                 | IndexerError::Unsubscribe(_)
                 | IndexerError::Close(_)
+                | IndexerError::Rpc(_)
+                | IndexerError::UnexpectedResponse(_)
         )
     }
 }
 
 pub struct IndexerConfig {
     pub ws_url: String,
+    pub rpc_url: String,
     pub db_path: String,
+    pub contract_address: Felt,
+    pub starting_block: Option<(u64, Felt)>,
     pub connect_timeout: Duration,
     pub backoff_initial_interval: Duration,
     pub backoff_max_interval: Duration,
@@ -65,7 +83,10 @@ impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
             ws_url: DEFAULT_WS_URL.to_string(),
+            rpc_url: DEFAULT_RPC_URL.to_string(),
             db_path: DEFAULT_DB_PATH.to_string(),
+            contract_address: Felt::ZERO,
+            starting_block: None,
             connect_timeout: Duration::from_secs(10),
             backoff_initial_interval: Duration::from_secs(1),
             backoff_max_interval: Duration::from_secs(60),
@@ -78,6 +99,7 @@ pub struct Indexer {
     config: IndexerConfig,
     backoff: ExponentialBackoff,
     rx_shutdown: broadcast::Receiver<()>,
+    rpc_client: JsonRpcClient<HttpTransport>,
 }
 
 impl Indexer {
@@ -87,16 +109,22 @@ impl Indexer {
             .with_max_interval(config.backoff_max_interval)
             .with_max_elapsed_time(config.backoff_max_elapsed_time)
             .build();
+
+        let rpc_url = Url::parse(&config.rpc_url).expect("Invalid RPC URL");
+        let rpc_client = JsonRpcClient::new(HttpTransport::new(rpc_url));
+
         Self {
             config,
             backoff,
             rx_shutdown,
+            rpc_client,
         }
     }
 
     /// Outer loop: handles reconnection with exponential backoff.
     pub async fn run(&mut self) -> Result<(), ()> {
         info!("Indexer started");
+        info!("Indexing contract: {:#066x}", self.config.contract_address);
 
         info!("Opening database at {}", self.config.db_path);
         let store = match SqliteStore::writer(&self.config.db_path).await {
@@ -135,13 +163,18 @@ impl Indexer {
         }
     }
 
-    /// Inner loop: connects, subscribes, processes messages until error or shutdown.
+    /// Inner loop: backfill to chain head, then process websocket updates.
     async fn run_inner(&mut self, store: &SqliteStore) -> Result<(), IndexerError> {
-        // Check for shutdown before connecting
         if self.rx_shutdown.try_recv().is_ok() {
             return Ok(());
         }
 
+        // Phase 1: Backfill to chain head
+        let chain_head = self.fetch_chain_head().await?;
+        self.index_to_head(store, chain_head).await?;
+        info!("Backfill complete, switching to websocket mode");
+
+        // Phase 2: Connect websocket and process new heads
         info!("Connecting to {}", self.config.ws_url);
         let stream =
             TungsteniteStream::connect(&self.config.ws_url, self.config.connect_timeout).await?;
@@ -150,7 +183,6 @@ impl Indexer {
         let mut subscription = stream.subscribe_new_heads(ConfirmedBlockId::Latest).await?;
         info!("Subscribed to new heads");
 
-        // Reset backoff after successful connection
         self.backoff.reset();
 
         loop {
@@ -158,29 +190,223 @@ impl Indexer {
                 update = subscription.recv() => {
                     match update? {
                         NewHeadsUpdate::NewHeader(head) => {
-                            info!("New block #{}: {:#064x}", head.block_number, head.block_hash);
-                            let mut tx = store.begin().await?;
-                            tx.store_block(head.block_number, head.block_hash).await?;
-                            tx.set_head(head.block_number, head.block_hash, head.timestamp).await?;
-                            tx.commit().await?;
+                            info!("New block #{}: {:#066x}", head.block_number, head.block_hash);
+
+                            // Store block + update chain head
+                            self.update_chain_head(store, &head).await?;
+
+                            // Index state diffs to new head
+                            self.index_to_head(store, head.block_number).await?;
                         }
                         NewHeadsUpdate::Reorg(reorg) => {
                             warn!(
                                 "Reorg detected: #{} -> #{}",
                                 reorg.starting_block_number, reorg.ending_block_number
                             );
-                            // TODO: Implement reorg handling - delete blocks and entries >= starting_block_number
+                            // TODO: Handle reorg
+                            // - Delete blocks from starting_block_number
+                            // - Delete storage_diffs from starting_block_number
+                            // - Reset indexed state to block before reorg
                         }
                     }
                 }
+
                 _ = self.rx_shutdown.recv() => {
-                    subscription.unsubscribe().await?;
+                    let _ = subscription.unsubscribe().await;
                     info!("Unsubscribed from new heads");
-                    stream.close().await?;
+                    let _ = stream.close().await;
                     info!("Closed WebSocket connection");
                     return Ok(());
                 }
             }
         }
+    }
+
+    /// Update chain head in database and cache new block.
+    async fn update_chain_head(
+        &self,
+        store: &SqliteStore,
+        block_header: &BlockHeader,
+    ) -> Result<(), IndexerError> {
+        let mut tx = store.begin().await?;
+        tx.store_block(block_header.block_number, block_header.block_hash)
+            .await?;
+        tx.set_head(
+            block_header.block_number,
+            block_header.block_hash,
+            block_header.timestamp,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+    /// Fetch current chain head via RPC.
+    async fn fetch_chain_head(&self) -> Result<u64, IndexerError> {
+        info!(
+            "Fetching remote chain head via RPC at {}",
+            self.config.rpc_url
+        );
+        let latest = self
+            .rpc_client
+            .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
+            .await?;
+
+        let height = match latest {
+            MaybePreConfirmedBlockWithTxHashes::Block(b) => b.block_number,
+            MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_) => {
+                return Err(IndexerError::UnexpectedResponse(
+                    "Latest block is pre-confirmed".to_string(),
+                ));
+            }
+        };
+        info!("Remote chain head: block #{}", height);
+        Ok(height)
+    }
+
+    /// Load indexed state with priority: DB > config > genesis RPC.
+    async fn load_indexed_state(&self, store: &SqliteStore) -> Result<IndexedState, IndexerError> {
+        // Check DB first (read-only, no transaction needed)
+        let db_state = {
+            let mut conn = store.acquire().await?;
+            conn.get_indexed_state().await?
+        };
+
+        if let Some(state) = db_state {
+            debug!(
+                "Resuming from indexed state: block #{} ({:#066x})",
+                state.block_height, state.block_hash
+            );
+            return Ok(state);
+        }
+
+        // Determine initial state: config > genesis RPC
+        let initial_state = if let Some((height, hash)) = self.config.starting_block {
+            info!(
+                "Using configured starting block: #{} ({:#066x})",
+                height, hash
+            );
+            IndexedState {
+                block_height: height,
+                block_hash: hash,
+            }
+        } else {
+            info!("No starting block configured, fetching genesis block via RPC");
+            let genesis = self
+                .rpc_client
+                .get_block_with_tx_hashes(BlockId::Number(0))
+                .await?;
+
+            let block_hash = match genesis {
+                MaybePreConfirmedBlockWithTxHashes::Block(b) => b.block_hash,
+                MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_) => {
+                    return Err(IndexerError::UnexpectedResponse(
+                        "Genesis block is pre-confirmed".to_string(),
+                    ));
+                }
+            };
+            info!("Genesis block hash: {:#066x}", block_hash);
+            IndexedState {
+                block_height: 0,
+                block_hash,
+            }
+        };
+
+        // Persist initial state
+        let mut tx = store.begin().await?;
+        tx.set_indexed_state(initial_state.block_height, initial_state.block_hash)
+            .await?;
+        tx.commit().await?;
+
+        Ok(initial_state)
+    }
+
+    /// Index state diffs from current indexed state to target height.
+    async fn index_to_head(&self, store: &SqliteStore, target: u64) -> Result<(), IndexerError> {
+        let current = self.load_indexed_state(store).await?;
+
+        if current.block_height > target {
+            // TODO: Handle reorg - indexed state is ahead of chain head
+            // Need to rollback indexed state and storage_diffs to target
+            warn!(
+                "Indexed state #{} is ahead of target #{}, possible reorg (unhandled)",
+                current.block_height, target
+            );
+            return Ok(());
+        }
+
+        if current.block_height == target {
+            info!("Already indexed to block #{}", target);
+            return Ok(());
+        }
+
+        let from = current.block_height + 1;
+        info!(
+            "Indexing {} blocks: #{} to #{}",
+            target - from + 1,
+            from,
+            target
+        );
+        for height in from..=target {
+            self.index_block(store, height).await?;
+        }
+        info!("Finished indexing to block #{}", target);
+        Ok(())
+    }
+
+    /// Index a single block's state diffs.
+    async fn index_block(&self, store: &SqliteStore, height: u64) -> Result<(), IndexerError> {
+        debug!("Fetching state update for block #{}", height);
+
+        let state_update = self
+            .rpc_client
+            .get_state_update(BlockId::Number(height))
+            .await?;
+
+        let state_update = match state_update {
+            MaybePreConfirmedStateUpdate::Update(su) => su,
+            MaybePreConfirmedStateUpdate::PreConfirmedUpdate(_) => {
+                debug!("Block #{} is pre-confirmed, skipping", height);
+                return Ok(());
+            }
+        };
+
+        // Filter storage diffs for contract_address
+        let entries: Vec<(Felt, Felt)> = state_update
+            .state_diff
+            .storage_diffs
+            .iter()
+            .filter(|d| d.address == self.config.contract_address)
+            .flat_map(|d| d.storage_entries.iter().map(|e| (e.key, e.value)))
+            .collect();
+
+        // Batch insert + update indexed state atomically
+        let mut tx = store.begin().await?;
+        if !entries.is_empty() {
+            debug!(
+                "Block #{}: inserting {} storage entries",
+                height,
+                entries.len()
+            );
+            tx.batch_insert_storage_diffs(height, &entries).await?;
+        }
+        tx.set_indexed_state(height, state_update.block_hash)
+            .await?;
+        tx.commit().await?;
+
+        if entries.is_empty() {
+            debug!(
+                "Indexed block #{} (no storage changes for target contract)",
+                height
+            );
+        } else {
+            info!(
+                "Indexed block #{}: {} storage entries ({:#066x})",
+                height,
+                entries.len(),
+                state_update.block_hash
+            );
+        }
+
+        Ok(())
     }
 }

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -5,6 +5,7 @@ use discovery_service::api_server::{ApiServer, ApiServerConfig};
 use discovery_service::indexer::{Indexer, IndexerConfig};
 use discovery_service::shutdown::Shutdown;
 use discovery_service::store::SqliteStore;
+use starknet::core::types::Felt;
 use tokio::task::JoinHandle;
 use tracing::{error, info, subscriber::set_global_default};
 use tracing_subscriber::filter::EnvFilter;
@@ -52,8 +53,26 @@ async fn main() {
     if let Ok(ws_url) = std::env::var("WS_URL") {
         indexer_config.ws_url = ws_url;
     }
+    if let Ok(rpc_url) = std::env::var("RPC_URL") {
+        indexer_config.rpc_url = rpc_url;
+    }
     if let Ok(db_path) = std::env::var("DB_PATH") {
         indexer_config.db_path = db_path;
+    }
+    if let Ok(addr) = std::env::var("CONTRACT_ADDRESS") {
+        indexer_config.contract_address =
+            Felt::from_hex(&addr).expect("Invalid CONTRACT_ADDRESS hex format");
+    }
+    if let Ok(starting) = std::env::var("STARTING_BLOCK") {
+        // Format: "height:hash" or just "height"
+        let parts: Vec<&str> = starting.split(':').collect();
+        let height: u64 = parts[0].parse().expect("Invalid STARTING_BLOCK height");
+        let hash = if parts.len() > 1 {
+            Felt::from_hex(parts[1]).expect("Invalid STARTING_BLOCK hash")
+        } else {
+            Felt::ZERO
+        };
+        indexer_config.starting_block = Some((height, hash));
     }
     let db_path = indexer_config.db_path.clone();
 

--- a/crates/discovery-service/src/store.rs
+++ b/crates/discovery-service/src/store.rs
@@ -38,6 +38,13 @@ pub struct Head {
     pub timestamp: u64,
 }
 
+/// Current indexed state for state diffs (separate from chain head).
+#[derive(Debug, Clone)]
+pub struct IndexedState {
+    pub block_height: u64,
+    pub block_hash: Felt,
+}
+
 /// Storage operations for the discovery service.
 #[async_trait::async_trait]
 pub trait Store: Send + Sync {
@@ -45,11 +52,27 @@ pub trait Store: Send + Sync {
     async fn store_block(&mut self, height: u64, hash: Felt) -> Result<(), StoreError>;
 
     /// Update the head with height, hash, and timestamp (Unix seconds).
-    async fn set_head(&mut self, height: u64, hash: Felt, timestamp: u64) -> Result<(), StoreError>;
+    async fn set_head(&mut self, height: u64, hash: Felt, timestamp: u64)
+        -> Result<(), StoreError>;
 
     /// Get current head information.
     /// Returns None if no head has been set yet.
     async fn get_head(&mut self) -> Result<Option<Head>, StoreError>;
+
+    /// Get the current indexed state (separate from chain head).
+    /// Returns None if no state has been indexed yet.
+    async fn get_indexed_state(&mut self) -> Result<Option<IndexedState>, StoreError>;
+
+    /// Set the indexed state height and hash.
+    async fn set_indexed_state(&mut self, height: u64, hash: Felt) -> Result<(), StoreError>;
+
+    /// Batch insert storage diffs for a block.
+    /// Each entry is (key, value).
+    async fn batch_insert_storage_diffs(
+        &mut self,
+        height: u64,
+        entries: &[(Felt, Felt)],
+    ) -> Result<(), StoreError>;
 
     /// Commit changes.
     async fn commit(&mut self) -> Result<(), StoreError>;
@@ -85,19 +108,17 @@ impl SqliteStore {
         Ok(store)
     }
 
-    /// Create a reader instance (multiple concurrent connections).
-    pub async fn reader<P: AsRef<Path>>(path: P) -> Result<Self, StoreError> {
+    /// Create a reader instance (multiple concurrent connections, lazy connect).
+    pub fn reader<P: AsRef<Path>>(path: P) -> Self {
         let options = SqliteConnectOptions::new()
             .filename(path.as_ref())
-            .read_only(true)
-            .busy_timeout(std::time::Duration::from_millis(SQLITE_BUSY_TIMEOUT_MS));
+            .read_only(true);
 
         let pool = SqlitePoolOptions::new()
             .max_connections(SQLITE_MAX_READERS)
-            .connect_with(options)
-            .await?;
+            .connect_lazy_with(options);
 
-        Ok(Self { pool })
+        Self { pool }
     }
 
     /// Acquire a connection from the pool.
@@ -134,6 +155,24 @@ impl SqliteStore {
             .execute(&self.pool)
             .await?;
 
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS storage_diffs (
+                block_height INTEGER NOT NULL,
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS idx_storage_diffs_block_height ON storage_diffs (block_height);"#,
+        )
+        .execute(&self.pool)
+        .await?;
+
         Ok(())
     }
 
@@ -159,7 +198,12 @@ impl Store for PoolConnection<Sqlite> {
         Ok(())
     }
 
-    async fn set_head(&mut self, height: u64, hash: Felt, timestamp: u64) -> Result<(), StoreError> {
+    async fn set_head(
+        &mut self,
+        height: u64,
+        hash: Felt,
+        timestamp: u64,
+    ) -> Result<(), StoreError> {
         sqlx::query(
             "INSERT OR REPLACE INTO meta (key, value) \
             VALUES ('head_height', ?), ('head_hash', ?), ('head_timestamp', ?)",
@@ -206,6 +250,69 @@ impl Store for PoolConnection<Sqlite> {
             })),
             _ => Ok(None),
         }
+    }
+
+    async fn get_indexed_state(&mut self) -> Result<Option<IndexedState>, StoreError> {
+        let rows = sqlx::query(
+            "SELECT key, value FROM meta WHERE key IN ('indexed_height', 'indexed_hash')",
+        )
+        .fetch_all(self.deref_mut())
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let mut height: Option<u64> = None;
+        let mut hash: Option<Felt> = None;
+
+        for row in rows {
+            let key: String = row.get("key");
+            let value: String = row.get("value");
+            match key.as_str() {
+                "indexed_height" => height = value.parse().ok(),
+                "indexed_hash" => hash = Felt::from_hex(&value).ok(),
+                _ => {}
+            }
+        }
+
+        match (height, hash) {
+            (Some(block_height), Some(block_hash)) => Ok(Some(IndexedState {
+                block_height,
+                block_hash,
+            })),
+            _ => Ok(None),
+        }
+    }
+
+    async fn set_indexed_state(&mut self, height: u64, hash: Felt) -> Result<(), StoreError> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO meta (key, value) \
+            VALUES ('indexed_height', ?), ('indexed_hash', ?)",
+        )
+        .bind(height.to_string())
+        .bind(format!("{:#066x}", hash))
+        .execute(self.deref_mut())
+        .await?;
+        Ok(())
+    }
+
+    async fn batch_insert_storage_diffs(
+        &mut self,
+        height: u64,
+        entries: &[(Felt, Felt)],
+    ) -> Result<(), StoreError> {
+        for (key, value) in entries {
+            sqlx::query(
+                "INSERT OR REPLACE INTO storage_diffs (block_height, key, value) VALUES (?, ?, ?)",
+            )
+            .bind(height as i64)
+            .bind(format!("{:#066x}", key))
+            .bind(format!("{:#066x}", value))
+            .execute(self.deref_mut())
+            .await?;
+        }
+        Ok(())
     }
 
     async fn commit(&mut self) -> Result<(), StoreError> {

--- a/crates/discovery-service/tests/integration.rs
+++ b/crates/discovery-service/tests/integration.rs
@@ -203,6 +203,9 @@ async fn test_reorg_notification() {
         .await
         .unwrap();
 
+    // Wait a bit to make sure the indexer has time to index the blocks before making a reorg
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
     // Abort to block1 (simulates reorg)
     devnet.abort_blocks(&block1).await.unwrap();
     indexer
@@ -330,6 +333,7 @@ async fn test_blocks_persisted_and_head_matches_latest() {
 struct HealthResponse {
     status: String,
     chain_head: Option<ChainHead>,
+    indexed_state: Option<IndexedState>,
     lag_secs: u64,
 }
 
@@ -338,6 +342,12 @@ struct ChainHead {
     block_number: u64,
     block_hash: String,
     timestamp: u64,
+}
+
+#[derive(Deserialize)]
+struct IndexedState {
+    block_number: u64,
+    block_hash: String,
 }
 
 #[tokio::test]
@@ -357,12 +367,15 @@ async fn test_health_endpoint_returns_ok() {
         .await
         .unwrap();
 
-    // Create a block so we have a chain head
+    // Create a block and wait for it to be processed
     devnet.create_block().await.unwrap();
     indexer
         .wait_for_log("New block #", Duration::from_secs(5))
         .await
         .unwrap();
+
+    // Give indexer time to complete state diff indexing
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Call health endpoint
     let client = reqwest::Client::new();
@@ -376,11 +389,23 @@ async fn test_health_endpoint_returns_ok() {
 
     let health: HealthResponse = resp.json().await.expect("Failed to parse health response");
     assert_eq!(health.status, "OK");
+
+    // Verify chain_head
     assert!(health.chain_head.is_some());
     let chain_head = health.chain_head.unwrap();
-    assert!(chain_head.block_number > 0);
+    assert!(chain_head.block_number >= 1, "expected at least 1 block");
     assert!(chain_head.block_hash.starts_with("0x"));
     assert!(chain_head.timestamp > 0);
+
+    // Verify indexed_state is present
+    assert!(health.indexed_state.is_some());
+    let indexed_state = health.indexed_state.unwrap();
+    assert!(indexed_state.block_hash.starts_with("0x"));
+    // Indexed state should be at or close to chain head
+    assert!(
+        indexed_state.block_number <= chain_head.block_number,
+        "indexed state should not exceed chain head"
+    );
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();


### PR DESCRIPTION
### TL;DR

Enhanced the discovery service to index and track storage diffs for a specific contract.

### What changed?

- Added state diff indexing capabilities to track storage changes for a specific contract
- Implemented a two-phase indexing approach: backfill to chain head, then process websocket updates
- Enhanced health endpoint to include indexed state information alongside chain head
- Added configuration options for RPC URL, contract address, and starting block
- Created new database schema for storing storage diffs with appropriate indexes
- Improved error handling and logging throughout the indexing process

### How to test?

1. Set environment variables to configure the service:
   ```
   CONTRACT_ADDRESS=0x123...  # Contract to index
   RPC_URL=http://127.0.0.1:5050/rpc  # Starknet RPC endpoint
   WS_URL=ws://127.0.0.1:5050/ws  # Starknet WebSocket endpoint
   STARTING_BLOCK=1000:0x456...  # Optional starting point (height:hash)
   ```

2. Start the service and check the health endpoint:
   ```
   curl http://localhost:3000/health
   ```
   
3. Verify the response includes both chain_head and indexed_state information

### Why make this change?

This enhancement allows the discovery service to track and index storage changes for a specific contract, making it possible to query historical state and monitor contract storage modifications. The two-phase approach ensures the service can efficiently catch up to the chain head before switching to real-time updates, providing a complete and consistent view of contract state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/197)
<!-- Reviewable:end -->
