### PR TITLE
feat(sdk): abstract private transfers and interface renames

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -1,5 +1,4 @@
 import type {
-  AccountInterface,
   AllowArray,
   BigNumberish,
   BlockIdentifier,
@@ -69,8 +68,8 @@ export type NoteId = BigNumberish;
 
 export type Proof = {
   readonly data: Uint8Array;
-  readonly outputHash: BigNumberish;
-  readonly output: BigNumberish[]; // array of felts
+  readonly outputHash: string;
+  readonly output: string[]; // array of felts
 };
 
 /**
@@ -96,14 +95,6 @@ export type ProofProviderConfig = {
 
 export type DiscoveryProviderConfig = {
   url: string;
-};
-
-export type PrivateTransfersConfig = {
-  account: AccountInterface;
-  viewingSigner: ViewingKey;
-  provingProvider: ProofProviderInterface;
-  discoveryProvider: DiscoveryProviderInterface;
-  pool: StarknetAddress;
 };
 
 export interface PrivateRecipient {
@@ -261,7 +252,7 @@ export type ExecuteResult = {
 /**
  * Simple interface for simple private transfer scenarios
  */
-export interface SimplePrivateTransfers {
+export interface SimplePrivateTransfersInterface {
   readonly user: StarknetAddress;
   readonly registry: PrivateRegistry;
 
@@ -300,23 +291,10 @@ export interface SimplePrivateTransfers {
     toToken: StarknetAddress,
     helperCall: Call
   ): Promise<ExecuteResult>;
-
-  /**
-   * Discover unspent notes per token
-   */
-  discoverNotes(params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): Promise<{
-    timestamp: BlockIdentifier;
-    notes: AddressMap<Note[]>;
-  }>;
-
-  /**
-   * Discover channels for one or more recipients
-   */
-  discoverChannels(...recipients: StarknetAddress[]): Promise<{
-    timestamp: BlockIdentifier;
-    channels: AddressMap<Channel>;
-  }>;
 }
+
+/** @deprecated Use SimplePrivateTransfersInterface instead */
+export type SimplePrivateTransfers = SimplePrivateTransfersInterface;
 
 /**
  * Main interface for clients to use. It is stateless.
@@ -334,8 +312,8 @@ export interface SimplePrivateTransfers {
  *   fn withdraw(addrowner, addrrecipient, kowner, note: (j: channel index, i: note index))
  *   fn transfer(addrowner, kowner, notes_to_use: Span<(j, i)>, notes_to_create: Span<(addrrecipient, token, i, amount)>)
  */
-export interface PrivateTransfers {
-  /** 
+export interface PrivateTransfersInterface {
+  /**
    * expected properties to be set by the implementing object
   readonly prover: ProveInterface;
   readonly viewingSigner: ViewingKey;
@@ -345,11 +323,9 @@ export interface PrivateTransfers {
   readonly user: StarknetAddress;
 
   /**
-   * given a recipient and token, check if the recipient has a Channel associated with it and if the token is in the channel.
-   * @returns {initial: boolean, token: boolean}
-   * initial: true if the recipient doesn't have a Channel associated with it
-   * token: true if the token is in the channel
-   * @throws if the account or recipient is not registered
+   * given a recipient and token, check if there needs to be a setup for the recipient and token.
+   * @returns SetupRequirement
+   * @throws if the user is not registered
    */
   discoverRequirement(
     recipient: StarknetAddress,
@@ -388,6 +364,9 @@ export interface PrivateTransfers {
   /** Create a builder for batching multiple operations */
   build(options?: ExecuteOptions): PrivateTransfersBuilder;
 }
+
+/** @deprecated Use PrivateTransfersInterface instead */
+export type PrivateTransfers = PrivateTransfersInterface;
 
 // ============ Builder Types ============
 

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -1,0 +1,106 @@
+/**
+ * Abstract base class for PrivateTransfers implementations
+ *
+ * Provides default implementations for discovery methods and builder creation,
+ * leaving only the execute method as abstract for subclasses to implement.
+ */
+
+import type { BlockIdentifier } from "starknet";
+import type {
+  Actions,
+  Channel,
+  DiscoveryProviderInterface,
+  ExecuteOptions,
+  ExecuteResult,
+  Note,
+  PrivateTransfersBuilder,
+  PrivateTransfersInterface,
+  StarknetAddress,
+  StarknetAddressBigint,
+  ViewingKey,
+  ViewingKeyProvider,
+} from "../interfaces.js";
+import { SetupRequirement } from "../interfaces.js";
+import { AddressMap } from "../utils/maps.js";
+import { toBigInt } from "../utils/crypto.js";
+import { PrivateTransfersBuilderImpl } from "./builders.js";
+import { NotesCursor } from "./channel.js";
+
+/**
+ * Abstract base class that implements the common functionality for PrivateTransfers.
+ * Subclasses only need to implement the execute method.
+ */
+export abstract class AbstractPrivateTransfers implements PrivateTransfersInterface {
+  readonly user: StarknetAddressBigint;
+
+  constructor(
+    userAddress: StarknetAddress,
+    protected readonly viewingKeyProvider: ViewingKeyProvider,
+    protected readonly discoveryProvider: DiscoveryProviderInterface
+  ) {
+    this.user = toBigInt(userAddress);
+  }
+
+  /**
+   * Get the current viewing key from the provider
+   */
+  protected async getViewingKey(): Promise<ViewingKey> {
+    return await this.viewingKeyProvider.getViewingKey();
+  }
+
+  /**
+   * Discover unspent notes per token
+   */
+  async discoverNotes(params: { since?: BlockIdentifier; cursor?: NotesCursor } = {}): Promise<{
+    timestamp: BlockIdentifier;
+    notes: AddressMap<Note[]>;
+  }> {
+    return this.discoveryProvider.discoverNotes(this.user, await this.getViewingKey(), params);
+  }
+
+  /**
+   * Discover channels for one or more recipients
+   */
+
+  async discoverChannels(
+    recipients: StarknetAddress[],
+    params?: { cursor?: AddressMap<Channel> }
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels: AddressMap<Channel>;
+  }> {
+    return this.discoveryProvider.discoverChannels(
+      this.user,
+      await this.getViewingKey(),
+      recipients.map(toBigInt),
+      params
+    );
+  }
+
+  /**
+   * Check the setup requirements for a recipient and token
+   */
+  async discoverRequirement(
+    recipient: StarknetAddress,
+    token: StarknetAddress
+  ): Promise<SetupRequirement> {
+    return this.discoveryProvider.discoverRequirement(
+      this.user,
+      await this.getViewingKey(),
+      toBigInt(recipient),
+      toBigInt(token)
+    );
+  }
+
+  /**
+   * Create a builder for batching multiple operations
+   */
+  build(options?: ExecuteOptions): PrivateTransfersBuilder {
+    return new PrivateTransfersBuilderImpl(this, this.user, options);
+  }
+
+  /**
+   * Execute raw actions - must be implemented by subclasses
+   */
+  abstract execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult>;
+}

--- a/sdk/src/internal/index.ts
+++ b/sdk/src/internal/index.ts
@@ -7,3 +7,4 @@ export * from "./channel.js";
 export { TokenOperationsBuilderImpl, PrivateTransfersBuilderImpl } from "./builders.js";
 export { ActionCompiler } from "./compiler.js";
 export { AbstractDiscoveryProvider } from "./abstract-discovery.js";
+export { AbstractPrivateTransfers } from "./abstract-private-transfers.js";

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -1,7 +1,7 @@
-import { BlockIdentifier, Call } from "starknet";
+import { Call } from "starknet";
 import {
-  SimplePrivateTransfers,
-  PrivateTransfers,
+  SimplePrivateTransfersInterface,
+  PrivateTransfersInterface,
   Amount,
   Channel,
   Note,
@@ -10,12 +10,12 @@ import {
   StarknetAddress,
   All,
   ExecuteResult,
-} from "./interfaces.js"; // Assuming you moved interfaces
+} from "./interfaces.js";
 import { AddressMap } from "./utils/maps.js";
 import { isAll } from "./utils/validation.js";
 
-export class SimplePrivateTransfersImpl implements SimplePrivateTransfers {
-  constructor(private inner: PrivateTransfers) {}
+export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterface {
+  constructor(private inner: PrivateTransfersInterface) {}
 
   get user(): StarknetAddress {
     return this.inner.user;
@@ -66,22 +66,6 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfers {
       .with(toToken)
       .transfer({ recipient: this.inner.user, amount: Open })
       .execute();
-  }
-
-  async discoverNotes(_params: { since?: BlockIdentifier; known?: AddressMap<Note[]> }): Promise<{
-    timestamp: BlockIdentifier;
-    notes: AddressMap<Note[]>;
-  }> {
-    // Note: SimplePrivateTransfers uses since/known params but PrivateTransfers uses cursor/tokens
-    // For now, we don't convert - just use the cursor stored in registry
-    return this.inner.discoverNotes({ cursor: this.registry.cursor });
-  }
-
-  async discoverChannels(...recipients: StarknetAddress[]): Promise<{
-    timestamp: BlockIdentifier;
-    channels: AddressMap<Channel>;
-  }> {
-    return this.inner.discoverChannels(recipients);
   }
 
   private build(token: StarknetAddress) {

--- a/sdk/src/testing/helpers.ts
+++ b/sdk/src/testing/helpers.ts
@@ -11,8 +11,8 @@ import { debugLog } from "../utils/logging.js";
 export function createMockProof(overrides?: Partial<Proof>): Proof {
   return {
     data: new Uint8Array([0, 1, 2, 3]),
-    outputHash: 0n,
-    output: [0n],
+    outputHash: "0x0",
+    output: ["0x0"],
     ...overrides,
   };
 }

--- a/sdk/src/testing/transfers.ts
+++ b/sdk/src/testing/transfers.ts
@@ -2,37 +2,19 @@
  * Mock PrivateTransfers implementation for testing.
  */
 
-import type {
-  Actions,
-  ExecuteOptions,
-  ExecuteResult,
-  Note,
-  PrivateTransfers,
-  PrivateTransfersBuilder,
-  StarknetAddress,
-} from "../interfaces.js";
-import { Channel, SetupRequirement } from "../interfaces.js";
-import type { NotesCursor } from "../internal/channel.js";
-import type { BlockIdentifier } from "starknet";
-import { num } from "starknet";
+import type { Actions, ExecuteOptions, ExecuteResult, StarknetAddress } from "../interfaces.js";
 import type { PrivateKey } from "../utils/crypto.js";
-import { AddressMap } from "../utils/maps.js";
+import { toBigInt } from "../utils/index.js";
 import { createMockCallAndProof } from "./helpers.js";
 import type { PrivacyPool } from "./pool.js";
 import { MockDiscoveryProvider } from "./discovery.js";
-import { PrivateTransfersBuilderImpl } from "../internal/builders.js";
 import { ActionCompiler } from "../internal/compiler.js";
 import { MockContracts } from "./contracts.js";
-import { debugLog } from "../utils/logging.js";
+import { consoleLogCallback, debugLog, withLogging } from "../utils/logging.js";
+import { AbstractPrivateTransfers } from "../internal/abstract-private-transfers.js";
 
-/** Normalize BigNumberish to bigint */
-const toBigInt = (value: StarknetAddress): bigint => num.toBigInt(value);
-
-export class MockPrivateTransfers implements PrivateTransfers {
+export class MockPrivateTransfers extends AbstractPrivateTransfers {
   // User credentials (set via configure)
-  readonly user: bigint;
-  private userViewingKey: PrivateKey = 0n;
-  private discoveryProvider: MockDiscoveryProvider;
   private compiler: ActionCompiler;
   private pool: PrivacyPool;
 
@@ -42,22 +24,16 @@ export class MockPrivateTransfers implements PrivateTransfers {
     userAddress: StarknetAddress,
     userPrivateKey: PrivateKey
   ) {
-    this.pool = this.contracts.get<PrivacyPool>(toBigInt(poolAddress));
-    this.discoveryProvider = new MockDiscoveryProvider(this.pool);
-    this.user = toBigInt(userAddress);
-    this.userViewingKey = userPrivateKey;
-    this.compiler = new ActionCompiler(this.user, userPrivateKey, this.discoveryProvider);
-  }
-
-  async discoverRequirement(
-    recipient: StarknetAddress,
-    token: StarknetAddress
-  ): Promise<SetupRequirement> {
-    return this.discoveryProvider.discoverRequirement(
-      this.user,
-      this.userViewingKey,
-      toBigInt(recipient),
-      toBigInt(token)
+    super(
+      userAddress,
+      { getViewingKey: () => userPrivateKey },
+      new MockDiscoveryProvider(contracts.get<PrivacyPool>(toBigInt(poolAddress)))
+    );
+    this.pool = contracts.get<PrivacyPool>(toBigInt(poolAddress));
+    this.compiler = withLogging(
+      new ActionCompiler(this.user, userPrivateKey, this.discoveryProvider),
+      "Compiler",
+      consoleLogCallback
     );
   }
 
@@ -80,36 +56,5 @@ export class MockPrivateTransfers implements PrivateTransfers {
       callAndProof: createMockCallAndProof(callbacks),
       registry,
     };
-  }
-
-  build(options?: ExecuteOptions): PrivateTransfersBuilder {
-    return new PrivateTransfersBuilderImpl(this, this.user, options);
-  }
-
-  async discoverNotes(params?: { cursor?: NotesCursor; tokens?: bigint[] }): Promise<{
-    timestamp: BlockIdentifier;
-    notes: AddressMap<Note[]>;
-  }> {
-    const result = await this.discoveryProvider.discoverNotes(
-      this.user,
-      this.userViewingKey,
-      params
-    );
-    return { timestamp: result.timestamp, notes: result.notes };
-  }
-
-  async discoverChannels(
-    recipients: StarknetAddress[],
-    params?: { cursor?: AddressMap<Channel> }
-  ): Promise<{
-    timestamp: BlockIdentifier;
-    channels: AddressMap<Channel>;
-  }> {
-    return this.discoveryProvider.discoverChannels(
-      this.user,
-      this.userViewingKey,
-      recipients.map(toBigInt),
-      params
-    );
   }
 }


### PR DESCRIPTION
- Add AbstractPrivateTransfers base class for PrivateTransfers implementations
- Rename PrivateTransfers -> PrivateTransfersInterface (with deprecated alias)
- Rename SimplePrivateTransfers -> SimplePrivateTransfersInterface (with deprecated alias)
- Remove discovery methods from SimplePrivateTransfersInterface
- Remove unused PrivateTransfersConfig type
- Change Proof.outputHash/output from BigNumberish to string
- Update MockPrivateTransfers to extend AbstractPrivateTransfers
- Export AbstractPrivateTransfers from internal/index.ts

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/270)
<!-- Reviewable:end -->
