### PR TITLE
feat(indexer): add incoming state sync endpoint

### DIFF
--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use discovery_core::storage_backend::StorageBackend;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ use tokio::sync::broadcast;
 use tracing::info;
 
 use crate::chain_state::{ChainHead, ChainState};
+use crate::incoming_sync::incoming_sync_handler;
 
 /// Configuration for the API server.
 #[derive(Debug, Clone)]
@@ -44,6 +45,7 @@ pub struct ApiServer<B> {
 impl<B> ApiServer<B>
 where
     B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
 {
     /// Creates a new API server.
     pub fn new(config: ApiServerConfig, rx_shutdown: broadcast::Receiver<()>, backend: B) -> Self {
@@ -63,6 +65,10 @@ where
 
         let app = Router::new()
             .route("/health", get(health_handler::<B>))
+            .route(
+                "/v1/discovery/incoming/sync",
+                post(incoming_sync_handler::<B>),
+            )
             .with_state(app_state);
 
         let listener = TcpListener::bind(&self.config.api_host)

--- a/crates/discovery-service/src/incoming_sync/handler.rs
+++ b/crates/discovery-service/src/incoming_sync/handler.rs
@@ -1,0 +1,111 @@
+//! Handler and supporting logic for POST /v1/discovery/incoming/sync.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use discovery_core::io_budget::IoBudget;
+use discovery_core::storage_backend::StorageBackend;
+use tracing::warn;
+
+use crate::api_server::{error_codes, ApiErrorResponse, AppState};
+use crate::chain_state::ChainState;
+
+use super::types::{IncomingSyncRequest, IncomingSyncResponse};
+use super::validation::ValidatedRequest;
+
+/// Handler for POST /v1/discovery/incoming/sync.
+pub async fn incoming_sync_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<IncomingSyncRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    match incoming_sync_impl(&state, request).await {
+        Ok(response) => (
+            StatusCode::OK,
+            Json(serde_json::to_value(response).unwrap()),
+        )
+            .into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn incoming_sync_impl<B>(
+    state: &AppState<B>,
+    request: IncomingSyncRequest,
+) -> Result<IncomingSyncResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    let validated = ValidatedRequest::from_request(request, &state.backend).await?;
+
+    let snapshot = state
+        .backend
+        .snapshot(Some(validated.query_block))
+        .await
+        .map_err(|e| {
+            warn!("Failed to create snapshot: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(
+                    error_codes::INTERNAL_ERROR,
+                    format!("Failed to create snapshot: {}", e),
+                ),
+            )
+        })?;
+
+    let budget = IoBudget::new(validated.max_reads);
+
+    let discovery_output = discovery_core::sync::incoming_state::sync_incoming_state(
+        &snapshot,
+        validated.recipient_address,
+        &validated.decryption_key,
+        validated.cursor,
+        &budget,
+    )
+    .await
+    .map_err(discovery_error_to_response)?;
+
+    Ok(IncomingSyncResponse {
+        block_ref: validated.block_ref,
+        channels: discovery_output.channels,
+        cursor: discovery_output.cursor,
+    })
+}
+
+fn discovery_error_to_response(
+    e: discovery_core::discovery::DiscoveryError,
+) -> (StatusCode, ApiErrorResponse) {
+    use discovery_core::discovery::DiscoveryError;
+
+    match e {
+        DiscoveryError::Storage(storage_err) => {
+            warn!("Storage error during discovery: {}", storage_err);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiErrorResponse::new(error_codes::RPC_UNAVAILABLE, "Upstream RPC is unavailable"),
+            )
+        }
+        DiscoveryError::Decryption { index, source } => (
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::with_details(
+                error_codes::INVALID_REQUEST,
+                format!("Decryption failed at index {}: {}", index, source),
+                serde_json::json!({ "index": index }),
+            ),
+        ),
+        DiscoveryError::TaskPanicked(msg) => {
+            warn!("Discovery task panicked: {}", msg);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
+            )
+        }
+    }
+}

