### PR TITLE
feat(indexer): sync outgoing state

### DIFF
--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -24,8 +24,8 @@ pub const COST_SUBCHANNEL_INFO: usize = 2;
 /// Cost for `get_note` + `nullifier_exists` (2 storage slot reads).
 pub const COST_NOTE: usize = 2;
 
-/// Cost for `get_outgoing_channel_info` (2 storage slot reads: salt + enc_recipient_addr).
-pub const COST_OUTGOING_CHANNEL_INFO: usize = 2;
+/// Cost for outgoing channel info (3 storage slot reads: salt + enc_recipient_addr + public_key).
+pub const COST_OUTGOING_CHANNEL_INFO: usize = 3;
 
 /// Cost for a single note existence probe (1 `get_note` read, no nullifier check).
 pub const COST_NOTE_PROBING: usize = 1;

--- a/crates/discovery-core/src/discovery/outgoing_channels.rs
+++ b/crates/discovery-core/src/discovery/outgoing_channels.rs
@@ -11,7 +11,7 @@ use super::DiscoveryError;
 use super::COST_OUTGOING_CHANNEL_INFO;
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::decrypt_outgoing_recipient_addr;
-use crate::privacy_pool::hashes::compute_outgoing_channel_id;
+use crate::privacy_pool::hashes::{compute_channel_key, compute_outgoing_channel_id};
 use crate::privacy_pool::types::SecretFelt;
 use crate::privacy_pool::views::IViews;
 
@@ -22,6 +22,8 @@ pub struct OutgoingChannel {
     pub index: u64,
     /// The decrypted recipient address.
     pub recipient_addr: Felt,
+    /// The channel key derived from sender + recipient identity.
+    pub channel_key: Felt,
 }
 
 /// Result of outgoing channel discovery operation.
@@ -83,10 +85,18 @@ pub async fn discover_outgoing_channels<PrivacyPool: IViews>(
 
         let recipient_addr =
             decrypt_outgoing_recipient_addr(&encrypted, sender_addr, viewing_key, index);
+        let recipient_public_key = privacy_pool.get_public_key(recipient_addr).await?;
+        let channel_key = compute_channel_key(
+            sender_addr,
+            viewing_key,
+            recipient_addr,
+            recipient_public_key,
+        );
 
         channels.push(OutgoingChannel {
             index,
             recipient_addr,
+            channel_key,
         });
         index += 1;
     }
