### PR TITLE
feat(indexer): notes discovery

### DIFF
--- a/.claude/commands/code-guidelines.md
+++ b/.claude/commands/code-guidelines.md
@@ -55,6 +55,11 @@ Apply these guidelines when writing or reviewing code in this codebase.
 - Inline directly in function arguments if it doesn't hurt readability
 - *Example:* `spawn(foo.clone(), bar.clone())` instead of `let foo = foo.clone(); let bar = bar.clone(); spawn(foo, bar)`
 
+### Check for existing utilities before adding new ones
+- Before writing a local helper function, search the codebase for existing shared utilities
+- If similar code exists in multiple places, extract to a shared module (e.g., `test_fixtures.rs` for test helpers)
+- *Example:* Test helpers like `get_channel_key()` belong in `test_fixtures.rs`, not duplicated in each test module
+
 ---
 
 ## Comments

--- a/crates/discovery-core/src/decryption.rs
+++ b/crates/discovery-core/src/decryption.rs
@@ -7,9 +7,10 @@ use starknet_types_core::{curve::AffinePoint, felt::Felt};
 use thiserror::Error;
 
 use crate::hashes::{
-    compute_enc_channel_key_hash, compute_enc_sender_addr_hash, compute_enc_token_hash,
+    compute_enc_amount_hash, compute_enc_channel_key_hash, compute_enc_sender_addr_hash,
+    compute_enc_token_hash,
 };
-use crate::types::{ChannelInfo, EncChannelInfo, EncSubchannelInfo};
+use crate::types::{felt_low_u128, ChannelInfo, EncChannelInfo, EncSubchannelInfo};
 
 /// Errors that can occur during decryption.
 #[derive(Debug, Error)]
@@ -68,6 +69,36 @@ pub fn decrypt_subchannel_token(enc: &EncSubchannelInfo, channel_key: &Felt, ind
     enc.enc_token - enc_token_hash
 }
 
+/// Unpacks a packed note amount into salt and encrypted amount.
+///
+/// Packed format (big-endian): `packed = salt * 2^128 + enc_amount`
+/// - Bytes [0..16]: salt
+/// - Bytes [16..32]: enc_amount
+pub fn unpack_note_amount(packed_amount: Felt) -> (u128, u128) {
+    let d = packed_amount.to_le_digits();
+    let enc_amount = d[0] as u128 | (d[1] as u128) << 64;
+    let salt = d[2] as u128 | (d[3] as u128) << 64;
+    (salt, enc_amount)
+}
+
+/// Decrypts an encrypted note amount.
+///
+/// `amount = (enc_amount - pad) % 2^128`
+/// where `pad = hash(ENC_AMOUNT_TAG, channel_key, token, index, 0, salt) % 2^128`
+pub fn decrypt_note_amount(
+    enc_amount: u128,
+    salt: u128,
+    channel_key: Felt,
+    token: Felt,
+    index: u64,
+) -> u128 {
+    let enc_amount_hash = compute_enc_amount_hash(channel_key, token, index, salt);
+    let pad = felt_low_u128(enc_amount_hash);
+
+    // Wrapping subtraction: (enc_amount - pad) % 2^128
+    enc_amount.wrapping_sub(pad)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +147,24 @@ mod tests {
         let token = decrypt_subchannel_token(&encrypted, &f.inputs.channel_key, f.inputs.index);
 
         assert_eq!(token, f.inputs.token);
+    }
+
+    #[test]
+    fn test_unpack_and_decrypt_note_amount_with_cairo_vectors() {
+        let f = load_cairo_ref_fixture();
+
+        let (salt, enc_amount) = unpack_note_amount(f.outputs.enc_note_amount);
+        // Compare salt as u128 by converting the fixture's Felt to u128
+        let expected_salt = felt_low_u128(f.inputs.salt);
+        assert_eq!(salt, expected_salt);
+
+        let amount = decrypt_note_amount(
+            enc_amount,
+            salt,
+            f.inputs.channel_key,
+            f.inputs.token,
+            f.inputs.index,
+        );
+        assert_eq!(amount, f.outputs.dec_note_amount as u128);
     }
 }

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -6,10 +6,8 @@ use crate::decryption::DecryptionError;
 use crate::storage::StorageError;
 
 pub mod incoming_channels;
+pub mod notes;
 pub mod subchannels;
