### PR TITLE
feat(sdk): add signature validation to the call mock proving provider

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -5,6 +5,7 @@ import type {
   BlockIdentifier,
   BlockNumber,
   Call,
+  constants,
   Invocation,
 } from "starknet";
 import { ec } from "starknet";
@@ -535,7 +536,7 @@ export type ProofInvocation = Invocation;
  * Extends AccountInvocationsFactoryDetails with chainId for signing.
  */
 export type ProofInvocationFactoryDetails = AccountInvocationsFactoryDetails & {
-  chainId: string;
+  chainId: constants.StarknetChainId;
 };
 
 ////// The following are more likely to change /////////

--- a/sdk/src/testing/mock-proof-provider.ts
+++ b/sdk/src/testing/mock-proof-provider.ts
@@ -14,7 +14,7 @@ import type {
 import type { ClientAction } from "../internal/client-actions.js";
 import type { MockPoolContract } from "./mock-pool-contract.js";
 import { bigintReviver } from "./mock-proof-invocation-factory.js";
-import { ETransactionVersion } from "starknet";
+import { constants, ETransactionVersion } from "starknet";
 
 /**
  * Mock proof provider that executes actions on MockPoolContract.
@@ -45,7 +45,7 @@ export class MockProofProvider implements ProofProviderInterface {
       nonceDataAvailabilityMode: "L1",
       feeDataAvailabilityMode: "L1",
       version: ETransactionVersion.V3,
-      chainId: "0x0", // Mock chain ID
+      chainId: constants.StarknetChainId.SN_SEPOLIA, // Mock chain ID
     };
   }
 

--- a/sdk/src/testing/mock-proving.ts
+++ b/sdk/src/testing/mock-proving.ts
@@ -5,14 +5,18 @@
  * to execute the invocation and capture the output.
  */
 
-import type { ProviderInterface } from "starknet";
-import { ETransactionVersion } from "starknet";
+import type { constants, ETransactionVersion3, ProviderInterface } from "starknet";
+import { EDAMode, encode, ETransactionVersion, hash, num, stark, transaction } from "starknet";
 import type {
   Proof,
   ProofProviderInterface,
   ProofInvocation,
   ProofInvocationFactoryDetails,
 } from "../interfaces.js";
+import { toBigInt } from "../utils/convert.js";
+
+/** VALIDATED constant - 'VALID' encoded as short string felt252 */
+const VALIDATED = encode.utf8ToBigInt("VALID");
 
 /**
  * A proving provider that uses Starknet calls to simulate proof generation.
@@ -22,7 +26,7 @@ import type {
 export class CallMockProofProvider implements ProofProviderInterface {
   constructor(
     private readonly provider: ProviderInterface,
-    private readonly chainId: string
+    private readonly chainId: constants.StarknetChainId
   ) {}
 
   getDefaultDetails(): ProofInvocationFactoryDetails {
@@ -46,6 +50,10 @@ export class CallMockProofProvider implements ProofProviderInterface {
   }
 
   async prove(invocation: ProofInvocation): Promise<Proof> {
+    // Validate signature similar to how __execute__ does in the contract.
+    // execute_view skips this since view functions don't have tx_info.
+    await this.validateSignature(invocation);
+
     const result = await this.provider.callContract({
       contractAddress: invocation.contractAddress,
       entrypoint: "execute_view",
@@ -55,5 +63,63 @@ export class CallMockProofProvider implements ProofProviderInterface {
     // execute_view returns Span<ServerAction> which is serialized with its length prefix.
     // execute_actions also expects Span<ServerAction> with the length prefix, so we pass it through as-is.
     return { output: result, outputHash: undefined!, data: undefined! };
+  }
+
+  /**
+   * Validates the signature by calling is_valid_signature on the user's account.
+   * This mirrors what the contract's __execute__ does after execute_view.
+   */
+  private async validateSignature(invocation: ProofInvocation): Promise<void> {
+    const signatureArray = invocation.signature ? stark.formatSignature(invocation.signature) : [];
+    if (signatureArray.length === 0) {
+      // No signature to validate (e.g., mock invocation factory)
+      return;
+    }
+
+    // Extract user address from calldata (first element in __execute__ calldata)
+    const calldata = invocation.calldata as string[];
+    const userAddress = num.toHex(calldata[0]);
+
+    // Compute transaction hash using the same parameters as the signer
+    // The signer wraps the call in getExecuteCalldata format
+    const details = this.getDefaultDetails();
+    const executeCalldata = transaction.getExecuteCalldata(
+      [
+        {
+          contractAddress: invocation.contractAddress,
+          entrypoint: "__execute__",
+          calldata,
+        },
+      ],
+      "1" // cairoVersion
+    );
+    const txHash = hash.calculateInvokeTransactionHash({
+      senderAddress: userAddress,
+      version: details.version as ETransactionVersion3,
+      compiledCalldata: executeCalldata,
+      chainId: this.chainId,
+      nonce: details.nonce!,
+      accountDeploymentData: details.accountDeploymentData!,
+      nonceDataAvailabilityMode: EDAMode[details.nonceDataAvailabilityMode!],
+      feeDataAvailabilityMode: EDAMode[details.feeDataAvailabilityMode!],
+      resourceBounds: details.resourceBounds!,
+      tip: details.tip!,
+      paymasterData: details.paymasterData!,
+    });
+
+    // Call is_valid_signature on user's account
+    // Calldata format: [hash, signature_length, ...signature_elements]
+    const isValidCalldata = [txHash, num.toHex(signatureArray.length), ...signatureArray];
+
+    const result = await this.provider.callContract({
+      contractAddress: userAddress,
+      entrypoint: "is_valid_signature",
+      calldata: isValidCalldata,
+    });
+
+    // Check result equals VALIDATED ('VALID' as felt252)
+    if (toBigInt(result[0]) !== VALIDATED) {
+      throw new Error(`Signature validation failed: expected ${VALIDATED}, got ${result[0]}`);
+    }
   }
 }


### PR DESCRIPTION
Add is_valid_signature call to mirror the real __execute__ flow in the
contract, since execute_view skips signature validation (view functions
don't have tx_info).

This ensures the mock proving path validates signatures the same way
the actual contract does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/351)
<!-- Reviewable:end -->
