### PR TITLE
feat(sdk): abstract discovery provider and async discovery

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -37,22 +37,22 @@ export type StarknetAddress = BigNumberish;
  * Values are ordered by priority (higher value = more setup needed).
  */
 export enum SetupRequirement {
-  /** Ready to transfer - no setup needed */
-  Ready = 0,
+  /** Recipient is not registered */
+  Register = 0,
+  /** Need to setup initial channel*/
+  SetupChannel = 1,
   /** Need to setup the token subchannel */
-  SetupToken = 1,
-  /** Need to setup initial channel (and token) */
-  SetupChannel = 2,
-  /** Need to register (and setup channel and token) */
-  Register = 3,
+  SetupToken = 2,
+  /** Ready to transfer - no setup needed */
+  Ready = 3,
 }
 
 /** A Starknet address normalized to bigint (for use as Map keys, etc.) */
 export type StarknetAddressBigint = bigint;
 
 // Import and re-export Witness class from internal.ts
-import { Witness, Channel } from "./internal/channel.js";
-export { Witness, Channel };
+import { Witness, Channel, NotesCursor } from "./internal/channel.js";
+export { Witness, Channel, NotesCursor as DiscoveryCursor };
 
 export type Note = {
   readonly id: NoteId;
@@ -219,6 +219,8 @@ export type PrivateRegistry = {
   channels: AddressMap<Channel>;
   /** Notes by token address */
   notes: AddressMap<Note[]>;
+  /** Cursor for discovery */
+  cursor?: NotesCursor;
 };
 
 /** Create an empty private registry */
@@ -302,18 +304,18 @@ export interface SimplePrivateTransfers {
   /**
    * Discover unspent notes per token
    */
-  discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): {
+  discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
-  };
+  }>;
 
   /**
    * Discover channels for one or more recipients
    */
-  discoverChannels(...recipients: StarknetAddress[]): {
+  discoverChannels(...recipients: StarknetAddress[]): Promise<{
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
-  };
+  }>;
 }
 
 /**
@@ -358,18 +360,21 @@ export interface PrivateTransfers {
    * Discover unspent notes per token
    *
    */
-  discoverNotes(params?: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): {
+  discoverNotes(params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
-  };
+  }>;
 
   /**
    * Discover channels for one or more recipients
    */
