### PR TITLE
refactor(sdk): extract pool simulator for compiler state tracking

### DIFF
--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -28,12 +28,11 @@ import type {
 import { Channel, createEmptyRegistry } from "../interfaces.js";
 import { AddressMap, AdvancedMap, toBigInt } from "../utils/index.js";
 import type { ClientAction } from "./client-actions.js";
-import { PrivacyPool } from "../testing/pool.js";
-import { MockContracts } from "../testing/contracts.js";
+import { PoolSimulator } from "./pool-simulator.js";
 import { assert, isOpen } from "../utils/validation.js";
 import type { BigNumberish } from "starknet";
 import { generateRandom } from "../utils/crypto.js";
-import { consoleLogCallback, withLogging, debugLog, hex } from "../utils/logging.js";
+import { debugLog, hex } from "../utils/logging.js";
 
 export type CompileResult = {
   clientActions: ClientAction[];
@@ -91,14 +90,14 @@ export class ActionCompiler {
     debugLog("compiler", "compile", "post resolveNotes", registry?.notes?.size, actions);
 
     // create a pool to simulate the execution of the actions
-    const pool = this.createPool(actions, registry, channels);
+    const pool = this.createPool(registry, channels);
 
     // Phase 3: Transform Actions to ClientAction[]
     const clientActions = this.transformToClientActions(actions, pool, recipientsNeeded, options);
 
     debugLog("compiler", "compile", "post transformToClientActions", clientActions);
 
-    return { clientActions, registry: pool.updateRegistry(this.userAddress, registry) };
+    return { clientActions, registry: pool.updateRegistry(registry) };
   }
 
   private getRecipientsNeeded(actions: Actions): AddressMap<boolean> {
@@ -139,53 +138,26 @@ export class ActionCompiler {
     return recipientsNeeded;
   }
 
-  private createPool(actions: Actions, registry?: PrivateRegistry, channels?: AddressMap<Channel>) {
-    const contracts = new MockContracts();
+  private createPool(registry?: PrivateRegistry, channels?: AddressMap<Channel>): PoolSimulator {
+    const pool = new PoolSimulator(this.userAddress);
 
-    const pool = withLogging(
-      new PrivacyPool(this.userAddress, contracts, false /* don't validate execution balances */),
-      "CompilerPool",
-      consoleLogCallback
-    );
-    contracts.register(pool);
-
-    // go over deposit actions and instantiate balances
-    if (actions.deposits) {
-      for (const deposit of actions.deposits) {
-        contracts.get(deposit.token).increaseBalance(this.userAddress, deposit.amount);
-      }
-    }
-
-    if (actions.withdraws) {
-      for (const withdraw of actions.withdraws) {
-        contracts.get(withdraw.token).increaseBalance(pool.address, withdraw.amount);
-      }
-    }
-
-    // the internal pool needs a viewing key to be set regardless if the already registered
-    pool.execute(this.userAddress, {
+    // The simulator needs a viewing key to be set regardless if already registered
+    pool.execute({
       type: "SetViewingKey",
       input: { privateKey: this.userViewingKey, random: generateRandom() },
     });
 
-    debugLog(
-      "compiler",
-      "after SetViewingKey, isRegistered?",
-      pool.isRegistered(this.userAddress),
-      "userAddress:",
-      hex(this.userAddress)
-    );
     debugLog("compiler", "setup discovered channels", channels);
 
     for (const [addr, channel] of channels?.entries() ?? []) {
-      pool.setupChannel(this.userAddress, this.userViewingKey, addr, channel);
+      pool.setupChannel(addr, channel);
     }
 
     debugLog("compiler", "setup registry channels", registry?.channels);
 
     for (const [addr, channel] of registry?.channels?.entries() ?? []) {
       if (channels?.has(addr)) continue; // skip channels that were already set up in the previous step
-      pool.setupChannel(this.userAddress, this.userViewingKey, addr, channel);
+      pool.setupChannel(addr, channel);
     }
 
     debugLog("compiler", "setup notes", registry?.notes);
@@ -193,7 +165,7 @@ export class ActionCompiler {
     if (registry?.notes) {
       for (const [token, notes] of registry.notes.entries()) {
         for (const note of notes) {
-          pool.setupNote(this.userAddress, note, token);
+          pool.setupNote(token, note);
         }
       }
     }
@@ -206,7 +178,7 @@ export class ActionCompiler {
    */
   private transformToClientActions(
     actions: Actions,
-    pool: PrivacyPool,
+    pool: PoolSimulator,
     recipientsNeeded: AddressMap<boolean>,
     options?: ExecuteOptions
   ): ClientAction[] {
@@ -231,7 +203,7 @@ export class ActionCompiler {
     }
 
     for (const recipient of recipientsNeeded.keys()) {
-      const channel = pool.getUsersChannel(this.userAddress, recipient);
+      const channel = pool.getChannel(recipient);
       if (!channel?.key && options?.autoSetup) {
         actions.openChannels ??= [];
         // Check if recipient is already in openChannels to avoid duplicates
@@ -247,7 +219,7 @@ export class ActionCompiler {
     }
 
     const execute = <T extends ClientAction>(input: T, arr: T[] = []): T => {
-      pool.execute(this.userAddress, input); // no need to run the callbacks since there's no state restore
+      pool.execute(input);
       arr.push(input);
       return input;
     };
@@ -272,7 +244,7 @@ export class ActionCompiler {
         if (seenRecipients.has(action.recipient)) continue;
         seenRecipients.add(action.recipient);
         debugLog("compiler", "open channel x", action.recipient);
-        const channel = pool.getUsersChannel(this.userAddress, action.recipient);
+        const channel = pool.getChannel(action.recipient);
         assert(channel, () => `Missing channel context for recipient ${hex(action.recipient)}`);
         const input = {
           type: "OpenChannel",
@@ -296,7 +268,7 @@ export class ActionCompiler {
       },
       force: boolean
     ) => {
-      const channel = pool.getUsersChannel(this.userAddress, action.recipient);
+      const channel = pool.getChannel(action.recipient);
       assert(channel, () => `Channel not found for recipient ${hex(action.recipient)}`);
       debugLog("compiler", "open channel", action.recipient, action, channel);
 
@@ -323,7 +295,7 @@ export class ActionCompiler {
       } as const; // typescipt magic
       execute(input, clientActions.openTokenChannels);
 
-      return pool.getUsersChannel(this.userAddress, action.recipient)!; // on the safe side, the pool is not supposed to create a new Channel object
+      return pool.getChannel(action.recipient)!; // on the safe side, the pool is not supposed to create a new Channel object
     };
 
     if (actions.openTokenChannels) {
@@ -368,9 +340,9 @@ export class ActionCompiler {
             noteIndex: action.note.witness.nonce,
           },
         } as const; // typescipt magic
-        if (!pool.hasNoteById(toBigInt(action.note.id))) {
+        if (!pool.hasNote(action.token, toBigInt(action.note.id))) {
           // this means the note is not in the registry, trust the user knows it exists
-          pool.setupNote(this.userAddress, action.note, action.token); // add it to the registry
+          pool.setupNote(action.token, action.note); // add it to the registry
         }
         execute(input, clientActions.useNotes);
       }

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -1,0 +1,231 @@
+/**
+ * PoolSimulator - Minimal state tracker for the compiler.
+ *
+ * This class tracks channel and note state without encryption, hashing, or balance validation.
+ * It's used by the ActionCompiler to simulate action execution and track nonces.
+ *
+ * Key differences from PrivacyPool:
+ * - No encrypted state (publicKeys, channels, subchannels, notes, nullifiers, outgoingChannels)
+ * - No encryption utilities
+ * - No balance validation
+ * - No callbacks - state is updated directly
+ * - Just tracks Channel objects with nonces and Note objects
+ */
+
+import type { Note, PrivateRegistry, StarknetAddressBigint } from "../interfaces.js";
+import { Channel } from "./channel.js";
+import { derivePublicKey, toBigInt } from "../utils/crypto.js";
+import { AddressMap } from "../utils/maps.js";
+import {
+  ClientAction,
+  CreateNoteInput,
+  OpenChannelInput,
+  OpenSubchannelInput,
+  SetViewingKeyInput,
+  UseNoteInput,
+} from "./client-actions.js";
+import { compute_channel_key, compute_note_id } from "../utils/hashes.js";
+import { debugLog, hex } from "../utils/logging.js";
+
+export class PoolSimulator {
+  // Per-user state: channels from this user to recipients, notes owned by this user
+  private channels = new AddressMap<Channel>();
+  private notes = new AddressMap<Map<bigint, Note>>(() => new Map<bigint, Note>());
+
+  constructor(private readonly userAddress: StarknetAddressBigint) {}
+
+  /**
+   * Execute a client action, updating the tracked state.
+   * No encryption, no hashing, no balance checks.
+   */
+  execute(action: ClientAction): void {
+    switch (action.type) {
+      case "SetViewingKey":
+        this.handleSetViewingKey(action.input);
+        break;
+
+      case "OpenChannel":
+        this.handleOpenChannel(action.input);
+        break;
+
+      case "OpenSubchannel":
+        this.handleOpenSubchannel(action.input);
+        break;
+
+      case "Deposit":
+        // Deposits don't affect tracking state (handled by MockPoolContract)
+        break;
+
+      case "UseNote":
+        this.handleUseNote(action.input);
+        break;
+
+      case "CreateNote":
+        this.handleCreateNote(action.input);
+        break;
+
+      case "Withdraw":
+        // Withdrawals don't affect tracking state (handled by MockPoolContract)
+        break;
+
+      case "FollowupCall":
+        // Followup calls don't affect tracking state
+        break;
+    }
+  }
+
+  /**
+   * Get the channel to a recipient.
+   */
+  getChannel(recipient: StarknetAddressBigint): Channel | undefined {
+    return this.channels.get(recipient);
+  }
+
+  /**
+   * Check if a note exists by ID.
+   */
+  hasNote(token: StarknetAddressBigint, noteId: bigint): boolean {
+    return this.notes.get(token)?.has(noteId) ?? false;
+  }
+
+  /**
+   * Setup a channel from registry/discovery.
+   * Used to initialize state before compilation.
+   */
+  setupChannel(recipientAddress: StarknetAddressBigint, channel: Channel): void {
+    this.channels.set(recipientAddress, new Channel(channel.publicKey, channel.key));
+
+    if (!channel.key) return;
+
+    // Copy token nonces from the channel
+    for (const [token, nonces] of channel.tokens.entries()) {
+      this.channels.get(recipientAddress)!.tokens.set(token, { ...nonces });
+    }
+  }
+
+  /**
+   * Setup a note from registry.
+   * Used to initialize state before compilation.
+   */
+  setupNote(token: StarknetAddressBigint, note: Note): void {
+    this.notes.get(token)!.set(toBigInt(note.id), note);
+  }
+
+  /**
+   * Export tracked state back to the registry.
+   */
+  updateRegistry(registry: PrivateRegistry): PrivateRegistry {
+    for (const [address, channel] of this.channels.entries()) {
+      registry.channels.set(address, channel);
+    }
+    for (const [token, notes] of this.notes.entries()) {
+      registry.notes.set(token, Array.from(notes.values()));
+    }
+    return registry;
+  }
+
+  private handleSetViewingKey(input: SetViewingKeyInput): void {
+    // Derive the real public key from the private key and create self-channel entry
+    const publicKey = derivePublicKey(input.privateKey);
+    this.channels.set(this.userAddress, new Channel(publicKey));
+
+    debugLog("pool-simulator", "SetViewingKey", hex(this.userAddress));
+  }
+
+  private handleOpenChannel(input: OpenChannelInput): void {
+    const { senderPrivateKey, recipientAddr, recipientPublicKey } = input;
+
+    // Compute the real channel key
+    const channelKey = compute_channel_key(
+      this.userAddress,
+      toBigInt(senderPrivateKey),
+      recipientAddr,
+      toBigInt(recipientPublicKey)
+    );
+
+    // Create/update channel
+    const channel = this.channels.get(recipientAddr, () => new Channel(recipientPublicKey))!;
+
+    channel.key = channelKey;
+
+    debugLog("pool-simulator", "OpenChannel", hex(this.userAddress), "->", hex(recipientAddr));
+  }
+
+  private handleOpenSubchannel(input: OpenSubchannelInput): void {
+    const { recipientAddr, token, index } = input;
+
+    // Update channel's token nonces
+    const channel = this.channels.get(recipientAddr)!;
+
+    channel.tokens.set(token, {
+      tokenIndex: index,
+      noteNonce: 0,
+    });
+
+    debugLog(
+      "pool-simulator",
+      "OpenSubchannel",
+      hex(this.userAddress),
+      "->",
+      hex(recipientAddr),
+      "token:",
+      hex(token)
+    );
+  }
+
+  private handleUseNote(input: UseNoteInput): void {
+    const { token } = input;
+
+    // Remove the note from tracking (it's being spent)
+    const tokenNotes = this.notes.get(token)!;
+
+    const noteId = compute_note_id(input.channelKey, token, input.noteIndex);
+
+    tokenNotes.delete(noteId);
+
+    debugLog("pool-simulator", "UseNote", hex(this.userAddress), "token:", hex(token));
+  }
+
+  private handleCreateNote(input: CreateNoteInput): void {
+    const { senderPrivateKey, recipientAddr, recipientPublicKey, token, amount, index } = input;
+
+    // Update sender's channel note nonce
+    const senderChannel = this.channels.get(recipientAddr)!;
+    senderChannel.incrementNoteNonce(token);
+
+    // Only track note if this is a self-transfer (recipient is us)
+    if (recipientAddr === this.userAddress) {
+      // Compute the channel key to generate the note ID
+      const channelKey = compute_channel_key(
+        this.userAddress,
+        toBigInt(senderPrivateKey),
+        recipientAddr,
+        toBigInt(recipientPublicKey)
+      );
+
+      // Compute the proper note ID using the hash function
+      const noteId = compute_note_id(channelKey, token, index);
+
+      this.notes.get(token)!.set(noteId, {
+        id: noteId,
+        amount: typeof amount === "bigint" ? amount : 0n,
+        witness: {
+          channelKey,
+          nonce: index,
+          r: input.random,
+        },
+        sender: this.userAddress,
+      });
+    }
+
+    debugLog(
+      "pool-simulator",
+      "CreateNote",
+      hex(this.userAddress),
+      "->",
+      hex(recipientAddr),
+      "token:",
+      hex(token)
+    );
+  }
+}


### PR DESCRIPTION
add pool simulator class that tracks channel and note state for the
action compiler. this separates state tracking from encrypted state
management in preparation for mock pool contract refactor.

- create pool-simulator.ts with minimal state tracking
- update compiler.ts to use pool simulator instead of privacy pool
- pool simulator computes channel keys and note IDs but doesn't
manage encrypted state



<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" alt="Reviewable">](https://reviewable.io/reviews/starkware-libs/starknet-privacy/287)

<!-- Reviewable:end -->