### PR TITLE
feat(indexer): api error types

### DIFF
--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -34,6 +34,7 @@ tower = { version = "0.5", features = ["limit"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 # Error handling
 thiserror = "2"

--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -86,9 +86,9 @@ where
 }
 
 /// Shared state for the API handlers.
-struct AppState<B> {
-    backend: B,
-    health_max_lag_secs: u64,
+pub struct AppState<B> {
+    pub backend: B,
+    pub health_max_lag_secs: u64,
 }
 
 /// Response for the health endpoint.
@@ -140,4 +140,58 @@ pub enum ApiServerError {
     Bind(String),
     #[error("server error: {0}")]
     Serve(String),
+}
+
+/// Standard error response format per spec 08-error-handling.md.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    pub error: ApiErrorBody,
+}
+
+/// Error body details.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorBody {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub details: Option<serde_json::Value>,
+}
+
+impl ApiErrorResponse {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            error: ApiErrorBody {
+                code: code.to_string(),
+                message: message.into(),
+                details: None,
+            },
+        }
+    }
+
+    pub fn with_details(
+        code: &'static str,
+        message: impl Into<String>,
+        details: serde_json::Value,
+    ) -> Self {
+        Self {
+            error: ApiErrorBody {
+                code: code.to_string(),
+                message: message.into(),
+                details: Some(details),
+            },
+        }
+    }
+}
+
+/// Error codes for the API endpoints.
+pub mod error_codes {
+    pub const INVALID_REQUEST: &str = "INVALID_REQUEST";
+    #[allow(dead_code)]
+    pub const INVALID_ADDRESS: &str = "INVALID_ADDRESS";
+    pub const MAX_READS_EXCEEDED: &str = "MAX_READS_EXCEEDED";
+    pub const BLOCK_NOT_FOUND: &str = "BLOCK_NOT_FOUND";
+    pub const BLOCK_REORGED: &str = "BLOCK_REORGED";
+    pub const SERVICE_UNAVAILABLE: &str = "SERVICE_UNAVAILABLE";
+    pub const RPC_UNAVAILABLE: &str = "RPC_UNAVAILABLE";
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
 }


### PR DESCRIPTION
### TL;DR

Added standardized API error response format and error codes to the discovery service.

### What changed?

- Added `serde_json` dependency to `Cargo.toml`
- Made `AppState` struct and its fields public
- Implemented standardized error response format with:
  - `ApiErrorResponse` struct for consistent error formatting
  - `ApiErrorBody` struct for error details
  - Helper methods for creating error responses with and without details
  - Defined common error codes in the `error_codes` module

### How to test?

- Verify that the new error response format can be properly serialized
- Test creating error responses with and without details
- Ensure the defined error codes are appropriate for the API endpoints

### Why make this change?

This change implements the standardized error handling format as specified in the `08-error-handling.md` spec document. Having a consistent error response format improves API usability and makes error handling more predictable for clients consuming the discovery service API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/412)
<!-- Reviewable:end -->
