### PR TITLE
fix: skip open channel when already exists

### DIFF
--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -265,6 +265,10 @@ export class ActionCompiler {
         debugLog("compiler", "open channel x", action.recipient);
         const channel = pool.getChannel(action.recipient);
         assert(channel, () => `Missing channel context for recipient ${toHex(action.recipient)}`);
+        if (channel.key) {
+          debugLog("compiler", "open channel skipped (already exists)", action.recipient);
+          continue;
+        }
         const input = {
           type: "OpenChannel",
           input: {


### PR DESCRIPTION
## Summary
- avoid emitting OpenChannel actions when the channel key is already known
- prevent NON_ZERO_VALUE reverts on transfers that include auto-setup

## Testing
- npm run check (sdk)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/394)
<!-- Reviewable:end -->
