### PR TITLE
feat(indexer): preflight endpoint, sync with abstract discovery provider interface

### DIFF
--- a/.claude/specs/discovery-service/06-api-design.md
+++ b/.claude/specs/discovery-service/06-api-design.md
@@ -37,9 +37,9 @@ The service works with soft finality to provide updates as soon as possible. All
 
 For use cases requiring stronger finality, clients should wait for L1 confirmation before acting on discovered notes.
 
-## 6.5 Incoming Notes Discovery Endpoint
+## 6.5 Incoming State Sync Endpoint
 
-`POST /v1/discovery/incoming/sync`
+`POST /v1/sync/incoming_state`
 
 A unified endpoint that discovers channels, subchannels, and notes in one call with a composite cursor. This is the primary endpoint for incoming notes discovery.
 
@@ -52,22 +52,24 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
   "last_known_block": "0x...",
   "block_ref": "0x...",
   "cursor": {
+    "skip_channel_discovery": false,
     "total_n_channels": 100,
     "last_channel_index": 5,
     "channels": {
-      "0x_channel_key": {
-        "sender_addr": "0x...",
-        "total_n_subchannels": 10,
+      "0x_sender_addr": {
+        "channel_key": "0x...",
+        "skip_subchannel_discovery": true,
         "last_subchannel_index": 2,
         "subchannels": {
           "0x_token_address": {
-            "last_note_index": 3
+            "last_note_index": 3,
+            "max_note_index": 10
           }
         }
       }
     }
   },
-  "max_reads": 1000
+  "max_reads": 50
 }
 ```
 
@@ -78,18 +80,20 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 - `last_known_block`: Block hash from last completed sync session. Used for reorg detection on the first request of a new session. Server returns `409 BLOCK_REORGED` if this block is no longer canonical. Omit on fresh syncs or pagination requests.
 - `block_ref`: Block hash to query state at. Ensures consistent reads across paginated requests. Omit on first request (server resolves current head and returns it in the response).
 - `cursor`: Discovery pagination state (see below). Omit or send `{}` on first request.
-- `max_reads`: Maximum number of storage reads per request. Defaults to 1000, capped at 5000.
+- `max_reads`: Maximum number of storage reads per request. Defaults to 50, capped at 100.
 
 **Cursor fields:**
 
+- `skip_channel_discovery`: When `true`, only processes channels already in the cursor — use this after channel discovery is complete. Defaults to `false`.
 - `total_n_channels`: Cached total channel count. Populated by the server after the first channel-count fetch. Avoids re-fetching on subsequent pages.
 - `last_channel_index`: Last fully processed channel index. Omit to start from the beginning.
-- `channels`: Map of in-progress channels keyed by channel key. Each channel entry contains:
-  - `sender_addr`: Sender address for this channel.
-  - `total_n_subchannels`: Cached total subchannel count for this channel.
+- `channels`: Map of in-progress channels keyed by **sender address**. Each channel entry contains:
+  - `channel_key`: The channel key for this channel.
+  - `skip_subchannel_discovery`: When `true`, only processes subchannels already in the cursor (skips discovery of new subchannels).
   - `last_subchannel_index`: Last fully processed subchannel index.
   - `subchannels`: Map of in-progress subchannels keyed by token address, each with:
-    - `last_note_index`: Last fully processed note index.
+    - `last_note_index`: Last scanned note index.
+    - `max_note_index`: Last index confirmed to exist by exponential probe. Linear scan reads notes up to this index. Re-probe triggers when `last_note_index == max_note_index`.
 
 All cursor fields are optional and omitted when empty/null, keeping the cursor compact.
 
@@ -99,38 +103,23 @@ All cursor fields are optional and omitted when empty/null, keeping the cursor c
 {
   "block_ref": "0x...",
   "channels": {
-    "0x_channel_key_1": {
-      "sender_addr": "0x...",
+    "0x_sender_addr": {
+      "channel_key": "0x...",
       "subchannels": {
-        "0x_token_address_1": [
-          { "index": 1, "note_id": "0x...", "amount": 1000 }
+        "0x_token_address": [
+          { "index": 1, "note_id": "0x...", "amount": 1000, "salt": 42 }
         ]
       }
     }
   },
-  "cursor": {
-    "total_n_channels": 100,
-    "last_channel_index": 10,
-    "channels": {
-      "0x_channel_key_1": {
-        "sender_addr": "0x...",
-        "total_n_subchannels": 5,
-        "last_subchannel_index": 3,
-        "subchannels": {
-          "0x_token_address_1": {
-            "last_note_index": 10
-          }
-        }
-      }
-    }
-  }
+  "cursor": { "..." }
 }
 ```
 
 **Response fields:**
 
 - `block_ref`: Block hash pinning all reads in this response. Pass back as-is on pagination requests. Use as `last_known_block` for the next sync session.
