### PR TITLE
feat(indexer): api server & health endpoint

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,6 +1,7 @@
 name: Auto Update Workflow
 permissions:
   contents: write
+  pull-requests: write
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +549,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "backoff",
  "clap",
  "discovery-core",
@@ -893,6 +946,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +965,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1302,6 +1362,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2065,6 +2131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,6 +2830,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -28,8 +28,12 @@ starknet-tokio-tungstenite = "0.3"
 url = "2"
 
 # HTTP
+axum = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 tower = { version = "0.5", features = ["limit"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
 
 # Error handling
 thiserror = "2"
@@ -47,7 +51,6 @@ expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"
 nix = { version = "0.29", features = ["signal"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 starknet-core = "0.16"
 starknet-types-core = { version = "0.2", features = ["serde"] }

--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -1,0 +1,143 @@
+//! Axum API server for the discovery service.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use discovery_core::storage::StorageBackend;
+use serde::{Deserialize, Serialize};
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tracing::info;
+
+use crate::chain_state::{ChainHead, ChainState};
+
+/// Configuration for the API server.
+#[derive(Debug, Clone)]
+pub struct ApiServerConfig {
+    /// Host and port to bind to (e.g., "127.0.0.1:8080").
+    pub api_host: String,
+    /// Maximum lag in seconds before health check returns unhealthy.
+    pub health_max_lag_secs: u64,
+}
+
+impl Default for ApiServerConfig {
+    fn default() -> Self {
+        Self {
+            api_host: "127.0.0.1:8080".to_string(),
+            health_max_lag_secs: 5,
+        }
+    }
+}
+
+/// API server for the discovery service.
+pub struct ApiServer<B> {
+    rx_shutdown: broadcast::Receiver<()>,
+    config: ApiServerConfig,
+    backend: B,
+}
+
+impl<B> ApiServer<B>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+{
+    /// Creates a new API server.
+    pub fn new(config: ApiServerConfig, rx_shutdown: broadcast::Receiver<()>, backend: B) -> Self {
+        Self {
+            rx_shutdown,
+            config,
+            backend,
+        }
+    }
+
+    /// Runs the API server until shutdown is signaled.
+    pub async fn run(&mut self) -> Result<(), ApiServerError> {
+        let app_state = Arc::new(AppState {
+            backend: self.backend.clone(),
+            health_max_lag_secs: self.config.health_max_lag_secs,
+        });
+
+        let app = Router::new()
+            .route("/health", get(health_handler::<B>))
+            .with_state(app_state);
+
+        let listener = TcpListener::bind(&self.config.api_host)
+            .await
+            .map_err(|e| ApiServerError::Bind(e.to_string()))?;
+
+        info!("API server listening on {}", self.config.api_host);
+
+        let mut rx_shutdown = self.rx_shutdown.resubscribe();
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx_shutdown.recv().await;
+                info!("API server shutting down");
+            })
+            .await
+            .map_err(|e| ApiServerError::Serve(e.to_string()))?;
+
+        info!("API server has shut down");
+        Ok(())
+    }
+}
+
+/// Shared state for the API handlers.
+struct AppState<B> {
+    backend: B,
+    health_max_lag_secs: u64,
+}
+
+/// Response for the health endpoint.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub chain_head: Option<ChainHead>,
+    pub lag_secs: u64,
+}
+
+/// Handler for GET /health.
+async fn health_handler<B>(State(state): State<Arc<AppState<B>>>) -> impl IntoResponse
+where
+    B: ChainState + Send + Sync + 'static,
+{
+    let head = state.backend.get_head().await;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let (status, lag_secs, status_code) = match &head {
+        Some(h) => {
+            let lag = now.saturating_sub(h.timestamp);
+            if lag <= state.health_max_lag_secs {
+                ("OK", lag, StatusCode::OK)
+            } else {
+                ("UNHEALTHY", lag, StatusCode::OK)
+            }
+        }
+        None => ("UNHEALTHY", 0, StatusCode::SERVICE_UNAVAILABLE),
+    };
+
+    let response = HealthResponse {
+        status: status.to_string(),
+        chain_head: head,
+        lag_secs,
+    };
+
+    (status_code, Json(response))
+}
+
+/// Errors that can occur in the API server.
+#[derive(Debug, thiserror::Error)]
+pub enum ApiServerError {
+    #[error("failed to bind to address: {0}")]
+    Bind(String),
+    #[error("server error: {0}")]
+    Serve(String),
+}

--- a/crates/discovery-service/src/chain_state.rs
+++ b/crates/discovery-service/src/chain_state.rs
@@ -1,12 +1,13 @@
 //! Chain state tracking for the Starknet indexer.
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use starknet_core::types::Felt;
 use starknet_providers::ProviderError;
 use thiserror::Error;
 
 /// Represents the current chain head.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChainHead {
     pub block_number: u64,
     pub block_hash: Felt,

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -4,7 +4,9 @@
 //! - RPC-based storage backend for reading privacy contract state
 //! - Indexer for Starknet new heads subscription
 //! - Chain state tracking for canonical block verification and recent head retrieval
+//! - API server with health endpoint
 
+pub mod api_server;
 pub mod chain_state;
 pub mod indexer;
 pub mod rpc_backend;

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use clap::Parser;
+use discovery_service::api_server::{ApiServer, ApiServerConfig};
 use discovery_service::indexer::{Indexer, IndexerConfig};
 use discovery_service::rpc_backend::{RpcBackend, RpcConfig};
 use discovery_service::shutdown::Shutdown;
@@ -16,6 +17,10 @@ struct Cli {
     /// Logging level (off, error, warn, info, debug, trace). Overrides RUST_LOG.
     #[arg(long)]
     log_level: Option<String>,
+
+    /// API server host and port (e.g., "127.0.0.1:8080"). Overrides API_HOST env var.
+    #[arg(long)]
+    api_host: Option<String>,
 }
 
 fn init_tracing(log_level: Option<&str>) {
@@ -62,11 +67,24 @@ async fn main() {
     }
     let rpc_backend = RpcBackend::new(rpc_config).expect("Failed to create RPC backend");
 
-    let mut indexer = Indexer::new(indexer_config, shutdown.subscribe(), rpc_backend);
+    let mut api_server_config = ApiServerConfig::default();
+    if let Some(api_host) = cli.api_host.or_else(|| std::env::var("API_HOST").ok()) {
+        api_server_config.api_host = api_host;
+    }
+
+    let mut indexer = Indexer::new(indexer_config, shutdown.subscribe(), rpc_backend.clone());
+    let mut api_server = ApiServer::new(api_server_config, shutdown.subscribe(), rpc_backend);
+
     let indexer_handle = tokio::spawn(async move { indexer.run().await });
+    let api_server_handle = tokio::spawn(async move { api_server.run().await });
+
     let shutdown_handle = tokio::spawn(async move { shutdown.run().await });
 
-    match tokio::try_join!(flatten(indexer_handle), flatten(shutdown_handle)) {
+    match tokio::try_join!(
+        flatten(indexer_handle),
+        flatten(api_server_handle),
+        flatten(shutdown_handle)
+    ) {
         Ok(_) => {
             info!("Discovery service has shut down");
             std::process::exit(0);

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
-use super::process::signal_process;
+use super::process::{find_free_port, signal_process};
 
 /// Wrapper for the discovery-service binary.
 pub struct IndexerClient {
@@ -19,9 +19,25 @@ pub struct IndexerClient {
 }
 
 impl IndexerClient {
-    pub async fn spawn_with_binary(binary: &str, ws_url: &str) -> Result<Self> {
+    pub async fn spawn_with_binary(
+        binary: &str,
+        ws_url: &str,
+        api_host: Option<&str>,
+    ) -> Result<Self> {
+        let auto_port;
+        let api_host = match api_host {
+            Some(h) => h,
+            None => {
+                let port = find_free_port()?;
+                auto_port = format!("127.0.0.1:{}", port);
+                &auto_port
+            }
+        };
+
         let mut process = Command::new(binary)
             .env("WS_URL", ws_url)
+            .arg("--api-host")
+            .arg(api_host)
             .stderr(std::process::Stdio::piped())
             .spawn()?;
 

--- a/crates/discovery-service/tests/common/mod.rs
+++ b/crates/discovery-service/tests/common/mod.rs
@@ -6,3 +6,4 @@ mod process;
 
 pub use devnet::{DevnetClient, DevnetConfig, DumpMetadata};
 pub use indexer::IndexerClient;
+pub use process::find_free_port;

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -1,0 +1,63 @@
+//! API server integration tests.
+//!
+//! ## Running tests
+//!
+//! ```sh
+//! cargo test -p discovery-service --test test_api
+//! ```
+
+mod common;
+
+use std::time::Duration;
+
+use common::{find_free_port, DevnetClient, DevnetConfig, IndexerClient};
+use discovery_service::api_server::HealthResponse;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
+
+#[tokio::test]
+async fn test_health_endpoint_returns_ok() {
+    let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
+    let api_port = find_free_port().expect("Failed to find free port");
+    let api_host = format!("127.0.0.1:{}", api_port);
+
+    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), Some(&api_host))
+        .await
+        .expect("Failed to spawn indexer");
+
+    // Wait for API server to be ready and indexer to subscribe
+    // (order depends on timing; wait for both)
+    indexer
+        .wait_for_log("API server listening", Duration::from_secs(10))
+        .await
+        .unwrap();
+    indexer
+        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    // Create a block so there's a chain head
+    devnet.create_block().await.unwrap();
+    indexer
+        .wait_for_log("New block #", Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    // Call the health endpoint
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://{}/health", api_host))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(resp.status(), 200);
+
+    let health: HealthResponse = resp.json().await.expect("Failed to parse response");
+    assert_eq!(health.status, "OK");
+    assert!(health.chain_head.is_some());
+    assert!(health.chain_head.unwrap().timestamp > 0);
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}

--- a/crates/discovery-service/tests/test_indexer.rs
+++ b/crates/discovery-service/tests/test_indexer.rs
@@ -17,7 +17,7 @@ const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
 #[tokio::test]
 async fn test_startup_and_shutdown() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url())
+    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
         .await
         .expect("Failed to spawn indexer");
 
@@ -38,7 +38,7 @@ async fn test_startup_and_shutdown() {
 #[tokio::test]
 async fn test_new_block_notification() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url())
+    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
         .await
         .expect("Failed to spawn indexer");
 
@@ -62,7 +62,7 @@ async fn test_new_block_notification() {
 async fn test_reconnection_on_devnet_restart() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
     let port = devnet.port();
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url())
+    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
         .await
         .expect("Failed to spawn indexer");
 


### PR DESCRIPTION
### TL;DR

Added a health API endpoint to the discovery service using Axum.

### What changed?

- Added Axum as a dependency for HTTP API server functionality
- Implemented a new API server module with a `/health` endpoint that reports the current chain head status
- Enhanced the `ChainHead` struct with serialization support
- Updated the main service to optionally start the API server based on configuration
- Added integration tests for the health endpoint

### How to test?

1. Start the discovery service with the API server enabled:
   ```
   cargo run --bin discovery-service -- --api-host 127.0.0.1:8080
   ```
   
2. Once the service is running, query the health endpoint:
   ```
   curl http://127.0.0.1:8080/health
   ```
   
3. The response should include the current chain head status, lag time, and an "OK" status if the service is healthy.

### Why make this change?

This change adds a simple health check API that allows external services to monitor the discovery service's status. The health endpoint reports whether the service is keeping up with the chain (based on configurable lag thresholds) and provides information about the current chain head, making it easier to integrate with monitoring systems and ensure the service is functioning properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/346)
<!-- Reviewable:end -->