--- a/crates/discovery-service/src/incoming_sync/mod.rs
+++ b/crates/discovery-service/src/incoming_sync/mod.rs
@@ -1,0 +1,10 @@
+//! Incoming sync endpoint for discovering channels, subchannels, and notes.
+//!
+//! Provides the `/v1/discovery/incoming/sync` endpoint.
+
+mod handler;
+mod types;
+pub(crate) mod validation;
+
+pub use handler::incoming_sync_handler;
+pub use types::{IncomingSyncRequest, IncomingSyncResponse, DEFAULT_MAX_READS, MAX_READS_CAP};

--- a/crates/discovery-service/src/incoming_sync/types.rs
+++ b/crates/discovery-service/src/incoming_sync/types.rs
@@ -1,0 +1,74 @@
+//! Request/response types for the incoming sync endpoint.
+
+use std::collections::HashMap;
+
+use discovery_core::discovery::cursor::DiscoveryCursor;
+use discovery_core::sync::incoming_state::ChannelOutput;
+use serde::{Deserialize, Serialize};
+use starknet_core::types::Felt;
+
+/// Default max_reads if not specified.
+pub const DEFAULT_MAX_READS: usize = 50;
+
+/// Server-enforced maximum for max_reads.
+pub const MAX_READS_CAP: u32 = 100;
+
+/// Request body for POST /v1/discovery/incoming/sync.
+///
+/// # Sync Flow
+///
+/// **First request** (fresh sync or new session):
+/// ```json
+/// {
+///   "recipient_address": "0x...",
+///   "decryption_key": "0x...",
+///   "last_known_block": "0x..."  // Optional: for reorg detection
+/// }
+/// ```
+///
+/// **Subsequent requests** (pagination within same session):
+/// ```json
+/// {
+///   "recipient_address": "0x...",
+///   "decryption_key": "0x...",
+///   "block_ref": "0x...",  // From previous response
+///   "cursor": { ... }      // From previous response
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncomingSyncRequest {
+    /// The recipient's address.
+    pub recipient_address: Felt,
+    /// The recipient's private viewing key.
+    pub decryption_key: Felt,
+    /// Block hash for reorg detection. Set on first request of a new sync
+    /// session to the `block_hash` from your last completed sync.
+    /// Server returns 409 if this block was reorged out.
+    /// Leave empty on pagination requests or fresh syncs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_known_block: Option<Felt>,
+    /// Block hash to query state at. Ensures consistent reads across
+    /// paginated requests. Leave empty on first request (server uses
+    /// current head). On pagination, use the value from previous response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_ref: Option<Felt>,
+    /// Discovery cursor for pagination. Use the cursor from previous
+    /// response to continue discovery.
+    #[serde(default)]
+    pub cursor: DiscoveryCursor,
+    /// Maximum number of storage reads to perform.
+    #[serde(default)]
+    pub max_reads: Option<u32>,
+}
+
+/// Response body for POST /v1/discovery/incoming/sync.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncomingSyncResponse {
+    /// Block hash pinning all reads in this response. Pass back as
+    /// `block_ref` in subsequent requests for consistency.
+    pub block_ref: Felt,
+    /// Discovered channel results, keyed by channel_key.
+    pub channels: HashMap<Felt, ChannelOutput>,
+    /// Updated cursor for continuation. Pass back as `cursor` in next request.
+    pub cursor: DiscoveryCursor,
+}