-- `channels`: Discovered data for this page — channels with their subchannels and decrypted notes.
+- `channels`: Discovered data for this page, keyed by **sender address**. Each channel contains `channel_key` and `subchannels` (a map of token address to arrays of decrypted notes). Each note has `index`, `note_id`, `amount`, and `salt`.
 - `cursor`: Updated pagination state. Pass back as-is on the next request.
 
 **Completion detection:** Discovery is complete when `cursor.channels` is empty (all channels and subchannels have been fully processed and pruned from the cursor).
@@ -143,35 +132,77 @@ All cursor fields are optional and omitted when empty/null, keeping the cursor c
 
 **Future: Note filtering.** For each decrypted note, the service will derive the nullifier and check if it exists in contract state. Only unspent notes (those whose nullifier does not exist) will be included in the response. This is not yet implemented.
 
-## 6.6 Outgoing Channel Sync Endpoint
+## 6.6 Outgoing State Sync Endpoint
 
-Whenever a user wants to make a private transfer there are several things to determine:
+`POST /v1/sync/outgoing_state`
 
-1. Is the sender registered in the pool?
-2. Is the receiver registered in the pool?
-3. Is there an existing outgoing channel for the destination address?
-4. Is there an existing subchannel for the target token?
-5. What is the latest note index in that subchannel (if it exists)?
-
-The channel key is computed on the client using the viewing key. This avoids sending additional secrets to the service.
-
-Typically users should have this information cached locally but in case there's a need to recover it, the following method would do all the checks and encrypted note discovery.
-
-`POST /v1/discovery/outgoing/sync`
+Discovers all outgoing channels for a sender, their subchannels, and the last note index in each subchannel. Uses the same cursor structure as the incoming endpoint, but channels are keyed by **recipient address** and subchannels contain `last_note_index` (the last used note index) instead of decrypted notes.
 
 **Request:**
 
 ```json
 {
-  "sender_addr": "0x...",
-  "recipient_addr": "0x...",
-  "channel_key": "0x...",
-  "token_address": "0x...",
+  "sender_address": "0x...",
+  "viewing_key": "0x...",
+  "last_known_block": "0x...",
   "block_ref": "0x...",
   "cursor": {
-    "start_note_index": 0
+    "skip_channel_discovery": false,
+    "total_n_channels": null,
+    "last_channel_index": null,
+    "channels": {}
   },
-  "max_reads": 1000
+  "max_reads": 50
+}
+```
+
+**Top-level request fields:**
+
+- `sender_address`: The sender's Starknet address.
+- `viewing_key`: The sender's private viewing key (used to derive outgoing channel IDs and decrypt recipient addresses).
+- `last_known_block`, `block_ref`, `cursor`, `max_reads`: Same semantics as incoming (§6.5).
+
+**Response:**
+
+```json
+{
+  "block_ref": "0x...",
+  "channels": {
+    "0x_recipient_addr": {
+      "channel_key": "0x...",
+      "subchannels": {
+        "0x_token_address": 5
+      }
+    }
+  },
+  "cursor": { "..." }
+}
+```
+
+**Response fields:**
+
+- `block_ref`: Block hash pinning all reads.
+- `channels`: Discovered outgoing channels keyed by **recipient address**. Each channel contains:
+  - `channel_key`: The channel key for this outgoing channel.
+  - `subchannels`: Map of token address to `Option<u64>` — the last used note index (`null` if subchannel has no notes yet).
+- `cursor`: Updated pagination state (same structure as incoming cursor).
+
+**Completion detection:** Same as incoming — `cursor.channels` empty means all outgoing channels are fully discovered.
+
+## 6.7 Preflight Endpoint
+
+`POST /v1/discovery/preflight`
+
+Checks what setup is needed before a sender can transfer a specific token to a specific recipient. Returns three boolean flags indicating the current setup state. Always queries at the latest indexed head (no `block_ref`/cursor — constant scope of at most 4 storage reads).
+
+**Request:**
+
+```json
+{
+  "sender_address": "0x...",
+  "viewing_key": "0x...",
+  "recipient": "0x...",
+  "token": "0x..."
 }
 ```
 
@@ -179,24 +210,28 @@ Typically users should have this information cached locally but in case there's 
 
 ```json
 {
-  "head": { "block_number": 123456, "block_hash": "0x..." },
+  "block_ref": "0x...",
   "sender_registered": true,
-  "receiver_registered": true,
   "channel_exists": true,
-  "subchannel_exists": true,
-  "total_n_notes": 57,
-  "cursor": {
-    "start_note_index": 57
-  },
-  "stats": { "reads_used": 100 }
+  "subchannel_exists": true
 }
 ```
 
-**Completion detection:** Client computes done status: `cursor.start_note_index >= total_n_notes`.
+**Response fields:**
 