-  discoverChannels(...recipients: StarknetAddress[]): {
+  discoverChannels(
+    recipients: StarknetAddress[],
+    params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
-  };
+  }>;
 
   /**
    * Execute raw actions. The implementation:
@@ -555,25 +560,24 @@ export interface DiscoveryProviderInterface {
    * Discover unspent notes per token
    */
   discoverNotes(
-    address: bigint,
+    address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    params?: { since?: BlockIdentifier; known?: AddressMap<Note[]>; tokens?: bigint[] }
-  ): {
+    params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }
+  ): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
-  };
+    cursor: NotesCursor;
+  }>;
 
   /**
    * Discover channels for one or more recipients
    */
   discoverChannels(
-    address: bigint,
+    address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    ...recipients: bigint[]
-  ): {
-    timestamp: BlockIdentifier;
-    channels: AddressMap<Channel>;
-  };
+    recipients: StarknetAddressBigint[],
+    params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }>;
 
   /**
    * Check the setup requirements for a recipient.
@@ -581,10 +585,10 @@ export interface DiscoveryProviderInterface {
    * @param recipient - The recipient to check the setup requirements for. if self, check for 'address'
    */
   discoverRequirement(
-    address: bigint,
+    address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipient: bigint,
-    token: bigint
+    recipient: StarknetAddressBigint,
+    token: StarknetAddressBigint
   ): Promise<SetupRequirement>;
 }
 

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -1,0 +1,77 @@
+import type { BlockIdentifier } from "starknet";
+import type {
+  Channel,
+  DiscoveryProviderInterface,
+  Note,
+  StarknetAddressBigint,
+  ViewingKey,
+} from "../interfaces.js";
+import { SetupRequirement } from "../interfaces.js";
+import { AddressMap } from "../utils/maps.js";
+import { NotesCursor, IncomingChannelCursor } from "./channel.js";
+
+export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInterface {
+  // Abstract methods that subclasses must implement
+  abstract discoverNotes(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    params?: {
+      since?: BlockIdentifier;
+      known?: AddressMap<Note[]>;
+      tokens?: StarknetAddressBigint[];
+    }
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    notes: AddressMap<Note[]>;
+    cursor: NotesCursor;
+  }>;
+
+  abstract discoverChannels(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    recipients: StarknetAddressBigint[],
+    params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }>;
+
+  // Default implementation provided by the abstract class
+  async discoverRequirement(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    recipient: StarknetAddressBigint,
+    token: StarknetAddressBigint
+  ): Promise<SetupRequirement> {
+    const { channels } = await this.discoverChannels(address, viewingKey, [recipient]);
+    const channel = channels.get(recipient);
+    return channel?.toSetupRequirement(token) ?? SetupRequirement.Register;
+  }
+
+  protected cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
+    if (!cursor) {
+      return {
+        blockId: 0,
+        incomingChannelsCount: 0,
+        incomingChannels: new AddressMap<IncomingChannelCursor>(),
+      };
+    }
+
+    const cloneIncomingChannelCursor = (sc: IncomingChannelCursor): IncomingChannelCursor => ({
+      channelKey: sc.channelKey,
+      subchannelKeyIndex: sc.subchannelKeyIndex,
+      noteIndexes: new AddressMap<number>(sc.noteIndexes.entries()),
+    });
+
+    const incomingChannels = new AddressMap<IncomingChannelCursor>(
+      [...cursor.incomingChannels.entries()].map(
+        ([k, v]): [StarknetAddressBigint, IncomingChannelCursor] => [
+          k,
+          cloneIncomingChannelCursor(v),
+        ]
+      )
+    );
+    return {
+      blockId: cursor.blockId,
+      incomingChannelsCount: cursor.incomingChannelsCount,
+      incomingChannels: incomingChannels,
+    };
+  }
+}

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -26,17 +26,14 @@ import type {
   ViewingKey,
 } from "../interfaces.js";
 import { Channel, createEmptyRegistry } from "../interfaces.js";
-import { AddressMap, AdvancedMap } from "../utils/maps.js";
+import { AddressMap, AdvancedMap, toBigInt } from "../utils/index.js";
 import type { ClientAction } from "./client-actions.js";
 import { PrivacyPool } from "../testing/pool.js";
 import { MockContracts } from "../testing/contracts.js";
 import { assert, isOpen } from "../utils/validation.js";
-import { num, BigNumberish } from "starknet";
+import type { BigNumberish } from "starknet";
 import { generateRandom } from "../utils/crypto.js";
 import { consoleLogCallback, withLogging, debugLog, hex } from "../utils/logging.js";
