### PR TITLE
feat(indexer): discovery-core -> storage slots calculation

### DIFF
--- a/.github/workflows/on-merge.yaml
+++ b/.github/workflows/on-merge.yaml
@@ -10,9 +10,6 @@ jobs:
     uses: ./.github/workflows/test.yaml
     secrets: inherit
 
-  rust_ci:
-    uses: ./.github/workflows/rust-ci.yaml
-
   notify-slack:
     needs: test
     if: failure()

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -12,6 +12,3 @@ jobs:
 
   check_formatting:
     uses: ./.github/workflows/check_formatting.yaml
-
-  rust_ci:
-    uses: ./.github/workflows/rust-ci.yaml

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -1,10 +1,20 @@
 name: Rust CI
 
 on:
-  workflow_call:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'packages/**'
+      - '.github/workflows/rust-ci.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   rust_ci:
+    name: Build & Test
     runs-on: ubuntu-latest
 
     steps:
@@ -12,6 +22,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/package-lock.json
+
+      - name: Install Scarb
+        uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.15.0"
+
+      - name: Install snforge
+        uses: foundry-rs/setup-snfoundry@v3
 
       - name: Rust fmt
         run: cargo fmt --all -- --check
@@ -21,6 +45,12 @@ jobs:
 
       - name: Rust build
         run: cargo build --workspace --all-targets
+
+      - name: Generate Cairo reference data
+        run: |
+          cd sdk
+          npm run generate:cairo-refs
+          cp tests/fixtures/cairo-reference-data.json ../crates/discovery-core/tests/fixtures/cairo-reference-data.json
 
       - name: Rust test
         run: cargo test --workspace --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +68,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "clap"