-**Current limitation:** This endpoint supports a single receiver/token pair per request. Future versions may support batch queries for multiple receivers to enable mass payout scenarios.
+- `block_ref`: Block hash pinning the reads.
+- `sender_registered`: Whether the sender has a public key registered on-chain. If `false`, the remaining flags are always `false` (can't derive channel key without sender registration).
+- `channel_exists`: Whether the channel from sender to recipient exists. Requires both sender and recipient to be registered. If the recipient is not registered, this is `false`.
+- `subchannel_exists`: Whether the token subchannel exists within the channel. Only `true` when both `sender_registered` and `channel_exists` are `true`.
 
-## 6.7 History Endpoint (Not Yet Specified)
+**Algorithm (4 direct storage lookups, no scanning):**
+
+1. `get_public_key(sender)` → if zero: `sender_registered=false`, done.
+2. `get_public_key(recipient)` → if zero: `channel_exists=false`, done.
+3. Derive `channel_key` + `channel_marker` → `channel_exists(marker)` → if false: `channel_exists=false`, done.
+4. Derive `subchannel_marker` → `subchannel_exists(marker)`.
+
+## 6.8 History Endpoint (Not Yet Specified)
 
 `POST /v1/discovery/history`
 

--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -40,10 +40,10 @@ pub struct ChannelCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub channel_key: Option<Felt>,
 
-    /// Total number of subchannels (cached when sentinel is found).
-    /// When set, subchannel discovery is skipped entirely — zero budget cost.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_n_subchannels: Option<u64>,
+    /// Skip subchannel discovery. When `true`, only processes subchannels
+    /// already in the cursor. Defaults to `false` (discover new subchannels).
+    #[serde(default)]
+    pub skip_subchannel_discovery: bool,
 
     /// Last fully processed subchannel index. `None` = start from index 0.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/discovery-core/src/discovery/incoming_channels.rs
+++ b/crates/discovery-core/src/discovery/incoming_channels.rs
@@ -189,7 +189,7 @@ pub async fn discover_incoming_channels_paginated<S: IViews>(
             .entry(channel.info.sender_addr)
             .or_insert(ChannelCursor {
                 channel_key: Some(channel.info.channel_key),
-                total_n_subchannels: None,
+                skip_subchannel_discovery: false,
                 last_subchannel_index: None,
                 subchannels: Default::default(),
             });

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -10,6 +10,7 @@ pub mod incoming_channels;
 pub mod last_note_index;
 pub mod notes;
 pub mod outgoing_channels;
+pub mod preflight;
 pub mod subchannels;
 
 /// Cost for `get_num_of_channels` (1 storage slot read).

--- a/crates/discovery-core/src/discovery/outgoing_channels.rs
+++ b/crates/discovery-core/src/discovery/outgoing_channels.rs
@@ -138,7 +138,7 @@ pub async fn discover_outgoing_channels_paginated<S: IViews>(
         let entry = cursor.channels.entry(ch.recipient_addr).or_insert_with(|| {
             super::cursor::ChannelCursor {
                 channel_key: None,
-                total_n_subchannels: None,
+                skip_subchannel_discovery: false,
                 last_subchannel_index: None,
                 subchannels: std::collections::HashMap::new(),
             }

--- a/crates/discovery-core/src/discovery/preflight.rs
+++ b/crates/discovery-core/src/discovery/preflight.rs
@@ -1,0 +1,154 @@
+//! Transfer readiness check (preflight).
+//!
+//! Checks what setup is needed before a sender can transfer a specific
+//! token to a specific recipient.
+
+use starknet_types_core::felt::Felt;
+
+use super::DiscoveryError;
+use crate::privacy_pool::hashes::{
+    compute_channel_key, compute_channel_marker, compute_subchannel_marker,
+};
+use crate::privacy_pool::types::SecretFelt;
+use crate::privacy_pool::views::IViews;
+
+/// Result of a preflight check — three boolean flags indicating setup state.
+#[derive(Debug, Clone)]
+pub struct PreflightOutput {
+    /// Whether the sender has a public key registered on-chain.
+    pub sender_registered: bool,
+    /// Whether the channel from sender to recipient exists.
+    pub channel_exists: bool,
+    /// Whether the token subchannel exists within the channel.
+    pub subchannel_exists: bool,
+}
+
+/// Checks transfer readiness for a `(sender, recipient, token)` tuple.
+///
+/// Performs at most 4 direct storage lookups (no scanning, no budget needed).
+/// Each subsequent check depends on the previous one — if the recipient isn't
+/// registered, we can't derive the channel key to check channel/subchannel existence.
+pub async fn preflight<S: IViews>(
+    pool: &S,
+    sender_addr: Felt,
+    viewing_key: &SecretFelt,
+    recipient: Felt,
+    token: Felt,
+) -> Result<PreflightOutput, DiscoveryError> {
+    // 1. Sender must be registered (caller error if not — can't derive anything)
+    let sender_pk = pool.get_public_key(sender_addr).await?;
+    if sender_pk == Felt::ZERO {
+        return Ok(PreflightOutput {
+            sender_registered: false,
+            channel_exists: false,
+            subchannel_exists: false,
+        });
+    }
+
+    // 2. Check recipient registration
+    let recipient_pk = pool.get_public_key(recipient).await?;
+    if recipient_pk == Felt::ZERO {
+        return Ok(PreflightOutput {
+            sender_registered: true,
+            channel_exists: false,
+            subchannel_exists: false,
+        });
+    }
+
+    // 3. Check channel existence
+    let channel_key = compute_channel_key(sender_addr, viewing_key, recipient, recipient_pk);
+    let channel_marker = compute_channel_marker(channel_key, sender_addr, recipient, recipient_pk);
+    let channel_exists = pool.channel_exists(channel_marker).await?;
+    if !channel_exists {
+        return Ok(PreflightOutput {
+            sender_registered: true,
+            channel_exists: false,
+            subchannel_exists: false,
+        });
+    }
+
+    // 4. Check subchannel existence
+    let subchannel_marker = compute_subchannel_marker(channel_key, recipient, recipient_pk, token);
+    let subchannel_exists = pool.subchannel_exists(subchannel_marker).await?;
+
+    Ok(PreflightOutput {
+        sender_registered: true,
+        channel_exists: true,
+        subchannel_exists,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_backend::MockBackend;
+    use crate::test_fixtures::load_devnet_fixture;
+
+    #[tokio::test]
+    async fn test_preflight_ready() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+        let c = &fixture.constants;
+
+        let viewing_key = SecretFelt::new(c.alice_viewing_key);
+        let result = preflight(
+            &backend,
+            c.alice_address,
+            &viewing_key,
+            c.bob_address,
+            c.strk_token,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.sender_registered);
+        assert!(result.channel_exists);
+        assert!(result.subchannel_exists);
+    }
+
+    #[tokio::test]
+    async fn test_preflight_setup_channel_unknown_recipient() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+        let c = &fixture.constants;
+
+        let viewing_key = SecretFelt::new(c.alice_viewing_key);
+        let unknown = Felt::from_hex_unchecked("0xdead");
+        let result = preflight(
+            &backend,
+            c.alice_address,
+            &viewing_key,
+            unknown,
+            c.strk_token,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.sender_registered);
+        assert!(!result.channel_exists);
+        assert!(!result.subchannel_exists);
+    }
+
+    #[tokio::test]
+    async fn test_preflight_register_unknown_sender() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+        let c = &fixture.constants;
+
+        let viewing_key = SecretFelt::new(Felt::from_hex_unchecked("0xbad"));
+        let unknown_sender = Felt::from_hex_unchecked("0xdead");
+        let result = preflight(
+            &backend,
+            unknown_sender,
+            &viewing_key,
+            c.bob_address,
+            c.strk_token,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result.sender_registered);
+        assert!(!result.channel_exists);
+        assert!(!result.subchannel_exists);
+    }
+}

--- a/crates/discovery-core/src/discovery/subchannels.rs
+++ b/crates/discovery-core/src/discovery/subchannels.rs
@@ -100,11 +100,11 @@ pub async fn discover_subchannels<PrivacyPool: IViews>(
 
 /// Discovers subchannels with cursor-based pagination.
 ///
-/// If `total_n_subchannels` is already set in the cursor (sentinel was found
+/// If `skip_subchannel_discovery` is set in the cursor (sentinel was found
 /// previously), returns an empty vec immediately — no budget consumed.
 ///
 /// Otherwise delegates to [`discover_subchannels`], adds new subchannels to the
-/// cursor, and sets `total_n_subchannels` once the sentinel is found.
+/// cursor, and sets `skip_subchannel_discovery` once the sentinel is found.
 pub async fn discover_subchannels_paginated<S: IViews>(
     pool: &S,
     channel_key: Felt,
@@ -112,7 +112,7 @@ pub async fn discover_subchannels_paginated<S: IViews>(
     budget: &IoBudget,
 ) -> Result<Vec<Subchannel>, DiscoveryError> {
     // Already fully enumerated — skip entirely.
-    if cursor.total_n_subchannels.is_some() {
+    if cursor.skip_subchannel_discovery {
         return Ok(Vec::new());
     }
 
@@ -128,7 +128,7 @@ pub async fn discover_subchannels_paginated<S: IViews>(
 
     // Sentinel found — cache the total count.
     if !result.has_more {
-        cursor.total_n_subchannels = Some(cursor.last_subchannel_index.map_or(0, |i| i + 1));
+        cursor.skip_subchannel_discovery = true;
     }
 
     Ok(result.subchannels)
@@ -295,7 +295,7 @@ mod tests {
 
         let mut cursor = ChannelCursor {
             channel_key: Some(channel_key),
-            total_n_subchannels: None,
+            skip_subchannel_discovery: false,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
         };
@@ -306,10 +306,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(subs.len(), 1, "should discover 1 subchannel (STRK)");
-        assert_eq!(
-            cursor.total_n_subchannels,
-            Some(1),
-            "total should be cached after sentinel"
+        assert!(
+            cursor.skip_subchannel_discovery,
+            "subchannel discovery should be marked complete after sentinel"
         );
         assert!(
             cursor
@@ -334,7 +333,7 @@ mod tests {
 
         let mut cursor = ChannelCursor {
             channel_key: Some(channel_key),
-            total_n_subchannels: None,
+            skip_subchannel_discovery: false,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
         };
@@ -344,7 +343,7 @@ mod tests {
         discover_subchannels_paginated(&backend, channel_key, &mut cursor, &budget)
             .await
             .unwrap();
-        assert!(cursor.total_n_subchannels.is_some());
+        assert!(cursor.skip_subchannel_discovery);
 
         // Second call: 0 budget — should return empty immediately
         let budget = IoBudget::new(0);
@@ -357,8 +356,8 @@ mod tests {
     }
 
     /// Both states have an empty subchannels map, but behavior differs:
-    /// - Fresh cursor (total_n_subchannels=None) → discovers subchannels
-    /// - Fully enumerated (total_n_subchannels=Some) → skips, zero budget cost
+    /// - Fresh cursor (skip_subchannel_discovery=false) → discovers subchannels
+    /// - Fully enumerated (skip_subchannel_discovery=true) → skips, zero budget cost
     #[tokio::test]
     async fn test_paginated_fresh_vs_fully_enumerated() {
         let fixture = load_devnet_fixture();
@@ -375,7 +374,7 @@ mod tests {
         // Fresh cursor: empty map + no total → should discover subchannels
         let mut fresh = ChannelCursor {
             channel_key: Some(channel_key),
-            total_n_subchannels: None,
+            skip_subchannel_discovery: false,
             last_subchannel_index: None,
             subchannels: HashMap::new(),
         };
@@ -385,11 +384,11 @@ mod tests {
             .unwrap();
         assert_eq!(subs.len(), 1, "fresh cursor should discover subchannels");
 
-        // Fully enumerated cursor: empty map + total set → should skip entirely
+        // Fully enumerated cursor: empty map + skip=true → should skip entirely
         // (simulates state after all notes processed and entries pruned)
         let mut done = ChannelCursor {
             channel_key: Some(channel_key),
-            total_n_subchannels: Some(1),
+            skip_subchannel_discovery: true,
             last_subchannel_index: Some(0),
             subchannels: HashMap::new(),
         };

--- a/crates/discovery-core/src/privacy_pool/hashes.rs
+++ b/crates/discovery-core/src/privacy_pool/hashes.rs
@@ -35,6 +35,14 @@ static NULLIFIER_TAG: LazyLock<Felt> = LazyLock::new(|| short_string_to_felt("NU
 static CHANNEL_KEY_TAG: LazyLock<Felt> =
     LazyLock::new(|| short_string_to_felt("CHANNEL_KEY_TAG:V1"));
 
+/// Domain separation tag for channel marker derivation.
+static CHANNEL_MARKER_TAG: LazyLock<Felt> =
+    LazyLock::new(|| short_string_to_felt("CHANNEL_MARKER_TAG:V1"));
+
+/// Domain separation tag for subchannel marker derivation.
+static SUBCHANNEL_MARKER_TAG: LazyLock<Felt> =
+    LazyLock::new(|| short_string_to_felt("SUBCHANNEL_MARKER_TAG:V1"));
+
 /// Domain separation tag for outgoing channel id derivation.
 static OUTGOING_CHANNEL_ID_TAG: LazyLock<Felt> =
     LazyLock::new(|| short_string_to_felt("OUTGOING_CHANNEL_ID_TAG:V1"));
@@ -157,6 +165,42 @@ pub fn compute_channel_key(
         **viewing_key,
         recipient_addr,
         recipient_public_key,
+    ])
+}
+
+/// Computes the channel marker for `channel_exists` storage lookup.
+///
+/// `channel_marker = hash(CHANNEL_MARKER_TAG, channel_key, sender_addr, recipient_addr, recipient_public_key)`
+pub fn compute_channel_marker(
+    channel_key: Felt,
+    sender_addr: Felt,
+    recipient_addr: Felt,
+    recipient_public_key: Felt,
+) -> Felt {
+    hash(&[
+        *CHANNEL_MARKER_TAG,
+        channel_key,
+        sender_addr,
+        recipient_addr,
+        recipient_public_key,
+    ])
+}
+
+/// Computes the subchannel marker for `subchannel_exists` storage lookup.
+///
+/// `subchannel_marker = hash(SUBCHANNEL_MARKER_TAG, channel_key, recipient_addr, recipient_public_key, token)`
+pub fn compute_subchannel_marker(
+    channel_key: Felt,
+    recipient_addr: Felt,
+    recipient_public_key: Felt,
+    token: Felt,
+) -> Felt {
+    hash(&[
+        *SUBCHANNEL_MARKER_TAG,
+        channel_key,
+        recipient_addr,
+        recipient_public_key,
+        token,
     ])
 }
 
@@ -308,6 +352,34 @@ mod tests {
         assert_eq!(
             compute_enc_recipient_addr_hash(f.inputs.sender, &key, f.inputs.index, f.inputs.salt),
             f.outputs.enc_recipient_addr_hash
+        );
+    }
+
+    #[test]
+    fn test_compute_channel_marker() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            compute_channel_marker(
+                f.inputs.channel_key,
+                f.inputs.sender,
+                f.inputs.recipient,
+                f.inputs.recipient_public_key,
+            ),
+            f.outputs.channel_marker
+        );
+    }
+
+    #[test]
+    fn test_compute_subchannel_marker() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            compute_subchannel_marker(
+                f.inputs.channel_key,
+                f.inputs.recipient,
+                f.inputs.recipient_public_key,
+                f.inputs.token,
+            ),
+            f.outputs.subchannel_marker
         );
     }
 }

--- a/crates/discovery-core/src/sync/incoming_state.rs
+++ b/crates/discovery-core/src/sync/incoming_state.rs
@@ -144,7 +144,7 @@ async fn process_channel<S: IViews>(
         }
     }
 
-    let fully_done = cursor.total_n_subchannels.is_some() && cursor.subchannels.is_empty();
+    let fully_done = cursor.skip_subchannel_discovery && cursor.subchannels.is_empty();
 
     Ok(ChannelResult {
         sender_addr,

--- a/crates/discovery-core/src/sync/outgoing_state.rs
+++ b/crates/discovery-core/src/sync/outgoing_state.rs
@@ -32,6 +32,8 @@ pub struct OutgoingDiscoveryOutput {
 /// Discovered data for a single outgoing channel within a run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutgoingChannelOutput {
+    /// The channel key for this outgoing channel.
+    pub channel_key: Felt,
     /// Last note index per subchannel, keyed by token address.
     pub subchannels: HashMap<Felt, Option<u64>>,
 }
@@ -129,11 +131,12 @@ async fn process_outgoing_channel<S: IViews>(
         }
     }
 
-    let fully_done = cursor.total_n_subchannels.is_some() && cursor.subchannels.is_empty();
+    let fully_done = cursor.skip_subchannel_discovery && cursor.subchannels.is_empty();
 
     Ok(OutgoingChannelResult {
         recipient_addr,
         output: OutgoingChannelOutput {
+            channel_key,
             subchannels: subchannel_results,
         },
         cursor: if fully_done { None } else { Some(cursor) },

--- a/crates/discovery-service/src/api_server.rs
+++ b/crates/discovery-service/src/api_server.rs
@@ -17,6 +17,7 @@ use tracing::{info, warn};
 use crate::chain_state::{ChainHead, ChainState};
 use crate::incoming_sync::incoming_sync_handler;
 use crate::outgoing_sync::outgoing_sync_handler;
+use crate::preflight::preflight_handler;
 
 /// Configuration for the API server.
 #[derive(Debug, Clone)]
@@ -69,6 +70,7 @@ where
             .route("/health", get(health_handler::<B>))
             .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
             .route("/v1/sync/outgoing_state", post(outgoing_sync_handler::<B>))
+            .route("/v1/discovery/preflight", post(preflight_handler::<B>))
             // TODO: Implement POST /v1/discovery/history endpoint (spec 6.7)
             .with_state(app_state);
 

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -11,5 +11,6 @@ pub mod chain_state;
 pub mod incoming_sync;
 pub mod indexer;
 pub mod outgoing_sync;
+pub mod preflight;
 pub mod rpc_backend;
 pub mod shutdown;

--- a/crates/discovery-service/src/preflight/handler.rs
+++ b/crates/discovery-service/src/preflight/handler.rs
@@ -1,0 +1,84 @@
+//! Handler for POST /v1/discovery/preflight.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use discovery_core::privacy_pool::types::SecretFelt;
+use discovery_core::storage_backend::StorageBackend;
+use tracing::warn;
+
+use crate::api_server::{discovery_error_to_response, error_codes, ApiErrorResponse, AppState};
+use crate::chain_state::ChainState;
+
+use super::types::{PreflightRequest, PreflightResponse};
+
+/// Handler for POST /v1/discovery/preflight.
+pub async fn preflight_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<PreflightRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    match preflight_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn preflight_impl<B>(
+    state: &AppState<B>,
+    request: PreflightRequest,
+) -> Result<PreflightResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    let head = state.backend.get_head().await.ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            ApiErrorResponse::new(
+                error_codes::SERVICE_UNAVAILABLE,
+                "No indexed head available yet",
+            ),
+        )
+    })?;
+
+    let snapshot = state
+        .backend
+        .snapshot(Some(starknet_core::types::BlockId::Hash(head.block_hash)))
+        .await
+        .map_err(|e| {
+            warn!("Failed to create snapshot: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(
+                    error_codes::INTERNAL_ERROR,
+                    format!("Failed to create snapshot: {}", e),
+                ),
+            )
+        })?;
+
+    let viewing_key = SecretFelt::new(request.viewing_key);
+
+    let output = discovery_core::discovery::preflight::preflight(
+        &snapshot,
+        request.sender_address,
+        &viewing_key,
+        request.recipient,
+        request.token,
+    )
+    .await
+    .map_err(discovery_error_to_response)?;
+
+    Ok(PreflightResponse {
+        block_ref: head.block_hash,
+        sender_registered: output.sender_registered,
+        channel_exists: output.channel_exists,
+        subchannel_exists: output.subchannel_exists,
+    })
+}

--- a/crates/discovery-service/src/preflight/mod.rs
+++ b/crates/discovery-service/src/preflight/mod.rs
@@ -1,0 +1,9 @@
+//! Preflight endpoint for transfer readiness checks.
+//!
+//! Provides the `POST /v1/discovery/preflight` endpoint.
+
+mod handler;
+mod types;
+
+pub use handler::preflight_handler;
+pub use types::{PreflightRequest, PreflightResponse};

--- a/crates/discovery-service/src/preflight/types.rs
+++ b/crates/discovery-service/src/preflight/types.rs
@@ -1,0 +1,30 @@
+//! Request/response types for the preflight endpoint.
+
+use serde::{Deserialize, Serialize};
+use starknet_core::types::Felt;
+
+/// Request body for POST /v1/discovery/preflight.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreflightRequest {
+    /// The sender's address.
+    pub sender_address: Felt,
+    /// The sender's private viewing key.
+    pub viewing_key: Felt,
+    /// The recipient's address.
+    pub recipient: Felt,
+    /// The token contract address.
+    pub token: Felt,
+}
+
+/// Response body for POST /v1/discovery/preflight.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreflightResponse {
+    /// Block hash pinning the reads in this response.
+    pub block_ref: Felt,
+    /// Whether the sender has a public key registered on-chain.
+    pub sender_registered: bool,
+    /// Whether the channel from sender to recipient exists.
+    pub channel_exists: bool,
+    /// Whether the token subchannel exists within the channel.
+    pub subchannel_exists: bool,
+}

--- a/crates/discovery-service/tests/common/devnet.rs
+++ b/crates/discovery-service/tests/common/devnet.rs
@@ -22,6 +22,9 @@ pub struct DumpMetadata {
     pub contract_address: Felt,
     pub alice_address: Felt,
     pub alice_viewing_key: Felt,
+    pub bob_address: Felt,
+    pub bob_viewing_key: Felt,
+    pub strk_token: Felt,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use discovery_service::api_server::ApiErrorResponse;
 use discovery_service::incoming_sync::{IncomingSyncRequest, IncomingSyncResponse};
 use discovery_service::outgoing_sync::{OutgoingSyncRequest, OutgoingSyncResponse};
+use discovery_service::preflight::{PreflightRequest, PreflightResponse};
 use nix::sys::signal::Signal;
 use reqwest::StatusCode;
 use starknet_types_core::felt::Felt;
@@ -163,6 +164,19 @@ impl IndexerClient {
         let status = resp.status();
         let error: ApiErrorResponse = resp.json().await?;
         Ok((status, error))
+    }
+
+    /// POST `/v1/discovery/preflight` and return the parsed success response.
+    pub async fn preflight(&self, req: &PreflightRequest) -> Result<PreflightResponse> {
+        let url = format!("http://{}/v1/discovery/preflight", self.api_host);
+        let resp = reqwest::Client::new().post(&url).json(req).send().await?;
+
+        let status = resp.status();
+        let body = resp.text().await?;
+        if status != StatusCode::OK {
+            return Err(anyhow!("Expected 200, got {}: {}", status, body));
+        }
+        Ok(serde_json::from_str(&body)?)
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/fixtures/devnet-dump.metadata.json
+++ b/crates/discovery-service/tests/fixtures/devnet-dump.metadata.json
@@ -2,5 +2,8 @@
   "timestamp": 1770398178,
   "contract_address": "0x2af189f2f77758dacd689baf7d0166e65b03f25be65f54f7d131b9cc8a0438d",
   "alice_address": "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba",
-  "alice_viewing_key": "0xa11ce"
+  "alice_viewing_key": "0xa11ce",
+  "bob_address": "0x2939f2dc3f80cc7d620e8a86f2e69c1e187b7ff44b74056647368b5c49dc370",
+  "bob_viewing_key": "0xb0b",
+  "strk_token": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
 }

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -1,4 +1,4 @@
-//! API server tests: health endpoint, incoming sync, outgoing sync.
+//! API server tests: health endpoint, incoming sync, outgoing sync, preflight.
 //!
 //! Run with: `cargo test -p discovery-service --test api_tests`
 //!
@@ -15,6 +15,7 @@ use common::{
 use discovery_service::api_server::HealthResponse;
 use discovery_service::incoming_sync::{IncomingSyncRequest, MAX_READS_CAP};
 use discovery_service::outgoing_sync::OutgoingSyncRequest;
+use discovery_service::preflight::PreflightRequest;
 use starknet_core::types::Felt;
 
 #[tokio::test]
@@ -282,6 +283,60 @@ async fn test_outgoing_sync_pagination() {
         2,
         "Should discover all 2 channels across pages"
     );
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_preflight_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // Alice→Bob for STRK: all setup complete
+    let resp = indexer
+        .preflight(&PreflightRequest {
+            sender_address: metadata.alice_address,
+            viewing_key: metadata.alice_viewing_key,
+            recipient: metadata.bob_address,
+            token: metadata.strk_token,
+        })
+        .await
+        .unwrap();
+
+    assert!(resp.sender_registered);
+    assert!(resp.channel_exists);
+    assert!(resp.subchannel_exists);
+
+    // Alice→unknown: recipient not registered, so channel/subchannel can't exist
+    let resp2 = indexer
+        .preflight(&PreflightRequest {
+            sender_address: metadata.alice_address,
+            viewing_key: metadata.alice_viewing_key,
+            recipient: Felt::from_hex_unchecked("0xdead"),
+            token: metadata.strk_token,
+        })
+        .await
+        .unwrap();
+
+    assert!(resp2.sender_registered);
+    assert!(!resp2.channel_exists);
+    assert!(!resp2.subchannel_exists);
+
+    // Random unregistered sender → all three false
+    let resp3 = indexer
+        .preflight(&PreflightRequest {
+            sender_address: Felt::from_hex_unchecked("0xdead"),
+            viewing_key: Felt::from_hex_unchecked("0xbad"),
+            recipient: metadata.bob_address,
+            token: metadata.strk_token,
+        })
+        .await
+        .unwrap();
+
+    assert!(!resp3.sender_registered);
+    assert!(!resp3.channel_exists);
+    assert!(!resp3.subchannel_exists);
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();


### PR DESCRIPTION
### TL;DR

Refactored the Discovery Service API with improved endpoint naming, enhanced cursor structure, and added a new preflight endpoint for transfer readiness checks.

### What changed?

- Renamed `/v1/discovery/incoming/sync` to `/v1/sync/incoming_state` for consistency
- Added new `/v1/discovery/preflight` endpoint to check transfer readiness
- Improved cursor structure:
  - Changed `total_n_subchannels` to `skip_subchannel_discovery` boolean flag
  - Added `skip_channel_discovery` flag to optimize channel discovery
  - Added `max_note_index` to optimize note scanning with exponential probing
  - Keyed channels by sender address instead of channel key for better organization
- Added helper functions for computing channel and subchannel markers
- Reduced default `max_reads` from 1000 to 50 (capped at 100) for better request sizing
- Enhanced response structure with more consistent field naming and organization

### How to test?

1. Use the new `/v1/sync/incoming_state` endpoint to discover incoming notes
2. Test the `/v1/sync/outgoing_state` endpoint to discover outgoing channels
3. Try the new `/v1/discovery/preflight` endpoint with:
   ```json
   {
     "sender_address": "0x...",
     "viewing_key": "0x...",
     "recipient": "0x...",
     "token": "0x..."
   }
   ```
4. Verify the preflight response contains the expected flags:
   ```json
   {
     "block_ref": "0x...",
     "sender_registered": true,
     "channel_exists": true,
     "subchannel_exists": true
   }
   ```

### Why make this change?

These changes improve the API's consistency, efficiency, and usability:

1. The preflight endpoint enables clients to quickly check transfer readiness with minimal storage reads (max 4)
2. The improved cursor structure reduces unnecessary storage reads by skipping already-discovered channels/subchannels
3. The exponential probing for note discovery optimizes scanning for sparse note distributions
4. Consistent naming and organization makes the API more intuitive and easier to use
5. Smaller default read limits help prevent excessive resource usage while still allowing pagination

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/439)
<!-- Reviewable:end -->