-
-/** Normalize BigNumberish to bigint */
-const toBigInt = (value: BigNumberish): bigint => num.toBigInt(value);
 
 export type CompileResult = {
   clientActions: ClientAction[];
@@ -75,24 +72,31 @@ export class ActionCompiler {
   /**
    * Compile actions by resolving contexts, updating the registry, and producing ClientAction[].
    */
-  compile(actions: Actions, options?: ExecuteOptions): CompileResult {
+  async compile(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
     const registry_ = options?.registry ?? createEmptyRegistry();
     const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
     // Phase 1: Resolve recipient channels
-    const channels = this.resolveRecipientChannels(actions, options, registry, recipientsNeeded);
+    const channels = await this.resolveRecipientChannels(
+      actions,
+      options,
+      registry,
+      recipientsNeeded
+    );
 
     // Phase 2: Resolve notes (discover and/or auto-select)
-    this.resolveNotes(actions, registry, options);
+    await this.resolveNotes(actions, registry, options);
 
-    // debugLog("compiler", "registry notes after resolve", registry?.notes?.size);
+    debugLog("compiler", "compile", "post resolveNotes", registry?.notes?.size, actions);
 
     // create a pool to simulate the execution of the actions
     const pool = this.createPool(actions, registry, channels);
 
     // Phase 3: Transform Actions to ClientAction[]
     const clientActions = this.transformToClientActions(actions, pool, recipientsNeeded, options);
+
+    debugLog("compiler", "compile", "post transformToClientActions", clientActions);
 
     return { clientActions, registry: pool.updateRegistry(this.userAddress, registry) };
   }
@@ -436,12 +440,12 @@ export class ActionCompiler {
   /**
    * Resolve recipient channels by discovering or using registry.
    */
-  private resolveRecipientChannels(
+  private async resolveRecipientChannels(
     actions: Actions,
     options: ExecuteOptions | undefined,
     registry: PrivateRegistry,
     recipientsNeeded: AddressMap<boolean>
-  ): AddressMap<Channel> | undefined {
+  ): Promise<AddressMap<Channel> | undefined> {
     const recipientDiscoveryLevel = options?.autoDiscover?.channels;
 
     if (!recipientDiscoveryLevel) {
@@ -469,10 +473,10 @@ export class ActionCompiler {
 
     // Discover channels for all recipients that need discovery in a single call
     // discoverChannels computes channel keys and returns current nonce state
-    const { channels } = this.discoveryProvider.discoverChannels(
+    const { channels } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      ...recipientsToDiscover
+      recipientsToDiscover
     );
 
     return channels;
@@ -481,11 +485,11 @@ export class ActionCompiler {
   /**
    * Resolve notes by discovering and/or auto-selecting from registry.
    */
-  private resolveNotes(
+  private async resolveNotes(
     actions: Actions,
     registry: PrivateRegistry,
     options?: ExecuteOptions
-  ): void {
+  ): Promise<void> {
     if (!actions.surpluses && !options?.autoSelectNotes) return;
 
     // Calculate token balances (inputs - outputs)
@@ -570,16 +574,17 @@ export class ActionCompiler {
       debugLog("compiler", "discovering notes", tokensToDiscover);
 
       if (!tokensToDiscover || tokensToDiscover.length > 0) {
-        const { notes } = this.discoveryProvider.discoverNotes(
+        const { notes, cursor } = await this.discoveryProvider.discoverNotes(
           this.userAddress,
           this.userViewingKey,
-          { known: registry.notes, tokens: tokensToDiscover }
+          { cursor: registry.cursor, tokens: tokensToDiscover }
         );
 
         // Replace registry notes (don't merge - some may have been spent)
         for (const [token, discoveredNotes] of notes.entries()) {
           registry.notes.set(token, discoveredNotes);
         }
+        registry.cursor = cursor;
       }
     }
 

--- a/sdk/src/internal/index.ts
+++ b/sdk/src/internal/index.ts
@@ -6,3 +6,4 @@ export * from "./channel.js";
 // Re-export builders, compiler, and registry updater
 export { TokenOperationsBuilderImpl, PrivateTransfersBuilderImpl } from "./builders.js";
 export { ActionCompiler } from "./compiler.js";
+export { AbstractDiscoveryProvider } from "./abstract-discovery.js";

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -68,17 +68,20 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfers {
       .execute();
   }
 
-  discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): {
+  async discoverNotes(_params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
-  } {
-    return this.inner.discoverNotes(params);
+  }> {
+    // Note: SimplePrivateTransfers uses since/known params but PrivateTransfers uses cursor/tokens
+    // For now, we don't convert - just use the cursor stored in registry
+    return this.inner.discoverNotes({ cursor: this.registry.cursor });
   }
-  discoverChannels(...recipients: StarknetAddress[]): {
+
+  async discoverChannels(...recipients: StarknetAddress[]): Promise<{
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
-  } {
-    return this.inner.discoverChannels(...recipients);
+  }> {
+    return this.inner.discoverChannels(recipients);
   }
 
   private build(token: StarknetAddress) {

--- a/sdk/src/testing/discovery.ts
+++ b/sdk/src/testing/discovery.ts
@@ -2,14 +2,8 @@
  * Mock DiscoveryProvider implementation for testing.
  */
 
-import type {
-  Amount,
-  DiscoveryProviderInterface,
-  Note,
-  NoteId,
-  ViewingKey,
-} from "../interfaces.js";
-import { Channel, SetupRequirement, Witness } from "../interfaces.js";
+import type { Amount, Note, NoteId, StarknetAddressBigint, ViewingKey } from "../interfaces.js";
+import { Channel, Witness } from "../interfaces.js";
 import { TokenChannel } from "../internal/channel.js";
 import type { BlockIdentifier } from "starknet";
 import { decryptChannelInfo } from "../utils/crypto.js";
@@ -18,16 +12,20 @@ import { assertViewingKey } from "../utils/validation.js";
 import type { PrivacyPool } from "./pool.js";
 import { hashes } from "../utils/hashes.js";
 import { debugLog } from "../utils/logging.js";
+import { AbstractDiscoveryProvider } from "../internal/abstract-discovery.js";
+import { NotesCursor, IncomingChannelCursor } from "../internal/channel.js";
 
-export class MockDiscoveryProvider implements DiscoveryProviderInterface {
+export class MockDiscoveryProvider extends AbstractDiscoveryProvider {
   private _currentBlock: BlockIdentifier = 0; // TODO: allow block advancement
-  constructor(private pool: PrivacyPool) {}
+  constructor(private pool: PrivacyPool) {
+    super();
+  }
 
-  discoverNotes(
+  async discoverNotes(
     address: bigint,
     viewingKey: ViewingKey,
-    params: { since?: BlockIdentifier; known?: AddressMap<Note[]>; tokens?: bigint[] } = {}
-  ): { timestamp: BlockIdentifier; notes: AddressMap<Note[]> } {
+    params: { since?: BlockIdentifier; cursor?: NotesCursor; tokens?: bigint[] } = {}
+  ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
     // TODO(ittay): Add usage of 'since' and 'known'
     assertViewingKey(viewingKey);
 
@@ -88,14 +86,20 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
     return {
       timestamp: this._currentBlock,
       notes: result,
+      cursor: {
+        blockId: this._currentBlock,
+        incomingChannelsCount: 0,
+        incomingChannels: new AddressMap<IncomingChannelCursor>(),
+      },
     };
   }
 
-  discoverChannels(
+  async discoverChannels(
     address: bigint,
     viewingKey: ViewingKey,
-    ...recipients: bigint[]
-  ): { timestamp: BlockIdentifier; channels: AddressMap<Channel> } {
+    recipients: StarknetAddressBigint[],
+    _params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }> {
     assertViewingKey(viewingKey);
 
     const result = new AddressMap<Channel>();
@@ -132,31 +136,5 @@ export class MockDiscoveryProvider implements DiscoveryProviderInterface {
     }
 
     return { timestamp: this._currentBlock, channels: result };
-  }
-
-  async discoverRequirement(
-    address: bigint,
-    viewingKey: ViewingKey,
-    recipient: bigint,
-    token: bigint
-  ): Promise<SetupRequirement> {
-    assertViewingKey(viewingKey);
-    if (!this.pool.isRegistered(recipient)) {
-      return SetupRequirement.Register;
-    }
-    const key = hashes.channelKey(
-      address,
-      viewingKey,
-      recipient,
-      this.pool.getPublicKey(recipient)
-    );
-
-    if (!this.pool.doesChannelExist(key, address, recipient)) {
-      return SetupRequirement.SetupChannel;
-    }
-    if (!this.pool.doesSubchannelExist(key, recipient, token)) {
-      return SetupRequirement.SetupToken;
-    }
-    return SetupRequirement.Ready;
   }
 }

--- a/sdk/src/testing/transfers.ts
+++ b/sdk/src/testing/transfers.ts
@@ -12,6 +12,7 @@ import type {
   StarknetAddress,
 } from "../interfaces.js";
 import { Channel, SetupRequirement } from "../interfaces.js";
+import type { NotesCursor } from "../internal/channel.js";
 import type { BlockIdentifier } from "starknet";
 import { num } from "starknet";
 import type { PrivateKey } from "../utils/crypto.js";
@@ -63,7 +64,7 @@ export class MockPrivateTransfers implements PrivateTransfers {
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
     debugLog("private-transfers", "execute", actions);
     // 1. Compile actions - resolves contexts and produces clientActions
-    const { clientActions, registry } = this.compiler.compile(actions, options);
+    const { clientActions, registry } = await this.compiler.compile(actions, options);
 
     debugLog("private-transfers", "clientActions", clientActions);
 
@@ -85,21 +86,30 @@ export class MockPrivateTransfers implements PrivateTransfers {
     return new PrivateTransfersBuilderImpl(this, this.user, options);
   }
 
-  discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> } = {}): {
+  async discoverNotes(params?: { cursor?: NotesCursor; tokens?: bigint[] }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
-  } {
-    return this.discoveryProvider.discoverNotes(this.user, this.userViewingKey, params);
+  }> {
+    const result = await this.discoveryProvider.discoverNotes(
+      this.user,
+      this.userViewingKey,
+      params
+    );
+    return { timestamp: result.timestamp, notes: result.notes };
   }
 
-  discoverChannels(...recipients: StarknetAddress[]): {
+  async discoverChannels(
+    recipients: StarknetAddress[],
+    params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{
     timestamp: BlockIdentifier;
     channels: AddressMap<Channel>;
-  } {
+  }> {
     return this.discoveryProvider.discoverChannels(
       this.user,
       this.userViewingKey,
-      ...recipients.map(toBigInt)
+      recipients.map(toBigInt),
+      params
     );
   }
 }

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -80,14 +80,14 @@ export async function setupSelfChannel(
   applyStateChanges(await user.build().register().execute());
   applyStateChanges(await user.build().setup(userAddress).execute());
 
-  let channel = user.discoverChannels(userAddress).channels.get(userAddress)!;
+  let channel = (await user.discoverChannels([userAddress])).channels.get(userAddress)!;
   const registry = createEmptyRegistry();
   registry.channels.set(userAddress, channel);
 
   applyStateChanges(await user.build({ registry }).with(token).setup(userAddress).execute());
 
   // Refresh channel to include token info
-  channel = user.discoverChannels(userAddress).channels.get(userAddress)!;
+  channel = (await user.discoverChannels([userAddress])).channels.get(userAddress)!;
   registry.channels.set(userAddress, channel);
 
   return registry;
@@ -107,14 +107,14 @@ export async function setupRecipientChannel(
   // Sender sets up channel to recipient
   applyStateChanges(await sender.build().setup(recipientAddress).execute());
 
-  let channel = sender.discoverChannels(recipientAddress).channels.get(recipientAddress)!;
+  let channel = (await sender.discoverChannels([recipientAddress])).channels.get(recipientAddress)!;
   const registry = createEmptyRegistry();
   registry.channels.set(recipientAddress, channel);
 
   applyStateChanges(await sender.build({ registry }).with(token).setup(recipientAddress).execute());
 
   // Refresh channel to include token info
-  channel = sender.discoverChannels(recipientAddress).channels.get(recipientAddress)!;
+  channel = (await sender.discoverChannels([recipientAddress])).channels.get(recipientAddress)!;
   registry.channels.set(recipientAddress, channel);
 
   return registry;

--- a/sdk/tests/internal/edge-cases.test.ts
+++ b/sdk/tests/internal/edge-cases.test.ts
@@ -49,7 +49,7 @@ describe("Edge Cases", () => {
           .execute()
       );
 
-      const notes = bob.discoverNotes().notes.get(ACE) ?? [];
+      const notes = (await bob.discoverNotes()).notes.get(ACE) ?? [];
       expect(notes.length).toBe(1);
 
       await expect(
@@ -78,7 +78,7 @@ describe("Edge Cases", () => {
           .execute()
       );
 
-      const notes = alice.discoverNotes().notes.get(ACE) ?? [];
+      const notes = (await alice.discoverNotes()).notes.get(ACE) ?? [];
 
       await expect(
         alice
@@ -92,10 +92,10 @@ describe("Edge Cases", () => {
   });
 
   describe("SetupRequirement Enum Ordering", () => {
-    it("Register > SetupChannel > SetupToken > Ready (higher = more setup needed)", () => {
-      expect(SetupRequirement.Register).toBeGreaterThan(SetupRequirement.SetupChannel);
-      expect(SetupRequirement.SetupChannel).toBeGreaterThan(SetupRequirement.SetupToken);
-      expect(SetupRequirement.SetupToken).toBeGreaterThan(SetupRequirement.Ready);
+    it("Ready > SetupToken > SetupChannel > Register (higher = more ready)", () => {
+      expect(SetupRequirement.Ready).toBeGreaterThan(SetupRequirement.SetupToken);
+      expect(SetupRequirement.SetupToken).toBeGreaterThan(SetupRequirement.SetupChannel);
+      expect(SetupRequirement.SetupChannel).toBeGreaterThan(SetupRequirement.Register);
     });
   });
 

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -80,7 +80,7 @@ describe("Private Transfers Integration", () => {
       expect(aliceNotes.length).toBe(1);
       expect(aliceNotes[0].amount).toBe(25n);
 
-      const bobNotes = bob.discoverNotes().notes.get(ACE) ?? [];
+      const bobNotes = (await bob.discoverNotes()).notes.get(ACE) ?? [];
       expect(bobNotes.length).toBe(1);
       expect(bobNotes[0].amount).toBe(50n);
 
@@ -129,7 +129,7 @@ describe("Private Transfers Integration", () => {
       expect(registry.notes.get(ACE)?.length).toBe(0);
       expect(registry.notes.get(BEE)?.length).toBe(1);
 
-      const bobNotes = bob.discoverNotes().notes;
+      const bobNotes = (await bob.discoverNotes()).notes;
       expect(bobNotes.get(ACE)?.length).toBe(1);
       expect(bobNotes.get(ACE)?.[0].amount).toBe(50n);
       expect(bobNotes.get(BEE)?.length).toBe(1);
@@ -164,7 +164,7 @@ describe("Private Transfers Integration", () => {
       // Phase 2: Use registry with channels but WITHOUT notes
       // This tests autoDiscover: "missing" (discovers notes not in registry)
       const channelOnly = createEmptyRegistry();
-      const channel = alice.discoverChannels(ALICE.address).channels.get(ALICE.address)!;
+      const channel = (await alice.discoverChannels([ALICE.address])).channels.get(ALICE.address)!;
       channelOnly.channels.set(ALICE.address, channel);
 
       // Deposit 30n with:
@@ -223,7 +223,7 @@ describe("Private Transfers Integration", () => {
       expect(result.notes.get(ACE)?.[0].amount).toBe(70n);
 
       // Bob got his 30n
-      const bobNotes = bob.discoverNotes().notes.get(ACE) ?? [];
+      const bobNotes = (await bob.discoverNotes()).notes.get(ACE) ?? [];
       expect(bobNotes.length).toBe(1);
       expect(bobNotes[0].amount).toBe(30n);
 
@@ -270,12 +270,12 @@ describe("Private Transfers Integration", () => {
     );
 
     // 4. Verify: Alice has 90n ACE change note
-    const aceNotes = alice.discoverNotes().notes.get(ACE) ?? [];
+    const aceNotes = (await alice.discoverNotes()).notes.get(ACE) ?? [];
     expect(aceNotes.length).toBe(1);
     expect(aceNotes[0].amount).toBe(90n);
 
     // Alice has 20n BEE note (swap helper gives 2x)
-    const beeNotes = alice.discoverNotes().notes.get(BEE) ?? [];
+    const beeNotes = (await alice.discoverNotes()).notes.get(BEE) ?? [];
     expect(beeNotes.length).toBe(1);
     expect(beeNotes[0].amount).toBe(20n);
     expect(beeNotes[0].open).toBe(true);


### PR DESCRIPTION
- Add AbstractDiscoveryProvider base class for discovery implementations
- Make DiscoveryProviderInterface methods async with Promise returns
- Make PrivateTransfersInterface and SimplePrivateTransfers discovery methods async
- Use cursor-based pagination in DiscoveryProviderInterface.discoverNotes
- Reorder SetupRequirement enum (Register=0, SetupChannel=1, SetupToken=2, Ready=3)
- Add NotesCursor export and cursor to PrivateRegistry type
- Update MockDiscoveryProvider to extend AbstractDiscoveryProvider
- Make compiler.ts compile/resolveRecipientChannels/resolveNotes async
- Update tests to handle async discovery methods

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/269)
<!-- Reviewable:end -->
