### PR TITLE
feat(discovery-core): paginated notes discovery with nullifier filtering

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -114,3 +114,13 @@ pub struct SubchannelCursor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_note_index: Option<u64>,
 }
+
+impl SubchannelCursor {
+    /// Returns the next note index to scan from.
+    ///
+    /// If `last_note_index` is `Some(i)`, returns `i + 1` (resume after last
+    /// scanned). If `None`, returns 0 (fresh cursor).
+    pub fn start_index(&self) -> u64 {
+        self.last_note_index.map_or(0, |i| i + 1)
+    }
+}

--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -1,0 +1,193 @@
+//! Note index boundary probing.
+//!
+//! Probes note existence at exponentially increasing indices — no decryption,
+//! no nullifier checks. Used by notes discovery to find `max_note_index`
+//! for a linear scan.
+
+use std::collections::HashMap;
+
+use starknet_types_core::felt::Felt;
+
+use crate::discovery::{DiscoveryError, COST_NOTE_PROBING};
+
+use crate::io_budget::IoBudget;
+use crate::privacy_pool::hashes::compute_note_id;
+use crate::privacy_pool::views::IViews;
+
+/// Maximum offset for exponential probing. Caps the jump distance to avoid
+/// overshooting into sparse index space (offsets: 0, 1, 3, 7, …, 1023).
+/// TODO: make configurable
+const MAX_PROBE_OFFSET: u64 = 1024;
+
+/// Result of a batched exponential probe.
+pub struct ExponentialProbeResult {
+    /// Probed notes that exist: index → (note_id, packed_amount).
+    /// Used as a cache during the linear scan to avoid re-fetching amounts.
+    pub cache: HashMap<u64, (Felt, Felt)>,
+    /// Last index confirmed to exist.
+    /// `None` if the first probe missed (empty subchannel) or budget exhausted.
+    pub last_found_index: Option<u64>,
+    /// Whether the probe conclusively found the boundary (sentinel or start-of-empty).
+    /// `false` when the batch was truncated by budget before reaching a boundary.
+    pub probe_complete: bool,
+}
+
+/// Probes note existence at exponentially increasing indices in a single batch.
+///
+/// From `start`, probes at offsets `0, 1, 3, 7, 15, ..., 2^k - 1` capped at
+/// [`MAX_PROBE_OFFSET`]. The `2^k - 1` pattern is denser at the start than
+/// powers of 2, yielding more cache hits for small subchannels.
+///
+/// `prior_max` narrows the search when a previous probe already found a bound:
+/// - `None` (first discovery): offsets up to `MAX_PROBE_OFFSET`
+/// - `Some(m)` (re-probe after scan): range capped at `m * 2`
+///
+/// All probed notes that exist are cached in the result for use by the
+/// linear scan phase.
+///
+/// Issues exactly one batch of probes via `pool.get_notes_batch()`. Callers
+/// handle iteration via cursor-based pagination.
+pub async fn exponential_ascend<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    start_index: u64,
+    prior_max_index: Option<u64>,
+    budget: &IoBudget,
+) -> Result<ExponentialProbeResult, DiscoveryError> {
+    let max_index = match prior_max_index {
+        None => start_index.saturating_add(MAX_PROBE_OFFSET),
+        Some(prior_max) => prior_max.saturating_mul(2).max(start_index),
+    };
+    let max_probe_offset = max_index.saturating_sub(start_index);
+
+    // Offsets: [0, 1, 3, 7, 15, ..., 2^k - 1] where 2^k - 1 <= min(max_probe_offset, MAX_PROBE_OFFSET).
+    let offsets: Vec<u64> = std::iter::once(0)
+        .chain(
+            (1..64)
+                .map(|exp| (1u64 << exp) - 1)
+                .take_while(|&offset| offset <= max_probe_offset.min(MAX_PROBE_OFFSET)),
+        )
+        .collect();
+
+    // Consume as many probes as budget allows.
+    let (batch_size, budget_exhausted) = budget.consume_up_to(offsets.len(), COST_NOTE_PROBING);
+    if batch_size == 0 {
+        return Ok(ExponentialProbeResult {
+            cache: HashMap::new(),
+            last_found_index: None,
+            probe_complete: !budget_exhausted,
+        });
+    }
+
+    let note_ids: Vec<_> = offsets[..batch_size]
+        .iter()
+        .map(|&off| compute_note_id(channel_key, token, start_index + off))
+        .collect();
+    let results = pool.get_notes_batch(&note_ids).await?;
+
+    let mut cache = HashMap::new();
+    let mut last_found_index: Option<u64> = None;
+    let mut first_empty_index: Option<u64> = None;
+
+    for (i, &packed) in results.iter().enumerate() {
+        let idx = start_index + offsets[i];
+        if packed != Felt::ZERO {
+            cache.insert(idx, (note_ids[i], packed));
+            last_found_index = Some(idx);
+        } else {
+            first_empty_index = Some(idx);
+            break;
+        }
+    }
+    // Probe is complete when we found a sentinel, or when no notes exist at all
+    // (first probe missed and budget wasn't the limiting factor).
+    let probe_complete =
+        first_empty_index.is_some() || (!budget_exhausted && last_found_index.is_none());
+
+    Ok(ExponentialProbeResult {
+        cache,
+        last_found_index,
+        probe_complete,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privacy_pool::hashes::compute_note_id;
+    use crate::privacy_pool::storage_slots;
+    use crate::storage_backend::MockBackend;
+
+    const CK: Felt = Felt::from_hex_unchecked("0x12345");
+    const TK: Felt = Felt::from_hex_unchecked("0x67890");
+
+    /// Creates a mock backend with notes at indices 0..=last_index.
+    fn mock_with_notes(last_index: Option<u64>) -> MockBackend {
+        let mut backend = MockBackend::empty();
+        if let Some(last) = last_index {
+            for i in 0..=last {
+                let note_id = compute_note_id(CK, TK, i);
+                let slot = storage_slots::notes(note_id);
+                backend.insert(slot, Felt::ONE); // non-zero = exists
+            }
+        }
+        backend
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_empty() {
+        let backend = mock_with_notes(None);
+        let budget = IoBudget::new(100);
+        let result = exponential_ascend(&backend, CK, TK, 0, None, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.last_found_index, None);
+        assert!(result.cache.is_empty());
+        assert!(result.probe_complete);
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_one_element() {
+        // Elements at 0 only. Probes: offset 0→0 (hit), 1→1 (miss).
+        let backend = mock_with_notes(Some(0));
+        let budget = IoBudget::new(100);
+        let result = exponential_ascend(&backend, CK, TK, 0, None, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.last_found_index, Some(0));
+        assert_eq!(result.cache.len(), 1);
+        assert!(result.probe_complete);
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_multiple_elements() {
+        // Elements at 0..=4. Probes: offset 0→0 (hit), 1→1 (hit),
+        // 3→3 (hit), 7→7 (miss)
+        let backend = mock_with_notes(Some(4));
+        let budget = IoBudget::new(100);
+        let result = exponential_ascend(&backend, CK, TK, 0, None, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.last_found_index, Some(3));
+        assert_eq!(result.cache.len(), 3);
+        assert!(result.probe_complete);
+    }
+
+    #[tokio::test]
+    async fn test_exponential_ascend_probe_incomplete() {
+        let backend = mock_with_notes(Some(100));
+        // Budget for only 2 probes: offsets 0, 1
+        let budget = IoBudget::new(2 * COST_NOTE_PROBING);
+        let result = exponential_ascend(&backend, CK, TK, 0, None, &budget)
+            .await
+            .unwrap();
+
+        assert_eq!(result.last_found_index, Some(1));
+        assert_eq!(result.cache.len(), 2);
+        assert!(!result.probe_complete);
+    }
+}

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -8,6 +8,7 @@ use crate::storage_backend::StorageError;
 pub mod cursor;
 pub use cursor::{ChannelCursor, DiscoveryCursor, SubchannelCursor};
 pub mod incoming_channels;
+pub mod last_note_index;
 pub mod notes;
 pub mod subchannels;
 

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -1,31 +1,43 @@
 //! Notes discovery for a subchannel (channel_key + token pair).
 //!
-//! This module provides functionality to discover and decrypt notes
-//! within a specific subchannel.
+//! Two-phase algorithm:
+//! 1. **Exponential probe**: batched probes at exponentially increasing indices
+//!    to find `max_note_index` (the last index confirmed to exist).
+//! 2. **Linear scan**: nullifier-first batches for all notes in
+//!    `start..=max_note_index`. Spent notes skip the amount fetch; cached
+//!    amounts from the probe phase skip it too.
 //!
-//! # Sequential vs Parallel Scanning
-//!
-//! Notes within a subchannel are scanned sequentially because:
-//! - Request budget is limited and pagination is cursor-based
-//! - Parallel requests may not all complete within budget
-//! - Sequential scanning avoids gaps in discovered indices
-//!
-//! However, parallelization is possible at higher levels:
+//! Parallelization is possible at higher levels:
 //! - Multiple subchannel scans (for notes) can run in parallel
 //! - Multiple channel scans (for subchannels) can run in parallel
 
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-use super::{DiscoveryError, COST_NOTE};
+use tracing::{debug, trace};
+
+use crate::discovery::cursor::SubchannelCursor;
+use crate::discovery::last_note_index::{exponential_ascend, ExponentialProbeResult};
+use crate::discovery::{DiscoveryError, COST_NOTE, COST_NOTE_PROBING};
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::{decrypt_note_amount, unpack_note_amount};
-use crate::privacy_pool::hashes::compute_note_id;
+use crate::privacy_pool::felt_hex;
+use crate::privacy_pool::hashes::{compute_note_id, compute_nullifier};
+use crate::privacy_pool::types::SecretFelt;
 use crate::privacy_pool::views::IViews;
 
 /// A discovered and decrypted note.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecryptedNote {
-    /// The index of this note within the subchannel.
+    /// The sender's address. Set by the sync orchestrator after discovery.
+    #[serde(default)]
+    pub sender_addr: Felt,
+    /// The token address. Set by the sync orchestrator after discovery.
+    #[serde(default)]
+    pub token: Felt,
+    /// The note's index within its subchannel.
     pub index: u64,
     /// The note ID (storage key).
     pub note_id: Felt,
@@ -40,85 +52,269 @@ pub struct DecryptedNote {
 pub struct NotesDiscoveryResult {
     /// List of discovered and decrypted notes.
     pub notes: Vec<DecryptedNote>,
-    /// Index of the last discovered note, or `None` if no notes
-    /// were discovered.
+    /// Index of the last scanned note, or `None` if no notes were scanned.
+    /// Includes spent (filtered) notes. Use for cursor updates:
+    /// `cursor.last_note_index = result.last_index`.
     pub last_index: Option<u64>,
     /// Whether there may be more notes to discover.
-    /// `true` if stopped due to budget exhaustion, `false` if sentinel was found.
+    /// `true` if stopped due to budget exhaustion, `false` if all notes scanned.
     pub has_more: bool,
 }
 
-/// Discovers and decrypts notes for a given channel key and token.
+/// Discovers notes with cursor-based pagination using batched RPC calls.
 ///
-/// # Algorithm
+/// Two-phase algorithm:
+/// 1. **Exponential probe** (when `max_note_index` is unknown or scan caught up):
+///    batched probes to find the last existing note index. All probe hits are
+///    cached for use by the linear scan.
+/// 2. **Linear scan** (when `last_note_index < max_note_index`): nullifier-first
+///    batches that skip amount fetches for spent and cached notes.
 ///
-/// For each note index starting from `start_index`:
-/// 1. Compute `note_id = hash(NOTE_ID_TAG, channel_key, token, index, 0)`
-/// 2. Fetch `packed_amount` from storage
-/// 3. If `packed_amount == 0`, stop (sentinel - no more notes)
-/// 4. Decrypt to get `(amount, salt)`
+/// `max_note_index` is kept after scan — used to bound the next exponential
+/// probe range. Re-probe triggers when `last_note_index == max_note_index`.
+pub async fn discover_notes_paginated<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    cursor: &mut SubchannelCursor,
+    private_key: &SecretFelt,
+    budget: &IoBudget,
+) -> Result<Vec<DecryptedNote>, DiscoveryError> {
+    let start_index = cursor.start_index();
+
+    debug!(
+        token = felt_hex(&token),
+        start_index,
+        max_note_index = ?cursor.max_note_index,
+        budget = budget.remaining(),
+        "discover_notes_paginated start"
+    );
+
+    let (probe_cache, probe_has_more) =
+        probe_note_boundary(pool, channel_key, token, cursor, budget).await?;
+
+    // None means empty subchannel (first probe missed) or budget exhausted
+    // before any probe ran — either way, nothing to scan.
+    let Some(max_note_index) = cursor.max_note_index else {
+        cursor.note_discovery_complete = !probe_has_more;
+        return Ok(Vec::new());
+    };
+
+    let NotesDiscoveryResult {
+        notes,
+        last_index,
+        has_more: scan_has_more,
+    } = discover_notes(
+        pool,
+        channel_key,
+        token,
+        start_index,
+        max_note_index,
+        private_key,
+        budget,
+        &probe_cache,
+    )
+    .await?;
+
+    if let Some(last_index) = last_index {
+        cursor.last_note_index = Some(last_index);
+    }
+    let has_more = scan_has_more || probe_has_more;
+    cursor.note_discovery_complete = !has_more;
+
+    debug!(
+        unspent = notes.len(),
+        last_scanned = ?last_index,
+        has_more,
+        budget = budget.remaining(),
+        "discover_notes_paginated done"
+    );
+
+    Ok(notes)
+}
+
+/// Probes for the note boundary, updating `cursor.max_note_index`.
 ///
-/// # Arguments
+/// Skips probing when the cursor already has a valid bound beyond `start_index`
+/// (resume-after-budget-exhaustion). Re-probing mid-scan would overwrite
+/// `max_note_index` with a smaller value, losing the known bound.
 ///
-/// * `privacy_pool` - Storage backend implementing the IViews trait.
-/// * `channel_key` - The channel key.
-/// * `token` - The token address for this subchannel.
-/// * `start_index` - Starting index (inclusive). For incremental discovery, pass
-///   `last_index + 1` from previous result.
-/// * `budget` - I/O budget to limit storage operations.
+/// Returns `(probe_cache, probe_has_more)`:
+/// - `probe_cache`: index -> (note_id, packed_amount) for probe hits.
+/// - `probe_has_more`: `true` when the probe couldn't conclusively find the
+///   boundary (budget exhausted or all probes hit). When `true`, the subchannel
+///   must not be pruned even if the scan reaches `max_note_index`.
+async fn probe_note_boundary<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    cursor: &mut SubchannelCursor,
+    budget: &IoBudget,
+) -> Result<(HashMap<u64, (Felt, Felt)>, bool), DiscoveryError> {
+    let start_index = cursor.start_index();
+
+    if cursor
+        .max_note_index
+        .is_some_and(|max_note_index| start_index < max_note_index)
+    {
+        return Ok((HashMap::new(), false));
+    }
+
+    let ExponentialProbeResult {
+        cache,
+        last_found_index,
+        probe_complete,
+    } = exponential_ascend(
+        pool,
+        channel_key,
+        token,
+        start_index,
+        cursor.max_note_index,
+        budget,
+    )
+    .await?;
+
+    // Clears max_note_index when no notes found, so the caller skips the linear scan.
+    cursor.max_note_index = last_found_index;
+
+    Ok((cache, !probe_complete))
+}
+
+/// Linear scan of notes in `start_index..=end_index`.
 ///
-/// # Returns
-///
-/// A `NotesDiscoveryResult` containing all discovered notes and metadata
-/// for incremental discovery.
-pub async fn discover_notes<PrivacyPool: IViews>(
-    privacy_pool: &PrivacyPool,
+/// Consumes as many notes as the budget allows in a single pass. The RPC
+/// backend handles chunking large slot reads internally.
+#[allow(clippy::too_many_arguments)]
+async fn discover_notes<S: IViews>(
+    pool: &S,
     channel_key: Felt,
     token: Felt,
     start_index: u64,
+    end_index: u64,
+    private_key: &SecretFelt,
     budget: &IoBudget,
+    probe_cache: &HashMap<u64, (Felt, Felt)>,
 ) -> Result<NotesDiscoveryResult, DiscoveryError> {
-    let mut notes = Vec::new();
-    let mut index = start_index;
-    let mut out_of_budget = false;
-
-    loop {
-        // Consume budget for get_note
-        if !budget.consume(COST_NOTE) {
-            out_of_budget = true;
-            break;
-        }
-
-        let note_id = compute_note_id(channel_key, token, index);
-        let packed_amount = privacy_pool.get_note(note_id).await?;
-
-        // Sentinel: contract stores zero for non-existent notes
-        if packed_amount == Felt::ZERO {
-            break;
-        }
-
-        let (salt, enc_amount) = unpack_note_amount(packed_amount);
-
-        // TODO: Open notes (salt == 1) store the amount in plaintext,
-        // so enc_amount is already the actual amount - no decryption needed.
-        let amount = decrypt_note_amount(enc_amount, salt, channel_key, token, index);
-
-        notes.push(DecryptedNote {
-            index,
-            note_id,
-            amount,
-            salt,
+    let num_remaining_notes = usize::try_from(end_index - start_index + 1)
+        .map_err(|_| DiscoveryError::InvalidCursor("note range too large".into()))?;
+    let (batch_size, budget_exhausted) = budget.consume_up_to(num_remaining_notes, COST_NOTE);
+    if batch_size == 0 {
+        return Ok(NotesDiscoveryResult {
+            notes: Vec::new(),
+            last_index: None,
+            has_more: budget_exhausted,
         });
-        index += 1;
     }
 
-    let last_index = notes.last().map(|n| n.index);
+    let batch_end = start_index
+        + u64::try_from(batch_size)
+            .map_err(|_| DiscoveryError::InvalidCursor("batch size overflow".into()))?;
+
+    let (notes, num_skipped) = process_note_batch(
+        pool,
+        channel_key,
+        token,
+        start_index..batch_end,
+        private_key,
+        probe_cache,
+    )
+    .await?;
+
+    // Reclaim the budget for the skipped notes.
+    budget.reclaim(num_skipped * COST_NOTE_PROBING);
 
     Ok(NotesDiscoveryResult {
         notes,
-        last_index,
-        has_more: out_of_budget,
+        last_index: Some(batch_end - 1), // we have checked batch size > 0, so it's safe
+        has_more: budget_exhausted,
     })
+}
+
+/// Processes a single batch of notes: nullifier check → resolve amounts → decrypt.
+///
+/// Budget for the batch was pre-consumed pessimistically at `COST_NOTE` (2) per
+/// note. Returns unspent notes and the number of notes that were skipped due to being spent or
+/// having a cached amount from the probe.
+async fn process_note_batch<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    indices: std::ops::Range<u64>,
+    private_key: &SecretFelt,
+    probe_cache: &HashMap<u64, (Felt, Felt)>,
+) -> Result<(Vec<DecryptedNote>, usize), DiscoveryError> {
+    // Batch-check nullifiers.
+    let nullifiers: Vec<_> = indices
+        .clone()
+        .map(|i| compute_nullifier(channel_key, token, i, private_key))
+        .collect();
+    let spent_flags = pool.nullifier_exists_batch(&nullifiers).await?;
+
+    // Classify: spent → skip, unspent+cached → insert with amount,
+    // unspent+uncached → collect for batch fetch.
+    let mut unspent_notes: HashMap<u64, (Felt, Felt)> = HashMap::new();
+    let mut indices_to_fetch: Vec<u64> = Vec::new();
+    let mut num_skipped = 0;
+
+    for (j, idx) in indices.clone().enumerate() {
+        if spent_flags[j] {
+            num_skipped += 1;
+            continue;
+        }
+        if let Some(&cached_note) = probe_cache.get(&idx) {
+            num_skipped += 1;
+            unspent_notes.insert(idx, cached_note);
+        } else {
+            indices_to_fetch.push(idx);
+        }
+    }
+
+    // Fetch amounts for uncached unspent notes, merge into map.
+    if !indices_to_fetch.is_empty() {
+        let note_ids: Vec<_> = indices_to_fetch
+            .iter()
+            .map(|&index| compute_note_id(channel_key, token, index))
+            .collect();
+        let packed_values = pool.get_notes_batch(&note_ids).await?;
+        for (index, (note_id, packed)) in indices_to_fetch
+            .iter()
+            .zip(note_ids.into_iter().zip(packed_values))
+        {
+            unspent_notes.insert(*index, (note_id, packed));
+        }
+    }
+
+    // Decrypt in index order by iterating the original batch range.
+    let notes = indices
+        .filter_map(|idx| {
+            unspent_notes
+                .remove(&idx)
+                .map(|(note_id, packed)| decrypt_note(channel_key, token, idx, note_id, packed))
+        })
+        .collect();
+
+    Ok((notes, num_skipped))
+}
+
+/// Unpacks and decrypts a single note from its packed storage value.
+fn decrypt_note(
+    channel_key: Felt,
+    token: Felt,
+    index: u64,
+    note_id: Felt,
+    packed: Felt,
+) -> DecryptedNote {
+    let (salt, enc_amount) = unpack_note_amount(packed);
+    let amount = decrypt_note_amount(enc_amount, salt, channel_key, token, index);
+    trace!(index, amount, "unspent note found");
+    DecryptedNote {
+        sender_addr: Felt::ZERO,
+        token: Felt::ZERO,
+        index,
+        note_id,
+        amount,
+        salt,
+    }
 }
 
 #[cfg(test)]
@@ -127,6 +323,29 @@ mod tests {
     use crate::storage_backend::MockBackend;
     use crate::test_fixtures::{get_channel_key, get_subchannel_token, load_devnet_fixture};
 
+    /// Helper: runs discover_notes_paginated with a fresh default cursor and
+    /// returns the result along with the cursor for inspection.
+    async fn discover_with_fresh_cursor(
+        backend: &MockBackend,
+        channel_key: Felt,
+        token: Felt,
+        private_key: &SecretFelt,
+        budget: &IoBudget,
+    ) -> (Vec<DecryptedNote>, SubchannelCursor) {
+        let mut cursor = SubchannelCursor::default();
+        let notes = discover_notes_paginated(
+            backend,
+            channel_key,
+            token,
+            &mut cursor,
+            private_key,
+            budget,
+        )
+        .await
+        .unwrap();
+        (notes, cursor)
+    }
+
     #[tokio::test]
     async fn test_discover_no_notes() {
         let backend = MockBackend::empty();
@@ -134,13 +353,15 @@ mod tests {
         let token = Felt::from_hex_unchecked("0x67890");
         let budget = IoBudget::new(100);
 
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
-            .await
-            .unwrap();
+        let zero_key = SecretFelt::new(Felt::ZERO);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &zero_key, &budget).await;
 
-        assert_eq!(result.notes.len(), 0);
-        assert_eq!(result.last_index, None);
-        assert!(!result.has_more);
+        assert_eq!(notes.len(), 0);
+        assert!(
+            cursor.note_discovery_complete,
+            "empty subchannel is complete"
+        );
     }
 
     #[tokio::test]
@@ -148,7 +369,6 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // Discover channel -> subchannel -> notes
         let channel_key = get_channel_key(
             &backend,
             fixture.constants.alice_address,
@@ -162,19 +382,17 @@ mod tests {
             .expect("Alice's channel should have at least one subchannel");
 
         let budget = IoBudget::new(100);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
-            .await
-            .unwrap();
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &key, &budget).await;
 
-        assert!(
-            !result.notes.is_empty(),
-            "Alice's self-channel should have notes"
-        );
-        assert_eq!(result.last_index, result.notes.last().map(|n| n.index));
-        assert!(!result.has_more);
-        assert_eq!(result.notes[0].index, 0);
-        // The amount should be positive
-        assert!(result.notes[0].amount > 0, "Note amount should be positive");
+        // Alice deposited 100 STRK, transferred 50 to Bob.
+        // The transfer consumed the deposit and wrote a change note (50 STRK)
+        // at index 0. This note is unspent.
+        assert_eq!(notes.len(), 1, "1 unspent change note");
+        assert!(notes[0].amount > 0, "Note amount should be positive");
+        assert_eq!(cursor.last_note_index, Some(0));
+        assert!(cursor.note_discovery_complete);
     }
 
     #[tokio::test]
@@ -182,7 +400,6 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // Discover Bob's incoming channel
         let channel_key = get_channel_key(
             &backend,
             fixture.constants.bob_address,
@@ -196,16 +413,14 @@ mod tests {
             .expect("Bob's channel should have at least one subchannel");
 
         let budget = IoBudget::new(100);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
-            .await
-            .unwrap();
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &key, &budget).await;
 
-        assert!(
-            !result.notes.is_empty(),
-            "Bob should have received notes from Alice"
-        );
-        assert!(!result.has_more);
-        assert!(result.notes[0].amount > 0, "Note amount should be positive");
+        // Bob withdrew his 50 STRK note → nullifier exists → filtered out
+        assert_eq!(notes.len(), 0, "Bob's note is spent");
+        assert_eq!(cursor.last_note_index, Some(0), "note 0 was scanned");
+        assert!(cursor.note_discovery_complete);
     }
 
     #[tokio::test]
@@ -213,7 +428,6 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // Discover Alice's channel and subchannel
         let channel_key = get_channel_key(
             &backend,
             fixture.constants.alice_address,
@@ -226,27 +440,24 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        // First discovery
+        // First discovery — Alice has 1 unspent change note (50 STRK at index 0)
         let budget = IoBudget::new(100);
-        let result1 = discover_notes(&backend, channel_key, token, 0, &budget)
-            .await
-            .unwrap();
-        assert!(!result1.notes.is_empty());
-        assert!(!result1.has_more);
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let mut cursor = SubchannelCursor::default();
+        let notes =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
+                .await
+                .unwrap();
+        assert_eq!(notes.len(), 1, "1 unspent change note");
+        assert!(cursor.note_discovery_complete);
 
-        // Incremental discovery starting from last_index + 1 - should find 0 new notes
-        let result2 = discover_notes(
-            &backend,
-            channel_key,
-            token,
-            result1.last_index.unwrap() + 1,
-            &budget,
-        )
-        .await
-        .unwrap();
-        assert_eq!(result2.notes.len(), 0);
-        assert_eq!(result2.last_index, None);
-        assert!(!result2.has_more);
+        // Incremental discovery — should find 0 new notes (sentinel at index 1)
+        let notes2 =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
+                .await
+                .unwrap();
+        assert_eq!(notes2.len(), 0);
+        assert!(cursor.note_discovery_complete);
     }
 
     #[tokio::test]
@@ -254,7 +465,6 @@ mod tests {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
-        // Discover Alice's channel and subchannel
         let channel_key = get_channel_key(
             &backend,
             fixture.constants.alice_address,
@@ -267,14 +477,178 @@ mod tests {
             .await
             .expect("Alice's channel should have at least one subchannel");
 
-        // Budget exhausted before starting (COST_NOTE = 2)
+        // Budget exhausted before starting
         let budget = IoBudget::new(0);
-        let result = discover_notes(&backend, channel_key, token, 0, &budget)
-            .await
-            .unwrap();
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &key, &budget).await;
 
-        assert_eq!(result.notes.len(), 0);
-        assert_eq!(result.last_index, None);
-        assert!(result.has_more);
+        assert_eq!(notes.len(), 0);
+        assert!(
+            !cursor.note_discovery_complete,
+            "budget exhausted is not complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_exponential_probe_empty_subchannel() {
+        // Empty subchannel: exponential probe finds sentinel at offset 0.
+        // All 11 offsets are probed in one batch. First probe (offset 0) misses,
+        // so sentinel is found immediately. Cost = 11 * COST_NOTE_PROBING = 11.
+        let backend = MockBackend::empty();
+        let channel_key = Felt::from_hex_unchecked("0x12345");
+        let token = Felt::from_hex_unchecked("0x67890");
+        let budget = IoBudget::new(100);
+
+        let zero_key = SecretFelt::new(Felt::ZERO);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &zero_key, &budget).await;
+
+        assert_eq!(notes.len(), 0);
+        assert!(
+            cursor.note_discovery_complete,
+            "sentinel found, not budget exhaustion"
+        );
+        assert_eq!(budget.remaining(), 89);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_full_discovery() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let mut cursor = SubchannelCursor::default();
+        let budget = IoBudget::new(100);
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
+        let notes =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
+                .await
+                .unwrap();
+
+        // Bob's note is spent → filtered out
+        assert_eq!(notes.len(), 0, "Bob's note is spent");
+        assert!(cursor.note_discovery_complete, "sentinel should be found");
+    }
+
+    #[tokio::test]
+    async fn test_budget_exhaustion_then_resume_skips_initial_probe() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let mut cursor = SubchannelCursor::default();
+
+        // First call with enough budget to discover notes.
+        let budget = IoBudget::new(100);
+        let notes =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
+                .await
+                .unwrap();
+        assert_eq!(notes.len(), 1);
+        assert!(cursor.note_discovery_complete);
+
+        // Now resume — cursor.last_note_index is Some(0), so start_index = 1.
+        // It should find sentinel at index 1 and return immediately.
+        let budget2 = IoBudget::new(100);
+        let notes2 =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget2)
+                .await
+                .unwrap();
+        assert_eq!(notes2.len(), 0);
+        assert!(cursor.note_discovery_complete);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_budget_limited() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.bob_address,
+            &fixture.constants.bob_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let mut cursor = SubchannelCursor::default();
+        let key = SecretFelt::new(fixture.constants.bob_viewing_key);
+        // Bob has 1 note at index 0.
+        // Exponential probe: 11 offsets consumed upfront. Hit at 0, miss at 1.
+        //   Cost = 11 * COST_NOTE_PROBING = 11.
+        // Scan: budget exhausted (0 remaining) → has_more = true.
+        let budget = IoBudget::new(11);
+        let notes =
+            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(notes.len(), 0, "no budget left for scan");
+        assert_eq!(
+            cursor.max_note_index,
+            Some(0),
+            "probe found note at index 0"
+        );
+        assert!(
+            !cursor.note_discovery_complete,
+            "scan budget exhausted is not complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_cache_saves_budget() {
+        // Alice has 1 unspent note at index 0. The probe hits index 0 and
+        // caches its packed_amount. The scan only needs a nullifier check —
+        // amount comes from cache, saving 1 budget unit.
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .unwrap();
+        let token = get_subchannel_token(&backend, channel_key).await.unwrap();
+
+        let key = SecretFelt::new(fixture.constants.alice_viewing_key);
+        let budget = IoBudget::new(100);
+
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &key, &budget).await;
+
+        assert_eq!(notes.len(), 1, "1 unspent note");
+        assert!(cursor.note_discovery_complete);
+        assert_eq!(cursor.last_note_index, Some(0));
+        // Probe: 11 probes (offsets 0, 1, 3, 7, ..., 1023) = 11 budget.
+        //   Hit at 0, miss at 1 → cache has index 0.
+        // Scan: pre-consume 2 (COST_NOTE), nullifier → unspent, cached → reclaim 1.
+        //   Net scan cost = 1. Total = 12.
+        // Without cache, scan would cost 2 (nullifier + amount fetch). Saves 1.
+        assert_eq!(
+            budget.remaining(),
+            88,
+            "cache saves 1 budget unit vs no-cache"
+        );
     }
 }

--- a/crates/discovery-core/src/io_budget.rs
+++ b/crates/discovery-core/src/io_budget.rs
@@ -44,6 +44,16 @@ impl IoBudget {
             .is_ok()
     }
 
+    /// Atomically returns `count` units back to the budget.
+    ///
+    /// Used when a pre-consumed unit turns out unnecessary (e.g., a spent note
+    /// doesn't need an amount fetch, or a cached note already has its amount).
+    pub fn reclaim(&self, count: usize) {
+        if count > 0 {
+            self.remaining.fetch_add(count, Ordering::SeqCst);
+        }
+    }
+
     /// Atomically consumes as many whole items as the budget allows.
     ///
     /// Returns `(num_consumed_items, budget_exhausted)`:
@@ -186,6 +196,20 @@ mod tests {
         // 100 / 2 = 50 items total possible
         assert_eq!(total, 50);
         assert_eq!(budget.remaining(), 0);
+    }
+
+    #[test]
+    fn test_reclaim_after_consume() {
+        let budget = IoBudget::new(10);
+        assert!(budget.consume(6));
+        assert_eq!(budget.remaining(), 4);
+
+        budget.reclaim(3);
+        assert_eq!(budget.remaining(), 7);
+
+        // Reclaim zero does nothing
+        budget.reclaim(0);
+        assert_eq!(budget.remaining(), 7);
     }
 
     #[test]

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -222,6 +222,7 @@ impl RawStorageAccess for RpcSnapshot {
         }
 
         let mut results = Vec::with_capacity(slots.len());
+        // TODO: consider provessing chunks concurrently
         for chunk in slots.chunks(self.backend.inner.max_batch_size) {
             let chunk_results = self.batch_read(chunk).await?;
             results.extend(chunk_results);

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -8,7 +8,14 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
+use super::devnet::DevnetClient;
 use super::process::{find_free_port, signal_process};
+
+/// Default timeout for startup-related waits (API + subscription + reconnection).
+pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default timeout for block-related waits (new block notification, shutdown, retry).
+pub const DEFAULT_BLOCK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Wrapper for the discovery-service binary.
 pub struct IndexerClient {
@@ -93,6 +100,20 @@ impl IndexerClient {
                 .collect();
             Err(anyhow!("Timeout waiting for: {}", missing.join(", ")))
         }
+    }
+
+    /// Wait for the indexer to be fully ready: API listening, subscribed, and
+    /// processing blocks.
+    pub async fn wait_until_ready(&mut self, devnet: &DevnetClient) -> Result<()> {
+        self.wait_for_logs(
+            &["API server listening", "Subscribed to new heads"],
+            DEFAULT_STARTUP_TIMEOUT,
+        )
+        .await?;
+        devnet.create_block().await?;
+        self.wait_for_log("New block #", DEFAULT_BLOCK_TIMEOUT)
+            .await?;
+        Ok(())
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/common/mod.rs
+++ b/crates/discovery-service/tests/common/mod.rs
@@ -5,5 +5,5 @@ mod indexer;
 mod process;
 
 pub use devnet::{DevnetClient, DevnetConfig, DumpMetadata};
-pub use indexer::IndexerClient;
+pub use indexer::{IndexerClient, DEFAULT_BLOCK_TIMEOUT, DEFAULT_STARTUP_TIMEOUT};
 pub use process::find_free_port;

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -8,8 +8,6 @@
 
 mod common;
 
-use std::time::Duration;
-
 use common::{find_free_port, DevnetClient, DevnetConfig, IndexerClient};
 use discovery_service::api_server::HealthResponse;
 
@@ -25,22 +23,7 @@ async fn test_health_endpoint_returns_ok() {
         .await
         .expect("Failed to spawn indexer");
 
-    // Wait for API server to be ready and indexer to subscribe.
-    // These happen concurrently so we must wait for both in any order.
-    indexer
-        .wait_for_logs(
-            &["API server listening", "Subscribed to new heads"],
-            Duration::from_secs(10),
-        )
-        .await
-        .unwrap();
-
-    // Create a block so there's a chain head
-    devnet.create_block().await.unwrap();
-    indexer
-        .wait_for_log("New block #", Duration::from_secs(5))
-        .await
-        .unwrap();
+    indexer.wait_until_ready(&devnet).await.unwrap();
 
     // Call the health endpoint
     let client = reqwest::Client::new();

--- a/crates/discovery-service/tests/test_indexer.rs
+++ b/crates/discovery-service/tests/test_indexer.rs
@@ -8,9 +8,9 @@
 
 mod common;
 
-use std::time::Duration;
-
-use common::{DevnetClient, DevnetConfig, IndexerClient};
+use common::{
+    DevnetClient, DevnetConfig, IndexerClient, DEFAULT_BLOCK_TIMEOUT, DEFAULT_STARTUP_TIMEOUT,
+};
 
 const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
 
@@ -24,13 +24,13 @@ async fn test_startup_and_shutdown() {
     indexer
         .wait_for_logs(
             &["Indexer started", "Subscribed to new heads"],
-            Duration::from_secs(10),
+            DEFAULT_STARTUP_TIMEOUT,
         )
         .await
         .unwrap();
 
     indexer.signal_shutdown().unwrap();
-    let status = tokio::time::timeout(Duration::from_secs(5), indexer.wait())
+    let status = tokio::time::timeout(DEFAULT_BLOCK_TIMEOUT, indexer.wait())
         .await
         .expect("Shutdown timed out")
         .unwrap();
@@ -47,14 +47,14 @@ async fn test_new_block_notification() {
         .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 
     // Create a block and verify we get notified
     devnet.create_block().await.unwrap();
     indexer
-        .wait_for_log("New block #", Duration::from_secs(5))
+        .wait_for_log("New block #", DEFAULT_BLOCK_TIMEOUT)
         .await
         .unwrap();
 
@@ -71,14 +71,14 @@ async fn test_reconnection_on_devnet_restart() {
         .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(10))
+        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 
     // Kill devnet (simulates connection loss)
     drop(devnet);
     indexer
-        .wait_for_log("will retry", Duration::from_secs(10))
+        .wait_for_log("will retry", DEFAULT_BLOCK_TIMEOUT)
         .await
         .unwrap();
 
@@ -89,7 +89,7 @@ async fn test_reconnection_on_devnet_restart() {
     })
     .expect("Failed to respawn devnet");
     indexer
-        .wait_for_log("Subscribed to new heads", Duration::from_secs(30))
+        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 


### PR DESCRIPTION
# Optimize Note Discovery with Two-Phase Algorithm

This PR introduces a more efficient note discovery algorithm that works in two phases:

1. **Exponential Probe**: Uses batched probes at exponentially increasing indices to find the last note index in a subchannel.
2. **Linear Scan**: Batch-reads amounts and nullifiers for all notes in the discovered range.

Key improvements:
- Adds `last_note_index.rs` module with exponential search + bisection to efficiently find the last note index
- Optimizes `notes.rs` to use the probe results for more efficient scanning
- Implements cursor-based pagination with proper budget handling
- Adds nullifier checks to filter out spent notes
- Includes single-note optimization for common case where only one note exists

The algorithm is resumable via cursor state and handles budget exhaustion gracefully. This approach significantly reduces RPC calls compared to the previous sequential scanning method.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/462)
<!-- Reviewable:end -->