### PR TITLE
feat(indexer): filter out spent notes, use secret felt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/discovery-core/Cargo.toml
+++ b/crates/discovery-core/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 url = "2"
+zeroize = "1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -21,7 +21,7 @@ use super::DiscoveryError;
 use super::{COST_CHANNEL_INFO, COST_NUM_CHANNELS};
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::decrypt_channel_info;
-use crate::privacy_pool::types::ChannelInfo;
+use crate::privacy_pool::types::{ChannelInfo, SecretFelt};
 use crate::privacy_pool::views::IViews;
 
 /// A discovered and decrypted incoming channel.
@@ -87,15 +87,10 @@ pub async fn get_incoming_channel_count<PrivacyPool: IViews>(
 /// # Returns
 ///
 /// A `DiscoveryResult` containing all discovered channels and whether more remain.
-///
-/// # Security
-///
-/// The caller should zero the `private_key` after use by calling
-/// `private_key.zeroize()` (see `crate::privacy_pool::types::Zeroize`).
 pub async fn discover_incoming_channels<PrivacyPool: IViews>(
     privacy_pool: &PrivacyPool,
     recipient_addr: Felt,
-    private_key: &Felt,
+    private_key: &SecretFelt,
     start_index: u64,
     total_n_channels: u64,
     budget: &IoBudget,
@@ -157,7 +152,7 @@ pub async fn discover_incoming_channels<PrivacyPool: IViews>(
 pub async fn discover_channels_paginated<S: IViews>(
     pool: &S,
     recipient: Felt,
-    decryption_key: &Felt,
+    decryption_key: &SecretFelt,
     cursor: &mut DiscoveryCursor,
     budget: &IoBudget,
 ) -> Result<Vec<IncomingChannel>, DiscoveryError> {
@@ -213,7 +208,7 @@ mod tests {
     async fn test_discover_no_channels() {
         let backend = MockBackend::empty();
         let recipient = Felt::from_hex_unchecked("0x123");
-        let key = Felt::from(1u64);
+        let key = SecretFelt::new(Felt::from(1u64));
         let budget = IoBudget::new(100);
 
         let count = get_incoming_channel_count(&backend, recipient, &budget)
@@ -252,10 +247,11 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
 
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
-            &fixture.constants.alice_viewing_key,
+            &key,
             0,
             count,
             &budget,
@@ -286,10 +282,11 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
 
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.bob_address,
-            &fixture.constants.bob_viewing_key,
+            &key,
             0,
             count,
             &budget,
@@ -320,11 +317,13 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
 
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+
         // First discovery - get all channels
         let result1 = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
-            &fixture.constants.alice_viewing_key,
+            &key,
             0,
             count,
             &budget,
@@ -341,7 +340,7 @@ mod tests {
         let result2 = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
-            &fixture.constants.alice_viewing_key,
+            &key,
             result1.last_index.unwrap() + 1,
             count,
             &budget,
@@ -382,10 +381,11 @@ mod tests {
 
         // Now discover with insufficient budget (COST_CHANNEL_INFO = 3)
         let budget = IoBudget::new(2);
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
         let result = discover_incoming_channels(
             &backend,
             fixture.constants.alice_address,
-            &fixture.constants.alice_viewing_key,
+            &key,
             0,
             count,
             &budget,
@@ -405,11 +405,12 @@ mod tests {
 
         let mut cursor = DiscoveryCursor::default();
         let budget = IoBudget::new(100);
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
 
         let channels = discover_channels_paginated(
             &backend,
             fixture.constants.bob_address,
-            &fixture.constants.bob_viewing_key,
+            &key,
             &mut cursor,
             &budget,
         )
@@ -437,11 +438,12 @@ mod tests {
         let mut cursor = DiscoveryCursor::default();
         // Budget = 0: can't even fetch channel count
         let budget = IoBudget::new(0);
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
 
         let channels = discover_channels_paginated(
             &backend,
             fixture.constants.bob_address,
-            &fixture.constants.bob_viewing_key,
+            &key,
             &mut cursor,
             &budget,
         )

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -19,8 +19,8 @@ pub const COST_CHANNEL_INFO: usize = 3;
 /// Cost for `get_subchannel_info` (2 storage slot reads).
 pub const COST_SUBCHANNEL_INFO: usize = 2;
 
-/// Cost for `get_note` (1 storage slot read).
-pub const COST_NOTE: usize = 1;
+/// Cost for `get_note` + `nullifier_exists` (2 storage slot reads).
+pub const COST_NOTE: usize = 2;
 
 /// Errors that can occur during channel discovery.
 #[derive(Debug, Error)]

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -22,7 +22,8 @@ use super::DiscoveryError;
 use super::COST_NOTE;
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::{decrypt_note_amount, unpack_note_amount};
-use crate::privacy_pool::hashes::compute_note_id;
+use crate::privacy_pool::hashes::{compute_note_id, compute_nullifier};
+use crate::privacy_pool::types::SecretFelt;
 use crate::privacy_pool::views::IViews;
 
 /// A discovered and decrypted note.
@@ -43,8 +44,9 @@ pub struct DecryptedNote {
 pub struct NotesDiscoveryResult {
     /// List of discovered and decrypted notes.
     pub notes: Vec<DecryptedNote>,
-    /// Index of the last discovered note, or `None` if no notes were discovered.
-    /// Use for cursor updates: `cursor.last_note_index = result.last_index`.
+    /// Index of the last scanned note, or `None` if no notes were scanned.
+    /// Includes spent (filtered) notes. Use for cursor updates:
+    /// `cursor.last_note_index = result.last_index`.
     pub last_index: Option<u64>,
     /// Whether there may be more notes to discover.
     /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
@@ -60,6 +62,7 @@ pub struct NotesDiscoveryResult {
 /// 2. Fetch `packed_amount` from storage
 /// 3. If `packed_amount == 0`, stop (sentinel - no more notes)
 /// 4. Decrypt to get `(amount, salt)`
+/// 5. Compute nullifier and check existence — skip spent notes
 ///
 /// # Arguments
 ///
@@ -68,25 +71,31 @@ pub struct NotesDiscoveryResult {
 /// * `token` - The token address for this subchannel.
 /// * `start_index` - Starting index (inclusive). For incremental discovery, pass
 ///   `last_index + 1` from previous result.
+/// * `decryption_key` - The owner's private (viewing) key for nullifier computation.
 /// * `budget` - I/O budget to limit storage operations.
 ///
 /// # Returns
 ///
 /// A `NotesDiscoveryResult` containing all discovered notes and metadata
 /// for incremental discovery.
+// TODO: Iterate in batches doing multiple RPC requests under the hood
+// (get_note + nullifier_exists per note), until reaching a non-existent note,
+// then bisect to find the exact boundary.
 pub async fn discover_notes<PrivacyPool: IViews>(
     privacy_pool: &PrivacyPool,
     channel_key: Felt,
     token: Felt,
     start_index: u64,
+    decryption_key: &SecretFelt,
     budget: &IoBudget,
 ) -> Result<NotesDiscoveryResult, DiscoveryError> {
     let mut notes = Vec::new();
     let mut index = start_index;
     let mut out_of_budget = false;
+    let mut last_scanned_index: Option<u64> = None;
 
     loop {
-        // Consume budget for get_note
+        // Consume budget for get_note + nullifier_exists
         if !budget.consume(COST_NOTE) {
             out_of_budget = true;
             break;
@@ -106,20 +115,25 @@ pub async fn discover_notes<PrivacyPool: IViews>(
         // so enc_amount is already the actual amount - no decryption needed.
         let amount = decrypt_note_amount(enc_amount, salt, channel_key, token, index);
 
-        notes.push(DecryptedNote {
-            index,
-            note_id,
-            amount,
-            salt,
-        });
+        let nullifier = compute_nullifier(channel_key, token, index, decryption_key);
+        let is_spent = privacy_pool.nullifier_exists(nullifier).await?;
+
+        last_scanned_index = Some(index);
+
+        if !is_spent {
+            notes.push(DecryptedNote {
+                index,
+                note_id,
+                amount,
+                salt,
+            });
+        }
         index += 1;
     }
 
-    let last_index = notes.last().map(|n| n.index);
-
     Ok(NotesDiscoveryResult {
         notes,
-        last_index,
+        last_index: last_scanned_index,
         has_more: out_of_budget,
     })
 }
@@ -135,10 +149,19 @@ pub async fn discover_notes_paginated<S: IViews>(
     channel_key: Felt,
     token: Felt,
     cursor: &mut SubchannelCursor,
+    decryption_key: &SecretFelt,
     budget: &IoBudget,
 ) -> Result<(Vec<DecryptedNote>, bool), DiscoveryError> {
     let start_index = cursor.last_note_index.map_or(0, |i| i + 1);
-    let result = discover_notes(pool, channel_key, token, start_index, budget).await?;
+    let result = discover_notes(
+        pool,
+        channel_key,
+        token,
+        start_index,
+        decryption_key,
+        budget,
+    )
+    .await?;
 
     cursor.last_note_index = result.last_index.or(cursor.last_note_index);
 
@@ -158,7 +181,8 @@ mod tests {
         let token = Felt::from_hex_unchecked("0x67890");
         let budget = IoBudget::new(100);
 
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
+        let zero_key = SecretFelt::new(Felt::ZERO);
+        let result = discover_notes(&backend, channel_key, token, 0, &zero_key, &budget)
             .await
             .unwrap();
 
@@ -186,19 +210,19 @@ mod tests {
             .expect("Alice's channel should have at least one subchannel");
 
         let budget = IoBudget::new(100);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let result = discover_notes(&backend, channel_key, token, 0, &key, &budget)
             .await
             .unwrap();
 
-        assert!(
-            !result.notes.is_empty(),
-            "Alice's self-channel should have notes"
-        );
-        assert_eq!(result.last_index, result.notes.last().map(|n| n.index));
-        assert!(!result.has_more);
+        // Alice deposited 100 STRK, transferred 50 to Bob.
+        // The transfer consumed the deposit and wrote a change note (50 STRK)
+        // at index 0. This note is unspent.
+        assert_eq!(result.notes.len(), 1, "1 unspent change note");
         assert_eq!(result.notes[0].index, 0);
-        // The amount should be positive
         assert!(result.notes[0].amount > 0, "Note amount should be positive");
+        assert_eq!(result.last_index, Some(0));
+        assert!(!result.has_more);
     }
 
     #[tokio::test]
@@ -220,16 +244,15 @@ mod tests {
             .expect("Bob's channel should have at least one subchannel");
 
         let budget = IoBudget::new(100);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
+        let result = discover_notes(&backend, channel_key, token, 0, &key, &budget)
             .await
             .unwrap();
 
-        assert!(
-            !result.notes.is_empty(),
-            "Bob should have received notes from Alice"
-        );
+        // Bob withdrew his 50 STRK note → nullifier exists → filtered out
+        assert_eq!(result.notes.len(), 0, "Bob's note is spent");
+        assert_eq!(result.last_index, Some(0), "note 0 was scanned");
         assert!(!result.has_more);
-        assert!(result.notes[0].amount > 0, "Note amount should be positive");
     }
 
     #[tokio::test]
@@ -250,17 +273,18 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        // First discovery
+        // First discovery — Alice has 1 unspent change note (50 STRK at index 0)
         let budget = IoBudget::new(100);
-        let result1 = discover_notes(&backend, channel_key, token, 0, &budget)
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let result1 = discover_notes(&backend, channel_key, token, 0, &key, &budget)
             .await
             .unwrap();
-        assert!(!result1.notes.is_empty());
+        assert_eq!(result1.notes.len(), 1, "1 unspent change note");
         assert!(!result1.has_more);
         let last_index = result1.last_index.unwrap();
 
         // Incremental discovery starting from last_index + 1 - should find 0 new notes
-        let result2 = discover_notes(&backend, channel_key, token, last_index + 1, &budget)
+        let result2 = discover_notes(&backend, channel_key, token, last_index + 1, &key, &budget)
             .await
             .unwrap();
         assert_eq!(result2.notes.len(), 0);
@@ -286,9 +310,10 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        // Budget exhausted before starting (COST_NOTE = 1)
+        // Budget exhausted before starting (COST_NOTE = 2)
         let budget = IoBudget::new(0);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let result = discover_notes(&backend, channel_key, token, 0, &key, &budget)
             .await
             .unwrap();
 
@@ -313,12 +338,14 @@ mod tests {
 
         let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
         let (notes, has_more) =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &budget)
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
                 .await
                 .unwrap();
 
-        assert!(!notes.is_empty(), "should discover at least one note");
+        // Bob's note is spent → filtered out
+        assert_eq!(notes.len(), 0, "Bob's note is spent");
         assert!(!has_more, "sentinel should be found");
     }
 
@@ -337,14 +364,16 @@ mod tests {
         let token = get_subchannel_token(&backend, channel_key).await.unwrap();
 
         let mut cursor = SubchannelCursor::default();
-        // Budget for exactly 1 note (COST_NOTE=1), not enough to hit sentinel
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
+        // Budget for exactly 1 note (COST_NOTE=2: get_note + nullifier_exists)
         let budget = IoBudget::new(COST_NOTE);
         let (notes, has_more) =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &budget)
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
                 .await
                 .unwrap();
 
-        assert_eq!(notes.len(), 1, "should discover exactly 1 note");
+        // Bob's note 0 is spent → filtered out, but still scanned
+        assert_eq!(notes.len(), 0, "Bob's note is spent");
         assert!(has_more, "sentinel not reached");
         assert_eq!(cursor.last_note_index, Some(0));
     }

--- a/crates/discovery-core/src/privacy_pool/decryption.rs
+++ b/crates/discovery-core/src/privacy_pool/decryption.rs
@@ -10,7 +10,7 @@ use super::hashes::{
     compute_enc_amount_hash, compute_enc_channel_key_hash, compute_enc_sender_addr_hash,
     compute_enc_token_hash,
 };
-use super::types::{felt_low_u128, ChannelInfo, EncChannelInfo, EncSubchannelInfo};
+use super::types::{felt_low_u128, ChannelInfo, EncChannelInfo, EncSubchannelInfo, SecretFelt};
 
 /// Errors that can occur during decryption.
 #[derive(Debug, Error)]
@@ -26,18 +26,14 @@ pub enum DecryptionError {
 /// 1. Recover the ephemeral public key point from its x-coordinate
 /// 2. Compute ECDH shared secret: `shared_point = ephemeral_pubkey * private_key`
 /// 3. Decrypt: `plaintext = ciphertext - hash(tag, shared_x)`
-///
-/// # Security
-///
-/// The caller should zero the `private_key` after use by calling `private_key.zeroize()`.
 pub fn decrypt_channel_info(
     enc: &EncChannelInfo,
-    private_key: &Felt,
+    private_key: &SecretFelt,
 ) -> Result<ChannelInfo, DecryptionError> {
     // Recover the ephemeral public key from x-coordinate..
     let ephemeral_point = AffinePoint::new_from_x(&enc.ephemeral_pubkey, false)
         .ok_or(DecryptionError::InvalidEphemeralPubkey)?;
-    let shared_point = &ephemeral_point * *private_key;
+    let shared_point = &ephemeral_point * **private_key;
     let shared_x = shared_point.x();
 
     // Decrypt: plaintext = ciphertext - hash(tag, shared_x)
@@ -111,7 +107,7 @@ mod tests {
             enc_channel_key: Felt::ONE,
             enc_sender_addr: Felt::TWO,
         };
-        let result = decrypt_channel_info(&enc, &Felt::from(12345u64));
+        let result = decrypt_channel_info(&enc, &SecretFelt::new(Felt::from(12345u64)));
         assert!(matches!(
             result,
             Err(DecryptionError::InvalidEphemeralPubkey)
@@ -128,8 +124,8 @@ mod tests {
             enc_sender_addr: f.outputs.enc_channel_sender_addr,
         };
 
-        let result = decrypt_channel_info(&encrypted, &f.inputs.recipient_private_key)
-            .expect("decryption should succeed");
+        let key = SecretFelt::new(f.inputs.recipient_private_key);
+        let result = decrypt_channel_info(&encrypted, &key).expect("decryption should succeed");
 
         assert_eq!(result.channel_key, f.inputs.channel_key);
         assert_eq!(result.sender_addr, f.inputs.sender);

--- a/crates/discovery-core/src/privacy_pool/hashes.rs
+++ b/crates/discovery-core/src/privacy_pool/hashes.rs
@@ -26,6 +26,9 @@ static NOTE_ID_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("NOTE
 /// Domain separation tag for encrypted amount.
 static ENC_AMOUNT_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("ENC_AMOUNT_TAG:V1"));
 
+/// Domain separation tag for nullifier derivation.
+static NULLIFIER_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("NULLIFIER_TAG:V1"));
+
 /// Converts a short string (up to 31 ASCII chars) to Felt.
 fn short_string_to_felt(s: &str) -> Felt {
     assert!(
@@ -106,9 +109,29 @@ pub fn compute_enc_amount_hash(channel_key: Felt, token: Felt, index: u64, salt:
     ])
 }
 
+/// Computes the nullifier for a note.
+///
+/// `nullifier = hash(NULLIFIER_TAG, channel_key, token, index, 0, decryption_key)`
+pub fn compute_nullifier(
+    channel_key: Felt,
+    token: Felt,
+    index: u64,
+    decryption_key: &super::types::SecretFelt,
+) -> Felt {
+    hash(&[
+        *NULLIFIER_TAG,
+        channel_key,
+        token,
+        Felt::from(index),
+        Felt::ZERO,
+        **decryption_key,
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::privacy_pool::types::SecretFelt;
     use crate::test_fixtures::load_cairo_ref_fixture;
 
     #[test]
@@ -154,6 +177,22 @@ mod tests {
         assert_eq!(
             compute_note_id(f.inputs.channel_key, f.inputs.token, f.inputs.index),
             f.outputs.note_id
+        );
+    }
+
+    #[test]
+    fn test_compute_nullifier() {
+        let f = load_cairo_ref_fixture();
+        // Reference data uses sender_private_key as the owner (note owner
+        // in the reference scenario is the sender).
+        assert_eq!(
+            compute_nullifier(
+                f.inputs.channel_key,
+                f.inputs.token,
+                f.inputs.index,
+                &SecretFelt::new(f.inputs.sender_private_key),
+            ),
+            f.outputs.nullifier
         );
     }
 

--- a/crates/discovery-core/src/privacy_pool/types.rs
+++ b/crates/discovery-core/src/privacy_pool/types.rs
@@ -3,7 +3,11 @@
 //! This module contains the data structures used by the privacy pool contract,
 //! including encrypted ciphertext types and decrypted plaintext types.
 
+use std::fmt;
+use std::ops::Deref;
+
 use starknet_types_core::felt::Felt;
+use zeroize::Zeroize;
 
 /// Extracts low 128 bits from a Felt.
 pub fn felt_low_u128(felt: Felt) -> u128 {
@@ -11,21 +15,45 @@ pub fn felt_low_u128(felt: Felt) -> u128 {
     d[0] as u128 | (d[1] as u128) << 64
 }
 
-/// Trait for securely zeroing sensitive data from memory.
+/// A Felt that automatically zeroes its memory on drop.
 ///
-/// This is a simplified version of the `zeroize` crate's `Zeroize` trait,
-/// implemented specifically for `Felt` to avoid the orphan rule.
-pub trait Zeroize {
-    /// Securely zeros the memory containing this value.
-    fn zeroize(&mut self);
+/// Implements `Deref<Target=Felt>` for transparent use where `&Felt` is expected.
+///
+/// Deliberately excludes `Copy` (silent copies of secrets are dangerous)
+/// and `Serde` (keys should be wrapped at the system boundary, not
+/// deserialized directly). `Debug` prints `[REDACTED]` to prevent
+/// accidental logging of key material.
+#[derive(Clone)]
+pub struct SecretFelt(Felt);
+
+impl SecretFelt {
+    pub fn new(felt: Felt) -> Self {
+        Self(felt)
+    }
 }
 
-impl Zeroize for Felt {
+impl Deref for SecretFelt {
+    type Target = Felt;
+    fn deref(&self) -> &Felt {
+        &self.0
+    }
+}
+
+impl Zeroize for SecretFelt {
     fn zeroize(&mut self) {
-        // Overwrite with zero
-        *self = Felt::ZERO;
-        // Use a compiler fence to prevent optimization from removing the write
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+        self.0 = Felt::ZERO;
+    }
+}
+
+impl Drop for SecretFelt {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl fmt::Debug for SecretFelt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
     }
 }
 
@@ -65,16 +93,4 @@ pub struct ChannelInfo {
     pub channel_key: Felt,
     /// The sender's address.
     pub sender_addr: Felt,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_zeroize_felt() {
-        let mut secret = Felt::from(42u64);
-        secret.zeroize();
-        assert_eq!(secret, Felt::ZERO);
-    }
 }

--- a/crates/discovery-core/src/sync/incoming_state.rs
+++ b/crates/discovery-core/src/sync/incoming_state.rs
@@ -17,6 +17,7 @@ use crate::discovery::notes::{discover_notes_paginated, DecryptedNote};
 use crate::discovery::subchannels::discover_subchannels_paginated;
 use crate::discovery::DiscoveryError;
 use crate::io_budget::IoBudget;
+use crate::privacy_pool::types::SecretFelt;
 use crate::privacy_pool::views::IViews;
 
 /// Output from a single discovery run.
@@ -61,14 +62,13 @@ struct SubchannelResult {
 /// and channels are pruned from the cursor so subsequent calls skip them.
 ///
 /// Channel and subchannel processing is parallelised via [`JoinSet`].
-// TODO: Derive nullifiers and filter spent notes (spec 6.5)
 // TODO: Handle open notes — notes with salt==OPEN_NOTE_SALT(1) have plaintext
 //       amounts, non-zero token and depositor fields (see Cairo objects.cairo
 //       Note struct)
 pub async fn sync_incoming_state<S>(
     pool: &S,
     recipient: Felt,
-    decryption_key: &Felt,
+    decryption_key: &SecretFelt,
     mut cursor: DiscoveryCursor,
     budget: &IoBudget,
 ) -> Result<DiscoveryOutput, DiscoveryError>
@@ -94,8 +94,10 @@ where
     for (channel_key, ch_cursor) in channels {
         let pool = pool.clone();
         let budget = budget.clone();
-        join_set
-            .spawn(async move { process_channel(&pool, channel_key, ch_cursor, &budget).await });
+        let key = decryption_key.clone();
+        join_set.spawn(async move {
+            process_channel(&pool, channel_key, ch_cursor, &key, &budget).await
+        });
     }
 
     let mut channels_output: HashMap<Felt, ChannelOutput> = HashMap::new();
@@ -119,6 +121,7 @@ async fn process_channel<S>(
     pool: &S,
     channel_key: Felt,
     mut cursor: ChannelCursor,
+    decryption_key: &SecretFelt,
     budget: &IoBudget,
 ) -> Result<ChannelResult, DiscoveryError>
 where
@@ -139,8 +142,9 @@ where
     for (token, sc_cursor) in subchannels {
         let pool = pool.clone();
         let budget = budget.clone();
+        let key = decryption_key.clone();
         join_set.spawn(async move {
-            process_subchannel(&pool, channel_key, token, sc_cursor, &budget).await
+            process_subchannel(&pool, channel_key, token, sc_cursor, &key, &budget).await
         });
     }
 
@@ -171,10 +175,18 @@ async fn process_subchannel<S: IViews>(
     channel_key: Felt,
     token: Felt,
     mut cursor: SubchannelCursor,
+    decryption_key: &SecretFelt,
     budget: &IoBudget,
 ) -> Result<SubchannelResult, DiscoveryError> {
-    let (notes, has_more) =
-        discover_notes_paginated(pool, channel_key, token, &mut cursor, budget).await?;
+    let (notes, has_more) = discover_notes_paginated(
+        pool,
+        channel_key,
+        token,
+        &mut cursor,
+        decryption_key,
+        budget,
+    )
+    .await?;
 
     Ok(SubchannelResult {
         token,
@@ -211,7 +223,7 @@ mod tests {
         let f = load_devnet_fixture();
         let backend = MockBackend::new(f.slots);
         let recipient = f.constants.bob_address;
-        let decryption_key = f.constants.bob_viewing_key;
+        let decryption_key = SecretFelt::new(f.constants.bob_viewing_key);
 
         // Step 1: budget = COST_NUM_CHANNELS (1)
         // Fetches total_n_channels = 1. No budget left for channel discovery.
@@ -293,9 +305,10 @@ mod tests {
             "step 4: subchannel still in cursor (notes not started)"
         );
 
-        // Step 5: budget = COST_NOTE (1)
-        // Subchannels skipped (total cached). Discovers note 0.
-        // Can't check note sentinel (needs another COST_NOTE).
+        // Step 5: budget = COST_NOTE (2)
+        // Subchannels skipped (total cached). Discovers note 0 (1 get_note +
+        // 1 nullifier_exists). Note is spent → filtered out. Budget=0, can't
+        // check sentinel.
         let budget = IoBudget::new(COST_NOTE);
         let out = sync_incoming_state(&backend, recipient, &decryption_key, out.cursor, &budget)
             .await
@@ -306,11 +319,15 @@ mod tests {
             "step 5: channel still in cursor (note sentinel not checked)"
         );
         let notes = &out.channels[&channel_key].subchannels[&subchannel_token];
-        assert_eq!(notes.len(), 1, "step 5: 1 note discovered");
-        assert!(notes[0].amount > 0, "step 5: note has positive amount");
+        assert_eq!(
+            notes.len(),
+            0,
+            "step 5: note discovered but spent (filtered out)"
+        );
 
-        // Step 6: budget = COST_NOTE (1)
-        // Subchannels skipped (total cached). Reads note index 1 → sentinel.
+        // Step 6: budget = COST_NOTE (2)
+        // Subchannels skipped (total cached). Reads note index 1 → sentinel
+        // (packed_amount=0 → break, no nullifier check). 1 budget unit unused.
         // All done: subchannel + channel pruned from cursor.
         let budget = IoBudget::new(COST_NOTE);
         let out = sync_incoming_state(&backend, recipient, &decryption_key, out.cursor, &budget)

--- a/crates/discovery-core/src/test_fixtures.rs
+++ b/crates/discovery-core/src/test_fixtures.rs
@@ -142,11 +142,14 @@ pub async fn get_channel_key(
     };
     use crate::io_budget::IoBudget;
 
+    use crate::privacy_pool::types::SecretFelt;
+
     let budget = IoBudget::new(100);
     let count = get_incoming_channel_count(backend, recipient, &budget)
         .await
         .ok()??;
-    let result = discover_incoming_channels(backend, recipient, viewing_key, 0, count, &budget)
+    let key = SecretFelt::new(*viewing_key);
+    let result = discover_incoming_channels(backend, recipient, &key, 0, count, &budget)
         .await
         .ok()?;
 

--- a/crates/discovery-service/src/incoming_sync/handler.rs
+++ b/crates/discovery-service/src/incoming_sync/handler.rs
@@ -7,7 +7,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use discovery_core::io_budget::IoBudget;
-use discovery_core::privacy_pool::types::Zeroize;
 use discovery_core::storage_backend::StorageBackend;
 use tracing::warn;
 
@@ -40,7 +39,7 @@ where
     B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
     B::Snapshot: Clone + Send + Sync + 'static,
 {
-    let mut validated = ValidatedRequest::from_request(request, &state.backend).await?;
+    let validated = ValidatedRequest::from_request(request, &state.backend).await?;
 
     let snapshot = state
         .backend
@@ -48,7 +47,6 @@ where
         .await
         .map_err(|e| {
             warn!("Failed to create snapshot: {}", e);
-            validated.decryption_key.zeroize();
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ApiErrorResponse::new(
@@ -67,11 +65,8 @@ where
         validated.cursor,
         &budget,
     )
-    .await;
-
-    validated.decryption_key.zeroize();
-
-    let discovery_output = discovery_output.map_err(discovery_error_to_response)?;
+    .await
+    .map_err(discovery_error_to_response)?;
 
     Ok(IncomingSyncResponse {
         block_ref: validated.block_ref,

--- a/crates/discovery-service/src/incoming_sync/validation.rs
+++ b/crates/discovery-service/src/incoming_sync/validation.rs
@@ -2,6 +2,7 @@
 
 use axum::http::StatusCode;
 use discovery_core::discovery::cursor::DiscoveryCursor;
+use discovery_core::privacy_pool::types::SecretFelt;
 use starknet_core::types::{BlockId, Felt};
 use tracing::warn;
 
@@ -18,7 +19,7 @@ pub struct ValidatedRequest {
     /// The recipient's address.
     pub recipient_address: Felt,
     /// The recipient's private viewing key.
-    pub decryption_key: Felt,
+    pub decryption_key: SecretFelt,
     /// Resolved block ID for the query.
     pub query_block: BlockId,
     /// Block hash pinning all reads (from head or request).
@@ -121,7 +122,7 @@ impl ValidatedRequest {
 
         Ok(ValidatedRequest {
             recipient_address: request.recipient_address,
-            decryption_key: request.decryption_key,
+            decryption_key: SecretFelt::new(request.decryption_key),
             query_block: BlockId::Hash(block_ref),
             block_ref,
             cursor: request.cursor,

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -1,4 +1,8 @@
 //! RPC-based implementation of the storage interface and chain state.
+//!
+// TODO: Implement batched "deferred" requests to seamlessly provide
+// parallelization for discovery operations (e.g. note fetch + nullifier
+// check can be issued as a single batched RPC call).
 
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION
### TL;DR

Filter out spent notes during discovery by checking nullifiers.

### What changed?

- Updated note discovery to check if notes are spent by computing their nullifiers and checking if they exist in the contract
- Increased `COST_NOTE` constant from 1 to 2 to account for the additional nullifier check
- Added `compute_nullifier` function to calculate note nullifiers
- Modified `discover_notes` to require the owner's private key for nullifier computation
- Updated `last_index` in `NotesDiscoveryResult` to track the last scanned note (including spent ones)
- Updated tests to verify spent notes are properly filtered out
- Modified `sync_incoming_state` to pass the decryption key to note discovery functions
- Added proper zeroizing of private keys after use

### How to test?

Run the updated tests which now verify:
- Unspent notes are properly discovered and returned
- Spent notes are scanned but filtered out from results
- The cursor is properly updated to include all scanned notes (even spent ones)
- Budget consumption accounts for both note fetching and nullifier checking

### Why make this change?

This change implements a critical privacy feature that prevents users from seeing spent notes in their balance. By checking nullifiers during discovery, we can filter out notes that have already been spent, ensuring users only see their actual available balance. This is essential for a correct user experience and prevents potential double-spending attempts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/422)
<!-- Reviewable:end -->