### PR TITLE
feat(indexer): io budget

### DIFF
--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -7,6 +7,7 @@ use starknet_types_core::felt::Felt;
 
 use super::DiscoveryError;
 use crate::decryption::decrypt_channel_info;
+use crate::io_budget::{IoBudget, COST_CHANNEL_INFO, COST_NUM_CHANNELS};
 use crate::storage::IViews;
 use crate::types::ChannelInfo;
 
@@ -24,9 +25,12 @@ pub struct IncomingChannel {
 pub struct DiscoveryResult {
     /// List of discovered and decrypted incoming channels.
     pub channels: Vec<IncomingChannel>,
-    /// Total number of channels for this recipient.
-    /// Use this as `start_index` for incremental discovery.
+    /// Next index to scan for incremental discovery.
+    /// Use this as `start_index` for the next discovery call.
     pub total_n_channels: u64,
+    /// Whether there may be more channels to discover.
+    /// `true` if stopped due to budget exhaustion, `false` if all channels were scanned.
+    pub has_more: bool,
 }
 
 /// Discovers and decrypts incoming channels for a recipient.
@@ -38,6 +42,7 @@ pub struct DiscoveryResult {
 /// * `private_key` - The private viewing key of that account.
 /// * `start_index` - Starting index (inclusive). Pass 0 to discover all channels.
 ///   Use `total_n_channels` from a previous result to continue incremental discovery.
+/// * `budget` - I/O budget to limit storage operations.
 ///
 /// # Returns
 ///
@@ -53,35 +58,61 @@ pub async fn discover_incoming_channels<PrivacyPool: IViews>(
     recipient_addr: Felt,
     private_key: &Felt,
     start_index: u64,
+    budget: &IoBudget,
 ) -> Result<DiscoveryResult, DiscoveryError> {
-    // Get total number of channels
-    let total_n_channels = privacy_pool.get_num_of_channels(recipient_addr).await?;
-
-    // If no new channels, return early
-    if start_index >= total_n_channels {
+    // Consume budget for get_num_of_channels
+    if !budget.consume(COST_NUM_CHANNELS) {
         return Ok(DiscoveryResult {
             channels: vec![],
-            total_n_channels,
+            total_n_channels: start_index,
+            has_more: true,
+        });
+    }
+
+    // Get total number of channels
+    let actual_total = privacy_pool.get_num_of_channels(recipient_addr).await?;
+
+    // If no new channels, return early
+    if start_index >= actual_total {
+        return Ok(DiscoveryResult {
+            channels: vec![],
+            total_n_channels: actual_total,
+            has_more: false,
         });
     }
 
     // Discover and decrypt each channel
-    let capacity = usize::try_from(total_n_channels.saturating_sub(start_index))
+    let capacity = usize::try_from(actual_total.saturating_sub(start_index))
         .expect("channel count exceeds usize");
     let mut channels = Vec::with_capacity(capacity);
+    let mut index = start_index;
+    let mut out_of_budget = false;
 
-    for index in start_index..total_n_channels {
+    loop {
+        // Check if we've processed all channels
+        if index >= actual_total {
+            break;
+        }
+
+        // Consume budget for get_channel_info
+        if !budget.consume(COST_CHANNEL_INFO) {
+            out_of_budget = true;
+            break;
+        }
+
         let encrypted = privacy_pool.get_channel_info(recipient_addr, index).await?;
 
         let info = decrypt_channel_info(&encrypted, private_key)
             .map_err(|source| DiscoveryError::Decryption { index, source })?;
 
         channels.push(IncomingChannel { index, info });
+        index += 1;
     }
 
     Ok(DiscoveryResult {
         channels,
-        total_n_channels,
+        total_n_channels: index,
+        has_more: out_of_budget,
     })
 }
 
@@ -96,21 +127,23 @@ mod tests {
         let backend = MockBackend::empty();
         let recipient = Felt::from_hex_unchecked("0x123");
         let key = Felt::from(1u64);
+        let budget = IoBudget::new(100);
 
         // Test with 0 (start from beginning)
-        let result1 = discover_incoming_channels(&backend, recipient, &key, 0)
+        let result1 = discover_incoming_channels(&backend, recipient, &key, 0, &budget)
             .await
             .unwrap();
 
         // Test with 5 (arbitrary index beyond total)
-        let result2 = discover_incoming_channels(&backend, recipient, &key, 5)
+        let result2 = discover_incoming_channels(&backend, recipient, &key, 5, &budget)
             .await
             .unwrap();
 
-        // Both should return empty
+        // Both should return empty with no more to discover
         for result in [&result1, &result2] {
             assert_eq!(result.channels.len(), 0);
             assert_eq!(result.total_n_channels, 0);
+            assert!(!result.has_more);
         }
     }
 
@@ -118,18 +151,21 @@ mod tests {
     async fn test_discover_alice_self_channel() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
+        let budget = IoBudget::new(100);
 
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
             &fixture.constants.alice_viewing_key,
             0,
+            &budget,
         )
         .await
         .unwrap();
 
         assert_eq!(result.channels.len(), 1, "Alice should have 1 channel");
         assert_eq!(result.total_n_channels, 1);
+        assert!(!result.has_more);
         assert_eq!(result.channels[0].index, 0);
         // Alice's channel is a self-channel (change from deposit+transfer)
         assert_eq!(
@@ -142,18 +178,21 @@ mod tests {
     async fn test_discover_bob_incoming_channel() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
+        let budget = IoBudget::new(100);
 
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.bob_address,
             &fixture.constants.bob_viewing_key,
             0,
+            &budget,
         )
         .await
         .unwrap();
 
         assert_eq!(result.channels.len(), 1, "Bob should have 1 channel");
         assert_eq!(result.total_n_channels, 1);
+        assert!(!result.has_more);
         assert_eq!(result.channels[0].index, 0);
         // Bob's channel is from Alice (transfer)
         assert_eq!(
@@ -166,6 +205,7 @@ mod tests {
     async fn test_discover_incremental() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
+        let budget = IoBudget::new(100);
 
         // First discovery - get all channels
         let result1 = discover_incoming_channels(
@@ -173,12 +213,14 @@ mod tests {
             fixture.constants.alice_address,
             &fixture.constants.alice_viewing_key,
             0,
+            &budget,
         )
         .await
         .unwrap();
 
         assert_eq!(result1.channels.len(), 1);
         assert_eq!(result1.total_n_channels, 1);
+        assert!(!result1.has_more);
 
         // Incremental discovery using total_n_channels as start_index
         // Should return empty since we've discovered all channels
@@ -187,11 +229,52 @@ mod tests {
             fixture.constants.alice_address,
             &fixture.constants.alice_viewing_key,
             result1.total_n_channels, // Start from 1, but only 1 channel exists
+            &budget,
         )
         .await
         .unwrap();
 
         assert_eq!(result2.channels.len(), 0);
         assert_eq!(result2.total_n_channels, 1); // Total unchanged
+        assert!(!result2.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_discover_out_of_budget() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // Budget exhausted before starting
+        let budget = IoBudget::new(0);
+        let result = discover_incoming_channels(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+            0,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.channels.len(), 0);
+        assert_eq!(result.total_n_channels, 0); // Returns start_index when budget exhausted
+        assert!(result.has_more);
+
+        // Budget allows get_num_of_channels but not get_channel_info
+        // COST_NUM_CHANNELS = 1, COST_CHANNEL_INFO = 3
+        let budget = IoBudget::new(2);
+        let result = discover_incoming_channels(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+            0,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.channels.len(), 0);
+        assert_eq!(result.total_n_channels, 0); // Returns start_index (0) when no channels fetched
+        assert!(result.has_more);
     }
 }

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -19,6 +19,7 @@ use starknet_types_core::felt::Felt;
 use super::DiscoveryError;
 use crate::decryption::{decrypt_note_amount, unpack_note_amount};
 use crate::hashes::compute_note_id;
+use crate::io_budget::{IoBudget, COST_NOTE};
 use crate::storage::IViews;
 
 /// A discovered and decrypted note.
@@ -39,9 +40,12 @@ pub struct DecryptedNote {
 pub struct NotesDiscoveryResult {
     /// List of discovered and decrypted notes.
     pub notes: Vec<DecryptedNote>,
-    /// Total number of notes discovered.
-    /// Use this as `start_index` for incremental discovery.
+    /// Next index to scan for incremental discovery.
+    /// Use this as `start_index` for the next discovery call.
     pub total_n_notes: u64,
+    /// Whether there may be more notes to discover.
+    /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
+    pub has_more: bool,
 }
 
 /// Discovers and decrypts notes for a given channel key and token.
@@ -61,6 +65,7 @@ pub struct NotesDiscoveryResult {
 /// * `token` - The token address for this subchannel.
 /// * `start_index` - Starting index (inclusive). For incremental discovery, pass
 ///   `total_n_notes` from previous result.
+/// * `budget` - I/O budget to limit storage operations.
 ///
 /// # Returns
 ///
@@ -71,11 +76,19 @@ pub async fn discover_notes<PrivacyPool: IViews>(
     channel_key: Felt,
     token: Felt,
     start_index: u64,
+    budget: &IoBudget,
 ) -> Result<NotesDiscoveryResult, DiscoveryError> {
     let mut notes = Vec::new();
     let mut index = start_index;
+    let mut out_of_budget = false;
 
     loop {
+        // Consume budget for get_note
+        if !budget.consume(COST_NOTE) {
+            out_of_budget = true;
+            break;
+        }
+
         let note_id = compute_note_id(channel_key, token, index);
         let packed_amount = privacy_pool.get_note(note_id).await?;
 
@@ -102,6 +115,7 @@ pub async fn discover_notes<PrivacyPool: IViews>(
     Ok(NotesDiscoveryResult {
         notes,
         total_n_notes: index,
+        has_more: out_of_budget,
     })
 }
 
@@ -116,13 +130,15 @@ mod tests {
         let backend = MockBackend::empty();
         let channel_key = Felt::from_hex_unchecked("0x12345");
         let token = Felt::from_hex_unchecked("0x67890");
+        let budget = IoBudget::new(100);
 
-        let result = discover_notes(&backend, channel_key, token, 0)
+        let result = discover_notes(&backend, channel_key, token, 0, &budget)
             .await
             .unwrap();
 
         assert_eq!(result.notes.len(), 0);
         assert_eq!(result.total_n_notes, 0);
+        assert!(!result.has_more);
     }
 
     #[tokio::test]
@@ -143,7 +159,8 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        let result = discover_notes(&backend, channel_key, token, 0)
+        let budget = IoBudget::new(100);
+        let result = discover_notes(&backend, channel_key, token, 0, &budget)
             .await
             .unwrap();
 
@@ -152,6 +169,7 @@ mod tests {
             "Alice's self-channel should have notes"
         );
         assert_eq!(result.total_n_notes, result.notes.len() as u64);
+        assert!(!result.has_more);
         assert_eq!(result.notes[0].index, 0);
         // The amount should be positive
         assert!(result.notes[0].amount > 0, "Note amount should be positive");
@@ -175,7 +193,8 @@ mod tests {
             .await
             .expect("Bob's channel should have at least one subchannel");
 
-        let result = discover_notes(&backend, channel_key, token, 0)
+        let budget = IoBudget::new(100);
+        let result = discover_notes(&backend, channel_key, token, 0, &budget)
             .await
             .unwrap();
 
@@ -183,6 +202,7 @@ mod tests {
             !result.notes.is_empty(),
             "Bob should have received notes from Alice"
         );
+        assert!(!result.has_more);
         assert!(result.notes[0].amount > 0, "Note amount should be positive");
     }
 
@@ -205,16 +225,48 @@ mod tests {
             .expect("Alice's channel should have at least one subchannel");
 
         // First discovery
-        let result1 = discover_notes(&backend, channel_key, token, 0)
+        let budget = IoBudget::new(100);
+        let result1 = discover_notes(&backend, channel_key, token, 0, &budget)
             .await
             .unwrap();
         assert!(!result1.notes.is_empty());
+        assert!(!result1.has_more);
 
         // Incremental discovery starting from total - should find 0 new notes
-        let result2 = discover_notes(&backend, channel_key, token, result1.total_n_notes)
+        let result2 = discover_notes(&backend, channel_key, token, result1.total_n_notes, &budget)
             .await
             .unwrap();
         assert_eq!(result2.notes.len(), 0);
         assert_eq!(result2.total_n_notes, result1.total_n_notes);
+        assert!(!result2.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_out_of_budget() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // Discover Alice's channel and subchannel
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        // Budget exhausted before starting (COST_NOTE = 1)
+        let budget = IoBudget::new(0);
+        let result = discover_notes(&backend, channel_key, token, 0, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.notes.len(), 0);
+        assert_eq!(result.total_n_notes, 0);
+        assert!(result.has_more);
     }
 }

--- a/crates/discovery-core/src/discovery/subchannels.rs
+++ b/crates/discovery-core/src/discovery/subchannels.rs
@@ -9,6 +9,7 @@ use starknet_types_core::felt::Felt;
 use super::DiscoveryError;
 use crate::decryption::decrypt_subchannel_token;
 use crate::hashes::compute_subchannel_key;
+use crate::io_budget::{IoBudget, COST_SUBCHANNEL_INFO};
 use crate::storage::IViews;
 
 /// A discovered and decrypted subchannel.
@@ -25,9 +26,12 @@ pub struct Subchannel {
 pub struct SubchannelDiscoveryResult {
     /// List of discovered and decrypted subchannels.
     pub subchannels: Vec<Subchannel>,
-    /// Total number of subchannels discovered.
-    /// Use this as `start_index` for incremental discovery.
+    /// Next index to scan for incremental discovery.
+    /// Use this as `start_index` for the next discovery call.
     pub total_n_subchannels: u64,
+    /// Whether there may be more subchannels to discover.
+    /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
+    pub has_more: bool,
 }
 
 /// Discovers and decrypts subchannels for a given channel key.
@@ -46,6 +50,7 @@ pub struct SubchannelDiscoveryResult {
 /// * `channel_key` - The channel key to discover subchannels for.
 /// * `start_index` - Starting index (inclusive). For incremental discovery, pass
 ///   `total_n_subchannels` from previous result.
+/// * `budget` - I/O budget to limit storage operations.
 ///
 /// # Returns
 ///
@@ -55,11 +60,19 @@ pub async fn discover_subchannels<PrivacyPool: IViews>(
     privacy_pool: &PrivacyPool,
     channel_key: Felt,
     start_index: u64,
+    budget: &IoBudget,
 ) -> Result<SubchannelDiscoveryResult, DiscoveryError> {
     let mut subchannels = Vec::new();
     let mut index = start_index;
+    let mut out_of_budget = false;
 
     loop {
+        // Consume budget for get_subchannel_info
+        if !budget.consume(COST_SUBCHANNEL_INFO) {
+            out_of_budget = true;
+            break;
+        }
+
         let subchannel_key = compute_subchannel_key(channel_key, index);
         let encrypted = privacy_pool.get_subchannel_info(subchannel_key).await?;
 
@@ -77,6 +90,7 @@ pub async fn discover_subchannels<PrivacyPool: IViews>(
     Ok(SubchannelDiscoveryResult {
         subchannels,
         total_n_subchannels: index,
+        has_more: out_of_budget,
     })
 }
 
@@ -91,13 +105,15 @@ mod tests {
         let backend = MockBackend::empty();
         // Use a random channel key - empty backend returns zero for all slots
         let channel_key = Felt::from_hex_unchecked("0x12345");
+        let budget = IoBudget::new(100);
 
-        let result = discover_subchannels(&backend, channel_key, 0)
+        let result = discover_subchannels(&backend, channel_key, 0, &budget)
             .await
             .unwrap();
 
         assert_eq!(result.subchannels.len(), 0);
         assert_eq!(result.total_n_subchannels, 0);
+        assert!(!result.has_more);
     }
 
     #[tokio::test]
@@ -115,7 +131,8 @@ mod tests {
         .expect("Alice should have at least one channel");
 
         // Now discover subchannels for this channel
-        let result = discover_subchannels(&backend, channel_key, 0)
+        let budget = IoBudget::new(100);
+        let result = discover_subchannels(&backend, channel_key, 0, &budget)
             .await
             .unwrap();
 
@@ -125,6 +142,7 @@ mod tests {
             "Alice's self-channel should have 1 subchannel (STRK)"
         );
         assert_eq!(result.total_n_subchannels, 1);
+        assert!(!result.has_more);
         assert_eq!(result.subchannels[0].index, 0);
         // The subchannel token should be STRK
         assert_eq!(result.subchannels[0].token, fixture.constants.strk_token);
@@ -145,7 +163,8 @@ mod tests {
         .expect("Bob should have at least one channel");
 
         // Now discover subchannels for this channel
-        let result = discover_subchannels(&backend, channel_key, 0)
+        let budget = IoBudget::new(100);
+        let result = discover_subchannels(&backend, channel_key, 0, &budget)
             .await
             .unwrap();
 
@@ -155,6 +174,7 @@ mod tests {
             "Bob's channel should have 1 subchannel (STRK)"
         );
         assert_eq!(result.total_n_subchannels, 1);
+        assert!(!result.has_more);
         assert_eq!(result.subchannels[0].index, 0);
         // The subchannel token should be STRK
         assert_eq!(result.subchannels[0].token, fixture.constants.strk_token);
@@ -175,17 +195,46 @@ mod tests {
         .expect("Alice should have at least one channel");
 
         // First discovery - should find 1 subchannel
-        let result1 = discover_subchannels(&backend, channel_key, 0)
+        let budget = IoBudget::new(100);
+        let result1 = discover_subchannels(&backend, channel_key, 0, &budget)
             .await
             .unwrap();
         assert_eq!(result1.subchannels.len(), 1);
         assert_eq!(result1.total_n_subchannels, 1);
+        assert!(!result1.has_more);
 
         // Incremental discovery starting from total - should find 0 new subchannels
-        let result2 = discover_subchannels(&backend, channel_key, result1.total_n_subchannels)
-            .await
-            .unwrap();
+        let result2 =
+            discover_subchannels(&backend, channel_key, result1.total_n_subchannels, &budget)
+                .await
+                .unwrap();
         assert_eq!(result2.subchannels.len(), 0);
         assert_eq!(result2.total_n_subchannels, 1);
+        assert!(!result2.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_discover_subchannels_out_of_budget() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        // First discover Alice's incoming channels to get the channel key
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        // Budget exhausted before starting (COST_SUBCHANNEL_INFO = 2)
+        let budget = IoBudget::new(1);
+        let result = discover_subchannels(&backend, channel_key, 0, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.subchannels.len(), 0);
+        assert_eq!(result.total_n_subchannels, 0);
+        assert!(result.has_more);
     }
 }

--- a/crates/discovery-core/src/io_budget.rs
+++ b/crates/discovery-core/src/io_budget.rs
@@ -1,0 +1,130 @@
+//! I/O budget tracking for discovery operations.
+//!
+//! This module provides a thread-safe budget counter to limit storage I/O
+//! operations during discovery. Each storage operation has an associated cost,
+//! and discovery functions consume from the budget before performing I/O.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Cost for `get_num_of_channels` (1 storage slot read).
+pub const COST_NUM_CHANNELS: usize = 1;
+
+/// Cost for `get_channel_info` (3 storage slot reads).
+pub const COST_CHANNEL_INFO: usize = 3;
+
+/// Cost for `get_subchannel_info` (2 storage slot reads).
+pub const COST_SUBCHANNEL_INFO: usize = 2;
+
+/// Cost for `get_note` (1 storage slot read).
+pub const COST_NOTE: usize = 1;
+
+/// Thread-safe I/O budget counter.
+///
+/// Used to limit the number of storage operations during discovery.
+/// Operations atomically consume from the budget before performing I/O.
+///
+/// `IoBudget` is cheap to clone - clones share the same underlying counter,
+/// making it easy to pass across async tasks.
+#[derive(Debug, Clone)]
+pub struct IoBudget {
+    remaining: Arc<AtomicUsize>,
+}
+
+impl IoBudget {
+    /// Creates a new budget with the given limit.
+    pub fn new(limit: usize) -> Self {
+        Self {
+            remaining: Arc::new(AtomicUsize::new(limit)),
+        }
+    }
+
+    /// Returns the current remaining budget.
+    pub fn remaining(&self) -> usize {
+        self.remaining.load(Ordering::Relaxed)
+    }
+
+    /// Atomically consumes `count` from the budget.
+    ///
+    /// Returns `true` on success, `false` if insufficient budget.
+    /// On `false`, the budget remains unchanged.
+    pub fn consume(&self, count: usize) -> bool {
+        self.remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                current.checked_sub(count)
+            })
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_consume_success() {
+        let budget = IoBudget::new(10);
+
+        assert_eq!(budget.remaining(), 10);
+
+        assert!(budget.consume(3));
+        assert_eq!(budget.remaining(), 7);
+
+        assert!(budget.consume(5));
+        assert_eq!(budget.remaining(), 2);
+
+        assert!(budget.consume(2));
+        assert_eq!(budget.remaining(), 0);
+    }
+
+    #[test]
+    fn test_consume_exhausted() {
+        let budget = IoBudget::new(5);
+
+        // Try to consume more than available
+        assert!(!budget.consume(10));
+        assert_eq!(budget.remaining(), 5); // Unchanged
+
+        // Partial consumption then exhaustion
+        assert!(budget.consume(3));
+        assert_eq!(budget.remaining(), 2);
+
+        assert!(!budget.consume(3));
+        assert_eq!(budget.remaining(), 2); // Unchanged
+
+        // Exact remaining works
+        assert!(budget.consume(2));
+        assert_eq!(budget.remaining(), 0);
+
+        // Zero budget, any consumption fails
+        assert!(!budget.consume(1));
+        assert_eq!(budget.remaining(), 0);
+    }
+
+    #[test]
+    fn test_concurrent_consume() {
+        let budget = IoBudget::new(1000);
+        let mut handles = vec![];
+
+        // Spawn 10 threads, each consuming 1 unit 100 times
+        for _ in 0..10 {
+            let budget = budget.clone(); // Cheap clone, shares the counter
+            handles.push(thread::spawn(move || {
+                let mut successes = 0;
+                for _ in 0..100 {
+                    if budget.consume(1) {
+                        successes += 1;
+                    }
+                }
+                successes
+            }));
+        }
+
+        let total_successes: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+
+        // All 1000 units should have been consumed exactly
+        assert_eq!(total_successes, 1000);
+        assert_eq!(budget.remaining(), 0);
+    }
+}

--- a/crates/discovery-core/src/lib.rs
+++ b/crates/discovery-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod decryption;
 pub mod discovery;
 pub mod hashes;
+pub mod io_budget;
 pub mod mock_backend;
 pub mod storage;
 pub mod storage_slots;

--- a/crates/discovery-core/src/test_fixtures.rs
+++ b/crates/discovery-core/src/test_fixtures.rs
@@ -138,8 +138,10 @@ pub async fn get_channel_key(
     viewing_key: &starknet_types_core::felt::Felt,
 ) -> Option<starknet_types_core::felt::Felt> {
     use crate::discovery::incoming_channels::discover_incoming_channels;
+    use crate::io_budget::IoBudget;
 
-    let result = discover_incoming_channels(backend, recipient, viewing_key, 0)
+    let budget = IoBudget::new(100);
+    let result = discover_incoming_channels(backend, recipient, viewing_key, 0, &budget)
         .await
         .ok()?;
 
@@ -152,8 +154,12 @@ pub async fn get_subchannel_token(
     channel_key: starknet_types_core::felt::Felt,
 ) -> Option<starknet_types_core::felt::Felt> {
     use crate::discovery::subchannels::discover_subchannels;
+    use crate::io_budget::IoBudget;
 
-    let result = discover_subchannels(backend, channel_key, 0).await.ok()?;
+    let budget = IoBudget::new(100);
+    let result = discover_subchannels(backend, channel_key, 0, &budget)
+        .await
+        .ok()?;
 
     result.subchannels.first().map(|s| s.token)
 }


### PR DESCRIPTION
Adds a thread-safe I/O budget counter to limit storage operations during discovery.                                                                                 
                                                                                                                                                                      
##  Changes                                                                                                                                                             
                                                                                                                                                                      
  - New IoBudget struct with Arc<AtomicUsize> for cheap cloning across async tasks                                                                                    
  - Cost constants: COST_NUM_CHANNELS (1), COST_CHANNEL_INFO (3), COST_SUBCHANNEL_INFO (2), COST_NOTE (1)                                                             
  - Discovery functions now accept budget: &IoBudget and break early when exhausted                                                                                   
                                                                                                                                                                      
##  Usage                                                                                                                                                               
  
```rust                                                                                                                                                                 
  let budget = IoBudget::new(1000);                                                                                                                                   
                                                                                                                                                                      
  // Share across tasks via clone                                                                                                                                     
  let task = tokio::spawn({                                                                                                                                           
      let budget = budget.clone();                                                                                                                                    
      async move { discover_notes(&pool, key, token, 0, &budget).await }                                                                                              
  });                                                                                                                                                                 
                                                                                                                                                            
  // Check remaining                                                                                                                                                  
  println!("remaining: {}", budget.remaining());
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/366)
<!-- Reviewable:end -->