--- a/crates/discovery-service/src/incoming_sync/validation.rs
+++ b/crates/discovery-service/src/incoming_sync/validation.rs
@@ -1,0 +1,230 @@
+//! Request validation for the incoming sync endpoint.
+
+use axum::http::StatusCode;
+use discovery_core::discovery::cursor::DiscoveryCursor;
+use starknet_core::types::{BlockId, Felt};
+use tracing::warn;
+
+use crate::api_server::{error_codes, ApiErrorResponse};
+use crate::chain_state::{ChainState, ChainStateError};
+
+use super::types::{IncomingSyncRequest, DEFAULT_MAX_READS, MAX_READS_CAP};
+
+/// Validated and resolved request data.
+///
+/// Contains all data needed to run discovery after validation passes.
+#[derive(Debug)]
+pub struct ValidatedRequest {
+    /// The recipient's address.
+    pub recipient_address: Felt,
+    /// The recipient's private viewing key.
+    pub decryption_key: Felt,
+    /// Resolved block ID for the query.
+    pub query_block: BlockId,
+    /// Block hash pinning all reads (from head or request).
+    pub block_ref: Felt,
+    /// Cursor for pagination.
+    pub cursor: DiscoveryCursor,
+    /// Validated max_reads value.
+    pub max_reads: usize,
+}
+
+impl ValidatedRequest {
+    /// Validates and resolves the incoming sync request.
+    ///
+    /// Performs the following validations:
+    /// 1. Validates max_reads doesn't exceed cap
+    /// 2. Checks last_known_block hasn't been reorged (if provided)
+    /// 3. Resolves block_ref (if provided) or uses current head
+    /// 4. Gets current chain head
+    pub async fn from_request<B: ChainState>(
+        request: IncomingSyncRequest,
+        backend: &B,
+    ) -> Result<Self, (StatusCode, ApiErrorResponse)> {
+        // 1. Validate and convert max_reads
+        let max_reads: usize = match request.max_reads {
+            Some(v) => {
+                if v > MAX_READS_CAP {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        ApiErrorResponse::with_details(
+                            error_codes::MAX_READS_EXCEEDED,
+                            format!("max_reads {} exceeds maximum {}", v, MAX_READS_CAP),
+                            serde_json::json!({ "max_allowed": MAX_READS_CAP }),
+                        ),
+                    ));
+                }
+                v.try_into().map_err(|_| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        ApiErrorResponse::new(
+                            error_codes::INVALID_REQUEST,
+                            "max_reads value cannot be represented on this platform",
+                        ),
+                    )
+                })?
+            }
+            None => DEFAULT_MAX_READS,
+        };
+
+        // 2. If last_known_block provided, check is_canonical
+        if let Some(last_known) = request.last_known_block {
+            match backend.is_canonical(last_known).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    return Err((
+                        StatusCode::CONFLICT,
+                        ApiErrorResponse::new(
+                            error_codes::BLOCK_REORGED,
+                            "last_known_block was reorged out; client should re-sync",
+                        ),
+                    ));
+                }
+                Err(ChainStateError::RpcError(e)) => {
+                    warn!("RPC error checking is_canonical: {}", e);
+                    return Err((
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        ApiErrorResponse::new(
+                            error_codes::RPC_UNAVAILABLE,
+                            "Upstream RPC is unavailable",
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // 3. Resolve query block
+        //
+        // If block_ref is specified, use it directly without validation.
+        // It's the client's responsibility to use a valid block_ref (typically
+        // from the cursor returned in a previous response). If invalid, the RPC
+        // call will fail and discovery will return an error.
+        let block_ref = if let Some(block_ref) = request.block_ref {
+            // Use block_ref directly - no validation, no head fetch needed
+            block_ref
+        } else {
+            // Use current head
+            let head = backend.get_head().await.ok_or_else(|| {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    ApiErrorResponse::new(
+                        error_codes::SERVICE_UNAVAILABLE,
+                        "No indexed head available yet",
+                    ),
+                )
+            })?;
+            head.block_hash
+        };
+
+        Ok(ValidatedRequest {
+            recipient_address: request.recipient_address,
+            decryption_key: request.decryption_key,
+            query_block: BlockId::Hash(block_ref),
+            block_ref,
+            cursor: request.cursor,
+            max_reads,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain_state::mock::MockChainState;
+
+    fn make_request() -> IncomingSyncRequest {
+        IncomingSyncRequest {
+            recipient_address: Felt::from_hex_unchecked("0x1"),
+            decryption_key: Felt::from_hex_unchecked("0x2"),
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+            max_reads: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_valid_request_uses_head_as_block_ref() {
+        let backend = MockChainState::new();
+        let request = make_request();
+
+        let validated = ValidatedRequest::from_request(request, &backend)
+            .await
+            .unwrap();
+        assert_eq!(validated.max_reads, DEFAULT_MAX_READS);
+        // block_ref is set from head when not specified in request
+        assert_eq!(validated.query_block, BlockId::Hash(validated.block_ref));
+    }
+
+    #[tokio::test]
+    async fn test_block_ref_used_directly() {
+        let backend = MockChainState::new();
+        let mut request = make_request();
+        request.block_ref = Some(Felt::from_hex_unchecked("0xabc"));
+
+        let validated = ValidatedRequest::from_request(request, &backend)
+            .await
+            .unwrap();
+        assert_eq!(validated.block_ref, Felt::from_hex_unchecked("0xabc"));
+        assert_eq!(
+            validated.query_block,
+            BlockId::Hash(Felt::from_hex_unchecked("0xabc"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_max_reads_exceeded() {
+        let backend = MockChainState::new();
+        let mut request = make_request();
+        request.max_reads = Some(MAX_READS_CAP + 1);
+
+        let result = ValidatedRequest::from_request(request, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error.code, error_codes::MAX_READS_EXCEEDED);
+    }
+
+    #[tokio::test]
+    async fn test_block_reorged() {
+        let backend = MockChainState::new();
+        let mut request = make_request();
+        request.last_known_block = Some(Felt::from_hex_unchecked("0x999")); // Not canonical
+
+        let result = ValidatedRequest::from_request(request, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(error.error.code, error_codes::BLOCK_REORGED);
+    }
+
+    #[tokio::test]
+    async fn test_no_head_available_without_block_ref() {
+        let backend = MockChainState::with_no_head();
+        let request = make_request();
+
+        let result = ValidatedRequest::from_request(request, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.error.code, error_codes::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_block_ref_works_without_head() {
+        // When block_ref is specified, we don't need the head
+        let backend = MockChainState::with_no_head();
+        let mut request = make_request();
+        request.block_ref = Some(Felt::from_hex_unchecked("0xabc"));
+
+        let validated = ValidatedRequest::from_request(request, &backend)
+            .await
+            .unwrap();
+        assert_eq!(validated.block_ref, Felt::from_hex_unchecked("0xabc"));
+    }
+
+    // RPC error handling is tested via integration tests with real devnet
+}

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -4,10 +4,11 @@
 //! - RPC-based storage backend for reading privacy contract state
 //! - Indexer for Starknet new heads subscription
 //! - Chain state tracking for canonical block verification and recent head retrieval
-//! - API server with health endpoint
+//! - API server with health endpoint and incoming sync endpoint
 
 pub mod api_server;
 pub mod chain_state;
+pub mod incoming_sync;
 pub mod indexer;
 pub mod rpc_backend;
 pub mod shutdown;

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -154,6 +154,7 @@ impl StorageBackend for RpcBackend {
 }
 
 /// Snapshot of storage at a specific block, accessed via RPC.
+#[derive(Clone)]
 pub struct RpcSnapshot {
     backend: RpcBackend,
     block_id: BlockId,

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -3,7 +3,11 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use discovery_service::api_server::ApiErrorResponse;
+use discovery_service::incoming_sync::IncomingSyncRequest;
+use discovery_service::incoming_sync::IncomingSyncResponse;
 use nix::sys::signal::Signal;
+use reqwest::StatusCode;
 use starknet_types_core::felt::Felt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -101,12 +105,38 @@ impl IndexerClient {
     pub async fn wait_until_ready(&mut self, devnet: &DevnetClient) -> Result<()> {
         self.wait_for_log("API server listening", Duration::from_secs(10))
             .await?;
-        self.wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        self.wait_for_log("Subscribed to new heads", Duration::from_secs(15))
             .await?;
         devnet.create_block().await?;
         self.wait_for_log("New block #", Duration::from_secs(5))
             .await?;
         Ok(())
+    }
+
+    /// POST `/v1/discovery/incoming/sync` and return the parsed success response.
+    pub async fn incoming_sync(&self, req: &IncomingSyncRequest) -> Result<IncomingSyncResponse> {
+        let url = format!("http://{}/v1/discovery/incoming/sync", self.api_host);
+        let resp = reqwest::Client::new().post(&url).json(req).send().await?;
+
+        let status = resp.status();
+        let body = resp.text().await?;
+        if status != StatusCode::OK {
+            return Err(anyhow!("Expected 200, got {}: {}", status, body));
+        }
+        Ok(serde_json::from_str(&body)?)
+    }
+
+    /// POST `/v1/discovery/incoming/sync` and return status + parsed error body.
+    pub async fn incoming_sync_error(
+        &self,
+        req: &IncomingSyncRequest,
+    ) -> Result<(StatusCode, ApiErrorResponse)> {
+        let url = format!("http://{}/v1/discovery/incoming/sync", self.api_host);
+        let resp = reqwest::Client::new().post(&url).json(req).send().await?;
+
+        let status = resp.status();
+        let error: ApiErrorResponse = resp.json().await?;
+        Ok((status, error))
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -1,11 +1,20 @@
-//! API server tests: health endpoint.
+//! API server tests: health endpoint, incoming sync.
 //!
-//! Run with: `cargo test -p discovery-service --test test_api`
+//! Run with: `cargo test -p discovery-service --test api_tests`
+//!
+//! Update snapshots with: `UPDATE_EXPECT=1 cargo test -p discovery-service --test api_tests`
 
 mod common;
 
-use common::{setup_indexer, DevnetClient, DevnetConfig};
+use std::time::Duration;
+
+use common::{
+    setup_devnet_with_dump, setup_indexer, DevnetClient, DevnetConfig, IndexerClient,
+    IndexerSpawnConfig,
+};
 use discovery_service::api_server::HealthResponse;
+use discovery_service::incoming_sync::{IncomingSyncRequest, MAX_READS_CAP};
+use starknet_core::types::Felt;
 
 #[tokio::test]
 async fn test_health_endpoint_returns_ok() {
@@ -25,6 +34,148 @@ async fn test_health_endpoint_returns_ok() {
     assert_eq!(health.status, "OK");
     assert!(health.chain_head.is_some());
     assert!(health.chain_head.unwrap().timestamp > 0);
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    let request = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        decryption_key: metadata.alice_private_key,
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+        max_reads: Some(MAX_READS_CAP),
+    };
+
+    let response = indexer.incoming_sync(&request).await.unwrap();
+
+    // block_ref is always present
+    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+
+    // With a large budget, all discovery should complete: cursor.channels is empty
+    assert!(
+        response.cursor.channels.is_empty(),
+        "All channels should be fully discovered (pruned from cursor)"
+    );
+
+    // Verify result structure
+    for (channel_key, channel) in &response.channels {
+        assert!(*channel_key != Felt::ZERO, "Channel key should not be zero");
+        for token in channel.subchannels.keys() {
+            assert!(*token != Felt::ZERO, "Token should not be zero");
+        }
+    }
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_pagination() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // First sync with very small budget (1 read - should just get channel count)
+    let request1 = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        decryption_key: metadata.alice_private_key,
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+        max_reads: Some(1),
+    };
+
+    let response1 = indexer.incoming_sync(&request1).await.unwrap();
+
+    // Second sync using block_ref and cursor from previous response
+    let request2 = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        decryption_key: metadata.alice_private_key,
+        last_known_block: None,
+        block_ref: Some(response1.block_ref),
+        cursor: response1.cursor.clone(),
+        max_reads: Some(MAX_READS_CAP),
+    };
+
+    let response2 = indexer.incoming_sync(&request2).await.unwrap();
+
+    // Should eventually complete: cursor.channels empty means all done
+    assert!(
+        response2.cursor.channels.is_empty(),
+        "Should complete with larger budget"
+    );
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_block_reorged() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // Use a fake block hash that doesn't exist (simulates reorg)
+    let fake_block = Felt::from_hex("0xdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+
+    let request = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        decryption_key: metadata.alice_private_key,
+        last_known_block: Some(fake_block),
+        block_ref: None,
+        cursor: Default::default(),
+        max_reads: Some(MAX_READS_CAP),
+    };
+
+    let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
+
+    assert_eq!(status, 409);
+    assert_eq!(error.error.code, "BLOCK_REORGED");
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_no_head() {
+    let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
+
+    let mut indexer = IndexerClient::spawn(
+        env!("CARGO_BIN_EXE_discovery-service"),
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
+
+    // Wait for API server only (don't create any blocks)
+    indexer
+        .wait_for_log("API server listening", Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    // Use any address/key - it doesn't matter since indexer has no head yet
+    let request = IncomingSyncRequest {
+        recipient_address: Felt::from_hex("0x1234").unwrap(),
+        decryption_key: Felt::from_hex("0x5678").unwrap(),
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+        max_reads: Some(MAX_READS_CAP),
+    };
+
+    let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
+
+    // Should return 503 SERVICE_UNAVAILABLE since no head is indexed yet
+    assert_eq!(status, 503);
+    assert_eq!(error.error.code, "SERVICE_UNAVAILABLE");
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();

--- a/crates/discovery-service/tests/test_indexer.rs
+++ b/crates/discovery-service/tests/test_indexer.rs
@@ -28,7 +28,7 @@ async fn test_startup_and_shutdown() {
         .await
         .unwrap();
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .wait_for_log("Subscribed to new heads", Duration::from_secs(15))
         .await
         .unwrap();
 
@@ -51,7 +51,7 @@ async fn test_new_block_notification() {
     .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .wait_for_log("Subscribed to new heads", Duration::from_secs(15))
         .await
         .unwrap();
 
@@ -80,7 +80,7 @@ async fn test_reconnection_on_devnet_restart() {
     .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .wait_for_log("Subscribed to new heads", Duration::from_secs(15))
         .await
         .unwrap();
 


### PR DESCRIPTION
### TL;DR

Added a new `/v1/discovery/incoming/sync` endpoint to the discovery service for retrieving decrypted channels, subchannels, and notes.

### What changed?

- Implemented a new API endpoint at `/v1/discovery/incoming/sync` that allows clients to discover incoming channels, subchannels, and notes
- Created request/response types for the incoming sync endpoint with support for pagination
- Added validation logic to handle block references, reorg detection, and request limits
- Integrated with the existing discovery core functionality for decrypting and retrieving messages
- Added comprehensive error handling for various failure scenarios
- Implemented integration tests for the new endpoint

### How to test?

Run the integration tests with:
```
cargo test -p discovery-service --test api_tests
```

The tests cover various scenarios including:
- Basic sync functionality
- Pagination with small read budgets
- Block reorg detection
- Error handling when no chain head is available

### Why make this change?

This endpoint is a critical part of the discovery service, allowing clients to efficiently retrieve and decrypt their incoming messages. The implementation includes important features like:

- Pagination support for handling large message volumes
- Consistent reads across paginated requests using block references
- Reorg detection to ensure data consistency
- Configurable read budgets to control resource usage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/413)
<!-- Reviewable:end -->
