### PR TITLE
fix: use next outgoing channel index

### DIFF
--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -80,6 +80,13 @@ export class ActionCompiler {
     const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
+    const needsOutgoingIndex = this.needsOutgoingChannelIndex(
+      actions,
+      options,
+      registry,
+      recipientsNeeded
+    );
+
     // Phase 1: Resolve recipient channels
     const channels = await this.resolveRecipientChannels(
       actions,
@@ -97,7 +104,28 @@ export class ActionCompiler {
     const pool = this.createPool(toBigInt(this.userViewingKey), registry, channels);
 
     // Phase 3: Transform Actions to ClientAction[]
-    const clientActions = this.transformToClientActions(actions, pool, recipientsNeeded, options);
+    const outgoingChannels = needsOutgoingIndex
+      ? (
+          await this.discoveryProvider.discoverChannels(
+            this.userAddress,
+            this.userViewingKey,
+            "all",
+            { cursor: registry.channels }
+          )
+        ).channels
+      : undefined;
+
+    const outgoingChannelIndexStart = needsOutgoingIndex
+      ? this.countOutgoingChannels(outgoingChannels, registry)
+      : undefined;
+
+    const clientActions = this.transformToClientActions(
+      actions,
+      pool,
+      recipientsNeeded,
+      options,
+      outgoingChannelIndexStart
+    );
 
     debugLog("compiler", "compile", "post transformToClientActions", clientActions);
 
@@ -191,7 +219,8 @@ export class ActionCompiler {
     actions: Actions,
     pool: PoolSimulator,
     recipientsNeeded: AddressMap<boolean>,
-    options?: ExecuteOptions
+    options?: ExecuteOptions,
+    outgoingChannelIndexStart?: number
   ): ClientAction[] {
     const clientActions: ClientActions = {
       setViewingKey: undefined,
@@ -258,6 +287,7 @@ export class ActionCompiler {
 
     // 2. OpenChannel (deduplicate by recipient to prevent duplicate channels)
     if (actions.openChannels) {
+      let outgoingChannelIndex = outgoingChannelIndexStart ?? 0;
       const seenRecipients = new Set<bigint>();
       for (const action of actions.openChannels) {
         if (seenRecipients.has(action.recipient)) continue;
@@ -270,12 +300,13 @@ export class ActionCompiler {
           input: {
             recipient_addr: action.recipient,
             recipient_public_key: channel.publicKey as bigint,
-            index: seenRecipients.size - 1, // TODO: track outgoing channel index properly
+            index: outgoingChannelIndex,
             random: generateRandom(),
             salt: generateRandom(),
           },
         } as const; // typescipt magic
         execute(input, clientActions.openChannels);
+        outgoingChannelIndex += 1;
       }
     }
 
@@ -647,6 +678,44 @@ export class ActionCompiler {
         }
       }
     }
+  }
+
+  private needsOutgoingChannelIndex(
+    actions: Actions,
+    options: ExecuteOptions | undefined,
+    registry: PrivateRegistry,
+    recipientsNeeded: AddressMap<boolean>
+  ): boolean {
+    if (actions.openChannels && actions.openChannels.length > 0) {
+      return true;
+    }
+
+    if (!options?.autoSetup) {
+      return false;
+    }
+
+    for (const recipient of recipientsNeeded.keys()) {
+      const channel = registry.channels.get(recipient);
+      if (!channel?.key) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private countOutgoingChannels(
+    channels: AddressMap<Channel> | undefined,
+    registry: PrivateRegistry
+  ): number {
+    const source = channels ?? registry.channels;
+    let count = 0;
+    for (const channel of source.values()) {
+      if (channel.key) {
+        count += 1;
+      }
+    }
+    return count;
   }
 
   private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {

--- a/sdk/src/testing/mock-pool-contract.ts
+++ b/sdk/src/testing/mock-pool-contract.ts
@@ -347,7 +347,15 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
     this.publicKeys.set(address, channel.publicKey);
 
     if (!channel.key) return;
-    this.setChannel(userAddress, viewingKey, address, channel.publicKey, generateRandom()).apply();
+    const outgoingIndex = this.outgoingChannelCounters.get(userAddress) ?? 0;
+    this.setChannel(
+      userAddress,
+      viewingKey,
+      address,
+      channel.publicKey,
+      outgoingIndex,
+      generateRandom()
+    ).apply();
 
     for (const [token, nonces] of channel.tokens.entries()) {
       this.setToken(
@@ -472,6 +480,7 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
             privateKey,
             action.input.recipient_addr,
             action.input.recipient_public_key,
+            action.input.index,
             action.input.random
           ),
         ];
@@ -562,6 +571,7 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
     fromPrivateKey: ViewingKey,
     to: StarknetAddressBigint,
     toPublicKey: PublicKey,
+    index: number,
     random: bigint
   ): MockServerAction {
     this.assertRegistered(from);
@@ -579,6 +589,10 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
     );
 
     const s = this.outgoingChannelCounters.get(from)!;
+    assert(
+      index === s,
+      () => `Outgoing channel index ${index} is not sequential for sender ${toHex(from)}`
+    );
     if (s > 0) {
       const prevOutgoingChannelId = compute_outgoing_channel_id(
         from,

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -102,6 +102,35 @@ describe("Private Transfers Integration", () => {
   // Auto Setup Flow
   // ============================================================================
   describe("Auto Setup Flow", () => {
+    it("reuses next outgoing channel index after self deposit", async () => {
+      const { mocknet, env, transfers } = testEnv;
+      const { alice, bob } = transfers;
+      const ace = toBigInt(env.ace);
+
+      mocknet.executeOutside(await bob.build().register().execute());
+
+      const registry = mocknet.executeOutside(
+        await alice
+          .build(AUTO_ALL)
+          .with(env.ace)
+          .deposit({ amount: 100n, recipient: env.alice.address })
+          .execute()
+      );
+
+      mocknet.executeOutside(
+        await alice
+          .build({ ...AUTO_ALL, registry })
+          .surplusTo(env.alice.address)
+          .with(env.ace)
+          .transfer({ recipient: env.bob.address, amount: 50n })
+          .execute()
+      );
+
+      const bobNotes = (await bob.discoverNotes()).notes.get(ace) ?? [];
+      expect(bobNotes.length).toBe(1);
+      expect(bobNotes[0].amount).toBe(50n);
+    });
+
     it("auto setup handles registration, channels, and token setup", async () => {
       const { mocknet, env, transfers } = testEnv;
       const { alice, bob } = transfers;


### PR DESCRIPTION
## Summary
- add regression test for deposit->transfer sequence that reuses outgoing channel index
- tighten mock pool to enforce sequential outgoing channel indices
- fix compiler to compute next outgoing channel index via discovery

## Problem
`OpenChannel.index` was using `seenRecipients.size - 1` (batch order), not the actual next outgoing channel slot. If a sender already has an outgoing channel (e.g., self-channel from deposit), the next transfer reuses index 0 and reverts with `NON_ZERO_VALUE`.

## Solution
When opening channels, discover all outgoing channels first to get the current count, then use that as the starting index and increment per new channel.

## Testing
- `pnpm -C sdk test` (all pass)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/423)
<!-- Reviewable:end -->
