### PR TITLE
feat(indexer): discover outgoing channels

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -8,11 +8,16 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-/// Top-level cursor tracking discovery progress across all channels.
+/// Top-level cursor for channel discovery (shared by incoming and outgoing).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DiscoveryCursor {
-    /// Total number of channels (cached from `get_num_of_channels`).
-    /// When set, skips the channel count RPC call.
+    /// Whether to discover new channels. Set to `false` to skip channel
+    /// discovery and only process specific channels already in cursor.
+    #[serde(default)]
+    pub discover_channels: bool,
+
+    /// Total number of channels (cached from `get_num_of_channels` for incoming).
+    /// Used as optimization to avoid redundant RPC calls.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_n_channels: Option<u64>,
 
@@ -20,16 +25,19 @@ pub struct DiscoveryCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_channel_index: Option<u64>,
 
-    /// Channels with pending subchannel/note discovery, keyed by channel_key.
+    /// Channels with pending subchannel/note discovery.
+    /// - Incoming: keyed by sender address.
+    /// - Outgoing: keyed by recipient address.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub channels: HashMap<Felt, ChannelCursor>,
 }
 
-/// Cursor state for a single channel.
+/// Cursor state for a single channel (shared by incoming and outgoing).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelCursor {
-    /// Sender address (cached from channel discovery).
-    pub sender_addr: Felt,
+    /// Channel key (set for incoming, None for outgoing where it's derivable).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_key: Option<Felt>,
 
     /// Total number of subchannels (cached when sentinel is found).
     /// When set, subchannel discovery is skipped entirely — zero budget cost.
@@ -45,24 +53,21 @@ pub struct ChannelCursor {
     pub subchannels: HashMap<Felt, SubchannelCursor>,
 }
 
-/// Cursor state for a single subchannel.
+/// Cursor state for a single subchannel (shared by incoming and outgoing).
+///
+/// For incoming (linear scan): only `last_note_index` is used.
+/// For outgoing (exponential search): `last_note_index` = lo, `max_note_index` = hi.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SubchannelCursor {
-    /// Last fully processed note index. `None` = start from index 0.
+    /// Last note index where a note exists.
+    /// - Incoming: last scanned index.
+    /// - Outgoing: lower bound (lo) for exponential search.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_note_index: Option<u64>,
-}
 
-/// Cursor for exponential search + bisection to find last occupied index.
-///
-/// Tracks the search boundary across ascending and bisection phases.
-/// - `lo: None, hi: None` — fresh start, ascending phase needed.
-/// - `lo: Some, hi: None` — ascending in progress, `lo` is last confirmed index.
-/// - `lo: Some, hi: Some` — ascending complete, bisection phase needed.
-#[derive(Debug, Clone, Default)]
-pub struct IndexSearchCursor {
-    /// Last index where an entry was confirmed to exist.
-    pub lo: Option<u64>,
-    /// First index where no entry exists (sentinel).
-    pub hi: Option<u64>,
+    /// First index where no note exists (sentinel).
+    /// - Incoming: not used.
+    /// - Outgoing: upper bound (hi) for exponential search; `Some` = bisection phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_note_index: Option<u64>,
 }

