### PR TITLE
feat(indexer): chain state

### DIFF
--- a/crates/discovery-service/src/chain_state.rs
+++ b/crates/discovery-service/src/chain_state.rs
@@ -1,0 +1,90 @@
+//! Chain state tracking for the Starknet indexer.
+
+use async_trait::async_trait;
+use starknet_core::types::Felt;
+use starknet_providers::ProviderError;
+use thiserror::Error;
+
+/// Represents the current chain head.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainHead {
+    pub block_number: u64,
+    pub block_hash: Felt,
+    pub timestamp: u64,
+}
+
+/// Errors that can occur during chain state operations.
+#[derive(Debug, Error)]
+pub enum ChainStateError {
+    #[error("RPC request failed: {0}")]
+    RpcError(#[source] ProviderError),
+}
+
+/// Trait for tracking chain state and verifying block canonicity.
+#[async_trait]
+pub trait ChainState: Send + Sync {
+    /// Get the current chain head, if known.
+    async fn get_head(&self) -> Option<ChainHead>;
+
+    /// Set the current chain head.
+    async fn set_head(&self, head: ChainHead);
+
+    /// Check if a block hash is in the canonical chain.
+    ///
+    /// Returns `Ok(true)` if the block exists in the canonical chain,
+    /// `Ok(false)` if the block is not found (orphaned or non-existent),
+    /// and `Err` for RPC failures.
+    async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError>;
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+
+    /// Mock chain state for testing.
+    pub struct MockChainState {
+        head: Option<ChainHead>,
+        canonical_blocks: Vec<Felt>,
+    }
+
+    impl MockChainState {
+        pub fn new() -> Self {
+            Self {
+                head: Some(ChainHead {
+                    block_number: 100,
+                    block_hash: Felt::from_hex_unchecked("0x123"),
+                    timestamp: 1000,
+                }),
+                canonical_blocks: vec![Felt::from_hex_unchecked("0x123")],
+            }
+        }
+
+        pub fn with_no_head() -> Self {
+            Self {
+                head: None,
+                canonical_blocks: vec![],
+            }
+        }
+    }
+
+    impl Default for MockChainState {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl ChainState for MockChainState {
+        async fn get_head(&self) -> Option<ChainHead> {
+            self.head
+        }
+
+        async fn set_head(&self, _head: ChainHead) {
+            // No-op for mock
+        }
+
+        async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
+            Ok(self.canonical_blocks.contains(&block_hash))
+        }
+    }
+}

--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 
+use crate::chain_state::{ChainHead, ChainState};
+
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:5050/ws";
 
 /// Errors that can occur during indexer operation.
@@ -74,15 +76,20 @@ impl Default for IndexerConfig {
 }
 
 /// Indexer that subscribes to Starknet new heads via WebSocket.
-pub struct Indexer {
+pub struct Indexer<C: ChainState> {
     config: IndexerConfig,
     backoff: ExponentialBackoff,
     rx_shutdown: broadcast::Receiver<()>,
+    chain_state: C,
 }
 
-impl Indexer {
-    /// Creates a new indexer with the given configuration and shutdown receiver.
-    pub fn new(config: IndexerConfig, rx_shutdown: broadcast::Receiver<()>) -> Self {
+impl<C: ChainState> Indexer<C> {
+    /// Creates a new indexer with the given configuration, shutdown receiver, and chain state.
+    pub fn new(
+        config: IndexerConfig,
+        rx_shutdown: broadcast::Receiver<()>,
+        chain_state: C,
+    ) -> Self {
         let backoff = ExponentialBackoffBuilder::default()
             .with_initial_interval(config.backoff_initial_interval)
             .with_max_interval(config.backoff_max_interval)
@@ -92,6 +99,7 @@ impl Indexer {
             config,
             backoff,
             rx_shutdown,
+            chain_state,
         }
     }
 
@@ -153,6 +161,11 @@ impl Indexer {
                     match update? {
                         NewHeadsUpdate::NewHeader(head) => {
                             info!("New block #{}: {:#064x}", head.block_number, head.block_hash);
+                            self.chain_state.set_head(ChainHead {
+                                block_number: head.block_number,
+                                block_hash: head.block_hash,
+                                timestamp: head.timestamp,
+                            }).await;
                         }
                         NewHeadsUpdate::Reorg(reorg) => {
                             warn!(

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -3,7 +3,9 @@
 //! This crate provides:
 //! - RPC-based storage backend for reading privacy contract state
 //! - Indexer for Starknet new heads subscription
+//! - Chain state tracking for canonical block verification and recent head retrieval
 
+pub mod chain_state;
 pub mod indexer;
 pub mod rpc_backend;
 pub mod shutdown;

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -2,10 +2,12 @@
 
 use clap::Parser;
 use discovery_service::indexer::{Indexer, IndexerConfig};
+use discovery_service::rpc_backend::{RpcBackend, RpcConfig};
 use discovery_service::shutdown::Shutdown;
 use tokio::task::JoinHandle;
 use tracing::{error, info, subscriber::set_global_default};
 use tracing_subscriber::filter::EnvFilter;
+use url::Url;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -42,12 +44,25 @@ async fn main() {
 
     let shutdown = Shutdown::default();
 
+    // TODO: load config from a file rather than environment variables
+
     let mut indexer_config = IndexerConfig::default();
     if let Ok(ws_url) = std::env::var("WS_URL") {
         indexer_config.ws_url = ws_url;
     }
 
-    let mut indexer = Indexer::new(indexer_config, shutdown.subscribe());
+    let mut rpc_config = RpcConfig::default();
+    if let Ok(rpc_url) = std::env::var("RPC_URL") {
+        rpc_config.rpc_url = Url::parse(&rpc_url).expect("Failed to parse RPC_URL");
+    }
+    if let Ok(contract_address) = std::env::var("CONTRACT_ADDRESS") {
+        rpc_config.contract_address = contract_address
+            .parse()
+            .expect("Failed to parse CONTRACT_ADDRESS");
+    }
+    let rpc_backend = RpcBackend::new(rpc_config).expect("Failed to create RPC backend");
+
+    let mut indexer = Indexer::new(indexer_config, shutdown.subscribe(), rpc_backend);
     let indexer_handle = tokio::spawn(async move { indexer.run().await });
     let shutdown_handle = tokio::spawn(async move { shutdown.run().await });
 

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -1,18 +1,21 @@
-//! RPC-based implementation of the storage interface.
+//! RPC-based implementation of the storage interface and chain state.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use discovery_core::storage::{RawStorageAccess, StorageBackend, StorageError, StorageSnapshot};
-use starknet_core::types::{requests::GetStorageAtRequest, BlockId, BlockTag, Felt};
+use starknet_core::types::{requests::GetStorageAtRequest, BlockId, BlockTag, Felt, StarknetError};
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderRequestData, ProviderResponseData,
+    Provider, ProviderError, ProviderRequestData, ProviderResponseData,
 };
 use thiserror::Error;
+use tokio::sync::RwLock;
 use tower::limit::concurrency::ConcurrencyLimitLayer;
 use url::Url;
+
+use crate::chain_state::{ChainHead, ChainState, ChainStateError};
 
 /// Errors specific to the RPC backend.
 #[derive(Debug, Error)]
@@ -58,6 +61,8 @@ impl Default for PoolConfig {
     }
 }
 
+const DEFAULT_RPC_URL: &str = "http://127.0.0.1:5050";
+
 /// Configuration for the RPC backend.
 #[derive(Debug, Clone)]
 pub struct RpcConfig {
@@ -70,7 +75,7 @@ pub struct RpcConfig {
 }
 
 impl RpcConfig {
-    /// Creates a new RPC configuration with default pool settings.
+    /// Creates a new RPC configuration with the given URL and contract address.
     pub fn new(rpc_url: Url, contract_address: Felt) -> Self {
         Self {
             rpc_url,
@@ -78,11 +83,15 @@ impl RpcConfig {
             pool_config: PoolConfig::default(),
         }
     }
+}
 
-    /// Sets the pool configuration.
-    pub fn with_pool_config(mut self, pool_config: PoolConfig) -> Self {
-        self.pool_config = pool_config;
-        self
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            rpc_url: Url::parse(DEFAULT_RPC_URL).unwrap(),
+            contract_address: Felt::ZERO,
+            pool_config: PoolConfig::default(),
+        }
     }
 }
 
@@ -90,6 +99,7 @@ impl RpcConfig {
 struct RpcBackendInner {
     provider: JsonRpcClient<HttpTransport>,
     contract_address: Felt,
+    head: RwLock<Option<ChainHead>>,
 }
 
 /// RPC-based storage backend that reads from a StarkNet node via JSON-RPC.
@@ -122,6 +132,7 @@ impl RpcBackend {
             inner: Arc::new(RpcBackendInner {
                 provider,
                 contract_address: config.contract_address,
+                head: RwLock::new(None),
             }),
         })
     }
@@ -165,12 +176,14 @@ impl RawStorageAccess for RpcSnapshot {
             return Ok(vec![self.read_slot(slots[0]).await?]);
         }
 
+        let contract_address = self.backend.inner.contract_address;
+
         // Build batch request
         let requests: Vec<ProviderRequestData> = slots
             .iter()
             .map(|&slot| {
                 ProviderRequestData::GetStorageAt(GetStorageAtRequest {
-                    contract_address: self.backend.inner.contract_address,
+                    contract_address,
                     key: slot,
                     block_id: self.block_id,
                 })
@@ -194,6 +207,30 @@ impl RawStorageAccess for RpcSnapshot {
                 _ => Err(RpcBackendError::UnexpectedResponseType.into()),
             })
             .collect()
+    }
+}
+
+#[async_trait]
+impl ChainState for RpcBackend {
+    async fn get_head(&self) -> Option<ChainHead> {
+        *self.inner.head.read().await
+    }
+
+    async fn set_head(&self, head: ChainHead) {
+        *self.inner.head.write().await = Some(head);
+    }
+
+    async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
+        match self
+            .inner
+            .provider
+            .get_block_transaction_count(BlockId::Hash(block_hash))
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(false),
+            Err(e) => Err(ChainStateError::RpcError(e)),
+        }
     }
 }
 


### PR DESCRIPTION
### TL;DR

Added chain state tracking to the discovery service to maintain information about the current chain head and verify block canonicity.

### What changed?

- Created a new `chain_state.rs` module with the `ChainState` trait for tracking chain state
- Implemented `ChainState` for `RpcBackend` to provide chain head tracking and block canonicity verification
- Modified the `Indexer` to accept a generic `ChainState` implementation and update it with new block headers
- Updated the main function to use `RpcBackend` as the chain state implementation
- Added environment variable support for RPC configuration

### How to test?

1. Run the discovery service with appropriate RPC_URL and CONTRACT_ADDRESS environment variables
2. Verify that the service correctly tracks the chain head as new blocks are received
3. Test the canonicity verification by checking if the service correctly identifies blocks that are part of the canonical chain

### Why make this change?

This change enables the discovery service to maintain awareness of the current chain state, which is essential for:
1. Verifying if blocks are part of the canonical chain (vs orphaned blocks)
2. Providing access to the latest chain head information
3. Supporting reorg detection and handling
4. Creating a foundation for more advanced chain state tracking features

The implementation uses the existing RPC backend to minimize additional dependencies while providing the necessary chain state functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/345)
<!-- Reviewable:end -->