-
-pub use incoming_channels::{discover_incoming_channels, DiscoveryResult, IncomingChannel};
-pub use subchannels::{discover_subchannels, Subchannel, SubchannelDiscoveryResult};
 
 /// Errors that can occur during channel discovery.
 #[derive(Debug, Error)]

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -1,0 +1,220 @@
+//! Notes discovery for a subchannel (channel_key + token pair).
+//!
+//! This module provides functionality to discover and decrypt notes
+//! within a specific subchannel.
+//!
+//! # Sequential vs Parallel Scanning
+//!
+//! Notes within a subchannel are scanned sequentially because:
+//! - Request budget is limited and pagination is cursor-based
+//! - Parallel requests may not all complete within budget
+//! - Sequential scanning avoids gaps in discovered indices
+//!
+//! However, parallelization is possible at higher levels:
+//! - Multiple subchannel scans (for notes) can run in parallel
+//! - Multiple channel scans (for subchannels) can run in parallel
+
+use starknet_types_core::felt::Felt;
+
+use super::DiscoveryError;
+use crate::decryption::{decrypt_note_amount, unpack_note_amount};
+use crate::hashes::compute_note_id;
+use crate::storage::IViews;
+
+/// A discovered and decrypted note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecryptedNote {
+    /// The index of this note within the subchannel.
+    pub index: u64,
+    /// The note ID (storage key).
+    pub note_id: Felt,
+    /// The decrypted amount.
+    pub amount: u128,
+    /// The salt used for encryption.
+    pub salt: u128,
+}
+
+/// Result of notes discovery operation.
+#[derive(Debug, Clone)]
+pub struct NotesDiscoveryResult {
+    /// List of discovered and decrypted notes.
+    pub notes: Vec<DecryptedNote>,
+    /// Total number of notes discovered.
+    /// Use this as `start_index` for incremental discovery.
+    pub total_n_notes: u64,
+}
+
+/// Discovers and decrypts notes for a given channel key and token.
+///
+/// # Algorithm
+///
+/// For each note index starting from `start_index`:
+/// 1. Compute `note_id = hash(NOTE_ID_TAG, channel_key, token, index, 0)`
+/// 2. Fetch `packed_amount` from storage
+/// 3. If `packed_amount == 0`, stop (sentinel - no more notes)
+/// 4. Decrypt to get `(amount, salt)`
+///
+/// # Arguments
+///
+/// * `privacy_pool` - Storage backend implementing the IViews trait.
+/// * `channel_key` - The channel key.
+/// * `token` - The token address for this subchannel.
+/// * `start_index` - Starting index (inclusive). For incremental discovery, pass
+///   `total_n_notes` from previous result.
+///
+/// # Returns
+///
+/// A `NotesDiscoveryResult` containing all discovered notes and metadata
+/// for incremental discovery.
+pub async fn discover_notes<PrivacyPool: IViews>(
+    privacy_pool: &PrivacyPool,
+    channel_key: Felt,
+    token: Felt,
+    start_index: u64,
+) -> Result<NotesDiscoveryResult, DiscoveryError> {
+    let mut notes = Vec::new();
+    let mut index = start_index;
+
+    loop {
+        let note_id = compute_note_id(channel_key, token, index);
+        let packed_amount = privacy_pool.get_note(note_id).await?;
+
+        // Sentinel: contract stores zero for non-existent notes
+        if packed_amount == Felt::ZERO {
+            break;
+        }
+
+        let (salt, enc_amount) = unpack_note_amount(packed_amount);
+
+        // TODO: Open notes (salt == 1) store the amount in plaintext,
+        // so enc_amount is already the actual amount - no decryption needed.
+        let amount = decrypt_note_amount(enc_amount, salt, channel_key, token, index);
+
+        notes.push(DecryptedNote {
+            index,
+            note_id,
+            amount,
+            salt,
+        });
+        index += 1;
+    }
+
+    Ok(NotesDiscoveryResult {
+        notes,
+        total_n_notes: index,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_backend::MockBackend;
+    use crate::test_fixtures::{get_channel_key, get_subchannel_token, load_devnet_fixture};
+
+    #[tokio::test]
+    async fn test_discover_no_notes() {
+        let backend = MockBackend::empty();
+        let channel_key = Felt::from_hex_unchecked("0x12345");
+        let token = Felt::from_hex_unchecked("0x67890");
+
+        let result = discover_notes(&backend, channel_key, token, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(result.notes.len(), 0);
+        assert_eq!(result.total_n_notes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_alice_self_channel() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // Discover channel -> subchannel -> notes
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        let result = discover_notes(&backend, channel_key, token, 0)
+            .await
+            .unwrap();
+
+        assert!(
+            !result.notes.is_empty(),
+            "Alice's self-channel should have notes"
+        );
+        assert_eq!(result.total_n_notes, result.notes.len() as u64);
+        assert_eq!(result.notes[0].index, 0);
+        // The amount should be positive
+        assert!(result.notes[0].amount > 0, "Note amount should be positive");
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_bob_incoming() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // Discover Bob's incoming channel
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .expect("Bob should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Bob's channel should have at least one subchannel");
+
+        let result = discover_notes(&backend, channel_key, token, 0)
+            .await
+            .unwrap();
+
+        assert!(
+            !result.notes.is_empty(),
+            "Bob should have received notes from Alice"
+        );
+        assert!(result.notes[0].amount > 0, "Note amount should be positive");
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_incremental() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // Discover Alice's channel and subchannel
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        // First discovery
+        let result1 = discover_notes(&backend, channel_key, token, 0)
+            .await
+            .unwrap();
+        assert!(!result1.notes.is_empty());
+
+        // Incremental discovery starting from total - should find 0 new notes
+        let result2 = discover_notes(&backend, channel_key, token, result1.total_n_notes)
+            .await
+            .unwrap();
+        assert_eq!(result2.notes.len(), 0);
+        assert_eq!(result2.total_n_notes, result1.total_n_notes);
+    }
+}

--- a/crates/discovery-core/src/discovery/subchannels.rs
+++ b/crates/discovery-core/src/discovery/subchannels.rs
@@ -84,22 +84,7 @@ pub async fn discover_subchannels<PrivacyPool: IViews>(
 mod tests {
     use super::*;
     use crate::mock_backend::MockBackend;
-    use crate::test_fixtures::load_devnet_fixture;
-
-    /// Helper to discover channels and get the channel key for a recipient.
-    async fn get_channel_key(
-        backend: &MockBackend,
-        recipient: Felt,
-        viewing_key: &Felt,
-    ) -> Option<Felt> {
-        use crate::discovery::discover_incoming_channels;
-
-        let result = discover_incoming_channels(backend, recipient, viewing_key, 0)
-            .await
-            .ok()?;
-
-        result.channels.first().map(|c| c.info.channel_key)
-    }
+    use crate::test_fixtures::{get_channel_key, load_devnet_fixture};
 
     #[tokio::test]
     async fn test_discover_no_subchannels() {

--- a/crates/discovery-core/src/hashes.rs
+++ b/crates/discovery-core/src/hashes.rs
@@ -20,6 +20,12 @@ static SUBCHANNEL_KEY_TAG: LazyLock<Felt> =
 /// Domain separation tag for encrypted token.
 static ENC_TOKEN_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("ENC_TOKEN_TAG:V1"));
 
+/// Domain separation tag for note ID derivation.
+static NOTE_ID_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("NOTE_ID_TAG:V1"));
+
+/// Domain separation tag for encrypted amount.
+static ENC_AMOUNT_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("ENC_AMOUNT_TAG:V1"));
+
 /// Converts a short string (up to 31 ASCII chars) to Felt.
 fn short_string_to_felt(s: &str) -> Felt {
     assert!(
@@ -73,6 +79,33 @@ pub fn compute_enc_token_hash(channel_key: Felt, index: u64, salt: Felt) -> Felt
     ])
 }
 
+/// Computes the note ID from channel key, token, and note index.
+///
+/// `note_id = hash(NOTE_ID_TAG, channel_key, token, index, 0)`
+pub fn compute_note_id(channel_key: Felt, token: Felt, index: u64) -> Felt {
+    hash(&[
+        *NOTE_ID_TAG,
+        channel_key,
+        token,
+        Felt::from(index),
+        Felt::ZERO,
+    ])
+}
+
+/// Computes the encryption mask for note amount.
+///
+/// `enc_amount_hash = hash(ENC_AMOUNT_TAG, channel_key, token, index, 0, salt)`
+pub fn compute_enc_amount_hash(channel_key: Felt, token: Felt, index: u64, salt: u128) -> Felt {
+    hash(&[
+        *ENC_AMOUNT_TAG,
+        channel_key,
+        token,
+        Felt::from(index),
+        Felt::ZERO,
+        Felt::from(salt),
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,6 +145,27 @@ mod tests {
         assert_eq!(
             compute_enc_token_hash(f.inputs.channel_key, f.inputs.index, f.inputs.salt),
             f.outputs.enc_token_hash
+        );
+    }
+
+    #[test]
+    fn test_compute_note_id() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            compute_note_id(f.inputs.channel_key, f.inputs.token, f.inputs.index),
+            f.outputs.note_id
+        );
+    }
+
+    #[test]
+    fn test_compute_enc_amount_hash() {
+        use crate::types::felt_low_u128;
+
+        let f = load_cairo_ref_fixture();
+        let salt = felt_low_u128(f.inputs.salt);
+        assert_eq!(
+            compute_enc_amount_hash(f.inputs.channel_key, f.inputs.token, f.inputs.index, salt),
+            f.outputs.enc_amount_hash
         );
     }
 }

--- a/crates/discovery-core/src/test_fixtures.rs
+++ b/crates/discovery-core/src/test_fixtures.rs
@@ -130,3 +130,30 @@ pub fn load_cairo_ref_fixture() -> CairoRefFixture {
     const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
     serde_json::from_str(JSON).expect("failed to parse Cairo reference fixture")
 }
+
+/// Helper to discover channels and get the first channel key for a recipient.
+pub async fn get_channel_key(
+    backend: &crate::mock_backend::MockBackend,
+    recipient: starknet_types_core::felt::Felt,
+    viewing_key: &starknet_types_core::felt::Felt,
+) -> Option<starknet_types_core::felt::Felt> {
+    use crate::discovery::incoming_channels::discover_incoming_channels;
+
+    let result = discover_incoming_channels(backend, recipient, viewing_key, 0)
+        .await
+        .ok()?;
+
+    result.channels.first().map(|c| c.info.channel_key)
+}
+
+/// Helper to discover subchannels and get the first token for a channel.
+pub async fn get_subchannel_token(
+    backend: &crate::mock_backend::MockBackend,
+    channel_key: starknet_types_core::felt::Felt,
+) -> Option<starknet_types_core::felt::Felt> {
+    use crate::discovery::subchannels::discover_subchannels;
+
+    let result = discover_subchannels(backend, channel_key, 0).await.ok()?;
+
+    result.subchannels.first().map(|s| s.token)
+}

--- a/crates/discovery-core/src/types.rs
+++ b/crates/discovery-core/src/types.rs
@@ -5,6 +5,12 @@
 
 use starknet_types_core::felt::Felt;
 
+/// Extracts low 128 bits from a Felt.
+pub fn felt_low_u128(felt: Felt) -> u128 {
+    let d = felt.to_le_digits();
+    d[0] as u128 | (d[1] as u128) << 64
+}
+
 /// Trait for securely zeroing sensitive data from memory.
 ///
 /// This is a simplified version of the `zeroize` crate's `Zeroize` trait,


### PR DESCRIPTION
### TL;DR

Added support for discovering and decrypting notes within subchannels.

### What changed?

- Implemented note discovery functionality in a new `notes.rs` module
- Added decryption utilities for note amounts:
  - `unpack_note_amount`: Extracts salt and encrypted amount from packed format
  - `decrypt_note_amount`: Decrypts the encrypted amount using the channel key, token, and index
- Added hash functions for note operations:
  - `compute_note_id`: Derives the storage key for a note
  - `compute_enc_amount_hash`: Computes the encryption mask for note amounts
- Exposed the new functionality through the discovery module's public API
- Added comprehensive tests for the new functionality using existing fixtures

### How to test?

Run the test suite with:
```
cargo test -p discovery-core
```

The implementation includes specific tests for:
- Discovering notes in empty channels
- Discovering notes in Alice's self-channel
- Discovering notes in Bob's incoming channel
- Incremental note discovery

### Why make this change?

This change completes the privacy protocol's discovery capabilities by adding support for notes, which represent the actual value transfers within channels. With this implementation, users can now:

1. Discover incoming channels using their viewing key
2. Discover subchannels (token types) within those channels
3. Discover and decrypt notes (amounts) within those subchannels

This enables full visibility into received funds while maintaining privacy guarantees of the protocol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/331)
<!-- Reviewable:end -->