--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -147,15 +147,21 @@ pub async fn discover_incoming_channels<PrivacyPool: IViews>(
 
 /// Discovers incoming channels with cursor-based pagination.
 ///
-/// Fetches and caches `total_n_channels` if not already in the cursor,
+/// If `cursor.discover_channels == false`, returns immediately without
+/// consuming budget. Otherwise fetches and caches `total_n_channels`,
 /// then delegates to [`discover_incoming_channels`] for new channels.
-pub async fn discover_channels_paginated<S: IViews>(
+pub async fn discover_incoming_channels_paginated<S: IViews>(
     pool: &S,
     recipient: Felt,
     decryption_key: &SecretFelt,
     cursor: &mut DiscoveryCursor,
     budget: &IoBudget,
 ) -> Result<Vec<IncomingChannel>, DiscoveryError> {
+    // Skip if channel discovery is disabled.
+    if !cursor.discover_channels {
+        return Ok(Vec::new());
+    }
+
     // 1. Get/cache total_n_channels.
     let total = match cursor.total_n_channels {
         Some(count) => count,
@@ -169,9 +175,10 @@ pub async fn discover_channels_paginated<S: IViews>(
         },
     };
 
-    // 2. All channels already enumerated — skip.
+    // 2. All channels already enumerated — stop discovering.
     let start_index = cursor.last_channel_index.map_or(0, |i| i + 1);
     if start_index >= total {
+        cursor.discover_channels = false;
         return Ok(Vec::new());
     }
 
@@ -180,13 +187,13 @@ pub async fn discover_channels_paginated<S: IViews>(
         discover_incoming_channels(pool, recipient, decryption_key, start_index, total, budget)
             .await?;
 
-    // 4. Register new channels in cursor.
+    // 4. Register new channels in cursor (keyed by sender_addr).
     for channel in &result.channels {
         cursor
             .channels
-            .entry(channel.info.channel_key)
+            .entry(channel.info.sender_addr)
             .or_insert(ChannelCursor {
-                sender_addr: channel.info.sender_addr,
+                channel_key: Some(channel.info.channel_key),
                 total_n_subchannels: None,
                 last_subchannel_index: None,
                 subchannels: Default::default(),
@@ -194,6 +201,11 @@ pub async fn discover_channels_paginated<S: IViews>(
     }
 
     cursor.last_channel_index = result.last_index.or(cursor.last_channel_index);
+
+    // Stop discovering once all channels are enumerated.
+    if !result.has_more {
+        cursor.discover_channels = false;
+    }
 
     Ok(result.channels)
 }
@@ -403,11 +415,14 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        let mut cursor = DiscoveryCursor::default();
+        let mut cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
         let budget = IoBudget::new(100);
         let key = SecretFelt::new(fixture.constants.bob_viewing_key);
 
-        let channels = discover_channels_paginated(
+        let channels = discover_incoming_channels_paginated(
             &backend,
             fixture.constants.bob_address,
             &key,
@@ -421,12 +436,13 @@ mod tests {
         assert_eq!(cursor.total_n_channels, Some(1));
         assert_eq!(cursor.last_channel_index, Some(0));
         assert_eq!(cursor.channels.len(), 1, "1 channel in cursor");
+        assert!(!cursor.discover_channels, "discovery complete");
 
-        let channel_key = channels[0].info.channel_key;
-        assert!(cursor.channels.contains_key(&channel_key));
+        let sender_addr = channels[0].info.sender_addr;
+        assert!(cursor.channels.contains_key(&sender_addr));
         assert_eq!(
-            cursor.channels[&channel_key].sender_addr,
-            fixture.constants.alice_address
+            cursor.channels[&sender_addr].channel_key,
+            Some(channels[0].info.channel_key)
         );
     }
 
@@ -435,12 +451,15 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        let mut cursor = DiscoveryCursor::default();
+        let mut cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
         // Budget = 0: can't even fetch channel count
         let budget = IoBudget::new(0);
         let key = SecretFelt::new(fixture.constants.bob_viewing_key);
 
-        let channels = discover_channels_paginated(
+        let channels = discover_incoming_channels_paginated(
             &backend,
             fixture.constants.bob_address,
             &key,

--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 
 use starknet_types_core::felt::Felt;
 
-use super::cursor::IndexSearchCursor;
+use super::cursor::SubchannelCursor;
 use super::DiscoveryError;
 use super::COST_NOTE_PROBING;
 use crate::io_budget::IoBudget;
@@ -28,7 +28,7 @@ pub async fn find_last_note_index_paginated<S: IViews>(
     pool: &S,
     channel_key: Felt,
     token: Felt,
-    cursor: &mut IndexSearchCursor,
+    cursor: &mut SubchannelCursor,
     budget: &IoBudget,
 ) -> Result<(Option<u64>, bool), DiscoveryError> {
     // Returns (Some(idx), _) if note exists, (None, false) if empty, (None, true) if out of budget.
@@ -48,20 +48,20 @@ pub async fn find_last_note_index_paginated<S: IViews>(
     };
 
     // Phase 1: Ascending (find bounds)
-    if cursor.hi.is_none() {
+    if cursor.max_note_index.is_none() {
         let found_sentinel = exponential_ascend(&probe, cursor).await?;
         if !found_sentinel {
-            return Ok((cursor.lo, true));
+            return Ok((cursor.last_note_index, true));
         }
         // Empty subchannel: first probe found sentinel
-        if cursor.lo.is_none() {
+        if cursor.last_note_index.is_none() {
             return Ok((None, false));
         }
     }
 
     // Phase 2: Bisection (narrow down to exact boundary)
     let complete = bisect_boundary(&probe, cursor).await?;
-    Ok((cursor.lo, !complete))
+    Ok((cursor.last_note_index, !complete))
 }
 
 /// Exponential ascending: probes at `lo+step`, `lo+2*step`, `lo+4*step`...
@@ -71,7 +71,7 @@ pub async fn find_last_note_index_paginated<S: IViews>(
 // TODO: Issue probes in batches to amortise RPC round-trip latency.
 async fn exponential_ascend<F, Fut>(
     probe: F,
-    cursor: &mut IndexSearchCursor,
+    cursor: &mut SubchannelCursor,
 ) -> Result<bool, DiscoveryError>
 where
     F: Fn(u64) -> Fut,
@@ -79,21 +79,23 @@ where
 {
     // Compute step from lo: 2^k where k = trailing_zeros(lo + 1).
     // Reconstructs the exponential sequence: 0, 1, 3, 7, 15, ...
-    let mut step = match cursor.lo {
+    let mut step = match cursor.last_note_index {
         None | Some(0) => 1,
         Some(n) => 1u64 << (n + 1).trailing_zeros(),
     };
-    let mut probe_at = cursor.lo.map_or(0, |lo| lo.saturating_add(step));
+    let mut probe_at = cursor
+        .last_note_index
+        .map_or(0, |lo| lo.saturating_add(step));
 
     loop {
         match probe(probe_at).await? {
             (Some(_), _) => {
-                cursor.lo = Some(probe_at);
+                cursor.last_note_index = Some(probe_at);
                 probe_at = probe_at.saturating_add(step);
                 step = step.saturating_mul(2);
             }
             (None, false) => {
-                cursor.hi = Some(probe_at);
+                cursor.max_note_index = Some(probe_at);
                 return Ok(true);
             }
             (None, true) => return Ok(false),
@@ -107,13 +109,13 @@ where
 /// Updates cursor in place. Returns `true` if complete, `false` if budget exhausted.
 async fn bisect_boundary<F, Fut>(
     probe: F,
-    cursor: &mut IndexSearchCursor,
+    cursor: &mut SubchannelCursor,
 ) -> Result<bool, DiscoveryError>
 where
     F: Fn(u64) -> Fut,
     Fut: Future<Output = Result<(Option<u64>, bool), DiscoveryError>>,
 {
-    let (mut lo, mut hi) = match (cursor.lo, cursor.hi) {
+    let (mut lo, mut hi) = match (cursor.last_note_index, cursor.max_note_index) {
         (Some(lo), Some(hi)) => (lo, hi),
         _ => return Ok(true), // Nothing to bisect
     };
@@ -124,15 +126,15 @@ where
             (Some(_), _) => lo = mid,
             (None, false) => hi = mid,
             (None, true) => {
-                cursor.lo = Some(lo);
-                cursor.hi = Some(hi);
+                cursor.last_note_index = Some(lo);
+                cursor.max_note_index = Some(hi);
                 return Ok(false);
             }
         }
     }
 
-    cursor.lo = Some(lo);
-    cursor.hi = Some(hi);
+    cursor.last_note_index = Some(lo);
+    cursor.max_note_index = Some(hi);
     Ok(true)
 }
 
@@ -158,66 +160,66 @@ mod tests {
 
     #[tokio::test]
     async fn test_exponential_ascend_empty() {
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
         let found = exponential_ascend(mock_probe(None), &mut cursor)
             .await
             .unwrap();
         assert!(found, "should find sentinel immediately");
-        assert_eq!(cursor.lo, None);
-        assert_eq!(cursor.hi, Some(0));
+        assert_eq!(cursor.last_note_index, None);
+        assert_eq!(cursor.max_note_index, Some(0));
     }
 
     #[tokio::test]
     async fn test_exponential_ascend_one_element() {
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
         let found = exponential_ascend(mock_probe(Some(0)), &mut cursor)
             .await
             .unwrap();
         assert!(found);
-        assert_eq!(cursor.lo, Some(0));
-        assert_eq!(cursor.hi, Some(1));
+        assert_eq!(cursor.last_note_index, Some(0));
+        assert_eq!(cursor.max_note_index, Some(1));
     }
 
     #[tokio::test]
     async fn test_exponential_ascend_multiple_elements() {
         // Elements at 0, 1, 2, 3, 4 (last_index = 4)
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
         let found = exponential_ascend(mock_probe(Some(4)), &mut cursor)
             .await
             .unwrap();
         assert!(found);
         // Probes: 0 (exists), 1 (exists), 3 (exists), 7 (empty)
-        assert_eq!(cursor.lo, Some(3));
-        assert_eq!(cursor.hi, Some(7));
+        assert_eq!(cursor.last_note_index, Some(3));
+        assert_eq!(cursor.max_note_index, Some(7));
     }
 
     #[tokio::test]
     async fn test_bisect_boundary_adjacent() {
         // lo=0, hi=1 → no bisection needed
-        let mut cursor = IndexSearchCursor {
-            lo: Some(0),
-            hi: Some(1),
+        let mut cursor = SubchannelCursor {
+            last_note_index: Some(0),
+            max_note_index: Some(1),
         };
         let complete = bisect_boundary(mock_probe(Some(0)), &mut cursor)
             .await
             .unwrap();
         assert!(complete);
-        assert_eq!(cursor.lo, Some(0));
+        assert_eq!(cursor.last_note_index, Some(0));
     }
 
     #[tokio::test]
     async fn test_bisect_boundary_gap() {
         // lo=3, hi=7, actual last is 4
-        let mut cursor = IndexSearchCursor {
-            lo: Some(3),
-            hi: Some(7),
+        let mut cursor = SubchannelCursor {
+            last_note_index: Some(3),
+            max_note_index: Some(7),
         };
         let complete = bisect_boundary(mock_probe(Some(4)), &mut cursor)
             .await
             .unwrap();
         assert!(complete);
-        assert_eq!(cursor.lo, Some(4));
-        assert_eq!(cursor.hi, Some(5));
+        assert_eq!(cursor.last_note_index, Some(4));
+        assert_eq!(cursor.max_note_index, Some(5));
     }
 
     #[tokio::test]
@@ -237,7 +239,7 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
 
         let (last_index, has_more) =
@@ -256,7 +258,7 @@ mod tests {
         let channel_key = Felt::from_hex_unchecked("0x12345");
         let token = Felt::from_hex_unchecked("0x67890");
 
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
 
         let (last_index, has_more) =
@@ -285,7 +287,7 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        let mut cursor = IndexSearchCursor::default();
+        let mut cursor = SubchannelCursor::default();
 
         // Budget for 1 probe: finds note at 0, exhausted before probing 1
         let budget = IoBudget::new(COST_NOTE_PROBING);
@@ -296,8 +298,8 @@ mod tests {
 
         assert_eq!(last_index, Some(0));
         assert!(has_more, "budget exhausted during ascending");
-        assert_eq!(cursor.lo, Some(0));
-        assert!(cursor.hi.is_none(), "sentinel not found yet");
+        assert_eq!(cursor.last_note_index, Some(0));
+        assert!(cursor.max_note_index.is_none(), "sentinel not found yet");
 
         // Resume with more budget
         let budget = IoBudget::new(100);

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -9,6 +9,7 @@ pub mod cursor;
 pub mod incoming_channels;
 pub mod last_note_index;
 pub mod notes;
+pub mod outgoing_channels;
 pub mod subchannels;
 
 /// Cost for `get_num_of_channels` (1 storage slot read).
@@ -22,6 +23,9 @@ pub const COST_SUBCHANNEL_INFO: usize = 2;
 
 /// Cost for `get_note` + `nullifier_exists` (2 storage slot reads).
 pub const COST_NOTE: usize = 2;
+
+/// Cost for `get_outgoing_channel_info` (2 storage slot reads: salt + enc_recipient_addr).
+pub const COST_OUTGOING_CHANNEL_INFO: usize = 2;
 
 /// Cost for a single note existence probe (1 `get_note` read, no nullifier check).
 pub const COST_NOTE_PROBING: usize = 1;
@@ -44,4 +48,7 @@ pub enum DiscoveryError {
     /// A spawned task panicked.
     #[error("spawned task panicked: {0}")]
     TaskPanicked(String),
+    /// Invalid cursor data provided by client.
+    #[error("invalid cursor: {0}")]
+    InvalidCursor(String),
 }

--- a/crates/discovery-core/src/discovery/outgoing_channels.rs
+++ b/crates/discovery-core/src/discovery/outgoing_channels.rs
@@ -1,0 +1,280 @@
+//! Outgoing channel discovery.
+//!
+//! This module provides functionality to discover outgoing channels
+//! for a given sender. Outgoing channels store encrypted recipient addresses
+//! that only the sender can decrypt using their viewing key.
+
+use starknet_types_core::felt::Felt;
+
+use super::cursor::DiscoveryCursor;
+use super::DiscoveryError;
+use super::COST_OUTGOING_CHANNEL_INFO;
+use crate::io_budget::IoBudget;
+use crate::privacy_pool::decryption::decrypt_outgoing_recipient_addr;
+use crate::privacy_pool::hashes::compute_outgoing_channel_id;
+use crate::privacy_pool::types::SecretFelt;
+use crate::privacy_pool::views::IViews;
+
+/// A discovered and decrypted outgoing channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutgoingChannel {
+    /// The index of this outgoing channel.
+    pub index: u64,
+    /// The decrypted recipient address.
+    pub recipient_addr: Felt,
+}
+
+/// Result of outgoing channel discovery operation.
+#[derive(Debug, Clone)]
+pub struct OutgoingChannelDiscoveryResult {
+    /// List of discovered and decrypted outgoing channels.
+    pub channels: Vec<OutgoingChannel>,
+    /// Index of the last discovered channel, or `None` if no channels were discovered.
+    pub last_index: Option<u64>,
+    /// Whether there may be more channels to discover.
+    /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
+    pub has_more: bool,
+}
+
+/// Discovers and decrypts outgoing channels for a given sender.
+///
+/// # Algorithm
+///
+/// For each outgoing channel index starting from `start_index`:
+/// 1. Compute `outgoing_channel_id = hash(OUTGOING_CHANNEL_ID_TAG, sender_addr, viewing_key, index, 0)`
+/// 2. Fetch `EncOutgoingChannelInfo { salt, enc_recipient_addr }` from storage
+/// 3. If `salt == 0`, stop (sentinel - no more outgoing channels)
+/// 4. Decrypt: `recipient_addr = enc_recipient_addr - hash(ENC_RECIPIENT_ADDR_TAG, sender_addr, viewing_key, index, 0, salt)`
+///
+/// # Arguments
+///
+/// * `privacy_pool` - Storage backend implementing the IViews trait.
+/// * `sender_addr` - The sender's address.
+/// * `viewing_key` - The sender's private viewing key.
+/// * `start_index` - Starting index (inclusive). For incremental discovery, pass
+///   `last_index + 1` from previous result.
+/// * `budget` - I/O budget to limit storage operations.
+pub async fn discover_outgoing_channels<PrivacyPool: IViews>(
+    privacy_pool: &PrivacyPool,
+    sender_addr: Felt,
+    viewing_key: &SecretFelt,
+    start_index: u64,
+    budget: &IoBudget,
+) -> Result<OutgoingChannelDiscoveryResult, DiscoveryError> {
+    let mut channels = Vec::new();
+    let mut index = start_index;
+    let mut out_of_budget = false;
+
+    loop {
+        if !budget.consume(COST_OUTGOING_CHANNEL_INFO) {
+            out_of_budget = true;
+            break;
+        }
+
+        let outgoing_channel_id = compute_outgoing_channel_id(sender_addr, viewing_key, index);
+        let encrypted = privacy_pool
+            .get_outgoing_channel_info(outgoing_channel_id)
+            .await?;
+
+        // Sentinel: salt == 0 means no more outgoing channels
+        if encrypted.salt == Felt::ZERO {
+            break;
+        }
+
+        let recipient_addr =
+            decrypt_outgoing_recipient_addr(&encrypted, sender_addr, viewing_key, index);
+
+        channels.push(OutgoingChannel {
+            index,
+            recipient_addr,
+        });
+        index += 1;
+    }
+
+    let last_index = channels.last().map(|c| c.index);
+
+    Ok(OutgoingChannelDiscoveryResult {
+        channels,
+        last_index,
+        has_more: out_of_budget,
+    })
+}
+
+/// Discovers outgoing channels with cursor-based pagination.
+///
+/// Manages resume state across calls. If `cursor.discover_channels == false`,
+/// returns immediately without consuming budget — use this to skip channel
+/// discovery and only process specific recipients/tokens already in cursor.
+///
+/// Returns discovered channels.
+pub async fn discover_outgoing_channels_paginated<S: IViews>(
+    pool: &S,
+    sender_addr: Felt,
+    viewing_key: &SecretFelt,
+    cursor: &mut DiscoveryCursor,
+    budget: &IoBudget,
+) -> Result<Vec<OutgoingChannel>, DiscoveryError> {
+    if !cursor.discover_channels {
+        return Ok(Vec::new());
+    }
+
+    let start_index = cursor.last_channel_index.map_or(0, |i| i + 1);
+    let result =
+        discover_outgoing_channels(pool, sender_addr, viewing_key, start_index, budget).await?;
+
+    cursor.last_channel_index = result.last_index.or(cursor.last_channel_index);
+    // Stop discovering once sentinel is found.
+    if !result.has_more {
+        cursor.discover_channels = false;
+    }
+
+    Ok(result.channels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_backend::MockBackend;
+    use crate::test_fixtures::load_devnet_fixture;
+
+    #[tokio::test]
+    async fn test_discover_no_outgoing_channels() {
+        let backend = MockBackend::empty();
+        let sender_addr = Felt::from_hex_unchecked("0x12345");
+        let viewing_key = SecretFelt::new(Felt::from_hex_unchecked("0x67890"));
+        let budget = IoBudget::new(100);
+
+        let result = discover_outgoing_channels(&backend, sender_addr, &viewing_key, 0, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.channels.len(), 0);
+        assert_eq!(result.last_index, None);
+        assert!(!result.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_discover_alice_outgoing_channels() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let viewing_key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let budget = IoBudget::new(100);
+
+        let result = discover_outgoing_channels(
+            &backend,
+            fixture.constants.alice_address,
+            &viewing_key,
+            0,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        // Alice deposited 100 STRK (self-channel) + transferred 50 to Bob,
+        // so she has 2 outgoing channels: one to herself and one to Bob.
+        assert_eq!(
+            result.channels.len(),
+            2,
+            "Alice should have 2 outgoing channels (self + Bob)"
+        );
+        assert_eq!(result.last_index, Some(1));
+        assert!(!result.has_more);
+
+        assert_eq!(result.channels[0].index, 0);
+        assert_eq!(
+            result.channels[0].recipient_addr, fixture.constants.alice_address,
+            "First outgoing channel should point to Alice (self-channel)"
+        );
+
+        assert_eq!(result.channels[1].index, 1);
+        assert_eq!(
+            result.channels[1].recipient_addr, fixture.constants.bob_address,
+            "Second outgoing channel should point to Bob"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_paginated_full_discovery() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let viewing_key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let mut cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
+        let budget = IoBudget::new(100);
+
+        let channels = discover_outgoing_channels_paginated(
+            &backend,
+            fixture.constants.alice_address,
+            &viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(channels.len(), 2);
+        assert_eq!(cursor.last_channel_index, Some(1));
+        assert!(!cursor.discover_channels, "discovery complete");
+
+        // Second call should return empty (already complete)
+        let channels2 = discover_outgoing_channels_paginated(
+            &backend,
+            fixture.constants.alice_address,
+            &viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert!(channels2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_paginated_budget_limited() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let viewing_key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let mut cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
+
+        // Budget for 1 channel (COST_OUTGOING_CHANNEL_INFO = 2)
+        let budget = IoBudget::new(COST_OUTGOING_CHANNEL_INFO);
+        let channels = discover_outgoing_channels_paginated(
+            &backend,
+            fixture.constants.alice_address,
+            &viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(cursor.last_channel_index, Some(0));
+        assert!(cursor.discover_channels, "discovery not complete yet");
+
+        // Resume with more budget
+        let budget = IoBudget::new(100);
+        let channels2 = discover_outgoing_channels_paginated(
+            &backend,
+            fixture.constants.alice_address,
+            &viewing_key,
+            &mut cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(channels2.len(), 1, "second channel discovered");
+        assert_eq!(cursor.last_channel_index, Some(1));
+        assert!(!cursor.discover_channels, "discovery complete");
+    }
+}

--- a/crates/discovery-core/src/discovery/subchannels.rs
+++ b/crates/discovery-core/src/discovery/subchannels.rs
@@ -294,7 +294,7 @@ mod tests {
         .unwrap();
 
         let mut cursor = ChannelCursor {
-            sender_addr: fixture.constants.alice_address,
+            channel_key: Some(channel_key),
             total_n_subchannels: None,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
@@ -333,7 +333,7 @@ mod tests {
         .unwrap();
 
         let mut cursor = ChannelCursor {
-            sender_addr: fixture.constants.alice_address,
+            channel_key: Some(channel_key),
             total_n_subchannels: None,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
@@ -374,7 +374,7 @@ mod tests {
 
         // Fresh cursor: empty map + no total → should discover subchannels
         let mut fresh = ChannelCursor {
-            sender_addr: fixture.constants.alice_address,
+            channel_key: Some(channel_key),
             total_n_subchannels: None,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
@@ -388,7 +388,7 @@ mod tests {
         // Fully enumerated cursor: empty map + total set → should skip entirely
         // (simulates state after all notes processed and entries pruned)
         let mut done = ChannelCursor {
-            sender_addr: fixture.constants.alice_address,
+            channel_key: Some(channel_key),
             total_n_subchannels: Some(1),
             last_subchannel_index: Some(0),
             subchannels: HashMap::new(),

--- a/crates/discovery-core/src/sync/incoming_state.rs
+++ b/crates/discovery-core/src/sync/incoming_state.rs
@@ -12,7 +12,7 @@ use starknet_types_core::felt::Felt;
 use tokio::task::JoinSet;
 
 use crate::discovery::cursor::{ChannelCursor, DiscoveryCursor, SubchannelCursor};
-use crate::discovery::incoming_channels::discover_channels_paginated;
+use crate::discovery::incoming_channels::discover_incoming_channels_paginated;
 use crate::discovery::notes::{discover_notes_paginated, DecryptedNote};
 use crate::discovery::subchannels::discover_subchannels_paginated;
 use crate::discovery::DiscoveryError;
@@ -23,7 +23,7 @@ use crate::privacy_pool::views::IViews;
 /// Output from a single discovery run.
 #[derive(Debug, Clone, Serialize)]
 pub struct DiscoveryOutput {
-    /// Discovered data per channel, keyed by channel_key.
+    /// Discovered data per channel, keyed by sender address.
     pub channels: HashMap<Felt, ChannelOutput>,
     /// Updated cursor for the next run. Fully-discovered channels and
     /// subchannels are pruned. An empty `cursor.channels` map means
@@ -34,15 +34,16 @@ pub struct DiscoveryOutput {
 /// Discovered data for a single channel within a run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelOutput {
-    /// Sender address for this channel.
-    pub sender_addr: Felt,
+    /// Channel key (set for incoming sync, None for outgoing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_key: Option<Felt>,
     /// Discovered notes per subchannel, keyed by token address.
     pub subchannels: HashMap<Felt, Vec<DecryptedNote>>,
 }
 
 /// Result of processing a single channel (internal).
 struct ChannelResult {
-    channel_key: Felt,
+    sender_addr: Felt,
     output: ChannelOutput,
     /// `None` means fully discovered — prune from cursor.
     cursor: Option<ChannelCursor>,
@@ -75,7 +76,8 @@ pub async fn sync_incoming_state<S>(
 where
     S: IViews + Clone + Send + Sync + 'static,
 {
-    discover_channels_paginated(pool, recipient, decryption_key, &mut cursor, budget).await?;
+    discover_incoming_channels_paginated(pool, recipient, decryption_key, &mut cursor, budget)
+        .await?;
 
     if cursor.channels.is_empty() {
         return Ok(DiscoveryOutput {
@@ -91,21 +93,21 @@ where
     //   Fix: reject or truncate cursor.channels to a max size (e.g., 256).
     let channels = std::mem::take(&mut cursor.channels);
     let mut join_set = JoinSet::new();
-    for (channel_key, ch_cursor) in channels {
+    for (sender_addr, ch_cursor) in channels {
         let pool = pool.clone();
         let budget = budget.clone();
         let key = decryption_key.clone();
         join_set.spawn(async move {
-            process_channel(&pool, channel_key, ch_cursor, &key, &budget).await
+            process_channel(&pool, sender_addr, ch_cursor, &key, &budget).await
         });
     }
 
     let mut channels_output: HashMap<Felt, ChannelOutput> = HashMap::new();
     while let Some(join_result) = join_set.join_next().await {
         let result = join_result.map_err(|e| DiscoveryError::TaskPanicked(e.to_string()))??;
-        channels_output.insert(result.channel_key, result.output);
+        channels_output.insert(result.sender_addr, result.output);
         if let Some(ch_cursor) = result.cursor {
-            cursor.channels.insert(result.channel_key, ch_cursor);
+            cursor.channels.insert(result.sender_addr, ch_cursor);
         }
     }
 
@@ -119,7 +121,7 @@ where
 /// discovery for each subchannel concurrently via [`JoinSet`].
 async fn process_channel<S>(
     pool: &S,
-    channel_key: Felt,
+    sender_addr: Felt,
     mut cursor: ChannelCursor,
     decryption_key: &SecretFelt,
     budget: &IoBudget,
@@ -127,7 +129,9 @@ async fn process_channel<S>(
 where
     S: IViews + Clone + Send + Sync + 'static,
 {
-    let sender_addr = cursor.sender_addr;
+    let channel_key = cursor.channel_key.ok_or_else(|| {
+        DiscoveryError::InvalidCursor("channel_key is required for incoming channel".into())
+    })?;
 
     discover_subchannels_paginated(pool, channel_key, &mut cursor, budget).await?;
 
@@ -160,9 +164,9 @@ where
     let fully_done = cursor.total_n_subchannels.is_some() && cursor.subchannels.is_empty();
 
     Ok(ChannelResult {
-        channel_key,
+        sender_addr,
         output: ChannelOutput {
-            sender_addr,
+            channel_key: Some(channel_key),
             subchannels: subchannel_notes,
         },
         cursor: if fully_done { None } else { Some(cursor) },
@@ -228,7 +232,10 @@ mod tests {
         // Step 1: budget = COST_NUM_CHANNELS (1)
         // Fetches total_n_channels = 1. No budget left for channel discovery.
         let budget = IoBudget::new(COST_NUM_CHANNELS);
-        let cursor = DiscoveryCursor::default();
+        let cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
         let out = sync_incoming_state(&backend, recipient, &decryption_key, cursor, &budget)
             .await
             .unwrap();
@@ -253,10 +260,10 @@ mod tests {
             "step 2: channel 0 discovered"
         );
         assert_eq!(out.cursor.channels.len(), 1, "step 2: 1 channel in cursor");
-        let channel_key = *out.cursor.channels.keys().next().unwrap();
-        assert_eq!(
-            out.channels[&channel_key].sender_addr, f.constants.alice_address,
-            "step 2: sender is Alice"
+        let sender_addr = f.constants.alice_address;
+        assert!(
+            out.cursor.channels.contains_key(&sender_addr),
+            "step 2: cursor keyed by sender (Alice)"
         );
 
         // Step 3: budget = COST_SUBCHANNEL_INFO (2)
@@ -268,15 +275,15 @@ mod tests {
             .unwrap();
 
         assert!(
-            out.cursor.channels.contains_key(&channel_key),
+            out.cursor.channels.contains_key(&sender_addr),
             "step 3: channel still in cursor (not fully done)"
         );
         assert_eq!(
-            out.cursor.channels[&channel_key].subchannels.len(),
+            out.cursor.channels[&sender_addr].subchannels.len(),
             1,
             "step 3: 1 subchannel found"
         );
-        let subchannel_token = *out.cursor.channels[&channel_key]
+        let subchannel_token = *out.cursor.channels[&sender_addr]
             .subchannels
             .keys()
             .next()
@@ -295,11 +302,11 @@ mod tests {
             .unwrap();
 
         assert!(
-            out.cursor.channels.contains_key(&channel_key),
+            out.cursor.channels.contains_key(&sender_addr),
             "step 4: channel still in cursor (notes pending)"
         );
         assert!(
-            out.cursor.channels[&channel_key]
+            out.cursor.channels[&sender_addr]
                 .subchannels
                 .contains_key(&subchannel_token),
             "step 4: subchannel still in cursor (notes not started)"
@@ -315,10 +322,10 @@ mod tests {
             .unwrap();
 
         assert!(
-            out.cursor.channels.contains_key(&channel_key),
+            out.cursor.channels.contains_key(&sender_addr),
             "step 5: channel still in cursor (note sentinel not checked)"
         );
-        let notes = &out.channels[&channel_key].subchannels[&subchannel_token];
+        let notes = &out.channels[&sender_addr].subchannels[&subchannel_token];
         assert_eq!(
             notes.len(),
             0,
@@ -339,7 +346,7 @@ mod tests {
             "step 6: cursor empty (all discovery complete)"
         );
         assert_eq!(
-            out.channels[&channel_key].subchannels[&subchannel_token].len(),
+            out.channels[&sender_addr].subchannels[&subchannel_token].len(),
             0,
             "step 6: no new notes discovered"
         );

--- a/crates/discovery-service/src/incoming_sync/handler.rs
+++ b/crates/discovery-service/src/incoming_sync/handler.rs
@@ -103,5 +103,9 @@ fn discovery_error_to_response(
                 ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
             )
         }
+        DiscoveryError::InvalidCursor(msg) => (
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(error_codes::INVALID_REQUEST, msg),
+        ),
     }
 }

--- a/crates/discovery-service/src/incoming_sync/types.rs
+++ b/crates/discovery-service/src/incoming_sync/types.rs
@@ -67,7 +67,7 @@ pub struct IncomingSyncResponse {
     /// Block hash pinning all reads in this response. Pass back as
     /// `block_ref` in subsequent requests for consistency.
     pub block_ref: Felt,
-    /// Discovered channel results, keyed by channel_key.
+    /// Discovered channel results, keyed by sender address.
     pub channels: HashMap<Felt, ChannelOutput>,
     /// Updated cursor for continuation. Pass back as `cursor` in next request.
     pub cursor: DiscoveryCursor,


### PR DESCRIPTION
### TL;DR

Refactored the discovery system to support both incoming and outgoing channel discovery with separate cursor types.

### What changed?

- Renamed `DiscoveryCursor` to `IncomingDiscoveryCursor` to clarify its purpose
- Added new `OutgoingDiscoveryCursor` for tracking outgoing channel discovery
- Restructured `ChannelCursor` to work with both incoming and outgoing channels:
  - Changed channel identification from `channel_key` to `sender_addr` for incoming channels
  - Added optional `channel_key` field that's only set for incoming channels
- Consolidated `IndexSearchCursor` into `SubchannelCursor` by adding `max_note_index` field
- Implemented new `outgoing_channels.rs` module with functions to discover channels sent by a user
- Updated all related code to work with the new cursor types

### How to test?

- Run the existing test suite which has been updated to use the new cursor types
- Test outgoing channel discovery with the new tests in `outgoing_channels.rs`
- Verify that both incoming and outgoing discovery work correctly with pagination and budget constraints

### Why make this change?

This change enables the wallet to discover both incoming and outgoing channels, providing users with a complete view of their transaction history. The separation of cursor types makes the code more maintainable and allows for different discovery strategies:

- Incoming discovery uses linear scanning to find all channels sent to a user
- Outgoing discovery allows users to see where they've sent funds
- The unified subchannel cursor supports both linear scanning (for incoming) and exponential search (for outgoing)

This foundation will allow the wallet to efficiently track both received and sent transactions while maintaining privacy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/430)
<!-- Reviewable:end -->
