### PR TITLE
feat(indexer): find last used note index

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -52,3 +52,17 @@ pub struct SubchannelCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_note_index: Option<u64>,
 }
+
+/// Cursor for exponential search + bisection to find last occupied index.
+///
+/// Tracks the search boundary across ascending and bisection phases.
+/// - `lo: None, hi: None` — fresh start, ascending phase needed.
+/// - `lo: Some, hi: None` — ascending in progress, `lo` is last confirmed index.
+/// - `lo: Some, hi: Some` — ascending complete, bisection phase needed.
+#[derive(Debug, Clone, Default)]
+pub struct IndexSearchCursor {
+    /// Last index where an entry was confirmed to exist.
+    pub lo: Option<u64>,
+    /// First index where no entry exists (sentinel).
+    pub hi: Option<u64>,
+}

--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -1,0 +1,312 @@
+//! Note index boundary probing.
+//!
+//! Finds the last note index in a subchannel via exponential search + bisection.
+//! No decryption, no nullifier checks — just probes note existence.
+//!
+//! We assume an exponential distribution of note counts (most users have very
+//! few notes), so exponential search finds the boundary quickly in the common case.
+
+use std::future::Future;
+
+use starknet_types_core::felt::Felt;
+
+use super::cursor::IndexSearchCursor;
+use super::DiscoveryError;
+use super::COST_NOTE_PROBING;
+use crate::io_budget::IoBudget;
+use crate::privacy_pool::hashes::compute_note_id;
+use crate::privacy_pool::views::IViews;
+
+/// Finds the last note index via [`exponential_ascend`] + [`bisect_boundary`].
+///
+/// Runs in two phases, resumable via cursor:
+/// 1. **Ascending**: exponential probing to find bounds (`lo`, `hi`).
+/// 2. **Bisection**: binary search for exact boundary.
+///
+/// Returns `(last_index, has_more)`. When `has_more` is `false`, the search is complete.
+pub async fn find_last_note_index_paginated<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    cursor: &mut IndexSearchCursor,
+    budget: &IoBudget,
+) -> Result<(Option<u64>, bool), DiscoveryError> {
+    // Returns (Some(idx), _) if note exists, (None, false) if empty, (None, true) if out of budget.
+    let probe = |idx: u64| {
+        let budget = budget.clone();
+        async move {
+            if !budget.consume(COST_NOTE_PROBING) {
+                return Ok((None, true));
+            }
+            let note_id = compute_note_id(channel_key, token, idx);
+            if pool.get_note(note_id).await? != Felt::ZERO {
+                Ok((Some(idx), false))
+            } else {
+                Ok((None, false))
+            }
+        }
+    };
+
+    // Phase 1: Ascending (find bounds)
+    if cursor.hi.is_none() {
+        let found_sentinel = exponential_ascend(&probe, cursor).await?;
+        if !found_sentinel {
+            return Ok((cursor.lo, true));
+        }
+        // Empty subchannel: first probe found sentinel
+        if cursor.lo.is_none() {
+            return Ok((None, false));
+        }
+    }
+
+    // Phase 2: Bisection (narrow down to exact boundary)
+    let complete = bisect_boundary(&probe, cursor).await?;
+    Ok((cursor.lo, !complete))
+}
+
+/// Exponential ascending: probes at `lo+step`, `lo+2*step`, `lo+4*step`...
+/// until finding an empty slot or exhausting budget.
+///
+/// Updates cursor in place. Returns `true` if sentinel found, `false` if budget exhausted.
+// TODO: Issue probes in batches to amortise RPC round-trip latency.
+async fn exponential_ascend<F, Fut>(
+    probe: F,
+    cursor: &mut IndexSearchCursor,
+) -> Result<bool, DiscoveryError>
+where
+    F: Fn(u64) -> Fut,
+    Fut: Future<Output = Result<(Option<u64>, bool), DiscoveryError>>,
+{
+    // Compute step from lo: 2^k where k = trailing_zeros(lo + 1).
+    // Reconstructs the exponential sequence: 0, 1, 3, 7, 15, ...
+    let mut step = match cursor.lo {
+        None | Some(0) => 1,
+        Some(n) => 1u64 << (n + 1).trailing_zeros(),
+    };
+    let mut probe_at = cursor.lo.map_or(0, |lo| lo.saturating_add(step));
+
+    loop {
+        match probe(probe_at).await? {
+            (Some(_), _) => {
+                cursor.lo = Some(probe_at);
+                probe_at = probe_at.saturating_add(step);
+                step = step.saturating_mul(2);
+            }
+            (None, false) => {
+                cursor.hi = Some(probe_at);
+                return Ok(true);
+            }
+            (None, true) => return Ok(false),
+        }
+    }
+}
+
+/// Binary search between `lo` (exists) and `hi` (absent) to find
+/// the exact last occupied index.
+///
+/// Updates cursor in place. Returns `true` if complete, `false` if budget exhausted.
+async fn bisect_boundary<F, Fut>(
+    probe: F,
+    cursor: &mut IndexSearchCursor,
+) -> Result<bool, DiscoveryError>
+where
+    F: Fn(u64) -> Fut,
+    Fut: Future<Output = Result<(Option<u64>, bool), DiscoveryError>>,
+{
+    let (mut lo, mut hi) = match (cursor.lo, cursor.hi) {
+        (Some(lo), Some(hi)) => (lo, hi),
+        _ => return Ok(true), // Nothing to bisect
+    };
+
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        match probe(mid).await? {
+            (Some(_), _) => lo = mid,
+            (None, false) => hi = mid,
+            (None, true) => {
+                cursor.lo = Some(lo);
+                cursor.hi = Some(hi);
+                return Ok(false);
+            }
+        }
+    }
+
+    cursor.lo = Some(lo);
+    cursor.hi = Some(hi);
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_backend::MockBackend;
+    use crate::test_fixtures::{get_channel_key, get_subchannel_token, load_devnet_fixture};
+
+    /// Helper: create a probe function that returns exists for indices < last_index.
+    fn mock_probe(
+        last_index: Option<u64>,
+    ) -> impl Fn(u64) -> std::future::Ready<Result<(Option<u64>, bool), DiscoveryError>> {
+        move |idx| {
+            let exists = last_index.is_some_and(|last| idx <= last);
+            std::future::ready(Ok(if exists {
+                (Some(idx), false)
+            } else {
+                (None, false)
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_empty() {
+        let mut cursor = IndexSearchCursor::default();
+        let found = exponential_ascend(mock_probe(None), &mut cursor)
+            .await
+            .unwrap();
+        assert!(found, "should find sentinel immediately");
+        assert_eq!(cursor.lo, None);
+        assert_eq!(cursor.hi, Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_one_element() {
+        let mut cursor = IndexSearchCursor::default();
+        let found = exponential_ascend(mock_probe(Some(0)), &mut cursor)
+            .await
+            .unwrap();
+        assert!(found);
+        assert_eq!(cursor.lo, Some(0));
+        assert_eq!(cursor.hi, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_multiple_elements() {
+        // Elements at 0, 1, 2, 3, 4 (last_index = 4)
+        let mut cursor = IndexSearchCursor::default();
+        let found = exponential_ascend(mock_probe(Some(4)), &mut cursor)
+            .await
+            .unwrap();
+        assert!(found);
+        // Probes: 0 (exists), 1 (exists), 3 (exists), 7 (empty)
+        assert_eq!(cursor.lo, Some(3));
+        assert_eq!(cursor.hi, Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_bisect_boundary_adjacent() {
+        // lo=0, hi=1 → no bisection needed
+        let mut cursor = IndexSearchCursor {
+            lo: Some(0),
+            hi: Some(1),
+        };
+        let complete = bisect_boundary(mock_probe(Some(0)), &mut cursor)
+            .await
+            .unwrap();
+        assert!(complete);
+        assert_eq!(cursor.lo, Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_bisect_boundary_gap() {
+        // lo=3, hi=7, actual last is 4
+        let mut cursor = IndexSearchCursor {
+            lo: Some(3),
+            hi: Some(7),
+        };
+        let complete = bisect_boundary(mock_probe(Some(4)), &mut cursor)
+            .await
+            .unwrap();
+        assert!(complete);
+        assert_eq!(cursor.lo, Some(4));
+        assert_eq!(cursor.hi, Some(5));
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_with_fixture() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        let mut cursor = IndexSearchCursor::default();
+        let budget = IoBudget::new(100);
+
+        let (last_index, has_more) =
+            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        // Alice has 1 note at index 0
+        assert_eq!(last_index, Some(0));
+        assert!(!has_more);
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_empty() {
+        let backend = MockBackend::empty();
+        let channel_key = Felt::from_hex_unchecked("0x12345");
+        let token = Felt::from_hex_unchecked("0x67890");
+
+        let mut cursor = IndexSearchCursor::default();
+        let budget = IoBudget::new(100);
+
+        let (last_index, has_more) =
+            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(last_index, None);
+        assert!(!has_more);
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_budget_exhausted_ascending() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        let mut cursor = IndexSearchCursor::default();
+
+        // Budget for 1 probe: finds note at 0, exhausted before probing 1
+        let budget = IoBudget::new(COST_NOTE_PROBING);
+        let (last_index, has_more) =
+            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(last_index, Some(0));
+        assert!(has_more, "budget exhausted during ascending");
+        assert_eq!(cursor.lo, Some(0));
+        assert!(cursor.hi.is_none(), "sentinel not found yet");
+
+        // Resume with more budget
+        let budget = IoBudget::new(100);
+        let (last_index, has_more) =
+            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(last_index, Some(0));
+        assert!(!has_more);
+    }
+}

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -7,6 +7,7 @@ use crate::storage_backend::StorageError;
 
 pub mod cursor;
 pub mod incoming_channels;
+pub mod last_note_index;
 pub mod notes;
 pub mod subchannels;
 
@@ -21,6 +22,9 @@ pub const COST_SUBCHANNEL_INFO: usize = 2;
 
 /// Cost for `get_note` + `nullifier_exists` (2 storage slot reads).
 pub const COST_NOTE: usize = 2;
+
+/// Cost for a single note existence probe (1 `get_note` read, no nullifier check).
+pub const COST_NOTE_PROBING: usize = 1;
 
 /// Errors that can occur during channel discovery.
 #[derive(Debug, Error)]


### PR DESCRIPTION
# Implement Last Note Index Search

### TL;DR

Added functionality to efficiently find the last note index in a subchannel using exponential search and bisection.

### What changed?

- Added `IndexSearchCursor` to track search boundaries for finding the last note index
- Implemented `last_note_index.rs` with an efficient two-phase algorithm:
  1. Exponential search to quickly find bounds
  2. Binary search to pinpoint the exact boundary
- Added comprehensive tests new modules

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/429)
<!-- Reviewable:end -->