### PR TITLE
feat(indexer): cursor pagination for discovery

### DIFF
--- a/crates/discovery-core/Cargo.toml
+++ b/crates/discovery-core/Cargo.toml
@@ -12,10 +12,10 @@ starknet-crypto = "0.8"
 starknet-types-core = { version = "0.2", features = ["curve", "serde"] }
 starknet-providers = "0.16"
 tracing = "0.1"
+serde = { version = "1.0", features = ["derive"] }
 url = "2"
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -1,0 +1,54 @@
+//! Cursor types for paginated discovery.
+//!
+//! These cursors track progress across paginated discovery calls, allowing
+//! callers to resume discovery from where they left off.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+/// Top-level cursor tracking discovery progress across all channels.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiscoveryCursor {
+    /// Total number of channels (cached from `get_num_of_channels`).
+    /// When set, skips the channel count RPC call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_n_channels: Option<u64>,
+
+    /// Last fully processed channel index. `None` = start from index 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_channel_index: Option<u64>,
+
+    /// Channels with pending subchannel/note discovery, keyed by channel_key.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub channels: HashMap<Felt, ChannelCursor>,
+}
+
+/// Cursor state for a single channel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelCursor {
+    /// Sender address (cached from channel discovery).
+    pub sender_addr: Felt,
+
+    /// Total number of subchannels (cached when sentinel is found).
+    /// When set, subchannel discovery is skipped entirely — zero budget cost.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_n_subchannels: Option<u64>,
+
+    /// Last fully processed subchannel index. `None` = start from index 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_subchannel_index: Option<u64>,
+
+    /// Subchannels with pending note discovery, keyed by token address.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub subchannels: HashMap<Felt, SubchannelCursor>,
+}
+
+/// Cursor state for a single subchannel.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubchannelCursor {
+    /// Last fully processed note index. `None` = start from index 0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_note_index: Option<u64>,
+}

--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -2,10 +2,23 @@
 //!
 //! This module provides functionality to discover and decrypt incoming channels
 //! for a recipient address.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // First request: get count, then discover
+//! let count = get_incoming_channel_count(&pool, recipient, &budget).await?;
+//! let result = discover_incoming_channels(&pool, recipient, &key, 0, count, &budget).await?;
+//!
+//! // Subsequent requests: use cached count
+//! let result = discover_incoming_channels(&pool, recipient, &key, start, cached_count, &budget).await?;
+//! ```
 
 use starknet_types_core::felt::Felt;
 
-use super::{DiscoveryError, COST_CHANNEL_INFO, COST_NUM_CHANNELS};
+use super::cursor::{ChannelCursor, DiscoveryCursor};
+use super::DiscoveryError;
+use super::{COST_CHANNEL_INFO, COST_NUM_CHANNELS};
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::decrypt_channel_info;
 use crate::privacy_pool::types::ChannelInfo;
