### PR TITLE
feat(indexer): concurrent rpc backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,9 @@ dependencies = [
  "starknet-providers",
  "starknet-types-core",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2400,8 +2402,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/discovery-core/src/storage.rs
+++ b/crates/discovery-core/src/storage.rs
@@ -12,18 +12,15 @@ use crate::types::{EncChannelInfo, EncPrivateKey, EncSubchannelInfo};
 /// Errors that can occur during storage operations.
 #[derive(Debug, Error)]
 pub enum StorageError {
-    /// RPC communication error.
-    #[error("RPC error: {0}")]
-    Rpc(String),
     /// Failed to compute storage slot address.
     #[error("slot computation failed: {0}")]
     SlotComputation(#[from] anyhow::Error),
-    /// Failed to establish connection.
-    #[error("connection failed: {0}")]
-    Connection(String),
     /// Failed to convert value to u64.
     #[error("value is too large to convert to u64: {0}")]
     CastToU64Error(Felt),
+    /// Backend-specific error.
+    #[error("{0}")]
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Factory for creating storage snapshots bound to a specific block.

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -25,6 +25,13 @@ starknet-providers = "0.16"
 starknet-types-core = "0.2"
 url = "2"
 
+# HTTP
+reqwest = { version = "0.12", features = ["json"] }
+tower = { version = "0.5", features = ["limit"] }
+
+# Error handling
+thiserror = "2"
+
 # CLI and logging
 clap = { version = "4", features = ["derive"] }
 dotenv = "0.15"
@@ -36,7 +43,6 @@ anyhow = "1.0"
 expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"
-reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 starknet-core = "0.16"

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -1,6 +1,7 @@
 //! RPC-based implementation of the storage interface.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use discovery_core::storage::{RawStorageAccess, StorageBackend, StorageError, StorageSnapshot};
@@ -9,7 +10,53 @@ use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
     Provider, ProviderRequestData, ProviderResponseData,
 };
+use thiserror::Error;
+use tower::limit::concurrency::ConcurrencyLimitLayer;
 use url::Url;
+
+/// Errors specific to the RPC backend.
+#[derive(Debug, Error)]
+pub enum RpcBackendError {
+    /// Failed to build the HTTP client.
+    #[error("failed to build HTTP client: {0}")]
+    HttpClientBuild(#[source] reqwest::Error),
+    /// RPC request failed.
+    #[error("RPC request failed: {0}")]
+    Request(String),
+    /// Unexpected response type from batch request.
+    #[error("unexpected response type from batch request")]
+    UnexpectedResponseType,
+}
+
+impl From<RpcBackendError> for StorageError {
+    fn from(err: RpcBackendError) -> Self {
+        StorageError::Backend(Box::new(err))
+    }
+}
+
+/// Configuration for the connection pool.
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Maximum number of concurrent RPC requests.
+    pub max_concurrent_requests: usize,
+    /// Connection timeout in seconds.
+    pub connect_timeout_secs: u64,
+    /// Request timeout in seconds.
+    pub request_timeout_secs: u64,
+    /// Maximum idle connections per host.
+    pub pool_max_idle_per_host: usize,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_requests: 10,
+            connect_timeout_secs: 30,
+            request_timeout_secs: 60,
+            pool_max_idle_per_host: 10,
+        }
+    }
+}
 
 /// Configuration for the RPC backend.
 #[derive(Debug, Clone)]
@@ -18,23 +65,65 @@ pub struct RpcConfig {
     pub rpc_url: Url,
     /// Address of the privacy contract to read from.
     pub contract_address: Felt,
+    /// Connection pool configuration.
+    pub pool_config: PoolConfig,
+}
+
+impl RpcConfig {
+    /// Creates a new RPC configuration with default pool settings.
+    pub fn new(rpc_url: Url, contract_address: Felt) -> Self {
+        Self {
+            rpc_url,
+            contract_address,
+            pool_config: PoolConfig::default(),
+        }
+    }
+
+    /// Sets the pool configuration.
+    pub fn with_pool_config(mut self, pool_config: PoolConfig) -> Self {
+        self.pool_config = pool_config;
+        self
+    }
+}
+
+/// Inner state shared across clones of RpcBackend.
+struct RpcBackendInner {
+    provider: JsonRpcClient<HttpTransport>,
+    contract_address: Felt,
 }
 
 /// RPC-based storage backend that reads from a StarkNet node via JSON-RPC.
+///
+/// This backend is cheaply cloneable and uses a connection pool with
+/// configurable concurrency limits. Cloned instances share the same
+/// underlying connection pool and concurrency limiter.
+#[derive(Clone)]
 pub struct RpcBackend {
-    provider: Arc<JsonRpcClient<HttpTransport>>,
-    contract_address: Felt,
+    inner: Arc<RpcBackendInner>,
 }
 
 impl RpcBackend {
     /// Creates a new RPC backend with the given configuration.
-    pub fn new(config: RpcConfig) -> Self {
-        let transport = HttpTransport::new(config.rpc_url);
-        let provider = Arc::new(JsonRpcClient::new(transport));
-        Self {
-            provider,
-            contract_address: config.contract_address,
-        }
+    pub fn new(config: RpcConfig) -> Result<Self, RpcBackendError> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(config.pool_config.connect_timeout_secs))
+            .timeout(Duration::from_secs(config.pool_config.request_timeout_secs))
+            .pool_max_idle_per_host(config.pool_config.pool_max_idle_per_host)
+            .connector_layer(ConcurrencyLimitLayer::new(
+                config.pool_config.max_concurrent_requests,
+            ))
+            .build()
+            .map_err(RpcBackendError::HttpClientBuild)?;
+
+        let transport = HttpTransport::new_with_client(config.rpc_url, client);
+        let provider = JsonRpcClient::new(transport);
+
+        Ok(Self {
+            inner: Arc::new(RpcBackendInner {
+                provider,
+                contract_address: config.contract_address,
+            }),
+        })
     }
 }
 
