### PR TITLE
refactor: simplify encrypt/decrypt note amount using wrapping arithmetic

### DIFF
--- a/packages/privacy/src/errors.cairo
+++ b/packages/privacy/src/errors.cairo
@@ -44,8 +44,6 @@ pub(crate) mod internal_errors {
     pub const ZERO_ENC_PRIVATE_KEY: felt252 = 'ZERO_ENC_PRIVATE_KEY';
     pub const DESERIALIZE_FAILED: felt252 = 'DESERIALIZE_FAILED';
     pub const EXPECTED_PANIC: felt252 = 'EXPECTED_PANIC';
-    pub const ENC_AMOUNT_OVERFLOW: felt252 = 'ENC_AMOUNT_OVERFLOW';
-    pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
     pub const PACK_OVERFLOW: felt252 = 'PACK_OVERFLOW';
     pub const UNPACK1_OUT_OF_BOUNDS: felt252 = 'UNPACK1_OUT_OF_BOUNDS';
     pub const ZERO_OUTGOING_CHANNEL_KEY: felt252 = 'ZERO_OUTGOING_CHANNEL_KEY';

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -1,7 +1,7 @@
 use core::ec::stark_curve::{GEN_X, GEN_Y, ORDER};
 use core::ec::{EcPoint, EcPointTrait};
 use core::never;
-use core::num::traits::Zero;
+use core::num::traits::{WrappingAdd, WrappingSub, Zero};
 use privacy::actions::{ServerAction, WriteOnceInput};
 use privacy::errors;
 use privacy::errors::internal_errors;
@@ -17,7 +17,6 @@ use privacy::utils::constants::{ENTRYPOINT_FAILED, OK_WRAPPER, OPEN_NOTE_SALT, T
 use starknet::storage::{StorageAsPointer, StoragePath};
 use starknet::syscalls::{call_contract_syscall, send_message_to_l1_syscall};
 use starknet::{ContractAddress, ExecutionInfo, Store, SyscallResultTrait, TxInfo, VALIDATED};
-use starkware_utils::constants::TWO_POW_128;
 
 pub mod constants {
     use core::num::traits::Pow;
@@ -209,11 +208,9 @@ pub(crate) fn is_canonical_key(key: felt252) -> bool {
 pub(crate) fn encrypt_note_amount(
     channel_key: felt252, token: ContractAddress, index: usize, salt: u128, amount: u128,
 ) -> felt252 {
-    let enc_amount = (compute_enc_amount_hash(:channel_key, :token, :index, :salt) + amount.into())
-        .into() % TWO_POW_128;
-    packing(
-        value_1: salt, value_2: enc_amount.try_into().expect(internal_errors::ENC_AMOUNT_OVERFLOW),
-    )
+    let enc_amount_hash: u256 = compute_enc_amount_hash(:channel_key, :token, :index, :salt).into();
+    let enc_amount: u128 = enc_amount_hash.low.wrapping_add(amount);
+    packing(value_1: salt, value_2: enc_amount)
 }
 
 /// Decrypts `enc_amount` using the other parameters.
@@ -221,11 +218,8 @@ pub(crate) fn encrypt_note_amount(
 pub(crate) fn decrypt_note_amount(
     enc_amount: u128, salt: u128, channel_key: felt252, token: ContractAddress, index: usize,
 ) -> u128 {
-    let enc_amount_u256: u256 = enc_amount.into(); // already < 2^128 by construction
-    let pad: u256 = compute_enc_amount_hash(:channel_key, :token, :index, :salt)
-        .into() % TWO_POW_128;
-    let amount: u256 = (enc_amount_u256 + TWO_POW_128 - pad) % TWO_POW_128;
-    amount.try_into().expect(internal_errors::AMOUNT_OVERFLOW)
+    let enc_amount_hash: u256 = compute_enc_amount_hash(:channel_key, :token, :index, :salt).into();
+    enc_amount.wrapping_sub(enc_amount_hash.low)
 }
 
 /// Returns the actual note amount from a packed value.


### PR DESCRIPTION
Use `WrappingAdd`/`WrappingSub` traits and `.low` field instead of manual modular arithmetic with u256 promotion.

All 153 Cairo tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/364)
<!-- Reviewable:end -->