@@ -25,18 +38,29 @@ pub struct IncomingChannel {
 pub struct ChannelDiscoveryResult {
     /// List of discovered and decrypted incoming channels.
     pub channels: Vec<IncomingChannel>,
-    /// Index of the last discovered channel, or `None` if no channels
-    /// were discovered.
+    /// Index of the last discovered channel, or `None` if no channels were discovered.
+    /// Use for cursor updates: `cursor.last_channel_index = result.last_index.or(cursor.last_channel_index)`.
     pub last_index: Option<u64>,
     /// Whether there may be more channels to discover.
     /// `true` if stopped due to budget exhaustion, `false` if all channels were scanned.
     pub has_more: bool,
 }
 
-/// Reads the on-chain channel count for a recipient.
+/// Gets the total number of incoming channels for a recipient.
 ///
-/// This is a thin wrapper around `IViews::get_num_of_channels` that
-/// consumes the appropriate I/O budget.
+/// Call this once to get the count, then pass it to [`discover_incoming_channels`]
+/// to avoid re-fetching on every call.
+///
+/// # Arguments
+///
+/// * `privacy_pool` - Storage backend implementing the IViews trait.
+/// * `recipient_addr` - The recipient's account address.
+/// * `budget` - I/O budget to limit storage operations.
+///
+/// # Returns
+///
+/// `Ok(Some(count))` - The total number of channels.
+/// `Ok(None)` - Budget exhausted before fetching the count.
 pub async fn get_incoming_channel_count<PrivacyPool: IViews>(
     privacy_pool: &PrivacyPool,
     recipient_addr: Felt,
@@ -57,15 +81,12 @@ pub async fn get_incoming_channel_count<PrivacyPool: IViews>(
 /// * `recipient_addr` - The recipient's account address.
 /// * `private_key` - The private viewing key of that account.
 /// * `start_index` - Starting index (inclusive). Pass 0 to discover all channels.
-/// * `total_n_channels` - Total number of channels for this recipient (from
-///   [`get_incoming_channel_count`]). The function will scan indices
-///   `start_index..total_n_channels`.
+/// * `total_n_channels` - Total number of channels (from [`get_incoming_channel_count`]).
 /// * `budget` - I/O budget to limit storage operations.
 ///
 /// # Returns
 ///
-/// A `ChannelDiscoveryResult` containing all discovered channels and metadata for
-/// incremental discovery.
+/// A `DiscoveryResult` containing all discovered channels and whether more remain.
 ///
 /// # Security
 ///
@@ -125,6 +146,59 @@ pub async fn discover_incoming_channels<PrivacyPool: IViews>(
     })
 }
 
+/// Discovers incoming channels with cursor-based pagination.
+///
+/// Fetches and caches `total_n_channels` if not already in the cursor,
+/// then delegates to [`discover_incoming_channels`] for new channels.
+pub async fn discover_channels_paginated<S: IViews>(
+    pool: &S,
+    recipient: Felt,
+    decryption_key: &Felt,
+    cursor: &mut DiscoveryCursor,
+    budget: &IoBudget,
+) -> Result<Vec<IncomingChannel>, DiscoveryError> {
+    // 1. Get/cache total_n_channels.
+    let total = match cursor.total_n_channels {
+        Some(count) => count,
+        None => match get_incoming_channel_count(pool, recipient, budget).await? {
+            Some(count) => {
+                cursor.total_n_channels = Some(count);
+                count
+            }
+            // Budget exhausted before getting count.
+            None => return Ok(Vec::new()),
+        },
+    };
+
+    // 2. All channels already enumerated — skip.
+    let start_index = cursor.last_channel_index.map_or(0, |i| i + 1);
+    if start_index >= total {
+        return Ok(Vec::new());
+    }
+
+    // 3. Discover new channels.
+    let result =
+        discover_incoming_channels(pool, recipient, decryption_key, start_index, total, budget)
+            .await?;
+
+    // 4. Register new channels in cursor.
+    for channel in &result.channels {
+        cursor
+            .channels
+            .entry(channel.info.channel_key)
+            .or_insert(ChannelCursor {
+                sender_addr: channel.info.sender_addr,
+                total_n_subchannels: None,
+                last_subchannel_index: None,
+                subchannels: Default::default(),
+            });
+    }
+
+    cursor.last_channel_index = result.last_index.or(cursor.last_channel_index);
+
+    Ok(result.channels)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -138,13 +212,19 @@ mod tests {
         let key = Felt::from(1u64);
         let budget = IoBudget::new(100);
 
+        let count = get_incoming_channel_count(&backend, recipient, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(count, 0);
+
         // Test with 0 (start from beginning)
-        let result1 = discover_incoming_channels(&backend, recipient, &key, 0, 0, &budget)
+        let result1 = discover_incoming_channels(&backend, recipient, &key, 0, count, &budget)
             .await
             .unwrap();
 
         // Test with 5 (arbitrary index beyond total)
-        let result2 = discover_incoming_channels(&backend, recipient, &key, 5, 0, &budget)
+        let result2 = discover_incoming_channels(&backend, recipient, &key, 5, count, &budget)
             .await
             .unwrap();
 
@@ -275,9 +355,8 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // No budget for the count query (COST_NUM_CHANNELS = 1)
+        // Budget exhausted before getting count
         let budget = IoBudget::new(0);
-
         let count = get_incoming_channel_count(&backend, fixture.constants.alice_address, &budget)
             .await
             .unwrap();
@@ -289,16 +368,16 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // Budget for count but not channel info
-        // COST_NUM_CHANNELS = 1, COST_CHANNEL_INFO = 3
-        let budget = IoBudget::new(2);
-
+        // Get count first with sufficient budget
+        let budget = IoBudget::new(100);
         let count = get_incoming_channel_count(&backend, fixture.constants.alice_address, &budget)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(count, 1);
 
+        // Now discover with insufficient budget (COST_CHANNEL_INFO = 3)
+        let budget = IoBudget::new(2);
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
@@ -313,5 +392,62 @@ mod tests {
         assert_eq!(result.channels.len(), 0);
         assert_eq!(result.last_index, None);
         assert!(result.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_full_discovery_populates_cursor() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let mut cursor = DiscoveryCursor::default();
+        let budget = IoBudget::new(100);
+
+        let channels = discover_channels_paginated(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(channels.len(), 1, "Bob should have 1 channel");
+        assert_eq!(cursor.total_n_channels, Some(1));
+        assert_eq!(cursor.last_channel_index, Some(0));
+        assert_eq!(cursor.channels.len(), 1, "1 channel in cursor");
+
+        let channel_key = channels[0].info.channel_key;
+        assert!(cursor.channels.contains_key(&channel_key));
+        assert_eq!(
+            cursor.channels[&channel_key].sender_addr,
+            fixture.constants.alice_address
+        );
+    }
+
+    #[tokio::test]
+    async fn test_paginated_budget_limited_count_returns_empty() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let mut cursor = DiscoveryCursor::default();
+        // Budget = 0: can't even fetch channel count
+        let budget = IoBudget::new(0);
+
+        let channels = discover_channels_paginated(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert!(channels.is_empty(), "no budget for count fetch");
+        assert!(
+            cursor.total_n_channels.is_none(),
+            "count should not be cached"
+        );
     }
 }

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -5,21 +5,22 @@ use thiserror::Error;
 use crate::privacy_pool::decryption::DecryptionError;
 use crate::storage_backend::StorageError;
 
+pub mod cursor;
 pub mod incoming_channels;
 pub mod notes;
 pub mod subchannels;
 
 /// Cost for `get_num_of_channels` (1 storage slot read).
-const COST_NUM_CHANNELS: usize = 1;
+pub const COST_NUM_CHANNELS: usize = 1;
 
 /// Cost for `get_channel_info` (3 storage slot reads).
-const COST_CHANNEL_INFO: usize = 3;
+pub const COST_CHANNEL_INFO: usize = 3;
 
 /// Cost for `get_subchannel_info` (2 storage slot reads).
-const COST_SUBCHANNEL_INFO: usize = 2;
+pub const COST_SUBCHANNEL_INFO: usize = 2;
 
 /// Cost for `get_note` (1 storage slot read).
-const COST_NOTE: usize = 1;
+pub const COST_NOTE: usize = 1;
 
 /// Errors that can occur during channel discovery.
 #[derive(Debug, Error)]
@@ -36,4 +37,7 @@ pub enum DiscoveryError {
         #[source]
         source: DecryptionError,
     },
+    /// A spawned task panicked.
+    #[error("spawned task panicked: {0}")]
+    TaskPanicked(String),
 }

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -14,16 +14,19 @@
 //! - Multiple subchannel scans (for notes) can run in parallel
 //! - Multiple channel scans (for subchannels) can run in parallel
 
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-use super::{DiscoveryError, COST_NOTE};
+use super::cursor::SubchannelCursor;
+use super::DiscoveryError;
+use super::COST_NOTE;
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::{decrypt_note_amount, unpack_note_amount};
 use crate::privacy_pool::hashes::compute_note_id;
 use crate::privacy_pool::views::IViews;
 
 /// A discovered and decrypted note.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecryptedNote {
     /// The index of this note within the subchannel.
     pub index: u64,
@@ -40,8 +43,8 @@ pub struct DecryptedNote {
 pub struct NotesDiscoveryResult {
     /// List of discovered and decrypted notes.
     pub notes: Vec<DecryptedNote>,
-    /// Index of the last discovered note, or `None` if no notes
-    /// were discovered.
+    /// Index of the last discovered note, or `None` if no notes were discovered.
+    /// Use for cursor updates: `cursor.last_note_index = result.last_index`.
     pub last_index: Option<u64>,
     /// Whether there may be more notes to discover.
     /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
@@ -119,6 +122,27 @@ pub async fn discover_notes<PrivacyPool: IViews>(
         last_index,
         has_more: out_of_budget,
     })
+}
+
+/// Discovers notes with cursor-based pagination.
+///
+/// Delegates to [`discover_notes`] and updates the cursor.
+///
+/// Returns discovered notes and `has_more`. `has_more = false` means
+/// the sentinel was found (no more notes in this subchannel).
+pub async fn discover_notes_paginated<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    cursor: &mut SubchannelCursor,
+    budget: &IoBudget,
+) -> Result<(Vec<DecryptedNote>, bool), DiscoveryError> {
+    let start_index = cursor.last_note_index.map_or(0, |i| i + 1);
+    let result = discover_notes(pool, channel_key, token, start_index, budget).await?;
+
+    cursor.last_note_index = result.last_index.or(cursor.last_note_index);
+
+    Ok((result.notes, result.has_more))
 }
 
 #[cfg(test)]
@@ -233,17 +257,12 @@ mod tests {
             .unwrap();
         assert!(!result1.notes.is_empty());
         assert!(!result1.has_more);
+        let last_index = result1.last_index.unwrap();
 
         // Incremental discovery starting from last_index + 1 - should find 0 new notes
-        let result2 = discover_notes(
-            &backend,
-            channel_key,
-            token,
-            result1.last_index.unwrap() + 1,
-            &budget,
-        )
-        .await
-        .unwrap();
+        let result2 = discover_notes(&backend, channel_key, token, last_index + 1, &budget)
+            .await
+            .unwrap();
         assert_eq!(result2.notes.len(), 0);
         assert_eq!(result2.last_index, None);
         assert!(!result2.has_more);
@@ -276,5 +295,57 @@ mod tests {
         assert_eq!(result.notes.len(), 0);
         assert_eq!(result.last_index, None);
         assert!(result.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_full_discovery() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let mut cursor = SubchannelCursor::default();
+        let budget = IoBudget::new(100);
+        let (notes, has_more) =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        assert!(!notes.is_empty(), "should discover at least one note");
+        assert!(!has_more, "sentinel should be found");
+    }
+
+    #[tokio::test]
+    async fn test_paginated_budget_limited() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let mut cursor = SubchannelCursor::default();
+        // Budget for exactly 1 note (COST_NOTE=1), not enough to hit sentinel
+        let budget = IoBudget::new(COST_NOTE);
+        let (notes, has_more) =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(notes.len(), 1, "should discover exactly 1 note");
+        assert!(has_more, "sentinel not reached");
+        assert_eq!(cursor.last_note_index, Some(0));
     }
 }

--- a/crates/discovery-core/src/discovery/subchannels.rs
+++ b/crates/discovery-core/src/discovery/subchannels.rs
@@ -6,7 +6,9 @@
 
 use starknet_types_core::felt::Felt;
 
-use super::{DiscoveryError, COST_SUBCHANNEL_INFO};
+use super::cursor::ChannelCursor;
+use super::DiscoveryError;
+use super::COST_SUBCHANNEL_INFO;
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::decrypt_subchannel_token;
 use crate::privacy_pool::hashes::compute_subchannel_id;
@@ -26,8 +28,8 @@ pub struct Subchannel {
 pub struct SubchannelDiscoveryResult {
     /// List of discovered and decrypted subchannels.
     pub subchannels: Vec<Subchannel>,
-    /// Index of the last discovered subchannel, or `None` if no
-    /// subchannels were discovered.
+    /// Index of the last discovered subchannel, or `None` if no subchannels were discovered.
+    /// Use for cursor updates: `cursor.last_subchannel_index = result.last_index`.
     pub last_index: Option<u64>,
     /// Whether there may be more subchannels to discover.
     /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
@@ -96,8 +98,46 @@ pub async fn discover_subchannels<PrivacyPool: IViews>(
     })
 }
 
+/// Discovers subchannels with cursor-based pagination.
+///
+/// If `total_n_subchannels` is already set in the cursor (sentinel was found
+/// previously), returns an empty vec immediately — no budget consumed.
+///
+/// Otherwise delegates to [`discover_subchannels`], adds new subchannels to the
+/// cursor, and sets `total_n_subchannels` once the sentinel is found.
+pub async fn discover_subchannels_paginated<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    cursor: &mut ChannelCursor,
+    budget: &IoBudget,
+) -> Result<Vec<Subchannel>, DiscoveryError> {
+    // Already fully enumerated — skip entirely.
+    if cursor.total_n_subchannels.is_some() {
+        return Ok(Vec::new());
+    }
+
+    let start_index = cursor.last_subchannel_index.map_or(0, |i| i + 1);
+    let result = discover_subchannels(pool, channel_key, start_index, budget).await?;
+
+    // Register newly discovered subchannels in the cursor.
+    for sub in &result.subchannels {
+        cursor.subchannels.entry(sub.token).or_default();
+    }
+
+    cursor.last_subchannel_index = result.last_index.or(cursor.last_subchannel_index);
+
+    // Sentinel found — cache the total count.
+    if !result.has_more {
+        cursor.total_n_subchannels = Some(cursor.last_subchannel_index.map_or(0, |i| i + 1));
+    }
+
+    Ok(result.subchannels)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::storage_backend::MockBackend;
     use crate::test_fixtures::{get_channel_key, load_devnet_fixture};
@@ -204,16 +244,12 @@ mod tests {
         assert_eq!(result1.subchannels.len(), 1);
         assert_eq!(result1.last_index, Some(0));
         assert!(!result1.has_more);
+        let last_index = result1.last_index.unwrap();
 
         // Incremental discovery starting from last_index + 1 - should find 0 new subchannels
-        let result2 = discover_subchannels(
-            &backend,
-            channel_key,
-            result1.last_index.unwrap() + 1,
-            &budget,
-        )
-        .await
-        .unwrap();
+        let result2 = discover_subchannels(&backend, channel_key, last_index + 1, &budget)
+            .await
+            .unwrap();
         assert_eq!(result2.subchannels.len(), 0);
         assert_eq!(result2.last_index, None);
         assert!(!result2.has_more);
@@ -242,5 +278,127 @@ mod tests {
         assert_eq!(result.subchannels.len(), 0);
         assert_eq!(result.last_index, None);
         assert!(result.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_full_discovery_sets_total() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+
+        let mut cursor = ChannelCursor {
+            sender_addr: fixture.constants.alice_address,
+            total_n_subchannels: None,
+            last_subchannel_index: None,
+            subchannels: HashMap::new(),
+        };
+
+        let budget = IoBudget::new(100);
+        let subs = discover_subchannels_paginated(&backend, channel_key, &mut cursor, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(subs.len(), 1, "should discover 1 subchannel (STRK)");
+        assert_eq!(
+            cursor.total_n_subchannels,
+            Some(1),
+            "total should be cached after sentinel"
+        );
+        assert!(
+            cursor
+                .subchannels
+                .contains_key(&fixture.constants.strk_token),
+            "STRK subchannel should be in cursor"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_paginated_second_call_returns_empty_with_zero_budget() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+
+        let mut cursor = ChannelCursor {
+            sender_addr: fixture.constants.alice_address,
+            total_n_subchannels: None,
+            last_subchannel_index: None,
+            subchannels: HashMap::new(),
+        };
+
+        // First call: full discovery
+        let budget = IoBudget::new(100);
+        discover_subchannels_paginated(&backend, channel_key, &mut cursor, &budget)
+            .await
+            .unwrap();
+        assert!(cursor.total_n_subchannels.is_some());
+
+        // Second call: 0 budget — should return empty immediately
+        let budget = IoBudget::new(0);
+        let subs = discover_subchannels_paginated(&backend, channel_key, &mut cursor, &budget)
+            .await
+            .unwrap();
+
+        assert!(subs.is_empty(), "should skip when total is cached");
+        assert_eq!(budget.remaining(), 0, "no budget should be consumed");
+    }
+
+    /// Both states have an empty subchannels map, but behavior differs:
+    /// - Fresh cursor (total_n_subchannels=None) → discovers subchannels
+    /// - Fully enumerated (total_n_subchannels=Some) → skips, zero budget cost
+    #[tokio::test]
+    async fn test_paginated_fresh_vs_fully_enumerated() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+
+        // Fresh cursor: empty map + no total → should discover subchannels
+        let mut fresh = ChannelCursor {
+            sender_addr: fixture.constants.alice_address,
+            total_n_subchannels: None,
+            last_subchannel_index: None,
+            subchannels: HashMap::new(),
+        };
+        let budget = IoBudget::new(100);
+        let subs = discover_subchannels_paginated(&backend, channel_key, &mut fresh, &budget)
+            .await
+            .unwrap();
+        assert_eq!(subs.len(), 1, "fresh cursor should discover subchannels");
+
+        // Fully enumerated cursor: empty map + total set → should skip entirely
+        // (simulates state after all notes processed and entries pruned)
+        let mut done = ChannelCursor {
+            sender_addr: fixture.constants.alice_address,
+            total_n_subchannels: Some(1),
+            last_subchannel_index: Some(0),
+            subchannels: HashMap::new(),
+        };
+        let budget = IoBudget::new(100);
+        let before = budget.remaining();
+        let subs = discover_subchannels_paginated(&backend, channel_key, &mut done, &budget)
+            .await
+            .unwrap();
+        assert!(subs.is_empty(), "enumerated cursor should skip");
+        assert_eq!(budget.remaining(), before, "zero budget consumed");
     }
 }


### PR DESCRIPTION
### TL;DR

Implement cursor-based pagination for privacy pool discovery to enable efficient resumable discovery.

### What changed?

- Added a new cursor module with structured types for tracking discovery progress:
  - `DiscoveryCursor`: Top-level cursor tracking all channels
  - `ChannelCursor`: Tracks progress within a channel
  - `SubchannelCursor`: Tracks progress within a subchannel
- Implemented paginated discovery functions that use and update these cursors:
  - `discover_channels_paginated`
  - `discover_subchannels_paginated`
  - `discover_notes_paginated`
- Refactored existing discovery functions to return more precise last index values
- Moved `serde` from dev-dependencies to regular dependencies to support cursor serialization
- Updated tests to verify cursor behavior and pagination

### How to test?

1. Test basic cursor functionality:
```rust
let mut cursor = DiscoveryCursor::default();
let channels = discover_channels_paginated(&pool, recipient, &key, &mut cursor, &budget).await?;
// Cursor now contains discovered channels and progress
```

2. Test resumable discovery:
```rust
// Save cursor between sessions
let serialized = serde_json::to_string(&cursor)?;
// Later, deserialize and resume
let mut cursor: DiscoveryCursor = serde_json::from_str(&serialized)?;
let more_channels = discover_channels_paginated(&pool, recipient, &key, &mut cursor, &budget).await?;
```

3. Test budget-limited discovery:
```rust
let limited_budget = IoBudget::new(5);
// Will discover until budget exhausted, cursor tracks progress
discover_channels_paginated(&pool, recipient, &key, &mut cursor, &limited_budget).await?;
```

### Why make this change?

Cursor-based pagination provides several benefits:
- Enables efficient resumable discovery across multiple sessions
- Caches discovery results to avoid redundant RPC calls
- Tracks progress precisely to minimize wasted work
- Supports serialization for persistence between app sessions
- Optimizes for limited I/O budgets by prioritizing undiscovered content

This is particularly important for mobile clients where discovery may be interrupted by network issues or app backgrounding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/408)
<!-- Reviewable:end -->
