### PR TITLE
feat(sdk): add rate limiter utility for concurrent async operations

### DIFF
--- a/sdk/src/utils/rate-limiter.ts
+++ b/sdk/src/utils/rate-limiter.ts
@@ -1,0 +1,97 @@
+/**
+ * Concurrency limiter and retry utilities for async operations.
+ * No external dependencies - browser/mobile compatible.
+ */
+
+export type RateLimitOptions = {
+  /** Maximum concurrent operations (default: 8) */
+  concurrency?: number;
+  /** Maximum retry attempts for failed operations (default: 3) */
+  maxRetries?: number;
+  /** Base delay in ms for exponential backoff (default: 100) */
+  baseDelayMs?: number;
+};
+
+/**
+ * Creates a concurrency limiter that restricts how many async operations
+ * can run simultaneously.
+ *
+ * @param concurrency Maximum number of concurrent operations
+ * @returns A function that wraps async operations with concurrency control
+ *
+ * @example
+ * const limit = createLimiter(2);
+ * // Only 2 of these will run at a time:
+ * await Promise.all([
+ *   limit(() => fetch('/a')),
+ *   limit(() => fetch('/b')),
+ *   limit(() => fetch('/c')),
+ * ]);
+ */
+export function createLimiter(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const run = async <T>(fn: () => Promise<T>): Promise<T> => {
+    // Wait if at capacity
+    if (active >= concurrency) {
+      await new Promise<void>((resolve) => queue.push(resolve));
+    }
+    active++;
+    try {
+      return await fn();
+    } finally {
+      active--;
+      // Wake up next queued task
+      queue.shift()?.();
+    }
+  };
+
+  return run;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wraps an object (typically a contract interface) with rate limiting and retry logic.
+ * All method calls on the returned proxy will be:
+ * 1. Limited to `concurrency` simultaneous executions
+ * 2. Retried with exponential backoff on failure
+ *
+ * @param obj The object to wrap
+ * @param options Rate limiting and retry configuration
+ * @returns A proxy with the same interface, but with rate limiting applied
+ *
+ * @example
+ * const limitedPool = createRateLimitedPool(poolContract, { concurrency: 4 });
+ * // Now all calls to limitedPool methods are rate-limited
+ */
+export function createRateLimitedObject<T extends object>(
+  obj: T,
+  options: RateLimitOptions = {}
+): T {
+  const { concurrency = 8, maxRetries = 3, baseDelayMs = 100 } = options;
+  const limit = createLimiter(concurrency);
+
+  const withRetry = async <R>(fn: () => Promise<R>): Promise<R> => {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (attempt === maxRetries) throw error;
+        await sleep(baseDelayMs * Math.pow(2, attempt));
+      }
+    }
+    throw new Error("Unreachable");
+  };
+
+  return new Proxy(obj, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function") {
+        return (...args: unknown[]) => limit(() => withRetry(() => value.apply(target, args)));
+      }
+      return value;
+    },
+  }) as T;
+}

--- a/sdk/tests/utils/rate-limiter.test.ts
+++ b/sdk/tests/utils/rate-limiter.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import { createLimiter, createRateLimitedObject } from "../../src/utils/rate-limiter.js";
+
+describe("createLimiter", () => {
+  it("respects concurrency limit", async () => {
+    const limit = createLimiter(2);
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const task = async (delay: number) => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((r) => setTimeout(r, delay));
+      concurrent--;
+      return delay;
+    };
+
+    const delay = 5;
+    // Launch 5 tasks, but only 2 should run at a time
+    const results = await Promise.all([
+      limit(() => task(delay)),
+      limit(() => task(delay)),
+      limit(() => task(delay)),
+      limit(() => task(delay)),
+      limit(() => task(delay)),
+    ]);
+
+    expect(maxConcurrent).toBe(2);
+    expect(results).toEqual([delay, delay, delay, delay, delay]);
+  });
+
+  it("maintains FIFO order for queued tasks", async () => {
+    const limit = createLimiter(1);
+    const order: number[] = [];
+
+    const task = async (id: number) => {
+      order.push(id);
+      await new Promise((r) => setTimeout(r, 10));
+      return id;
+    };
+
+    await Promise.all([limit(() => task(1)), limit(() => task(2)), limit(() => task(3))]);
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("handles errors without blocking the queue", async () => {
+    const limit = createLimiter(1);
+    const results: (number | string)[] = [];
+
+    const successTask = async (id: number) => {
+      results.push(id);
+      return id;
+    };
+
+    const failTask = async () => {
+      throw new Error("fail");
+    };
+
+    const p1 = limit(() => successTask(1));
+    const p2 = limit(failTask).catch(() => "caught");
+    const p3 = limit(() => successTask(3));
+
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(r1).toBe(1);
+    expect(r2).toBe("caught");
+    expect(r3).toBe(3);
+    expect(results).toEqual([1, 3]);
+  });
+});
+
+describe("createRateLimitedPool", () => {
+  it("applies concurrency across multiple methods", async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const obj = {
+      async methodA() {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 20));
+        concurrent--;
+        return "A";
+      },
+      async methodB() {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 20));
+        concurrent--;
+        return "B";
+      },
+    };
+
+    const limited = createRateLimitedObject(obj, { concurrency: 2, maxRetries: 0 });
+
+    const results = await Promise.all([
+      limited.methodA(),
+      limited.methodB(),
+      limited.methodA(),
+      limited.methodB(),
+    ]);
+
+    expect(maxConcurrent).toBe(2);
+    expect(results).toContain("A");
+    expect(results).toContain("B");
+  });
+
+  it("retries failed operations with exponential backoff", async () => {
+    let attempts = 0;
+
+    const obj = {
+      async flaky() {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error(`Attempt ${attempts} failed`);
+        }
+        return "success";
+      },
+    };
+
+    const limited = createRateLimitedObject(obj, {
+      concurrency: 1,
+      maxRetries: 3,
+      baseDelayMs: 10,
+    });
+
+    const result = await limited.flaky();
+
+    expect(result).toBe("success");
+    expect(attempts).toBe(3);
+  });
+
+  it("throws after max retries exceeded", async () => {
+    const obj = {
+      async alwaysFails() {
+        throw new Error("Always fails");
+      },
+    };
+
+    const limited = createRateLimitedObject(obj, {
+      concurrency: 1,
+      maxRetries: 2,
+      baseDelayMs: 1,
+    });
+
+    await expect(limited.alwaysFails()).rejects.toThrow("Always fails");
+  });
+
+  it("handles synchronous methods", async () => {
+    const pool = {
+      sync() {
+        return 42;
+      },
+    };
+
+    const limited = createRateLimitedObject(pool, { concurrency: 1 });
+
+    // Synchronous methods still get wrapped and return promises
+    const result = await limited.sync();
+    expect(result).toBe(42);
+  });
+});


### PR DESCRIPTION
Add a concurrency limiter with retry logic to control parallel async
operations. This is in preparation for parallelizing contract discovery.

- createLimiter(n): limits concurrent async operations to n
- createRateLimitedObject(obj, opts): wraps object methods with rate
  limiting and exponential backoff retry

Zero external dependencies, browser/mobile compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/316)
<!-- Reviewable:end -->
