### PR TITLE
feat(sdk): add outgoing channel support for recipient discovery

### DIFF
--- a/packages/privacy/src/tests/generate_reference_hashes.cairo
+++ b/packages/privacy/src/tests/generate_reference_hashes.cairo
@@ -12,7 +12,7 @@ use privacy::hashes::{
 };
 use privacy::utils::{
     decrypt_note_amount, derive_public_key, encrypt_channel_info, encrypt_note_amount,
-    encrypt_subchannel_info,
+    encrypt_outgoing_channel_info, encrypt_private_key, encrypt_subchannel_info, encrypt_user_addr,
 };
 use starknet::ContractAddress;
 
@@ -29,6 +29,9 @@ const SHARED_X: felt252 = 0x9abc;
 // Additional inputs for encryption tests
 const EPHEMERAL_SECRET: felt252 = 0xabcd;
 const AMOUNT: u128 = 1000;
+const COMPLIANCE_PRIVATE_KEY: felt252 = 0x54321;
+const USER_ADDR: felt252 = 0x999;
+const USER_PRIVATE_KEY: felt252 = 0x888;
 
 fn to_address(addr: felt252) -> ContractAddress {
     addr.try_into().unwrap()
@@ -81,6 +84,23 @@ fn generate_reference_hashes() {
     let enc_note_amount = encrypt_note_amount(CHANNEL_KEY, token, INDEX, SALT, AMOUNT);
     let dec_note_amount = decrypt_note_amount(enc_note_amount, CHANNEL_KEY, token, INDEX);
 
+    // Derive compliance public key for ECDH tests
+    let compliance_public_key = derive_public_key(COMPLIANCE_PRIVATE_KEY);
+    let user_addr = to_address(USER_ADDR);
+
+    // Encrypt outgoing channel info
+    let enc_outgoing = encrypt_outgoing_channel_info(
+        sender, SENDER_PRIVATE_KEY, INDEX, recipient, SALT.into(),
+    );
+
+    // Encrypt private key (for compliance)
+    let enc_private_key = encrypt_private_key(
+        EPHEMERAL_SECRET, compliance_public_key, USER_PRIVATE_KEY,
+    );
+
+    // Encrypt user address (for compliance)
+    let enc_user_addr = encrypt_user_addr(EPHEMERAL_SECRET, compliance_public_key, user_addr);
+
     // Print in format parseable by sdk/scripts/generate-cairo-refs.ts
     println!("=== CAIRO REFERENCE HASHES ===");
 
@@ -98,6 +118,10 @@ fn generate_reference_hashes() {
     println!("inputs.amount: {}", AMOUNT);
     println!("inputs.recipientPrivateKey: 0x{:x}", recipient_private_key);
     println!("inputs.recipientPublicKeyDerived: 0x{:x}", recipient_public_key_derived);
+    println!("inputs.compliancePrivateKey: 0x{:x}", COMPLIANCE_PRIVATE_KEY);
+    println!("inputs.compliancePublicKey: 0x{:x}", compliance_public_key);
+    println!("inputs.userAddr: 0x{:x}", USER_ADDR);
+    println!("inputs.userPrivateKey: 0x{:x}", USER_PRIVATE_KEY);
 
     // Outputs (computed hashes)
     println!("outputs.channelKey: 0x{:x}", channel_key);
@@ -122,6 +146,18 @@ fn generate_reference_hashes() {
     println!("outputs.encChannelSenderAddr: 0x{:x}", enc_channel.enc_sender_addr);
     println!("outputs.encNoteAmount: 0x{:x}", enc_note_amount);
     println!("outputs.decNoteAmount: {}", dec_note_amount);
+
+    // Outgoing channel info outputs
+    println!("outputs.encOutgoingSalt: 0x{:x}", enc_outgoing.salt);
+    println!("outputs.encOutgoingRecipientAddr: 0x{:x}", enc_outgoing.enc_recipient_addr);
+
+    // Encrypt private key outputs
+    println!("outputs.encPrivateKeyEphemeralPubkey: 0x{:x}", enc_private_key.ephemeral_pubkey);
+    println!("outputs.encPrivateKeyValue: 0x{:x}", enc_private_key.enc_private_key);
+
+    // Encrypt user address outputs
+    println!("outputs.encUserAddrEphemeralPubkey: 0x{:x}", enc_user_addr.ephemeral_pubkey);
+    println!("outputs.encUserAddrValue: 0x{:x}", enc_user_addr.enc_user_addr);
     println!("==============================");
 }
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -549,12 +549,13 @@ export interface DiscoveryProviderInterface {
   }>;
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * Pass "all" to discover all outgoing channels by iterating through the outgoing channel map.
    */
   discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: StarknetAddressBigint[],
+    recipients: StarknetAddressBigint[] | "all",
     params?: { cursor?: AddressMap<Channel> }
   ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }>;
 

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -29,7 +29,7 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
   abstract discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: StarknetAddressBigint[],
+    recipients: StarknetAddressBigint[] | "all",
     params?: { cursor?: AddressMap<Channel> }
   ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }>;
 

--- a/sdk/src/testing/contract-discovery.ts
+++ b/sdk/src/testing/contract-discovery.ts
@@ -10,6 +10,7 @@ import {
   compute_channel_id,
   compute_subchannel_key,
   compute_note_id,
+  compute_outgoing_channel_key,
 } from "../utils/hashes.js";
 import { encryptions } from "../utils/encryptions.js";
 import { NotesCursor } from "../internal/channel.js";
@@ -111,10 +112,26 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: StarknetAddressBigint[],
+    _recipients: StarknetAddressBigint[] | "all",
     params?: { cursor?: AddressMap<Channel> }
   ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }> {
+    const recipients = _recipients === "all" ? [] : [..._recipients];
     const channels = new AddressMap([...(params?.cursor?.entries() ?? [])]);
+    if (_recipients === "all") {
+      for (let s = 0; ; s++) {
+        const encOutgoingChannelInfo = await this.pool.get_outgoing_channel_info(
+          compute_outgoing_channel_key(address, toBigInt(viewingKey), s)
+        );
+        if (toBigInt(encOutgoingChannelInfo.salt) === 0n) break;
+        const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
+          encOutgoingChannelInfo,
+          address,
+          viewingKey,
+          s
+        );
+        recipients.push(recipientAddr);
+      }
+    }
 
     // discover channel
     for (const recipient of recipients) {

--- a/sdk/src/testing/discovery.ts
+++ b/sdk/src/testing/discovery.ts
@@ -10,7 +10,7 @@ import { encryptions } from "../utils/encryptions.js";
 import { AddressMap } from "../utils/maps.js";
 import { assertViewingKey } from "../utils/validation.js";
 import type { PrivacyPool } from "./pool.js";
-import { compute_channel_key } from "../utils/hashes.js";
+import { compute_channel_key, compute_outgoing_channel_key } from "../utils/hashes.js";
 import { toBigInt } from "../utils/crypto.js";
 import { debugLog } from "../utils/logging.js";
 import { AbstractDiscoveryProvider } from "../internal/abstract-discovery.js";
@@ -27,17 +27,22 @@ export class MockDiscoveryProvider extends AbstractDiscoveryProvider {
     viewingKey: ViewingKey,
     params: { since?: BlockIdentifier; cursor?: NotesCursor; tokens?: bigint[] } = {}
   ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
-    // TODO(ittay): Add usage of 'since' and 'known'
     assertViewingKey(viewingKey);
 
     const result = new AddressMap<Note[]>(() => []);
 
     const channels = this.pool.getChannels(address);
 
-    debugLog("discovery", "discovering notes address", address, "channelCount:", channels.length);
+    debugLog(
+      "mock-discovery",
+      "discovering notes address",
+      address,
+      "channelCount:",
+      channels.length
+    );
     for (const encryptedChannel of channels) {
       const channel = encryptions.decryptChannelInfo(encryptedChannel, toBigInt(viewingKey));
-      debugLog("discovery", "processing channel key:", channel.key, "sender:", channel.sender);
+      debugLog("mock-discovery", "processing channel key:", channel.key, "sender:", channel.sender);
       const key = channel.key;
 
       // Iterate token sequences
@@ -47,7 +52,7 @@ export class MockDiscoveryProvider extends AbstractDiscoveryProvider {
         if (params.tokens && !params.tokens.includes(token)) {
           continue;
         }
-        debugLog("discovery", "discovering notes token", token, tokenSequence - 1);
+        debugLog("mock-discovery", "discovering notes token", token, tokenSequence - 1);
         // Iterate note sequences for this token
         let noteSequence = 0;
         let note: { id: NoteId; amount: Amount; r: bigint; open: boolean } | false; // TODO: add explicit type name
@@ -59,14 +64,18 @@ export class MockDiscoveryProvider extends AbstractDiscoveryProvider {
             token,
             viewingKey
           );
-          debugLog("discovery", "checking nullifier", { nonce, noteId: note.id, nullifierResult });
+          debugLog("mock-discovery", "checking nullifier", {
+            nonce,
+            noteId: note.id,
+            nullifierResult,
+          });
           if (nullifierResult !== false) {
-            debugLog("discovery", "skipping nullified note", { nonce, noteId: note.id });
+            debugLog("mock-discovery", "skipping nullified note", { nonce, noteId: note.id });
             noteSequence++;
             continue;
           }
 
-          debugLog("discovery", "discovering notes note", {
+          debugLog("mock-discovery", "discovering notes note", {
             token,
             nonce,
             noteId: note.id,
@@ -98,14 +107,40 @@ export class MockDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: bigint,
     viewingKey: ViewingKey,
-    recipients: StarknetAddressBigint[],
+    recipients: StarknetAddressBigint[] | "all",
     _params?: { cursor?: AddressMap<Channel> }
   ): Promise<{ timestamp: BlockIdentifier; channels: AddressMap<Channel> }> {
     assertViewingKey(viewingKey);
 
+    // If "all", discover recipients from outgoing channels
+    let recipientList: StarknetAddressBigint[];
+    if (recipients === "all") {
+      recipientList = [];
+      for (let s = 0; ; s++) {
+        const outgoingChannelKey = compute_outgoing_channel_key(address, toBigInt(viewingKey), s);
+        const encOutgoingChannelInfo = this.pool.getOutgoingChannelInfo(outgoingChannelKey);
+        if (!encOutgoingChannelInfo) break;
+        const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
+          encOutgoingChannelInfo,
+          address,
+          viewingKey,
+          s
+        );
+        recipientList.push(recipientAddr);
+      }
+    } else {
+      recipientList = recipients;
+    }
+
     const result = new AddressMap<Channel>();
-    for (const recipient of recipients) {
+    for (const recipient of recipientList) {
       if (!this.pool.isRegistered(recipient)) {
+        debugLog(
+          "mock-discovery",
+          "discoverChannels",
+          "skipping unregistered recipient",
+          recipient
+        );
         continue;
       }
       const publicKey = this.pool.getPublicKey(recipient);

--- a/sdk/src/testing/pool.ts
+++ b/sdk/src/testing/pool.ts
@@ -15,7 +15,12 @@ import {
   generateRandom,
   toBigInt,
 } from "../utils/crypto.js";
-import { encryptions, type EncChannelInfo, type EncSubchannelInfo } from "../utils/encryptions.js";
+import {
+  encryptions,
+  type EncChannelInfo,
+  type EncSubchannelInfo,
+  type EncOutgoingChannelInfo,
+} from "../utils/encryptions.js";
 import { AdvancedMap, AddressMap } from "../utils/maps.js";
 import { assert, isOpen } from "../utils/validation.js";
 import type { MockContracts, MockContract } from "./contracts.js";
@@ -26,6 +31,7 @@ import {
   compute_subchannel_id,
   compute_note_id,
   compute_nullifier,
+  compute_outgoing_channel_key,
 } from "../utils/hashes.js";
 import { ClientAction } from "../internal/client-actions.js";
 import { debugLog, hex } from "../utils/logging.js";
@@ -53,6 +59,8 @@ export type PrivacyPoolSnapshot = {
   subchannelIds: Set<Hash>;
   notes: Map<Hash, EncryptedNote | OpenNote>;
   nullifiers: Set<Hash>;
+  outgoingChannels: Map<bigint, EncOutgoingChannelInfo>;
+  outgoingChannelCounters: Map<bigint, number>;
   tracking: Map<bigint, TrackingState>;
 };
 
@@ -81,6 +89,10 @@ export class PrivacyPool implements MockContract {
   private subchannelIds = new Set<Hash>();
   private notes = new Map<Hash, EncryptedNote | OpenNote>();
   private nullifiers = new Set<Hash>();
+  // Outgoing channels: key = h(sender_addr, sender_private_key, s) -> EncOutgoingChannelInfo
+  private outgoingChannels = new Map<bigint, EncOutgoingChannelInfo>();
+  // Track sequential counter s per sender for outgoing channels
+  private outgoingChannelCounters = new AddressMap<number>(() => 0);
 
   // state tracking, not part of the official spec
   private tracking = new AddressMap<TrackingState>(() => ({
@@ -141,6 +153,8 @@ export class PrivacyPool implements MockContract {
       subchannelIds: new Set(this.subchannelIds),
       notes: notesSnapshot,
       nullifiers: new Set(this.nullifiers),
+      outgoingChannels: new Map(this.outgoingChannels),
+      outgoingChannelCounters: new Map(this.outgoingChannelCounters.entries()),
       tracking: trackingSnapshot,
     };
   }
@@ -164,6 +178,11 @@ export class PrivacyPool implements MockContract {
     this.subchannelIds = new Set(s.subchannelIds);
     this.notes = new Map(s.notes);
     this.nullifiers = new Set(s.nullifiers);
+    this.outgoingChannels = new Map(s.outgoingChannels);
+
+    // Restore outgoing channel counters (AddressMap)
+    this.outgoingChannelCounters.clear();
+    for (const [k, v] of s.outgoingChannelCounters) this.outgoingChannelCounters.set(k, v);
 
     // Restore tracking by deep cloning the snapshot's structure
     this.tracking.clear();
@@ -257,6 +276,10 @@ export class PrivacyPool implements MockContract {
     return this.nullifiers.has(
       compute_nullifier(witness.channelKey, token, witness.nonce, toBigInt(ownerPrivateKey))
     );
+  }
+
+  getOutgoingChannelInfo(key: bigint): EncOutgoingChannelInfo | undefined {
+    return this.outgoingChannels.get(key);
   }
 
   getUsersChannel(sender: bigint, recipient: bigint): Channel | undefined {
@@ -517,11 +540,41 @@ export class PrivacyPool implements MockContract {
       channelKey,
       from
     );
+
+    // Outgoing channel info for sender discovery
+    const s = this.outgoingChannelCounters.get(from)!;
+    // Verify sequential check: s = 0 or previous outgoing channel exists
+    if (s > 0) {
+      const prevOutgoingChannelKey = compute_outgoing_channel_key(
+        from,
+        toBigInt(fromPrivateKey),
+        s - 1
+      );
+      assert(
+        this.outgoingChannels.has(prevOutgoingChannelKey),
+        () => `Outgoing channel index ${s} is not sequential for sender ${hex(from)}`
+      );
+    }
+    const outgoingChannelKey = compute_outgoing_channel_key(from, toBigInt(fromPrivateKey), s);
+    const outgoingSalt = generateRandom();
+    const encOutgoingChannelInfo = encryptions.encryptOutgoingChannelInfo(
+      from,
+      toBigInt(fromPrivateKey),
+      s,
+      to,
+      outgoingSalt
+    );
+
     return () => {
       debugLog("pool.callback", "setChannel callback executing from:", hex(from), "to:", hex(to));
       this.tracking.get(from)!.channels.get(to, () => new Channel(toPublicKey))!.key = channelKey;
       this.channels.get({ address: to, publicKey: toPublicKey })!.push(channelInfo);
       this.channelIds.add(compute_channel_id(channelKey, from, to, toBigInt(toPublicKey)));
+
+      // Store outgoing channel info
+      this.outgoingChannels.set(outgoingChannelKey, encOutgoingChannelInfo);
+      this.outgoingChannelCounters.set(from, s + 1);
+
       debugLog("pool.callback", "channels after setChannel", {
         to: hex(to),
         channelsLength: this.channels.get({ address: to, publicKey: toPublicKey })!.length,

--- a/sdk/src/utils/encryptions.ts
+++ b/sdk/src/utils/encryptions.ts
@@ -11,6 +11,9 @@ import {
   compute_enc_sender_addr_hash,
   compute_enc_token_hash,
   compute_enc_amount_hash,
+  compute_enc_recipient_addr_hash,
+  compute_enc_private_key_hash,
+  compute_enc_address_hash,
 } from "./hashes.js";
 import { toBigInt } from "./crypto.js";
 
@@ -87,6 +90,30 @@ export type EncSubchannelInfo = {
 export type SubchannelInfo = {
   token: bigint;
   salt: bigint;
+};
+
+/** Encrypted outgoing channel information (matches Cairo EncOutgoingChannelInfo struct) */
+export type EncOutgoingChannelInfo = {
+  salt: BigNumberish;
+  enc_recipient_addr: BigNumberish;
+};
+
+/** Decrypted outgoing channel information */
+export type OutgoingChannelInfo = {
+  recipientAddr: bigint;
+  salt: bigint;
+};
+
+/** Encrypted private key (matches Cairo EncPrivateKey struct) */
+export type EncPrivateKey = {
+  ephemeralPubkey: bigint;
+  encPrivateKey: bigint;
+};
+
+/** Encrypted user address (matches Cairo EncUserAddr struct) */
+export type EncUserAddr = {
+  ephemeralPubkey: bigint;
+  encUserAddr: bigint;
 };
 
 // ============ Encryptions Module ============
@@ -278,5 +305,183 @@ export const encryptions = {
     const privateKeyBytes = toBytes32(privateKey);
     const publicKeyBytes = starkCurve.getPublicKey(privateKeyBytes);
     return getXCoordinateFromBytes(publicKeyBytes);
+  },
+
+  // ============ Outgoing Channel Info ============
+
+  /**
+   * Encrypt outgoing channel info.
+   * Matches Cairo's encrypt_outgoing_channel_info in utils.cairo.
+   *
+   * enc_recipient_addr = h(ENC_RECIPIENT_ADDR_TAG, sender_addr, sender_private_key, index, salt) + recipient_addr
+   *
+   * @param senderAddr - The sender's address
+   * @param senderPrivateKey - The sender's private key
+   * @param index - The channel index
+   * @param recipientAddr - The recipient's address to encrypt
+   * @param salt - Random salt for encryption
+   */
+  encryptOutgoingChannelInfo: (
+    senderAddr: bigint,
+    senderPrivateKey: bigint,
+    index: number,
+    recipientAddr: bigint,
+    salt: bigint
+  ): EncOutgoingChannelInfo => {
+    const encRecipientAddrHash = compute_enc_recipient_addr_hash(
+      senderAddr,
+      senderPrivateKey,
+      index,
+      salt
+    );
+    const enc_recipient_addr = (encRecipientAddrHash + recipientAddr) % FIELD_PRIME;
+    return { salt, enc_recipient_addr };
+  },
+
+  /**
+   * Decrypt outgoing channel info.
+   * Inverse of encrypt_outgoing_channel_info.
+   *
+   * @param encrypted - The encrypted outgoing channel info
+   * @param senderAddr - The sender's address
+   * @param senderPrivateKey - The sender's private key
+   * @param index - The channel index
+   */
+  decryptOutgoingChannelInfo: (
+    encrypted: EncOutgoingChannelInfo,
+    senderAddr: BigNumberish,
+    senderPrivateKey: BigNumberish,
+    index: number
+  ): OutgoingChannelInfo => {
+    const salt = toBigInt(encrypted.salt);
+    const enc_recipient_addr = toBigInt(encrypted.enc_recipient_addr);
+    const encRecipientAddrHash = compute_enc_recipient_addr_hash(
+      toBigInt(senderAddr),
+      toBigInt(senderPrivateKey),
+      index,
+      salt
+    );
+    const recipientAddr =
+      (((enc_recipient_addr - encRecipientAddrHash) % FIELD_PRIME) + FIELD_PRIME) % FIELD_PRIME;
+    return { recipientAddr, salt };
+  },
+
+  // ============ Private Key (ECDH) ============
+
+  /**
+   * Encrypt private key using ECDH.
+   * Matches Cairo's encrypt_private_key in utils.cairo.
+   *
+   * @param ephemeralSecret - Random scalar for ECDH
+   * @param compliancePublicKey - Compliance's public key (x-coordinate)
+   * @param privateKey - The private key to encrypt
+   */
+  encryptPrivateKey: (
+    ephemeralSecret: bigint,
+    compliancePublicKey: bigint,
+    privateKey: bigint
+  ): EncPrivateKey => {
+    const ephemeralSecretBytes = toBytes32(ephemeralSecret);
+
+    // Compute ephemeral public key
+    const ephemeralPubPoint = starkCurve.getPublicKey(ephemeralSecretBytes);
+    const ephemeralPubkey = getXCoordinateFromBytes(ephemeralPubPoint);
+
+    // Recover compliance public key point from x-coordinate
+    const compliancePubBytes = recoverPointFromX(compliancePublicKey);
+
+    // Compute shared secret via ECDH
+    const sharedPoint = starkCurve.getSharedSecret(ephemeralSecretBytes, compliancePubBytes);
+    const sharedX = getXCoordinateFromBytes(sharedPoint);
+
+    // Encrypt using field addition (matching Cairo)
+    const encPrivateKey = (compute_enc_private_key_hash(sharedX) + privateKey) % FIELD_PRIME;
+
+    return { ephemeralPubkey, encPrivateKey };
+  },
+
+  /**
+   * Decrypt private key using ECDH.
+   * Inverse of encrypt_private_key.
+   *
+   * @param encrypted - The encrypted private key
+   * @param compliancePrivateKey - The compliance's private key
+   */
+  decryptPrivateKey: (encrypted: EncPrivateKey, compliancePrivateKey: bigint): bigint => {
+    const privateKeyBytes = toBytes32(compliancePrivateKey);
+
+    // Recover ephemeral public key point from x-coordinate
+    const ephemeralPubBytes = recoverPointFromX(encrypted.ephemeralPubkey);
+
+    // Compute shared secret via ECDH
+    const sharedPoint = starkCurve.getSharedSecret(privateKeyBytes, ephemeralPubBytes);
+    const sharedX = getXCoordinateFromBytes(sharedPoint);
+
+    // Decrypt using field subtraction (matching Cairo)
+    const privateKey =
+      (((encrypted.encPrivateKey - compute_enc_private_key_hash(sharedX)) % FIELD_PRIME) +
+        FIELD_PRIME) %
+      FIELD_PRIME;
+
+    return privateKey;
+  },
+
+  // ============ User Address (ECDH) ============
+
+  /**
+   * Encrypt user address using ECDH.
+   * Matches Cairo's encrypt_user_addr in utils.cairo.
+   *
+   * @param ephemeralSecret - Random scalar for ECDH
+   * @param compliancePublicKey - Compliance's public key (x-coordinate)
+   * @param userAddr - The user address to encrypt
+   */
+  encryptUserAddr: (
+    ephemeralSecret: bigint,
+    compliancePublicKey: bigint,
+    userAddr: bigint
+  ): EncUserAddr => {
+    const ephemeralSecretBytes = toBytes32(ephemeralSecret);
+
+    // Compute ephemeral public key
+    const ephemeralPubPoint = starkCurve.getPublicKey(ephemeralSecretBytes);
+    const ephemeralPubkey = getXCoordinateFromBytes(ephemeralPubPoint);
+
+    // Recover compliance public key point from x-coordinate
+    const compliancePubBytes = recoverPointFromX(compliancePublicKey);
+
+    // Compute shared secret via ECDH
+    const sharedPoint = starkCurve.getSharedSecret(ephemeralSecretBytes, compliancePubBytes);
+    const sharedX = getXCoordinateFromBytes(sharedPoint);
+
+    // Encrypt using field addition (matching Cairo)
+    const encUserAddr = (compute_enc_address_hash(sharedX) + userAddr) % FIELD_PRIME;
+
+    return { ephemeralPubkey, encUserAddr };
+  },
+
+  /**
+   * Decrypt user address using ECDH.
+   * Inverse of encrypt_user_addr.
+   *
+   * @param encrypted - The encrypted user address
+   * @param compliancePrivateKey - The compliance's private key
+   */
+  decryptUserAddr: (encrypted: EncUserAddr, compliancePrivateKey: bigint): bigint => {
+    const privateKeyBytes = toBytes32(compliancePrivateKey);
+
+    // Recover ephemeral public key point from x-coordinate
+    const ephemeralPubBytes = recoverPointFromX(encrypted.ephemeralPubkey);
+
+    // Compute shared secret via ECDH
+    const sharedPoint = starkCurve.getSharedSecret(privateKeyBytes, ephemeralPubBytes);
+    const sharedX = getXCoordinateFromBytes(sharedPoint);
+
+    // Decrypt using field subtraction (matching Cairo)
+    const userAddr =
+      (((encrypted.encUserAddr - compute_enc_address_hash(sharedX)) % FIELD_PRIME) + FIELD_PRIME) %
+      FIELD_PRIME;
+
+    return userAddr;
   },
 };

--- a/sdk/tests/fixtures/cairo-reference-hashes.json
+++ b/sdk/tests/fixtures/cairo-reference-hashes.json
@@ -14,7 +14,11 @@
     "ephemeralSecret": "0xabcd",
     "amount": 1000,
     "recipientPrivateKey": "0x12345",
-    "recipientPublicKeyDerived": "0x2f8ffcb446d2a062ef18561eb507b08ea01d52d4c594e90cfca47f075cb952"
+    "recipientPublicKeyDerived": "0x2f8ffcb446d2a062ef18561eb507b08ea01d52d4c594e90cfca47f075cb952",
+    "compliancePrivateKey": "0x54321",
+    "compliancePublicKey": "0x61d0f6b01e5696a475786dbbd6de15f984b23a553be50018489781de416140",
+    "userAddr": "0x999",
+    "userPrivateKey": "0x888"
   },
   "outputs": {
     "channelKey": "0x67db9bd0362ca14c4418ecd78e743d96b069a24c0a5abe7cdb01f95cd0174e",
@@ -36,6 +40,12 @@
     "encChannelKey": "0x7eaa38a527e70c99d613e27b4a869ff8014c4a6d48747935be6f8d6bd438ee4",
     "encChannelSenderAddr": "0x126179bd879f2b3e1f5b475211bd36a59ebbf95a980f58355882563f1bc9a97",
     "encNoteAmount": "0x56783a87f2a9a38084b01a2bdfadc68a0f46",
-    "decNoteAmount": 1000
+    "decNoteAmount": 1000,
+    "encOutgoingSalt": "0x5678",
+    "encOutgoingRecipientAddr": "0x92f3d5665196247dcc74ce8870e4e6f32a6ab61bd2073c589d553cf1be9f12",
+    "encPrivateKeyEphemeralPubkey": "0x43299cc92ce884c67fa0353094e10e3d80b77f10607f266c79972941a42518a",
+    "encPrivateKeyValue": "0x504b7c4a2644b422c371db6f65cb24775c40a6cae2b36701a70073122463fea",
+    "encUserAddrEphemeralPubkey": "0x43299cc92ce884c67fa0353094e10e3d80b77f10607f266c79972941a42518a",
+    "encUserAddrValue": "0xc45038c16fb79d8db9a211879eab281bb0ba26838c15bf5b9b90642a239bc6"
   }
 }

--- a/sdk/tests/utils/encryption.test.ts
+++ b/sdk/tests/utils/encryption.test.ts
@@ -22,6 +22,12 @@ describe("Encryption Compatibility with Cairo", () => {
   const recipientPrivateKey = BigInt(inputs.recipientPrivateKey);
   const recipientPublicKeyDerived = BigInt(inputs.recipientPublicKeyDerived);
   const ephemeralSecret = BigInt(inputs.ephemeralSecret);
+  const senderPrivateKey = BigInt(inputs.senderPrivateKey);
+  const recipient = BigInt(inputs.recipient);
+  const compliancePrivateKey = BigInt(inputs.compliancePrivateKey);
+  const compliancePublicKey = BigInt(inputs.compliancePublicKey);
+  const userAddr = BigInt(inputs.userAddr);
+  const userPrivateKey = BigInt(inputs.userPrivateKey);
 
   describe("Public Key Derivation", () => {
     it("derivePublicKey matches Cairo", () => {
@@ -136,6 +142,137 @@ describe("Encryption Compatibility with Cairo", () => {
       const decrypted = encryptions.decryptChannelInfo(encrypted, recipientPrivateKey);
       expect(decrypted.key.toString(16)).toBe(channelKey.toString(16));
       expect(decrypted.sender.toString(16)).toBe(sender.toString(16));
+    });
+  });
+
+  describe("Outgoing Channel Info Encryption", () => {
+    it("encryptOutgoingChannelInfo salt matches Cairo", () => {
+      const result = encryptions.encryptOutgoingChannelInfo(
+        sender,
+        senderPrivateKey,
+        index,
+        recipient,
+        salt
+      );
+      expect(result.salt.toString(16)).toBe(BigInt(outputs.encOutgoingSalt).toString(16));
+    });
+
+    it("encryptOutgoingChannelInfo enc_recipient_addr matches Cairo", () => {
+      const result = encryptions.encryptOutgoingChannelInfo(
+        sender,
+        senderPrivateKey,
+        index,
+        recipient,
+        salt
+      );
+      expect(result.enc_recipient_addr.toString(16)).toBe(
+        BigInt(outputs.encOutgoingRecipientAddr).toString(16)
+      );
+    });
+
+    it("decryptOutgoingChannelInfo recovers original recipient", () => {
+      const encrypted = {
+        salt,
+        enc_recipient_addr: BigInt(outputs.encOutgoingRecipientAddr),
+      };
+      const decrypted = encryptions.decryptOutgoingChannelInfo(
+        encrypted,
+        sender,
+        senderPrivateKey,
+        index
+      );
+      expect(decrypted.recipientAddr.toString(16)).toBe(recipient.toString(16));
+      expect(decrypted.salt).toBe(salt);
+    });
+
+    it("encrypt then decrypt recovers original recipient", () => {
+      const encrypted = encryptions.encryptOutgoingChannelInfo(
+        sender,
+        senderPrivateKey,
+        index,
+        recipient,
+        salt
+      );
+      const decrypted = encryptions.decryptOutgoingChannelInfo(
+        encrypted,
+        sender,
+        senderPrivateKey,
+        index
+      );
+      expect(decrypted.recipientAddr.toString(16)).toBe(recipient.toString(16));
+      expect(decrypted.salt).toBe(salt);
+    });
+  });
+
+  describe("Private Key Encryption (ECDH)", () => {
+    it("ephemeral pubkey matches Cairo", () => {
+      const result = encryptions.encryptPrivateKey(
+        ephemeralSecret,
+        compliancePublicKey,
+        userPrivateKey
+      );
+      expect(result.ephemeralPubkey.toString(16)).toBe(
+        BigInt(outputs.encPrivateKeyEphemeralPubkey).toString(16)
+      );
+    });
+
+    it("encrypted private key matches Cairo", () => {
+      const result = encryptions.encryptPrivateKey(
+        ephemeralSecret,
+        compliancePublicKey,
+        userPrivateKey
+      );
+      expect(result.encPrivateKey.toString(16)).toBe(
+        BigInt(outputs.encPrivateKeyValue).toString(16)
+      );
+    });
+
+    it("decryptPrivateKey recovers original private key", () => {
+      const encrypted = {
+        ephemeralPubkey: BigInt(outputs.encPrivateKeyEphemeralPubkey),
+        encPrivateKey: BigInt(outputs.encPrivateKeyValue),
+      };
+      const decrypted = encryptions.decryptPrivateKey(encrypted, compliancePrivateKey);
+      expect(decrypted.toString(16)).toBe(userPrivateKey.toString(16));
+    });
+
+    it("encrypt then decrypt recovers original private key", () => {
+      const encrypted = encryptions.encryptPrivateKey(
+        ephemeralSecret,
+        compliancePublicKey,
+        userPrivateKey
+      );
+      const decrypted = encryptions.decryptPrivateKey(encrypted, compliancePrivateKey);
+      expect(decrypted.toString(16)).toBe(userPrivateKey.toString(16));
+    });
+  });
+
+  describe("User Address Encryption (ECDH)", () => {
+    it("ephemeral pubkey matches Cairo", () => {
+      const result = encryptions.encryptUserAddr(ephemeralSecret, compliancePublicKey, userAddr);
+      expect(result.ephemeralPubkey.toString(16)).toBe(
+        BigInt(outputs.encUserAddrEphemeralPubkey).toString(16)
+      );
+    });
+
+    it("encrypted user addr matches Cairo", () => {
+      const result = encryptions.encryptUserAddr(ephemeralSecret, compliancePublicKey, userAddr);
+      expect(result.encUserAddr.toString(16)).toBe(BigInt(outputs.encUserAddrValue).toString(16));
+    });
+
+    it("decryptUserAddr recovers original user addr", () => {
+      const encrypted = {
+        ephemeralPubkey: BigInt(outputs.encUserAddrEphemeralPubkey),
+        encUserAddr: BigInt(outputs.encUserAddrValue),
+      };
+      const decrypted = encryptions.decryptUserAddr(encrypted, compliancePrivateKey);
+      expect(decrypted.toString(16)).toBe(userAddr.toString(16));
+    });
+
+    it("encrypt then decrypt recovers original user addr", () => {
+      const encrypted = encryptions.encryptUserAddr(ephemeralSecret, compliancePublicKey, userAddr);
+      const decrypted = encryptions.decryptUserAddr(encrypted, compliancePrivateKey);
+      expect(decrypted.toString(16)).toBe(userAddr.toString(16));
     });
   });
 });


### PR DESCRIPTION
- Add discovery even if no recipient is given
- Add "all" to auto discovery level, consolidating with notes
  autodiscovery
- Better alignment with contract return types
- Added outgoing channel support to mock pool

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/280)
<!-- Reviewable:end -->
