### PR TITLE
feat(indexer): subchannel decryption and common test fixtures

### DIFF
--- a/crates/discovery-core/src/decryption.rs
+++ b/crates/discovery-core/src/decryption.rs
@@ -6,8 +6,10 @@
 use starknet_types_core::{curve::AffinePoint, felt::Felt};
 use thiserror::Error;
 
-use crate::hashes::{compute_enc_channel_key_hash, compute_enc_sender_addr_hash};
-use crate::types::{ChannelInfo, EncChannelInfo};
+use crate::hashes::{
+    compute_enc_channel_key_hash, compute_enc_sender_addr_hash, compute_enc_token_hash,
+};
+use crate::types::{ChannelInfo, EncChannelInfo, EncSubchannelInfo};
 
 /// Errors that can occur during decryption.
 #[derive(Debug, Error)]
@@ -47,37 +49,29 @@ pub fn decrypt_channel_info(
     })
 }
 
+/// Decrypts encrypted subchannel info to get the token address.
+///
+/// The decryption process:
+/// `token = enc_token - hash(ENC_TOKEN_TAG, channel_key, index, 0, salt)`
+///
+/// # Arguments
+///
+/// * `enc` - The encrypted subchannel info (salt and enc_token).
+/// * `channel_key` - The channel key for this subchannel.
+/// * `index` - The subchannel index.
+///
+/// # Returns
+///
+/// The decrypted token address.
+pub fn decrypt_subchannel_token(enc: &EncSubchannelInfo, channel_key: &Felt, index: u64) -> Felt {
+    let enc_token_hash = compute_enc_token_hash(*channel_key, index, enc.salt);
+    enc.enc_token - enc_token_hash
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Inputs {
-        recipient_private_key: Felt,
-        channel_key: Felt,
-        sender: Felt,
-    }
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Outputs {
-        enc_channel_ephemeral_pubkey: Felt,
-        enc_channel_key: Felt,
-        enc_channel_sender_addr: Felt,
-    }
-
-    #[derive(Deserialize)]
-    struct Fixture {
-        inputs: Inputs,
-        outputs: Outputs,
-    }
-
-    fn load_fixture() -> Fixture {
-        const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
-        serde_json::from_str(JSON).expect("failed to parse fixture")
-    }
+    use crate::test_fixtures::load_cairo_ref_fixture;
 
     #[test]
     fn test_decrypt_channel_info_invalid_pubkey() {
@@ -95,20 +89,32 @@ mod tests {
 
     #[test]
     fn test_decrypt_channel_info_with_cairo_vectors() {
-        let f = load_fixture();
-        let i = &f.inputs;
-        let o = &f.outputs;
+        let f = load_cairo_ref_fixture();
 
         let encrypted = EncChannelInfo {
-            ephemeral_pubkey: o.enc_channel_ephemeral_pubkey,
-            enc_channel_key: o.enc_channel_key,
-            enc_sender_addr: o.enc_channel_sender_addr,
+            ephemeral_pubkey: f.outputs.enc_channel_ephemeral_pubkey,
+            enc_channel_key: f.outputs.enc_channel_key,
+            enc_sender_addr: f.outputs.enc_channel_sender_addr,
         };
 
-        let result = decrypt_channel_info(&encrypted, &i.recipient_private_key)
+        let result = decrypt_channel_info(&encrypted, &f.inputs.recipient_private_key)
             .expect("decryption should succeed");
 
-        assert_eq!(result.channel_key, i.channel_key);
-        assert_eq!(result.sender_addr, i.sender);
+        assert_eq!(result.channel_key, f.inputs.channel_key);
+        assert_eq!(result.sender_addr, f.inputs.sender);
+    }
+
+    #[test]
+    fn test_decrypt_subchannel_token_with_cairo_vectors() {
+        let f = load_cairo_ref_fixture();
+
+        let encrypted = EncSubchannelInfo {
+            salt: f.outputs.enc_subchannel_salt,
+            enc_token: f.outputs.enc_subchannel_token,
+        };
+
+        let token = decrypt_subchannel_token(&encrypted, &f.inputs.channel_key, f.inputs.index);
+
+        assert_eq!(token, f.inputs.token);
     }
 }

--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -87,32 +87,9 @@ pub async fn discover_incoming_channels<PrivacyPool: IViews>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use serde::Deserialize;
-
     use super::*;
     use crate::mock_backend::MockBackend;
-
-    // TODO: Refactor fixture loading to be shared across test modules.
-    #[derive(Deserialize)]
-    struct DevnetFixture {
-        constants: DevnetConstants,
-        slots: HashMap<Felt, Felt>,
-    }
-
-    #[derive(Deserialize)]
-    struct DevnetConstants {
-        alice_address: Felt,
-        alice_viewing_key: Felt,
-        bob_address: Felt,
-        bob_viewing_key: Felt,
-    }
-
-    fn load_devnet_fixture() -> DevnetFixture {
-        const JSON: &str = include_str!("../../tests/fixtures/devnet-state.json");
-        serde_json::from_str(JSON).expect("failed to parse devnet fixture")
-    }
+    use crate::test_fixtures::load_devnet_fixture;
 
     #[tokio::test]
     async fn test_discover_no_channels() {

--- a/crates/discovery-core/src/hashes.rs
+++ b/crates/discovery-core/src/hashes.rs
@@ -13,6 +13,13 @@ static ENC_CHANNEL_KEY_TAG: LazyLock<Felt> =
 static ENC_SENDER_ADDR_TAG: LazyLock<Felt> =
     LazyLock::new(|| short_string_to_felt("ENC_SENDER_ADDR_TAG:V1"));
 
+/// Domain separation tag for subchannel key derivation.
+static SUBCHANNEL_KEY_TAG: LazyLock<Felt> =
+    LazyLock::new(|| short_string_to_felt("SUBCHANNEL_KEY_TAG:V1"));
+
+/// Domain separation tag for encrypted token.
+static ENC_TOKEN_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("ENC_TOKEN_TAG:V1"));
+
 /// Converts a short string (up to 31 ASCII chars) to Felt.
 fn short_string_to_felt(s: &str) -> Felt {
     assert!(
@@ -41,34 +48,35 @@ pub fn compute_enc_sender_addr_hash(shared_x: Felt) -> Felt {
     hash(&[*ENC_SENDER_ADDR_TAG, shared_x])
 }
 
+/// Computes the subchannel key from channel key and index.
+///
+/// `subchannel_key = hash(SUBCHANNEL_KEY_TAG, channel_key, index, 0)`
+pub fn compute_subchannel_key(channel_key: Felt, index: u64) -> Felt {
+    hash(&[
+        *SUBCHANNEL_KEY_TAG,
+        channel_key,
+        Felt::from(index),
+        Felt::ZERO,
+    ])
+}
+
+/// Computes the encryption mask for token encryption.
+///
+/// `enc_token_hash = hash(ENC_TOKEN_TAG, channel_key, index, 0, salt)`
+pub fn compute_enc_token_hash(channel_key: Felt, index: u64, salt: Felt) -> Felt {
+    hash(&[
+        *ENC_TOKEN_TAG,
+        channel_key,
+        Felt::from(index),
+        Felt::ZERO,
+        salt,
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Inputs {
-        shared_x: Felt,
-    }
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Outputs {
-        enc_channel_key_hash: Felt,
-        enc_sender_addr_hash: Felt,
-    }
-
-    #[derive(Deserialize)]
-    struct Fixture {
-        inputs: Inputs,
-        outputs: Outputs,
-    }
-
-    fn load_fixture() -> Fixture {
-        const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
-        serde_json::from_str(JSON).expect("failed to parse fixture")
-    }
+    use crate::test_fixtures::load_cairo_ref_fixture;
 
     #[test]
     fn test_short_string_to_felt() {
@@ -78,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_hashes_with_cairo_vectors() {
-        let f = load_fixture();
+        let f = load_cairo_ref_fixture();
         assert_eq!(
             compute_enc_channel_key_hash(f.inputs.shared_x),
             f.outputs.enc_channel_key_hash
@@ -86,6 +94,24 @@ mod tests {
         assert_eq!(
             compute_enc_sender_addr_hash(f.inputs.shared_x),
             f.outputs.enc_sender_addr_hash
+        );
+    }
+
+    #[test]
+    fn test_compute_subchannel_key() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            compute_subchannel_key(f.inputs.channel_key, f.inputs.index),
+            f.outputs.subchannel_key
+        );
+    }
+
+    #[test]
+    fn test_compute_enc_token_hash() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            compute_enc_token_hash(f.inputs.channel_key, f.inputs.index, f.inputs.salt),
+            f.outputs.enc_token_hash
         );
     }
 }

--- a/crates/discovery-core/src/lib.rs
+++ b/crates/discovery-core/src/lib.rs
@@ -5,3 +5,6 @@ pub mod mock_backend;
 pub mod storage;
 pub mod storage_slots;
 pub mod types;
+
+#[cfg(test)]
+mod test_fixtures;

--- a/crates/discovery-core/src/storage_slots.rs
+++ b/crates/discovery-core/src/storage_slots.rs
@@ -117,94 +117,66 @@ pub fn nullifiers(nullifier: Felt) -> Result<Felt> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::Deserialize;
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Slots {
-        compliance_public_key_address: Felt,
-        sender_public_key_address: Felt,
-        recipient_public_key_address: Felt,
-        enc_private_key_ephemeral_address: Felt,
-        enc_private_key_enc_key_address: Felt,
-        channel_exists_address: Felt,
-        recipient_channels_base_address: Felt,
-        recipient_channels_element_address: Felt,
-        subchannel_exists_address: Felt,
-        subchannel_tokens_salt_address: Felt,
-        subchannel_tokens_enc_token_address: Felt,
-        notes_address: Felt,
-        nullifiers_address: Felt,
-    }
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    struct Inputs {
-        sender: Felt,
-        recipient: Felt,
-        channel_id: Felt,
-        subchannel_key: Felt,
-        subchannel_id: Felt,
-        note_id: Felt,
-        nullifier: Felt,
-    }
-
-    #[derive(Deserialize)]
-    struct Fixture {
-        slots: Slots,
-        inputs: Inputs,
-    }
-
-    fn load_fixture() -> Fixture {
-        const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
-        serde_json::from_str(JSON).expect("failed to parse fixture")
-    }
+    use crate::test_fixtures::load_cairo_ref_fixture;
 
     #[test]
     fn test_storage_slots_with_cairo_vectors() {
-        let f = load_fixture();
-        let i = &f.inputs;
-        let s = &f.slots;
+        let f = load_cairo_ref_fixture();
 
         assert_eq!(
             compliance_public_key().unwrap(),
-            s.compliance_public_key_address
+            f.slots.compliance_public_key_address
         );
-        assert_eq!(public_key(i.sender).unwrap(), s.sender_public_key_address);
         assert_eq!(
-            public_key(i.recipient).unwrap(),
-            s.recipient_public_key_address
+            public_key(f.inputs.sender).unwrap(),
+            f.slots.sender_public_key_address
+        );
+        assert_eq!(
+            public_key(f.inputs.recipient).unwrap(),
+            f.slots.recipient_public_key_address
         );
 
-        let enc_pk = enc_private_key(i.sender).unwrap();
-        assert_eq!(enc_pk.ephemeral_pubkey, s.enc_private_key_ephemeral_address);
-        assert_eq!(enc_pk.enc_private_key, s.enc_private_key_enc_key_address);
+        let enc_pk = enc_private_key(f.inputs.sender).unwrap();
+        assert_eq!(
+            enc_pk.ephemeral_pubkey,
+            f.slots.enc_private_key_ephemeral_address
+        );
+        assert_eq!(
+            enc_pk.enc_private_key,
+            f.slots.enc_private_key_enc_key_address
+        );
 
         assert_eq!(
-            channel_exists(i.channel_id).unwrap(),
-            s.channel_exists_address
+            channel_exists(f.inputs.channel_id).unwrap(),
+            f.slots.channel_exists_address
         );
         assert_eq!(
-            recipient_channels_base(i.recipient).unwrap(),
-            s.recipient_channels_base_address
+            recipient_channels_base(f.inputs.recipient).unwrap(),
+            f.slots.recipient_channels_base_address
         );
         assert_eq!(
-            recipient_channels_element(i.recipient, 0)
+            recipient_channels_element(f.inputs.recipient, 0)
                 .unwrap()
                 .ephemeral_pubkey,
-            s.recipient_channels_element_address
+            f.slots.recipient_channels_element_address
         );
 
         assert_eq!(
-            subchannel_exists(i.subchannel_id).unwrap(),
-            s.subchannel_exists_address
+            subchannel_exists(f.inputs.subchannel_id).unwrap(),
+            f.slots.subchannel_exists_address
         );
 
-        let tokens = subchannel_tokens(i.subchannel_key).unwrap();
-        assert_eq!(tokens.salt, s.subchannel_tokens_salt_address);
-        assert_eq!(tokens.enc_token, s.subchannel_tokens_enc_token_address);
+        let tokens = subchannel_tokens(f.inputs.subchannel_key).unwrap();
+        assert_eq!(tokens.salt, f.slots.subchannel_tokens_salt_address);
+        assert_eq!(
+            tokens.enc_token,
+            f.slots.subchannel_tokens_enc_token_address
+        );
 
-        assert_eq!(notes(i.note_id).unwrap(), s.notes_address);
-        assert_eq!(nullifiers(i.nullifier).unwrap(), s.nullifiers_address);
+        assert_eq!(notes(f.inputs.note_id).unwrap(), f.slots.notes_address);
+        assert_eq!(
+            nullifiers(f.inputs.nullifier).unwrap(),
+            f.slots.nullifiers_address
+        );
     }
 }

--- a/crates/discovery-core/src/test_fixtures.rs
+++ b/crates/discovery-core/src/test_fixtures.rs
@@ -1,0 +1,132 @@
+//! Shared test fixtures for discovery-core tests.
+//!
+//! This module provides common fixture loading utilities for tests
+//! across different modules.
+
+// Allow unused fields in fixture structs - they map to JSON files and
+// not all fields are used by current tests.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use starknet_types_core::felt::Felt;
+
+/// Devnet fixture loaded from devnet-state.json.
+#[derive(Deserialize)]
+pub struct DevnetFixture {
+    pub constants: DevnetConstants,
+    pub slots: HashMap<Felt, Felt>,
+}
+
+/// Constants from the devnet fixture.
+#[derive(Deserialize)]
+pub struct DevnetConstants {
+    pub contract_address: Felt,
+    pub alice_address: Felt,
+    pub alice_viewing_key: Felt,
+    pub bob_address: Felt,
+    pub bob_viewing_key: Felt,
+    pub admin_address: Felt,
+    pub eth_token: Felt,
+    pub strk_token: Felt,
+}
+
+/// Cairo reference fixture loaded from cairo-reference-data.json.
+#[derive(Deserialize)]
+pub struct CairoRefFixture {
+    pub inputs: CairoRefInputs,
+    pub outputs: CairoRefOutputs,
+    pub slots: CairoRefSlots,
+}
+
+/// Inputs from the Cairo reference fixture.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CairoRefInputs {
+    pub sender: Felt,
+    pub recipient: Felt,
+    pub sender_private_key: Felt,
+    pub recipient_public_key: Felt,
+    pub channel_key: Felt,
+    pub token: Felt,
+    pub index: u64,
+    pub salt: Felt,
+    pub shared_x: Felt,
+    pub ephemeral_secret: Felt,
+    pub amount: u64,
+    pub recipient_private_key: Felt,
+    pub recipient_public_key_derived: Felt,
+    pub compliance_private_key: Felt,
+    pub compliance_public_key: Felt,
+    pub user_addr: Felt,
+    pub user_private_key: Felt,
+    pub channel_id: Felt,
+    pub subchannel_key: Felt,
+    pub subchannel_id: Felt,
+    pub note_id: Felt,
+    pub nullifier: Felt,
+}
+
+/// Outputs from the Cairo reference fixture.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CairoRefOutputs {
+    pub channel_key: Felt,
+    pub channel_id: Felt,
+    pub subchannel_key: Felt,
+    pub subchannel_id: Felt,
+    pub note_id: Felt,
+    pub nullifier: Felt,
+    pub enc_amount_hash: Felt,
+    pub enc_token_hash: Felt,
+    pub enc_private_key_hash: Felt,
+    pub enc_channel_key_hash: Felt,
+    pub enc_sender_addr_hash: Felt,
+    pub enc_recipient_addr_hash: Felt,
+    pub outgoing_channel_key: Felt,
+    pub enc_subchannel_salt: Felt,
+    pub enc_subchannel_token: Felt,
+    pub enc_channel_ephemeral_pubkey: Felt,
+    pub enc_channel_key: Felt,
+    pub enc_channel_sender_addr: Felt,
+    pub enc_note_amount: Felt,
+    pub dec_note_amount: u64,
+    pub enc_outgoing_salt: Felt,
+    pub enc_outgoing_recipient_addr: Felt,
+    pub enc_private_key_ephemeral_pubkey: Felt,
+    pub enc_private_key_value: Felt,
+    pub enc_user_addr_ephemeral_pubkey: Felt,
+    pub enc_user_addr_value: Felt,
+}
+
+/// Storage slot addresses from the Cairo reference fixture.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CairoRefSlots {
+    pub compliance_public_key_address: Felt,
+    pub sender_public_key_address: Felt,
+    pub recipient_public_key_address: Felt,
+    pub enc_private_key_ephemeral_address: Felt,
+    pub enc_private_key_enc_key_address: Felt,
+    pub channel_exists_address: Felt,
+    pub recipient_channels_base_address: Felt,
+    pub recipient_channels_element_address: Felt,
+    pub subchannel_exists_address: Felt,
+    pub subchannel_tokens_salt_address: Felt,
+    pub subchannel_tokens_enc_token_address: Felt,
+    pub notes_address: Felt,
+    pub nullifiers_address: Felt,
+}
+
+/// Loads the devnet fixture from the embedded JSON file.
+pub fn load_devnet_fixture() -> DevnetFixture {
+    const JSON: &str = include_str!("../tests/fixtures/devnet-state.json");
+    serde_json::from_str(JSON).expect("failed to parse devnet fixture")
+}
+
+/// Loads the Cairo reference fixture from the embedded JSON file.
+pub fn load_cairo_ref_fixture() -> CairoRefFixture {
+    const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
+    serde_json::from_str(JSON).expect("failed to parse Cairo reference fixture")
+}


### PR DESCRIPTION
### TL;DR

Added subchannel token decryption functionality and refactored test fixtures for better reuse.

### What changed?

- Added `decrypt_subchannel_token` function to decrypt token addresses from encrypted subchannel info
- Added new hash functions:
  - `compute_subchannel_key` to derive subchannel keys from channel keys and indices
  - `compute_enc_token_hash` to calculate encryption masks for token encryption
- Added new domain separation tags for subchannel operations
- Created a shared `test_fixtures` module to centralize fixture loading code
- Added tests for the new decryption and hash functions

### How to test?

- Run the unit tests with `cargo test` to verify the new functionality
- The tests use reference vectors from Cairo implementation to ensure compatibility

### Why make this change?

This change enables the discovery of tokens within subchannels, which is a critical part of the privacy protocol. By decrypting subchannel information, users can identify which tokens are available in their channels. The refactoring of test fixtures improves code maintainability by centralizing fixture loading logic that was previously duplicated across multiple test modules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/327)
<!-- Reviewable:end -->
