### PR TITLE
feat(indexer): rpc storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,15 +190,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.55"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.55"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -436,19 +436,24 @@ name = "discovery-service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
+ "discovery-core",
  "dotenv",
+ "expect-test",
  "flate2",
  "libc",
  "reqwest",
  "serde",
  "serde_json",
  "starknet-core",
+ "starknet-providers",
  "starknet-types-core",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -461,6 +466,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "dotenv"
@@ -527,6 +538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expect-test"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,9 +555,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -552,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -827,14 +848,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1577,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1588,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -1765,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1876,7 +1896,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -1949,9 +1969,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2127,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2952,18 +2972,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3032,6 +3052,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -3,8 +3,29 @@ name = "discovery-service"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "discovery_service"
+path = "src/lib.rs"
+
+[[bin]]
+name = "discovery-service"
+path = "src/main.rs"
+
 [dependencies]
+# Internal
+discovery-core = { path = "../discovery-core" }
+
+# Async
+async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync"] }
+
+# StarkNet
+starknet-core = "0.16"
+starknet-providers = "0.16"
+starknet-types-core = "0.2"
+url = "2"
+
+# CLI and logging
 clap = { version = "4", features = ["derive"] }
 dotenv = "0.15"
 tracing = "0.1"
@@ -12,6 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/discovery-service/README.md
+++ b/crates/discovery-service/README.md
@@ -70,6 +70,14 @@ npm test -- --run devnet.test.ts
 ```
 This generates `devnet-dump.json.gz` and `devnet-dump.metadata.json` in the fixtures directory.
 
+### Time-sensitive transactions in fixtures
+
+The SDK tests use SNIP-9 outside execution to simulate a paymaster flow. Outside execution transactions include time bounds (`execute_after` and `execute_before`) that are validated against `block.timestamp` during execution.
+
+When `devnet_load` replays the dump, it uses the current system time for new blocks rather than preserving the original timestamps. This causes outside execution transactions to fail with "SRC9: now >= execute_before" if the dump is replayed after the time window expires.
+
+**Workaround:** The test harness prepends a `devnet_setTime` JSON-RPC call to the dump before loading. This sets devnet's clock to the timestamp recorded in the metadata file, ensuring the replayed transactions execute within their valid time window. See `load_dump()` in `tests/common/devnet.rs`.
+
 ### Run integration tests
 ```bash
 cargo test -p discovery-service --test integration

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -1,0 +1,6 @@
+//! Discovery service library.
+//!
+//! This crate provides the RPC-based storage backend for reading privacy contract
+//! state from a StarkNet node via JSON-RPC.
+
+pub mod rpc_backend;

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -1,0 +1,114 @@
+//! RPC-based implementation of the storage interface.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use discovery_core::storage::{RawStorageAccess, StorageBackend, StorageError, StorageSnapshot};
+use starknet_core::types::{requests::GetStorageAtRequest, BlockId, BlockTag, Felt};
+use starknet_providers::{
+    jsonrpc::{HttpTransport, JsonRpcClient},
+    Provider, ProviderRequestData, ProviderResponseData,
+};
+use url::Url;
+
+/// Configuration for the RPC backend.
+#[derive(Debug, Clone)]
+pub struct RpcConfig {
+    /// URL of the StarkNet JSON-RPC endpoint.
+    pub rpc_url: Url,
+    /// Address of the privacy contract to read from.
+    pub contract_address: Felt,
+}
+
+/// RPC-based storage backend that reads from a StarkNet node via JSON-RPC.
+pub struct RpcBackend {
+    provider: Arc<JsonRpcClient<HttpTransport>>,
+    contract_address: Felt,
+}
+
+impl RpcBackend {
+    /// Creates a new RPC backend with the given configuration.
+    pub fn new(config: RpcConfig) -> Self {
+        let transport = HttpTransport::new(config.rpc_url);
+        let provider = Arc::new(JsonRpcClient::new(transport));
+        Self {
+            provider,
+            contract_address: config.contract_address,
+        }
+    }
+}
+
+#[async_trait]
+impl StorageBackend for RpcBackend {
+    type Snapshot = RpcSnapshot;
+
+    async fn snapshot(&self, block_id: Option<BlockId>) -> Result<Self::Snapshot, StorageError> {
+        let block_id = block_id.unwrap_or(BlockId::Tag(BlockTag::Latest));
+        Ok(RpcSnapshot {
+            provider: Arc::clone(&self.provider),
+            contract_address: self.contract_address,
+            block_id,
+        })
+    }
+}
+
+/// Snapshot of storage at a specific block, accessed via RPC.
+pub struct RpcSnapshot {
+    provider: Arc<JsonRpcClient<HttpTransport>>,
+    contract_address: Felt,
+    block_id: BlockId,
+}
+
+#[async_trait]
+impl RawStorageAccess for RpcSnapshot {
+    async fn read_slot(&self, slot: Felt) -> Result<Felt, StorageError> {
+        self.provider
+            .get_storage_at(self.contract_address, slot, self.block_id)
+            .await
+            .map_err(|e| StorageError::Rpc(e.to_string()))
+    }
+
+    async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError> {
+        if slots.is_empty() {
+            return Ok(vec![]);
+        }
+        if slots.len() == 1 {
+            return Ok(vec![self.read_slot(slots[0]).await?]);
+        }
+
+        // Build batch request
+        let requests: Vec<ProviderRequestData> = slots
+            .iter()
+            .map(|&slot| {
+                ProviderRequestData::GetStorageAt(GetStorageAtRequest {
+                    contract_address: self.contract_address,
+                    key: slot,
+                    block_id: self.block_id,
+                })
+            })
+            .collect();
+
+        // Execute batch
+        let responses = self
+            .provider
+            .batch_requests(&requests)
+            .await
+            .map_err(|e| StorageError::Rpc(e.to_string()))?;
+
+        // Extract results
+        responses
+            .into_iter()
+            .map(|resp| match resp {
+                ProviderResponseData::GetStorageAt(value) => Ok(value),
+                _ => Err(StorageError::Rpc("Unexpected response type".into())),
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl StorageSnapshot for RpcSnapshot {
+    fn block_id(&self) -> BlockId {
+        self.block_id
+    }
+}

--- a/crates/discovery-service/tests/common/devnet.rs
+++ b/crates/discovery-service/tests/common/devnet.rs
@@ -84,60 +84,50 @@ impl Devnet {
         bail!("devnet failed to start")
     }
 
-    /// Load dump from fixtures directory using metadata file.
-    /// Loads the dump state, then sets devnet time from metadata.
-    /// Returns metadata containing contract and alice addresses.
-    pub async fn load_dump(&mut self, fixtures_dir: &Path) -> Result<DumpMetadata> {
+    /// Read metadata from fixtures directory.
+    fn read_metadata(fixtures_dir: &Path) -> Result<DumpMetadata> {
         let metadata_path = fixtures_dir.join("devnet-dump.metadata.json");
         let metadata: DumpMetadata = serde_json::from_str(
             &fs::read_to_string(&metadata_path)
                 .with_context(|| format!("failed to read {}", metadata_path.display()))?,
         )?;
+        Ok(metadata)
+    }
+
+    /// Load dump from fixtures directory.
+    /// Prepends a devnet_setTime call to ensure correct block timestamps during replay.
+    pub async fn load_dump(&mut self, fixtures_dir: &Path) -> Result<DumpMetadata> {
+        let metadata = Self::read_metadata(fixtures_dir)?;
 
         let dump_path = fixtures_dir.join("devnet-dump.json.gz");
         let gz_bytes = fs::read(&dump_path)
             .with_context(|| format!("failed to read {}", dump_path.display()))?;
 
-        self.set_time(metadata.timestamp).await?;
-        self.load_dump_bytes(&gz_bytes).await?;
+        // Decompress
+        let mut decoder = GzDecoder::new(&gz_bytes[..]);
+        let mut json_bytes = Vec::new();
+        decoder.read_to_end(&mut json_bytes)?;
 
-        Ok(metadata)
-    }
+        // Parse as JSON array
+        let mut dump: Vec<serde_json::Value> = serde_json::from_slice(&json_bytes)?;
 
-    /// Set devnet block timestamp via devnet_setTime JSON-RPC.
-    async fn set_time(&self, timestamp: u64) -> Result<()> {
-        let resp: serde_json::Value = reqwest::Client::new()
-            .post(self.rpc_url())
-            .json(&serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "devnet_setTime",
-                "params": { "time": timestamp }
-            }))
-            .send()
-            .await?
-            .json()
-            .await?;
+        // Prepend devnet_setTime call
+        let set_time_call = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "devnet_setTime",
+            "params": { "time": metadata.timestamp }
+        });
+        dump.insert(0, set_time_call);
 
-        if resp.get("error").is_some() {
-            bail!("devnet_setTime failed: {resp}");
-        }
-        Ok(())
-    }
-
-    /// Load gzipped dump bytes via devnet_load JSON-RPC.
-    async fn load_dump_bytes(&mut self, gz_bytes: &[u8]) -> Result<()> {
-        // Decompress to temp file
+        // Write modified dump to temp file
         let mut temp = NamedTempFile::new()?;
-        let mut decoder = GzDecoder::new(gz_bytes);
-        let mut buf = Vec::new();
-        decoder.read_to_end(&mut buf)?;
-        temp.write_all(&buf)?;
+        serde_json::to_writer(&mut temp, &dump)?;
         temp.flush()?;
 
         let path = temp.path().to_string_lossy().to_string();
 
-        // Call devnet_load
+        // Load via devnet_load
         let resp: serde_json::Value = reqwest::Client::new()
             .post(self.rpc_url())
             .json(&serde_json::json!({
@@ -156,7 +146,7 @@ impl Devnet {
         }
 
         self._temp_dump = Some(temp);
-        Ok(())
+        Ok(metadata)
     }
 
     pub fn rpc_url(&self) -> String {

--- a/crates/discovery-service/tests/common/mod.rs
+++ b/crates/discovery-service/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 mod devnet;
 
 pub use devnet::{Devnet, DevnetConfig};

--- a/crates/discovery-service/tests/integration.rs
+++ b/crates/discovery-service/tests/integration.rs
@@ -1,0 +1,67 @@
+//! Integration tests for RpcBackend against local devnet.
+//!
+//! ## Running tests
+//!
+//! ```sh
+//! cargo test -p discovery-service --test integration
+//! ```
+//!
+//! ## Updating snapshots
+//!
+//! When expected values change, update snapshots with:
+//! ```sh
+//! UPDATE_EXPECT=1 cargo test -p discovery-service --test integration
+//! ```
+
+mod common;
+
+use std::path::Path;
+
+use common::{Devnet, DevnetConfig};
+use discovery_core::storage::{IViews, StorageBackend};
+use discovery_service::rpc_backend::{RpcBackend, RpcConfig};
+use expect_test::expect;
+use starknet_core::types::Felt;
+use url::Url;
+
+async fn setup_devnet() -> (Devnet, Felt, Felt) {
+    let mut devnet = Devnet::spawn(DevnetConfig {
+        seed: 42,
+        accounts: 3,
+    })
+    .expect("failed to spawn devnet");
+
+    let fixtures_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let metadata = devnet
+        .load_dump(&fixtures_dir)
+        .await
+        .expect("failed to load dump");
+
+    (devnet, metadata.contract_address, metadata.alice_address)
+}
+
+#[tokio::test]
+async fn test_public_key_lookup() {
+    let (devnet, contract_address, alice_address) = setup_devnet().await;
+
+    let backend = RpcBackend::new(RpcConfig {
+        rpc_url: Url::parse(&devnet.rpc_url()).unwrap(),
+        contract_address,
+    });
+
+    let snapshot = backend.snapshot(None).await.unwrap();
+
+    // Alice should have a registered public key
+    let alice_pubkey = snapshot.get_public_key(alice_address).await.unwrap();
+    expect![[r#"
+        0x07913e4dbbc06e873598f6e0bb0076449079fbdd951650c7f7a258d1c6b6a82d
+    "#]]
+    .assert_eq(&format!("{:#066x}\n", alice_pubkey));
+
+    // Random address should have no public key (zero)
+    let random_pubkey = snapshot
+        .get_public_key(Felt::from_hex("0xdeadbeef").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(random_pubkey, Felt::ZERO);
+}


### PR DESCRIPTION
### TL;DR

Added RPC-based storage backend for the discovery service to read privacy contract state from StarkNet nodes.

### What changed?

- Created a new library structure for the discovery service with a dedicated RPC backend
- Implemented `RpcBackend` and `RpcSnapshot` that connect to StarkNet JSON-RPC endpoints
- Added integration tests using a local devnet with fixture data
- Updated the crate dependencies to include StarkNet libraries and async-trait
- Added comprehensive documentation for running integration tests

### How to test?

1. Install starknet-devnet: `cargo install starknet-devnet`
2. Build the privacy contract: `scarb build`
3. Run integration tests: `cargo test -p discovery-service --test integration`
4. To update snapshots when expected values change: `UPDATE_EXPECT=1 cargo test -p discovery-service --test integration`

### Why make this change?

This implementation allows the discovery service to read privacy contract state directly from StarkNet nodes via JSON-RPC, providing a crucial backend for the storage interface. The RPC backend enables querying public keys and other contract state, which is essential for the privacy protocol's functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/332)
<!-- Reviewable:end -->