@@ -114,6 +178,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "discovery-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "starknet-core",
+ "starknet-crypto",
+ "starknet-types-core",
+]
+
+[[package]]
 name = "discovery-service"
 version = "0.1.0"
 dependencies = [
@@ -131,6 +301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,16 +317,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "lambdaworks-crypto"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
+dependencies = [
+ "lambdaworks-math",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
+dependencies = [
+ "getrandom 0.2.17",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "lazy_static"
@@ -186,6 +511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +538,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -224,6 +593,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +626,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +701,130 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_json_pythonic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -278,16 +846,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "starknet-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb7212226769766c1c7d79b70f9242ffbd213290a41604ecc7e78faa0ed0deb"
+dependencies = [
+ "base64 0.21.7",
+ "crypto-bigint",
+ "flate2",
+ "foldhash",
+ "hex",
+ "indexmap",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with",
+ "sha3",
+ "starknet-core-derive",
+ "starknet-crypto",
+ "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-core-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "starknet-crypto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2",
+ "starknet-curve",
+ "starknet-types-core",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
+dependencies = [
+ "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-types-core"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90d23b1bc014ee4cce40056ab3114bcbcdc2dbc1e845bbfb1f8bd0bab63507d4"
+dependencies = [
+ "blake2",
+ "digest",
+ "lambdaworks-crypto",
+ "lambdaworks-math",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand 0.9.2",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -308,6 +968,25 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "tokio"
@@ -396,6 +1075,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,10 +1099,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"
@@ -433,3 +1178,41 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/discovery-core",
     "crates/discovery-service",
 ]

--- a/crates/discovery-core/Cargo.toml
+++ b/crates/discovery-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "discovery-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+starknet-core = "0.16"
+starknet-crypto = "0.8"
+starknet-types-core = "0.2"
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+starknet-types-core = { version = "0.2", features = ["serde"] }

--- a/crates/discovery-core/README.md
+++ b/crates/discovery-core/README.md
@@ -1,0 +1,13 @@
+# discovery-core
+
+Core discovery logic for the privacy pool, including storage slot computation and a simple RPC backend for testing and benchmarking.
+
+## Test Vectors
+
+Test vectors are generated from the Cairo contract. To regenerate:
+
+```bash
+cd sdk
+npm run generate:cairo-refs
+cp tests/fixtures/cairo-reference-data.json ../crates/discovery-core/tests/fixtures/cairo-reference-data.json
+```

--- a/crates/discovery-core/src/lib.rs
+++ b/crates/discovery-core/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod storage_slots;

--- a/crates/discovery-core/src/storage_slots.rs
+++ b/crates/discovery-core/src/storage_slots.rs
@@ -1,0 +1,210 @@
+use anyhow::{Context, Result};
+use starknet_core::utils::get_storage_var_address;
+use starknet_crypto::pedersen_hash;
+use starknet_types_core::felt::Felt;
+
+/// Storage slots for encrypted private key (2 consecutive slots).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncPrivateKeySlots {
+    pub ephemeral_pubkey: Felt,
+    pub enc_private_key: Felt,
+}
+
+/// Storage slots for encrypted channel info in recipient_channels Vec.
+/// Each EncChannelInfo has 3 fields stored in consecutive slots.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncChannelInfoSlots {
+    pub ephemeral_pubkey: Felt,
+    pub enc_channel_key: Felt,
+    pub enc_sender_addr: Felt,
+}
+
+/// Storage slots for encrypted subchannel info (2 consecutive slots).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncSubchannelInfoSlots {
+    pub salt: Felt,
+    pub enc_token: Felt,
+}
+
+/// Storage slot for the compliance public key.
+/// Cairo: `compliance_public_key: PublicKey`
+pub fn compliance_public_key() -> Result<Felt> {
+    get_storage_var_address("compliance_public_key", &[])
+        .context("failed to compute compliance_public_key storage address")
+}
+
+/// Storage slot for a user's public key.
+/// Cairo: `public_key: LegacyMap<ContractAddress, PublicKey>`
+pub fn public_key(user_address: Felt) -> Result<Felt> {
+    get_storage_var_address("public_key", &[user_address])
+        .context("failed to compute public_key storage address")
+}
+
+/// Storage slots for a user's encrypted private key.
+/// Cairo: `enc_private_key: LegacyMap<ContractAddress, EncPrivateKey>`
+/// EncPrivateKey has 2 fields: ephemeral_public_key and enc_private_key.
+pub fn enc_private_key(user_address: Felt) -> Result<EncPrivateKeySlots> {
+    let base = get_storage_var_address("enc_private_key", &[user_address])
+        .context("failed to compute enc_private_key storage address")?;
+    Ok(EncPrivateKeySlots {
+        ephemeral_pubkey: base,
+        enc_private_key: base + Felt::ONE,
+    })
+}
+
+/// Storage slot for checking if a channel exists.
+/// Cairo: `channel_exists: LegacyMap<ChannelId, bool>`
+pub fn channel_exists(channel_id: Felt) -> Result<Felt> {
+    get_storage_var_address("channel_exists", &[channel_id])
+        .context("failed to compute channel_exists storage address")
+}
+
+/// Base storage address for recipient's channels Vec.
+/// Cairo: `recipient_channels: LegacyMap<ContractAddress, Vec<EncChannelInfo>>`
+/// The base address stores the length of the Vec.
+pub fn recipient_channels_base(recipient_address: Felt) -> Result<Felt> {
+    get_storage_var_address("recipient_channels", &[recipient_address])
+        .context("failed to compute recipient_channels storage address")
+}
+
+/// Storage slots for a specific element in recipient's channels Vec.
+/// Each EncChannelInfo has 3 fields stored consecutively.
+pub fn recipient_channels_element(
+    recipient_address: Felt,
+    index: u64,
+) -> Result<EncChannelInfoSlots> {
+    let base = recipient_channels_base(recipient_address)?;
+    let element_base = pedersen_hash(&base, &Felt::from(index));
+    Ok(EncChannelInfoSlots {
+        ephemeral_pubkey: element_base,
+        enc_channel_key: element_base + Felt::ONE,
+        enc_sender_addr: element_base + Felt::TWO,
+    })
+}
+
+/// Storage slot for checking if a subchannel exists.
+/// Cairo: `subchannel_exists: LegacyMap<SubchannelId, bool>`
+pub fn subchannel_exists(subchannel_id: Felt) -> Result<Felt> {
+    get_storage_var_address("subchannel_exists", &[subchannel_id])
+        .context("failed to compute subchannel_exists storage address")
+}
+
+/// Storage slots for encrypted subchannel info.
+/// Cairo: `subchannel_tokens: Map<felt252, EncSubchannelInfo>`
+/// EncSubchannelInfo has 2 fields: salt and enc_token.
+pub fn subchannel_tokens(subchannel_key: Felt) -> Result<EncSubchannelInfoSlots> {
+    let base = get_storage_var_address("subchannel_tokens", &[subchannel_key])
+        .context("failed to compute subchannel_tokens storage address")?;
+    Ok(EncSubchannelInfoSlots {
+        salt: base,
+        enc_token: base + Felt::ONE,
+    })
+}
+
+/// Storage slot for a note's existence.
+/// Cairo: `notes: LegacyMap<NoteId, bool>`
+pub fn notes(note_id: Felt) -> Result<Felt> {
+    get_storage_var_address("notes", &[note_id]).context("failed to compute notes storage address")
+}
+
+/// Storage slot for a nullifier's existence.
+/// Cairo: `nullifiers: LegacyMap<Nullifier, bool>`
+pub fn nullifiers(nullifier: Felt) -> Result<Felt> {
+    get_storage_var_address("nullifiers", &[nullifier])
+        .context("failed to compute nullifiers storage address")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Slots {
+        compliance_public_key_address: Felt,
+        sender_public_key_address: Felt,
+        recipient_public_key_address: Felt,
+        enc_private_key_ephemeral_address: Felt,
+        enc_private_key_enc_key_address: Felt,
+        channel_exists_address: Felt,
+        recipient_channels_base_address: Felt,
+        recipient_channels_element_address: Felt,
+        subchannel_exists_address: Felt,
+        subchannel_tokens_salt_address: Felt,
+        subchannel_tokens_enc_token_address: Felt,
+        notes_address: Felt,
+        nullifiers_address: Felt,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Inputs {
+        sender: Felt,
+        recipient: Felt,
+        channel_id: Felt,
+        subchannel_key: Felt,
+        subchannel_id: Felt,
+        note_id: Felt,
+        nullifier: Felt,
+    }
+
+    #[derive(Deserialize)]
+    struct Fixture {
+        slots: Slots,
+        inputs: Inputs,
+    }
+
+    fn load_fixture() -> Fixture {
+        const JSON: &str = include_str!("../tests/fixtures/cairo-reference-data.json");
+        serde_json::from_str(JSON).expect("failed to parse fixture")
+    }
+
+    #[test]
+    fn test_storage_slots_with_cairo_vectors() {
+        let f = load_fixture();
+        let i = &f.inputs;
+        let s = &f.slots;
+
+        assert_eq!(
+            compliance_public_key().unwrap(),
+            s.compliance_public_key_address
+        );
+        assert_eq!(public_key(i.sender).unwrap(), s.sender_public_key_address);
+        assert_eq!(
+            public_key(i.recipient).unwrap(),
+            s.recipient_public_key_address
+        );
+
+        let enc_pk = enc_private_key(i.sender).unwrap();
+        assert_eq!(enc_pk.ephemeral_pubkey, s.enc_private_key_ephemeral_address);
+        assert_eq!(enc_pk.enc_private_key, s.enc_private_key_enc_key_address);
+
+        assert_eq!(
+            channel_exists(i.channel_id).unwrap(),
+            s.channel_exists_address
+        );
+        assert_eq!(
+            recipient_channels_base(i.recipient).unwrap(),
+            s.recipient_channels_base_address
+        );
+        assert_eq!(
+            recipient_channels_element(i.recipient, 0)
+                .unwrap()
+                .ephemeral_pubkey,
+            s.recipient_channels_element_address
+        );
+
+        assert_eq!(
+            subchannel_exists(i.subchannel_id).unwrap(),
+            s.subchannel_exists_address
+        );
+
+        let tokens = subchannel_tokens(i.subchannel_key).unwrap();
+        assert_eq!(tokens.salt, s.subchannel_tokens_salt_address);
+        assert_eq!(tokens.enc_token, s.subchannel_tokens_enc_token_address);
+
+        assert_eq!(notes(i.note_id).unwrap(), s.notes_address);
+        assert_eq!(nullifiers(i.nullifier).unwrap(), s.nullifiers_address);
+    }
+}

--- a/crates/discovery-core/tests/fixtures/cairo-reference-data.json
+++ b/crates/discovery-core/tests/fixtures/cairo-reference-data.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Reference values from Cairo implementation. Regenerate with: npx tsx scripts/generate-cairo-refs.ts",
+  "_ttl_days": 1,
+  "_generated": "2026-01-25",
+  "inputs": {
+    "sender": "0x123",
+    "recipient": "0x456",
+    "senderPrivateKey": "0x789",
+    "recipientPublicKey": "0xabc",
+    "channelKey": "0xdef",
+    "token": "0x1234",
+    "index": 5,
+    "channelId": "0x7309a89bdfa0bb6b922eacee506760a8b68c53256b4ef7dd0181181f6671bcb",
+    "subchannelKey": "0x3a8c0e4f11d30d06a65772a5ddbf598f40446d41dede067aaa9b321b79dc90a",
+    "subchannelId": "0x5d017d0ab753ba429478f7b484cd49ec19f15d272272de7ebd5c2051822d959",
+    "noteId": "0x70221e8eadc952c74cf4cb481069330705bccd96dcfb9cabbf0bbb301fdf9f5",
+    "nullifier": "0x6934fcf1d982c246779f75fda7340a81592af6bc1ea4f627ae67a41bceca0fc"
+  },
+  "slots": {
+    "compliancePublicKeyAddress": "0xf8612cacb74429aab92a1b3e95db91c6a0c6e6436b0777064ed21bb4ecb0ed",
+    "senderPublicKeyAddress": "0x5935778edf7d690937af7b24298a23b064e54fcfd2e01e181ba011593a848bf",
+    "recipientPublicKeyAddress": "0x703dc5fd86f5987705cf14bd6c50c0e55120f37a0ecac2d8895ccd7e909e62f",
+    "encPrivateKeyEphemeralAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aac",
+    "encPrivateKeyEncKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aad",
+    "channelExistsAddress": "0x6bbc6fc39c5a0cb5f933973721507ada6cebf16fc0871d5867c22ded6acb942",
+    "recipientChannelsBaseAddress": "0x5039a0f3a2efd831149644f87a421ded13d54721469cd2a552d761d2f523646",
+    "recipientChannelsElementAddress": "0x1964d92b29305036d5487cc7726d73ef02560413e3cb5a8358009f7651eeb6e",
+    "subchannelExistsAddress": "0x44fe24f62aea383cf5113a3a10767a29d70951d3d003b492b35ef1188586d24",
+    "subchannelTokensSaltAddress": "0x5f9e2041e312007e495740073f749dabf1e3a66badbca56daaf34ee887e0177",
+    "subchannelTokensEncTokenAddress": "0x5f9e2041e312007e495740073f749dabf1e3a66badbca56daaf34ee887e0178",
+    "notesAddress": "0x31a26a8a4a17cebab81d6bff13db6d53a45c5fcd059fbaba84d1e2b68506d17",
+    "nullifiersAddress": "0x74d2869e4d7e4bfde6ed569ba47e8e8773952ab689eeb85d8f6a263c0c77f6b"
+  },
+  "outputs": {
+    "channelKey": "0x67db9bd0362ca14c4418ecd78e743d96b069a24c0a5abe7cdb01f95cd0174e",
+    "channelId": "0x7309a89bdfa0bb6b922eacee506760a8b68c53256b4ef7dd0181181f6671bcb",
+    "subchannelKey": "0x3a8c0e4f11d30d06a65772a5ddbf598f40446d41dede067aaa9b321b79dc90a",
+    "subchannelId": "0x5d017d0ab753ba429478f7b484cd49ec19f15d272272de7ebd5c2051822d959",
+    "noteId": "0x70221e8eadc952c74cf4cb481069330705bccd96dcfb9cabbf0bbb301fdf9f5",
+    "nullifier": "0x6934fcf1d982c246779f75fda7340a81592af6bc1ea4f627ae67a41bceca0fc"
+  }
+}

--- a/packages/privacy/src/tests.cairo
+++ b/packages/privacy/src/tests.cairo
@@ -1,4 +1,4 @@
-pub mod generate_reference_hashes;
+pub mod generate_reference_data;
 pub mod mock_account;
 pub mod test_client;
 pub mod test_compliance;

--- a/packages/privacy/src/tests/generate_reference_data.cairo
+++ b/packages/privacy/src/tests/generate_reference_data.cairo
@@ -1,9 +1,9 @@
 /// Reference hash generator for TypeScript SDK compatibility testing.
 ///
 /// This test is ignored by default. Run explicitly with:
-///   snforge test generate_reference_hashes --include-ignored
+///   snforge test generate_reference --include-ignored
 ///
-/// The output should be used to update: sdk/tests/fixtures/cairo-reference-hashes.json
+/// The output should be used to update: sdk/tests/fixtures/cairo-reference-data.json
 use privacy::hashes::{
     compute_channel_id, compute_channel_key, compute_enc_amount_hash, compute_enc_channel_key_hash,
     compute_enc_private_key_hash, compute_enc_recipient_addr_hash, compute_enc_sender_addr_hash,
@@ -14,9 +14,10 @@ use privacy::utils::{
     decrypt_note_amount, derive_public_key, encrypt_channel_info, encrypt_note_amount,
     encrypt_outgoing_channel_info, encrypt_private_key, encrypt_subchannel_info, encrypt_user_addr,
 };
+use snforge_std::map_entry_address;
 use starknet::ContractAddress;
 
-// Test inputs - must match sdk/tests/fixtures/cairo-reference-hashes.json
+// Test inputs - must match sdk/tests/fixtures/cairo-reference-data.json
 const SENDER: felt252 = 0x123;
 const RECIPIENT: felt252 = 0x456;
 const SENDER_PRIVATE_KEY: felt252 = 0x789;
@@ -161,3 +162,113 @@ fn generate_reference_hashes() {
     println!("==============================");
 }
 
+/// Storage slot test vector generator for discovery service compatibility testing.
+///
+/// This test is ignored by default. Run explicitly with:
+///   snforge test generate_storage_slots --include-ignored
+///
+/// The output provides test vectors allowing the discovery service to verify their
+/// storage address computation implementation.
+///
+/// Storage address formula for Map<K, V>:
+///   address = pedersen(sn_keccak(variable_name), key) mod (2^251 - 256)
+/// where sn_keccak is keccak256 truncated to 250 bits.
+#[test]
+#[ignore]
+fn generate_reference_storage_slots() {
+    let sender = to_address(SENDER);
+    let recipient = to_address(RECIPIENT);
+    let token = to_address(TOKEN);
+
+    // Compute hash values needed as keys
+    let channel_id = compute_channel_id(CHANNEL_KEY, sender, recipient, RECIPIENT_PUBLIC_KEY);
+    let subchannel_key = compute_subchannel_key(CHANNEL_KEY, INDEX);
+    let subchannel_id = compute_subchannel_id(CHANNEL_KEY, recipient, RECIPIENT_PUBLIC_KEY, token);
+    let note_id = compute_note_id(CHANNEL_KEY, token, INDEX);
+    let nullifier = compute_nullifier(CHANNEL_KEY, token, INDEX, SENDER_PRIVATE_KEY);
+
+    println!("=== STORAGE SLOTS ===");
+    // Formula for maps: address = pedersen(sn_keccak(variable_name), key) mod (2^251 - 256)
+    // Formula for simple vars: address = sn_keccak(variable_name)
+
+    // --- Simple variables ---
+    // compliance_public_key - felt252 (simple variable, address = sn_keccak(name))
+    let compliance_public_key_slot = selector!("compliance_public_key");
+
+    // public_key[user_addr] - Map<ContractAddress, felt252>
+    let public_key_slot = map_entry_address(
+        map_selector: selector!("public_key"), keys: [SENDER].span(),
+    );
+
+    // public_key[recipient_addr] - verification read
+    let recipient_public_key_slot = map_entry_address(
+        map_selector: selector!("public_key"), keys: [RECIPIENT].span(),
+    );
+
+    // enc_private_key[user_addr] - Map<ContractAddress, EncPrivateKey>
+    // EncPrivateKey is a struct with 2 fields stored at consecutive addresses
+    let enc_private_key_slot = map_entry_address(
+        map_selector: selector!("enc_private_key"), keys: [SENDER].span(),
+    );
+
+    // channel_exists[channel_id] - Map<felt252, bool>
+    let channel_exists_slot = map_entry_address(
+        map_selector: selector!("channel_exists"), keys: [channel_id].span(),
+    );
+
+    // recipient_channels[recipient_addr] - Vec<EncChannelInfo>
+    // Vec base address stores the length
+    let recipient_channels_base = map_entry_address(
+        map_selector: selector!("recipient_channels"), keys: [RECIPIENT].span(),
+    );
+    // Vec element address: pedersen(base_address, index)
+    let vec_index: felt252 = 0;
+    let recipient_channels_element = map_entry_address(
+        map_selector: recipient_channels_base, keys: [vec_index].span(),
+    );
+
+    // subchannel_exists[subchannel_id] - Map<felt252, bool>
+    let subchannel_exists_slot = map_entry_address(
+        map_selector: selector!("subchannel_exists"), keys: [subchannel_id].span(),
+    );
+
+    // subchannel_tokens[subchannel_key] - Map<felt252, EncSubchannelInfo>
+    // EncSubchannelInfo is a struct with 2 fields stored at consecutive addresses
+    let subchannel_tokens_slot = map_entry_address(
+        map_selector: selector!("subchannel_tokens"), keys: [subchannel_key].span(),
+    );
+
+    // notes[note_id] - Map<felt252, felt252>
+    let notes_slot = map_entry_address(map_selector: selector!("notes"), keys: [note_id].span());
+
+    // nullifiers[nullifier] - Map<felt252, bool>
+    let nullifiers_slot = map_entry_address(
+        map_selector: selector!("nullifiers"), keys: [nullifier].span(),
+    );
+
+    // Flat output for discovery-core compatibility
+    println!("slots.compliancePublicKeyAddress: 0x{:x}", compliance_public_key_slot);
+    println!("slots.senderPublicKeyAddress: 0x{:x}", public_key_slot);
+    println!("slots.recipientPublicKeyAddress: 0x{:x}", recipient_public_key_slot);
+    println!("slots.encPrivateKeyEphemeralAddress: 0x{:x}", enc_private_key_slot);
+    println!("slots.encPrivateKeyEncKeyAddress: 0x{:x}", enc_private_key_slot + 1);
+    println!("slots.channelExistsAddress: 0x{:x}", channel_exists_slot);
+    println!("slots.recipientChannelsBaseAddress: 0x{:x}", recipient_channels_base);
+    println!("slots.recipientChannelsElementAddress: 0x{:x}", recipient_channels_element);
+    println!("slots.subchannelExistsAddress: 0x{:x}", subchannel_exists_slot);
+    println!("slots.subchannelTokensSaltAddress: 0x{:x}", subchannel_tokens_slot);
+    println!("slots.subchannelTokensEncTokenAddress: 0x{:x}", subchannel_tokens_slot + 1);
+    println!("slots.notesAddress: 0x{:x}", notes_slot);
+    println!("slots.nullifiersAddress: 0x{:x}", nullifiers_slot);
+
+    // Inputs used for key computation
+    println!("inputs.sender: 0x{:x}", SENDER);
+    println!("inputs.recipient: 0x{:x}", RECIPIENT);
+    println!("inputs.channelId: 0x{:x}", channel_id);
+    println!("inputs.subchannelKey: 0x{:x}", subchannel_key);
+    println!("inputs.subchannelId: 0x{:x}", subchannel_id);
+    println!("inputs.noteId: 0x{:x}", note_id);
+    println!("inputs.nullifier: 0x{:x}", nullifier);
+
+    println!("==============================");
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -22,7 +22,7 @@
     "scarb:build": "cd .. && scarb build",
     "generate:abi": "node scripts/generate-abi.js",
     "generate:hashes": "npx tsx scripts/generate-hashes.ts && prettier --write src/utils/hashes.ts",
-    "generate:cairo-refs": "cd .. && scarb test -p privacy -- --color always generate_reference_hashes --include-ignored 2>&1 | tee target/cairo-refs-output.txt && cd sdk && npx tsx scripts/generate-cairo-refs.ts ../target/cairo-refs-output.txt",
+    "generate:cairo-refs": "cd .. && scarb test -p privacy -- --color always generate_reference --include-ignored 2>&1 | tee target/cairo-refs-output.txt && cd sdk && npx tsx scripts/generate-cairo-refs.ts ../target/cairo-refs-output.txt",
     "generate": "npm run scarb:build && npm run generate:abi && npm run generate:hashes && npm run generate:cairo-refs",
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint src tests --fix",

--- a/sdk/scripts/generate-cairo-refs.ts
+++ b/sdk/scripts/generate-cairo-refs.ts
@@ -1,5 +1,5 @@
 /**
- * Script to parse Cairo test output and generate reference hash JSON.
+ * Script to parse Cairo test output and generate reference data JSON.
  *
  * This script reads a file containing Cairo test output and extracts
  * key-value pairs like "path.to.key: 0x123" into a JSON structure.
@@ -12,7 +12,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const fixturesPath = join(__dirname, "../tests/fixtures/cairo-reference-hashes.json");
+const fixturesPath = join(__dirname, "../tests/fixtures/cairo-reference-data.json");
 
 // Get input file from command line argument
 const inputFile = process.argv[2];

--- a/sdk/tests/fixtures/cairo-reference-data.json
+++ b/sdk/tests/fixtures/cairo-reference-data.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Reference hash values from Cairo implementation. Regenerate by running Cairo and updating this file.",
+  "_comment": "Reference values from Cairo implementation. Regenerate with: npx tsx scripts/generate-cairo-refs.ts",
   "_ttl_days": 1,
   "inputs": {
     "sender": "0x123",
@@ -18,7 +18,27 @@
     "compliancePrivateKey": "0x54321",
     "compliancePublicKey": "0x61d0f6b01e5696a475786dbbd6de15f984b23a553be50018489781de416140",
     "userAddr": "0x999",
-    "userPrivateKey": "0x888"
+    "userPrivateKey": "0x888",
+    "channelId": "0x7309a89bdfa0bb6b922eacee506760a8b68c53256b4ef7dd0181181f6671bcb",
+    "subchannelKey": "0x3a8c0e4f11d30d06a65772a5ddbf598f40446d41dede067aaa9b321b79dc90a",
+    "subchannelId": "0x5d017d0ab753ba429478f7b484cd49ec19f15d272272de7ebd5c2051822d959",
+    "noteId": "0x70221e8eadc952c74cf4cb481069330705bccd96dcfb9cabbf0bbb301fdf9f5",
+    "nullifier": "0x6934fcf1d982c246779f75fda7340a81592af6bc1ea4f627ae67a41bceca0fc"
+  },
+  "slots": {
+    "compliancePublicKeyAddress": "0xf8612cacb74429aab92a1b3e95db91c6a0c6e6436b0777064ed21bb4ecb0ed",
+    "senderPublicKeyAddress": "0x5935778edf7d690937af7b24298a23b064e54fcfd2e01e181ba011593a848bf",
+    "recipientPublicKeyAddress": "0x703dc5fd86f5987705cf14bd6c50c0e55120f37a0ecac2d8895ccd7e909e62f",
+    "encPrivateKeyEphemeralAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aac",
+    "encPrivateKeyEncKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aad",
+    "channelExistsAddress": "0x6bbc6fc39c5a0cb5f933973721507ada6cebf16fc0871d5867c22ded6acb942",
+    "recipientChannelsBaseAddress": "0x5039a0f3a2efd831149644f87a421ded13d54721469cd2a552d761d2f523646",
+    "recipientChannelsElementAddress": "0x1964d92b29305036d5487cc7726d73ef02560413e3cb5a8358009f7651eeb6e",
+    "subchannelExistsAddress": "0x44fe24f62aea383cf5113a3a10767a29d70951d3d003b492b35ef1188586d24",
+    "subchannelTokensSaltAddress": "0x5f9e2041e312007e495740073f749dabf1e3a66badbca56daaf34ee887e0177",
+    "subchannelTokensEncTokenAddress": "0x5f9e2041e312007e495740073f749dabf1e3a66badbca56daaf34ee887e0178",
+    "notesAddress": "0x31a26a8a4a17cebab81d6bff13db6d53a45c5fcd059fbaba84d1e2b68506d17",
+    "nullifiersAddress": "0x74d2869e4d7e4bfde6ed569ba47e8e8773952ab689eeb85d8f6a263c0c77f6b"
   },
   "outputs": {
     "channelKey": "0x67db9bd0362ca14c4418ecd78e743d96b069a24c0a5abe7cdb01f95cd0174e",

--- a/sdk/tests/utils/encryption.test.ts
+++ b/sdk/tests/utils/encryption.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { encryptions } from "../../src/utils/encryptions.js";
-import referenceHashes from "../fixtures/cairo-reference-hashes.json" with { type: "json" };
+import referenceHashes from "../fixtures/cairo-reference-data.json" with { type: "json" };
 
 describe("Encryption Compatibility with Cairo", () => {
   const { inputs, outputs } = referenceHashes;

--- a/sdk/tests/utils/hashes.test.ts
+++ b/sdk/tests/utils/hashes.test.ts
@@ -21,7 +21,7 @@ import {
   compute_enc_recipient_addr_hash,
   compute_outgoing_channel_key,
 } from "../../src/utils/hashes.js";
-import referenceHashes from "../fixtures/cairo-reference-hashes.json" with { type: "json" };
+import referenceHashes from "../fixtures/cairo-reference-data.json" with { type: "json" };
 
 describe("Hash Compatibility with Cairo", () => {
   const { inputs, outputs } = referenceHashes;


### PR DESCRIPTION
### TL;DR

Refactor Rust CI workflow and add discovery-core crate for storage slot computation.

### What changed?

- Refactored the Rust CI workflow to run on specific file paths rather than on every PR
- Added a new `discovery-core` crate with storage slot computation logic
- Added tests that verify storage slot computation against Cairo reference data
- Updated the Cairo test to generate storage slot reference data
- Renamed `cairo-reference-hashes.json` to `cairo-reference-data.json` to reflect its expanded purpose

### How to test?

1. Run the Rust tests:
   ```bash
   cargo test -p discovery-core
   ```

2. Generate Cairo reference data:
   ```bash
   cd sdk
   npm run generate:cairo-refs
   ```

3. Verify the Rust implementation matches the Cairo reference data:
   ```bash
   cargo test -p discovery-core -- --nocapture
   ```

### Why make this change?

This change adds core functionality for the discovery service to compute storage slots for the privacy pool contract. The storage slot computation is essential for the discovery service to efficiently read encrypted data from the contract storage. By implementing this in Rust, we ensure consistent behavior between the discovery service and the Cairo contract.

The CI workflow changes optimize the build process by only running Rust tests when relevant files change, and by setting up the necessary dependencies for testing against Cairo reference data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/334)
<!-- Reviewable:end -->
