### PR TITLE
fix(ci): ensure cairo contracts available for typescript tests

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -115,12 +115,18 @@ jobs:
           git commit -m "chore(sdk): update generated files"
           git push
 
-      # === TypeScript only: run full CI with lint/format ===
+      # === TypeScript only: minimal Cairo build for devnet tests ===
+      - name: Setup Scarb (TS only)
+        if: ${{ !inputs.cairo_changed }}
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.15.0"
+
+      - name: Build Cairo (minimal, for devnet tests)
+        if: ${{ !inputs.cairo_changed }}
+        working-directory: .
+        run: scarb build
+
       - name: Full CI (lint, format, build, test)
         if: ${{ !inputs.cairo_changed }}
-        run: |
-          if npm run ci --if-present 2>/dev/null; then
-            echo "Ran npm run ci"
-          else
-            npm run check
-          fi
+        run: npm run check


### PR DESCRIPTION
When only TypeScript files change, cairo_ci doesn't run, but devnet
tests still need the contract artifacts. Previously this caused test
failures when the cache was unavailable.

Now typescript_ci always runs a minimal `scarb build` when cairo_changed
is false, ensuring the contract files exist for devnet tests regardless
of cache availability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/323)
<!-- Reviewable:end -->