@@ -45,8 +134,7 @@ impl StorageBackend for RpcBackend {
     async fn snapshot(&self, block_id: Option<BlockId>) -> Result<Self::Snapshot, StorageError> {
         let block_id = block_id.unwrap_or(BlockId::Tag(BlockTag::Latest));
         Ok(RpcSnapshot {
-            provider: Arc::clone(&self.provider),
-            contract_address: self.contract_address,
+            backend: self.clone(),
             block_id,
         })
     }
@@ -54,18 +142,19 @@ impl StorageBackend for RpcBackend {
 
 /// Snapshot of storage at a specific block, accessed via RPC.
 pub struct RpcSnapshot {
-    provider: Arc<JsonRpcClient<HttpTransport>>,
-    contract_address: Felt,
+    backend: RpcBackend,
     block_id: BlockId,
 }
 
 #[async_trait]
 impl RawStorageAccess for RpcSnapshot {
     async fn read_slot(&self, slot: Felt) -> Result<Felt, StorageError> {
-        self.provider
-            .get_storage_at(self.contract_address, slot, self.block_id)
+        self.backend
+            .inner
+            .provider
+            .get_storage_at(self.backend.inner.contract_address, slot, self.block_id)
             .await
-            .map_err(|e| StorageError::Rpc(e.to_string()))
+            .map_err(|e| RpcBackendError::Request(e.to_string()).into())
     }
 
     async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError> {
@@ -81,7 +170,7 @@ impl RawStorageAccess for RpcSnapshot {
             .iter()
             .map(|&slot| {
                 ProviderRequestData::GetStorageAt(GetStorageAtRequest {
-                    contract_address: self.contract_address,
+                    contract_address: self.backend.inner.contract_address,
                     key: slot,
                     block_id: self.block_id,
                 })
@@ -90,17 +179,19 @@ impl RawStorageAccess for RpcSnapshot {
 
         // Execute batch
         let responses = self
+            .backend
+            .inner
             .provider
             .batch_requests(&requests)
             .await
-            .map_err(|e| StorageError::Rpc(e.to_string()))?;
+            .map_err(|e| RpcBackendError::Request(e.to_string()))?;
 
         // Extract results
         responses
             .into_iter()
             .map(|resp| match resp {
                 ProviderResponseData::GetStorageAt(value) => Ok(value),
-                _ => Err(StorageError::Rpc("Unexpected response type".into())),
+                _ => Err(RpcBackendError::UnexpectedResponseType.into()),
             })
             .collect()
     }

--- a/crates/discovery-service/tests/integration.rs
+++ b/crates/discovery-service/tests/integration.rs
@@ -44,10 +44,11 @@ async fn setup_devnet() -> (Devnet, Felt, Felt) {
 async fn test_public_key_lookup() {
     let (devnet, contract_address, alice_address) = setup_devnet().await;
 
-    let backend = RpcBackend::new(RpcConfig {
-        rpc_url: Url::parse(&devnet.rpc_url()).unwrap(),
+    let backend = RpcBackend::new(RpcConfig::new(
+        Url::parse(&devnet.rpc_url()).unwrap(),
         contract_address,
-    });
+    ))
+    .unwrap();
 
     let snapshot = backend.snapshot(None).await.unwrap();
 


### PR DESCRIPTION
### TL;DR

Improved RPC backend with connection pooling, concurrency limits, and better error handling.

### What changed?

- Refactored the RPC backend to use connection pooling with configurable timeouts and concurrency limits
- Added `tower` dependency for request rate limiting
- Implemented a more structured error handling approach:
  - Created a dedicated `RpcBackendError` enum for RPC-specific errors
  - Updated `StorageError` to use a generic backend error type
- Made `RpcBackend` cheaply cloneable with shared connection pool
- Added configuration options for connection pool settings (timeouts, max concurrent requests, etc.)
- Provided builder-style API for RPC configuration

### How to test?

- Run the integration tests to verify the RPC backend works with the new connection pooling
- Test with high concurrency to ensure the rate limiting works as expected
- Verify error handling by triggering various error conditions (invalid URLs, timeouts, etc.)

### Why make this change?

The previous implementation lacked proper connection management and could lead to resource exhaustion under high load. This change improves reliability and performance by:

1. Limiting concurrent requests to prevent overwhelming the RPC node
2. Reusing connections through connection pooling
3. Providing configurable timeouts to handle unresponsive nodes
4. Implementing a more robust error handling system that preserves error context

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/336)
<!-- Reviewable:end -->