@@ -121,6 +131,19 @@ pub async fn discover_outgoing_channels_paginated<S: IViews>(
     let start_index = cursor.last_channel_index.map_or(0, |i| i + 1);
     let result =
         discover_outgoing_channels(pool, sender_addr, viewing_key, start_index, budget).await?;
+
+    // Register discovered channels in cursor with their channel_key.
+    for ch in &result.channels {
+        let entry = cursor.channels.entry(ch.recipient_addr).or_insert_with(|| {
+            super::cursor::ChannelCursor {
+                channel_key: None,
+                total_n_subchannels: None,
+                last_subchannel_index: None,
+                subchannels: std::collections::HashMap::new(),
+            }
+        });
+        entry.channel_key = Some(ch.channel_key);
+    }
 
     cursor.last_channel_index = result.last_index.or(cursor.last_channel_index);
     // Stop discovering once sentinel is found.
@@ -245,7 +268,7 @@ mod tests {
             ..Default::default()
         };
 
-        // Budget for 1 channel (COST_OUTGOING_CHANNEL_INFO = 2)
+        // Budget for 1 channel (COST_OUTGOING_CHANNEL_INFO = 3)
         let budget = IoBudget::new(COST_OUTGOING_CHANNEL_INFO);
         let channels = discover_outgoing_channels_paginated(
             &backend,

--- a/crates/discovery-core/src/sync/mod.rs
+++ b/crates/discovery-core/src/sync/mod.rs
@@ -3,3 +3,4 @@
 //! Composes discovery primitives into complete sync workflows.
 
 pub mod incoming_state;
+pub mod outgoing_state;

--- a/crates/discovery-core/src/sync/outgoing_state.rs
+++ b/crates/discovery-core/src/sync/outgoing_state.rs
@@ -1,0 +1,296 @@
+//! Outgoing sync orchestrator.
+//!
+//! Composes paginated outgoing channel, subchannel, and note-index discovery
+//! into a single [`sync_outgoing_state`] call that advances a [`DiscoveryCursor`].
+//!
+//! Channel and subchannel processing is parallelised via [`tokio::task::JoinSet`].
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+use tokio::task::JoinSet;
+
+use crate::discovery::cursor::{ChannelCursor, DiscoveryCursor, SubchannelCursor};
+use crate::discovery::last_note_index::find_last_note_index_paginated;
+use crate::discovery::outgoing_channels::discover_outgoing_channels_paginated;
+use crate::discovery::subchannels::discover_subchannels_paginated;
+use crate::discovery::DiscoveryError;
+use crate::io_budget::IoBudget;
+use crate::privacy_pool::types::SecretFelt;
+use crate::privacy_pool::views::IViews;
+
+/// Output from a single outgoing discovery run.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutgoingDiscoveryOutput {
+    /// Discovered data per channel, keyed by recipient address.
+    pub channels: HashMap<Felt, OutgoingChannelOutput>,
+    /// Updated cursor for the next run.
+    pub cursor: DiscoveryCursor,
+}
+
+/// Discovered data for a single outgoing channel within a run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutgoingChannelOutput {
+    /// Last note index per subchannel, keyed by token address.
+    pub subchannels: HashMap<Felt, Option<u64>>,
+}
+
+/// Result of processing a single outgoing channel (internal).
+struct OutgoingChannelResult {
+    recipient_addr: Felt,
+    output: OutgoingChannelOutput,
+    /// `None` means fully discovered — prune from cursor.
+    cursor: Option<ChannelCursor>,
+}
+
+/// Result of processing a single outgoing subchannel (internal).
+struct OutgoingSubchannelResult {
+    token: Felt,
+    last_note_index: Option<u64>,
+    /// `None` means fully discovered — prune from cursor.
+    cursor: Option<SubchannelCursor>,
+}
+
+/// Runs hierarchical outgoing discovery: channels → subchannels → note index probing.
+///
+/// Each level uses cursor-based pagination. Fully-discovered subchannels
+/// and channels are pruned from the cursor so subsequent calls skip them.
+///
+/// Channel and subchannel processing is parallelised via [`JoinSet`].
+pub async fn sync_outgoing_state<S>(
+    pool: &S,
+    sender_addr: Felt,
+    viewing_key: &SecretFelt,
+    mut cursor: DiscoveryCursor,
+    budget: &IoBudget,
+) -> Result<OutgoingDiscoveryOutput, DiscoveryError>
+where
+    S: IViews + Clone + Send + Sync + 'static,
+{
+    discover_outgoing_channels_paginated(pool, sender_addr, viewing_key, &mut cursor, budget)
+        .await?;
+
+    if cursor.channels.is_empty() {
+        return Ok(OutgoingDiscoveryOutput {
+            channels: HashMap::new(),
+            cursor,
+        });
+    }
+
+    let channels = std::mem::take(&mut cursor.channels);
+    let mut join_set = JoinSet::new();
+    for (recipient_addr, ch_cursor) in channels {
+        let pool = pool.clone();
+        let budget = budget.clone();
+        join_set.spawn(async move {
+            process_outgoing_channel(&pool, recipient_addr, ch_cursor, &budget).await
+        });
+    }
+
+    let mut channels_output: HashMap<Felt, OutgoingChannelOutput> = HashMap::new();
+    while let Some(join_result) = join_set.join_next().await {
+        let result = join_result.map_err(|e| DiscoveryError::TaskPanicked(e.to_string()))??;
+        channels_output.insert(result.recipient_addr, result.output);
+        if let Some(ch_cursor) = result.cursor {
+            cursor.channels.insert(result.recipient_addr, ch_cursor);
+        }
+    }
+
+    Ok(OutgoingDiscoveryOutput {
+        channels: channels_output,
+        cursor,
+    })
+}
+
+/// Processes a single outgoing channel: discovers subchannels, then spawns
+/// note-index probing for each subchannel concurrently via [`JoinSet`].
+async fn process_outgoing_channel<S>(
+    pool: &S,
+    recipient_addr: Felt,
+    mut cursor: ChannelCursor,
+    budget: &IoBudget,
+) -> Result<OutgoingChannelResult, DiscoveryError>
+where
+    S: IViews + Clone + Send + Sync + 'static,
+{
+    let channel_key = cursor.channel_key.ok_or_else(|| {
+        DiscoveryError::InvalidCursor("channel_key is required for outgoing channel".into())
+    })?;
+
+    discover_subchannels_paginated(pool, channel_key, &mut cursor, budget).await?;
+
+    let subchannels: Vec<(Felt, SubchannelCursor)> = std::mem::take(&mut cursor.subchannels)
+        .into_iter()
+        .collect();
+
+    let mut join_set = JoinSet::new();
+    for (token, sc_cursor) in subchannels {
+        let pool = pool.clone();
+        let budget = budget.clone();
+        join_set.spawn(async move {
+            process_outgoing_subchannel(&pool, channel_key, token, sc_cursor, &budget).await
+        });
+    }
+
+    let mut subchannel_results: HashMap<Felt, Option<u64>> = HashMap::new();
+    while let Some(join_result) = join_set.join_next().await {
+        let result = join_result.map_err(|e| DiscoveryError::TaskPanicked(e.to_string()))??;
+        subchannel_results.insert(result.token, result.last_note_index);
+        if let Some(sc_cursor) = result.cursor {
+            cursor.subchannels.insert(result.token, sc_cursor);
+        }
+    }
+
+    let fully_done = cursor.total_n_subchannels.is_some() && cursor.subchannels.is_empty();
+
+    Ok(OutgoingChannelResult {
+        recipient_addr,
+        output: OutgoingChannelOutput {
+            subchannels: subchannel_results,
+        },
+        cursor: if fully_done { None } else { Some(cursor) },
+    })
+}
+
+/// Processes a single outgoing subchannel: probes for last note index.
+async fn process_outgoing_subchannel<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    mut cursor: SubchannelCursor,
+    budget: &IoBudget,
+) -> Result<OutgoingSubchannelResult, DiscoveryError> {
+    let (last_index, has_more) =
+        find_last_note_index_paginated(pool, channel_key, token, &mut cursor, budget).await?;
+
+    Ok(OutgoingSubchannelResult {
+        token,
+        last_note_index: last_index,
+        cursor: if has_more { Some(cursor) } else { None },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::COST_OUTGOING_CHANNEL_INFO;
+    use crate::storage_backend::MockBackend;
+    use crate::test_fixtures::load_devnet_fixture;
+
+    /// Full discovery with generous budget. Alice has 2 outgoing channels
+    /// (self + Bob), each with 1 STRK subchannel, each with last_note_index=0.
+    #[tokio::test]
+    async fn test_sync_outgoing_state_full_discovery() {
+        let f = load_devnet_fixture();
+        let backend = MockBackend::new(f.slots);
+        let viewing_key = SecretFelt::new(f.constants.alice_viewing_key);
+
+        let cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
+        let budget = IoBudget::new(100);
+
+        let out = sync_outgoing_state(
+            &backend,
+            f.constants.alice_address,
+            &viewing_key,
+            cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            out.channels.len(),
+            2,
+            "Alice has 2 outgoing channels (self + Bob)"
+        );
+
+        // Self-channel (Alice → Alice)
+        let alice_ch = &out.channels[&f.constants.alice_address];
+        assert_eq!(
+            alice_ch.subchannels[&f.constants.strk_token],
+            Some(0),
+            "Alice self-channel: STRK last_note_index=0"
+        );
+
+        // Bob channel (Alice → Bob)
+        let bob_ch = &out.channels[&f.constants.bob_address];
+        assert_eq!(
+            bob_ch.subchannels[&f.constants.strk_token],
+            Some(0),
+            "Alice→Bob channel: STRK last_note_index=0"
+        );
+
+        assert!(
+            out.cursor.channels.is_empty(),
+            "all discovery complete — cursor empty"
+        );
+    }
+
+    /// Pagination test: first call discovers channels only (budget=9 covers
+    /// 3 × COST_OUTGOING_CHANNEL_INFO = ch0 + ch1 + sentinel), then second
+    /// call with generous budget finishes subchannel + note discovery.
+    #[tokio::test]
+    async fn test_sync_outgoing_state_pagination() {
+        let f = load_devnet_fixture();
+        let backend = MockBackend::new(f.slots);
+        let viewing_key = SecretFelt::new(f.constants.alice_viewing_key);
+
+        // Step 1: budget = 3 × COST_OUTGOING_CHANNEL_INFO = 9
+        // Discovers 2 channels + sentinel. No budget left for subchannels.
+        let cursor = DiscoveryCursor {
+            discover_channels: true,
+            ..Default::default()
+        };
+        let budget = IoBudget::new(3 * COST_OUTGOING_CHANNEL_INFO);
+
+        let out = sync_outgoing_state(
+            &backend,
+            f.constants.alice_address,
+            &viewing_key,
+            cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            out.cursor.channels.len(),
+            2,
+            "step 1: 2 channels registered in cursor"
+        );
+        assert!(
+            !out.cursor.discover_channels,
+            "step 1: channel discovery complete (sentinel found)"
+        );
+
+        // Step 2: generous budget to finish everything.
+        let budget = IoBudget::new(100);
+        let out = sync_outgoing_state(
+            &backend,
+            f.constants.alice_address,
+            &viewing_key,
+            out.cursor,
+            &budget,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out.channels.len(), 2, "step 2: both channels processed");
+        assert!(
+            out.cursor.channels.is_empty(),
+            "step 2: all discovery complete"
+        );
+        assert_eq!(
+            out.channels[&f.constants.alice_address].subchannels[&f.constants.strk_token],
+            Some(0)
+        );
+        assert_eq!(
+            out.channels[&f.constants.bob_address].subchannels[&f.constants.strk_token],
+            Some(0)
+        );
+    }
+}


### PR DESCRIPTION
### TL;DR

Added outgoing state synchronization for privacy pools with improved channel key handling.

### What changed?

- Increased `COST_OUTGOING_CHANNEL_INFO` from 2 to 3 to account for public key retrieval
- Enhanced `OutgoingChannel` struct to include a `channel_key` derived from sender and recipient identities
- Added channel key registration in the discovery cursor
- Created a new `outgoing_state` module that orchestrates the full outgoing sync workflow:
  - Implements hierarchical discovery (channels → subchannels → note indices)
  - Parallelizes channel and subchannel processing using `tokio::task::JoinSet`
  - Provides cursor-based pagination with pruning of fully-discovered elements
- Added comprehensive tests for full discovery and pagination scenarios

### How to test?

Run the new tests in the `outgoing_state` module:
- `test_sync_outgoing_state_full_discovery`: Verifies complete discovery with a generous budget
- `test_sync_outgoing_state_pagination`: Tests pagination across multiple calls with limited budgets

### Why make this change?

This change completes the outgoing state synchronization workflow, enabling efficient discovery of outgoing channels, subchannels, and note indices. The addition of channel key handling improves the security model, while the parallelized processing enhances performance. The pagination support with cursor pruning ensures efficient resource usage during discovery operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/433)
<!-- Reviewable:end -->
