### PR TITLE
fix(sdk): reflect abi changes

### DIFF
--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -20,10 +20,6 @@ export const PrivacyPoolABI = [
     name: "privacy::actions::SetViewingKeyInput",
     members: [
       {
-        name: "private_key",
-        type: "core::felt252",
-      },
-      {
         name: "random",
         type: "core::felt252",
       },
@@ -33,10 +29,6 @@ export const PrivacyPoolABI = [
     type: "struct",
     name: "privacy::actions::OpenChannelInput",
     members: [
-      {
-        name: "sender_private_key",
-        type: "core::felt252",
-      },
       {
         name: "recipient_addr",
         type: "core::starknet::contract_address::ContractAddress",
@@ -94,10 +86,6 @@ export const PrivacyPoolABI = [
     name: "privacy::actions::CreateNoteInput",
     members: [
       {
-        name: "sender_private_key",
-        type: "core::felt252",
-      },
-      {
         name: "recipient_addr",
         type: "core::starknet::contract_address::ContractAddress",
       },
@@ -141,10 +129,6 @@ export const PrivacyPoolABI = [
     type: "struct",
     name: "privacy::actions::UseNoteInput",
     members: [
-      {
-        name: "owner_private_key",
-        type: "core::felt252",
-      },
       {
         name: "channel_key",
         type: "core::felt252",
@@ -486,6 +470,10 @@ export const PrivacyPoolABI = [
             type: "core::starknet::contract_address::ContractAddress",
           },
           {
+            name: "user_private_key",
+            type: "core::felt252",
+          },
+          {
             name: "client_actions",
             type: "core::array::Span::<privacy::actions::ClientAction>",
           },
@@ -500,6 +488,10 @@ export const PrivacyPoolABI = [
           {
             name: "user_addr",
             type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "user_private_key",
+            type: "core::felt252",
           },
           {
             name: "client_actions",
@@ -518,6 +510,10 @@ export const PrivacyPoolABI = [
             type: "core::starknet::contract_address::ContractAddress",
           },
           {
+            name: "user_private_key",
+            type: "core::felt252",
+          },
+          {
             name: "client_actions",
             type: "core::array::Span::<privacy::actions::ClientAction>",
           },
@@ -527,7 +523,7 @@ export const PrivacyPoolABI = [
             type: "core::array::Span::<privacy::actions::ServerAction>",
           },
         ],
-        state_mutability: "external",
+        state_mutability: "view",
       },
       {
         type: "function",
@@ -536,6 +532,10 @@ export const PrivacyPoolABI = [
           {
             name: "user_addr",
             type: "core::starknet::contract_address::ContractAddress",
+          },
+          {
+            name: "user_private_key",
+            type: "core::felt252",
           },
           {
             name: "client_actions",

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -52,8 +52,9 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
   }
 
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
-    // Get compiler with current viewing key
-    const compiler = await this.getCompiler();
+    // Get viewing key for both compiler and calldata
+    const viewingKey = await this.params.viewingKeyProvider.getViewingKey();
+    const compiler = new ActionCompiler(this.user, viewingKey, this.params.discoveryProvider);
 
     // Compile actions
     const { clientActions, registry } = await compiler.compile(actions, options);
@@ -63,7 +64,11 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
 
     // Use CallData to compile the arguments
     const callDataCompiler = new CallData(PrivacyPoolABI);
-    const compiledCalldata = callDataCompiler.compile("__execute__", [this.user, cairoActions]);
+    const compiledCalldata = callDataCompiler.compile("__execute__", [
+      this.user,
+      viewingKey,
+      cairoActions,
+    ]);
 
     // Create invocation from the populated call (no account abstraction needed for proving)
     const invocation = {


### PR DESCRIPTION
### TL;DR

Updated the privacy pool ABI to move private keys from individual action inputs to the main execute function parameters.

### What changed?

- Removed `private_key` fields from various action input structs:
  - `SetViewingKeyInput`
  - `OpenChannelInput`
  - `CreateNoteInput`
  - `UseNoteInput`
- Added `user_private_key` parameter to all execute functions in the ABI
- Changed the state mutability of one execute function from `external` to `view`
- Updated the `execute` method in `PrivateTransfers` class to:
  - Pass the viewing key to both the compiler and calldata
  - Include the viewing key in the compiled calldata arguments

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/333)
<!-- Reviewable:end -->
