### PR TITLE
feat(discovery-service): add incoming sync endpoint with validation and error handling

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -13,12 +13,22 @@ use starknet_types_core::felt::Felt;
 /// These caps prevent unbounded cursor expansion when processing accounts
 /// with many channels or subchannels. Discovery stops adding new entries
 /// once the cursor reaches the limit; existing entries are still processed.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(default)]
 pub struct CursorLimits {
     /// Maximum number of channels in the cursor at once.
     pub max_channels: usize,
     /// Maximum number of subchannels per channel in the cursor at once.
     pub max_subchannels: usize,
+}
+
+impl Default for CursorLimits {
+    fn default() -> Self {
+        Self {
+            max_channels: 256,
+            max_subchannels: 64,
+        }
+    }
 }
 
 /// Top-level cursor for channel discovery (shared by incoming and outgoing).

--- a/crates/discovery-core/src/storage_backend.rs
+++ b/crates/discovery-core/src/storage_backend.rs
@@ -46,11 +46,7 @@ pub trait StorageBackend: Send + Sync {
 
     /// Creates a snapshot at the specified block for the given contract.
     /// If `block_id` is `None`, uses the latest block.
-    async fn snapshot(
-        &self,
-        contract_address: Felt,
-        block_id: Option<BlockId>,
-    ) -> Result<Self::Snapshot, StorageError>;
+    async fn snapshot(&self, contract_address: Felt, block_id: Option<BlockId>) -> Self::Snapshot;
 }
 
 /// Consistent view of storage at a specific block.

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -7,8 +7,17 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use discovery_core::io_budget::IoBudget;
+use discovery_core::storage_backend::StorageBackend;
+use starknet_core::types::BlockId;
+use tracing::debug;
 
-use crate::api::types::HealthResponse;
+use discovery_core::privacy_pool::types::SecretFelt;
+
+use crate::api::types::{
+    ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
+};
+use crate::api::validators::{validate_block_ref, validate_cursor};
 use crate::api::AppState;
 use crate::chain_state::ChainState;
 
@@ -43,4 +52,74 @@ where
     };
 
     (status_code, Json(response))
+}
+
+/// Handler for POST /v1/sync/incoming_state.
+pub async fn incoming_sync_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<IncomingSyncRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    match incoming_sync_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn incoming_sync_impl<B>(
+    state: &AppState<B>,
+    request: IncomingSyncRequest,
+) -> Result<IncomingSyncResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    validate_cursor(&request.cursor, &state.validation_limits)?;
+    let block_ref =
+        validate_block_ref(request.last_known_block, request.block_ref, &state.backend).await?;
+    let viewing_key = SecretFelt::new(request.viewing_key);
+
+    let snapshot = state
+        .backend
+        .snapshot(request.contract_address, Some(BlockId::Hash(block_ref)))
+        .await;
+
+    let budget = IoBudget::new(state.validation_limits.server_budget);
+    let cursor_limits = state.validation_limits.cursor_limits;
+
+    debug!(
+        recipient = %format!("{:#x}", request.recipient_address),
+        block = %block_ref,
+        "incoming_sync request"
+    );
+
+    let discovery_output = discovery_core::sync::incoming_state::sync_incoming_state(
+        &snapshot,
+        request.recipient_address,
+        &viewing_key,
+        request.cursor,
+        cursor_limits,
+        &budget,
+    )
+    .await
+    .map_err(crate::api::types::discovery_error_to_response)?;
+
+    debug!(
+        channels = discovery_output.channels.len(),
+        subchannels = discovery_output.subchannels.len(),
+        notes = discovery_output.notes.len(),
+        cursor_complete = discovery_output.cursor.is_complete(),
+        "incoming_sync response"
+    );
+
+    Ok(IncomingSyncResponse {
+        block_ref,
+        channels: discovery_output.channels,
+        subchannels: discovery_output.subchannels,
+        notes: discovery_output.notes,
+        cursor: discovery_output.cursor,
+    })
 }

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -1,11 +1,12 @@
 //! Axum API server for the discovery service.
 
-mod handlers;
+pub mod handlers;
 pub mod types;
+pub mod validators;
 
 use std::sync::Arc;
 
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 use discovery_core::storage_backend::StorageBackend;
 use tokio::net::TcpListener;
@@ -15,8 +16,10 @@ use tracing::info;
 use crate::chain_state::ChainState;
 use crate::config::{ApiServerConfig, ValidationLimits};
 
-pub use handlers::health_handler;
-pub use types::{ApiErrorBody, ApiErrorResponse, HealthResponse};
+pub use handlers::{health_handler, incoming_sync_handler};
+pub use types::{
+    ApiErrorBody, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
+};
 
 /// API server for the discovery service.
 pub struct ApiServer<B> {
@@ -66,6 +69,7 @@ where
         // TODO: Add TLS termination (spec 5.1)
         let app = Router::new()
             .route("/health", get(health_handler::<B>))
+            .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
             .with_state(app_state);
 
         let listener = TcpListener::bind(&self.config.host)

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -1,8 +1,14 @@
-//! Shared API types: health response, error response, error codes.
+//! Shared API types: health response, error response, error codes,
+//! and endpoint-specific request/response types.
 
 use axum::http::StatusCode;
+use discovery_core::discovery::incoming_channels::IncomingChannel;
+use discovery_core::discovery::notes::DecryptedNote;
+use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::discovery::DiscoveryError;
+use discovery_core::sync::incoming_state::IncomingSubchannel;
 use serde::{Deserialize, Serialize};
+use starknet_core::types::Felt;
 use tracing::warn;
 
 use crate::chain_state::ChainHead;
@@ -58,8 +64,7 @@ impl ApiErrorResponse {
 }
 
 /// Maps [`DiscoveryError`] to an HTTP status + API error response.
-#[allow(dead_code)] // Used by endpoint handlers in slices 15a–15c.
-pub(crate) fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErrorResponse) {
+pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErrorResponse) {
     match error {
         DiscoveryError::Storage(storage_err) => {
             warn!("Storage error during discovery: {}", storage_err);
@@ -88,6 +93,71 @@ pub(crate) fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode,
             ApiErrorResponse::new(error_codes::INVALID_REQUEST, msg),
         ),
     }
+}
+
+/// Request body for POST /v1/sync/incoming_state.
+///
+/// # Sync Flow
+///
+/// **First request** (fresh sync or new session):
+/// ```json
+/// {
+///   "contract_address": "0x...",
+///   "recipient_address": "0x...",
+///   "viewing_key": "0x...",
+///   "last_known_block": "0x..."  // Optional: for reorg detection
+/// }
+/// ```
+///
+/// **Subsequent requests** (pagination within same session):
+/// ```json
+/// {
+///   "contract_address": "0x...",
+///   "recipient_address": "0x...",
+///   "viewing_key": "0x...",
+///   "block_ref": "0x...",  // From previous response
+///   "cursor": { ... }      // From previous response
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncomingSyncRequest {
+    /// The privacy pool contract address.
+    pub contract_address: Felt,
+    /// The recipient's address.
+    pub recipient_address: Felt,
+    /// The recipient's private viewing key.
+    pub viewing_key: Felt,
+    /// Block hash for reorg detection. Set on first request of a new sync
+    /// session to the `block_hash` from your last completed sync.
+    /// Server returns 409 if this block was reorged out.
+    /// Leave empty on pagination requests or fresh syncs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_known_block: Option<Felt>,
+    /// Block hash to query state at. Ensures consistent reads across
+    /// paginated requests. Leave empty on first request (server uses
+    /// current head). On pagination, use the value from previous response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_ref: Option<Felt>,
+    /// Discovery cursor for pagination. Use the cursor from previous
+    /// response to continue discovery.
+    #[serde(default)]
+    pub cursor: DiscoveryCursor,
+}
+
+/// Response body for POST /v1/sync/incoming_state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncomingSyncResponse {
+    /// Block hash pinning all reads in this response. Pass back as
+    /// `block_ref` in subsequent requests for consistency.
+    pub block_ref: Felt,
+    /// Discovered incoming channels (one per sender).
+    pub channels: Vec<IncomingChannel>,
+    /// Discovered incoming subchannels (one per sender×token pair).
+    pub subchannels: Vec<IncomingSubchannel>,
+    /// Discovered notes with sender and token context.
+    pub notes: Vec<DecryptedNote>,
+    /// Updated cursor for continuation. Pass back as `cursor` in next request.
+    pub cursor: DiscoveryCursor,
 }
 
 /// Well-known error codes.

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -1,0 +1,251 @@
+//! Request validation for sync endpoints.
+
+use std::collections::HashSet;
+
+use axum::http::StatusCode;
+use discovery_core::discovery::DiscoveryCursor;
+use starknet_core::types::Felt;
+use tracing::warn;
+
+use crate::api::types::{error_codes, ApiErrorResponse};
+use crate::chain_state::{ChainState, ChainStateError};
+use crate::config::ValidationLimits;
+
+/// Validates block reference for sync endpoints.
+///
+/// Performs the following:
+/// 1. Checks last_known_block hasn't been reorged (if provided)
+/// 2. Resolves block_ref (if provided) or uses current head
+pub async fn validate_block_ref<B: ChainState>(
+    last_known_block: Option<Felt>,
+    block_ref: Option<Felt>,
+    backend: &B,
+) -> Result<Felt, (StatusCode, ApiErrorResponse)> {
+    // 1. If last_known_block provided, check is_canonical
+    if let Some(last_known) = last_known_block {
+        match backend.is_canonical(last_known).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    ApiErrorResponse::new(
+                        error_codes::BLOCK_REORGED,
+                        "last_known_block was reorged out; client should re-sync",
+                    ),
+                ));
+            }
+            Err(ChainStateError::RpcError(e)) => {
+                warn!("RPC error checking is_canonical: {}", e);
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    ApiErrorResponse::new(
+                        error_codes::RPC_UNAVAILABLE,
+                        "Upstream RPC is unavailable",
+                    ),
+                ));
+            }
+        }
+    }
+
+    // 2. Resolve query block
+    //
+    // If block_ref is specified, use it directly without validation.
+    // It's the client's responsibility to use a valid block_ref (typically
+    // from the cursor returned in a previous response). If invalid, the RPC
+    // call will fail and discovery will return an error.
+    let block_ref = if let Some(block_ref) = block_ref {
+        block_ref
+    } else {
+        let head = backend.get_head().await.ok_or_else(|| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiErrorResponse::new(
+                    error_codes::SERVICE_UNAVAILABLE,
+                    "No indexed head available yet",
+                ),
+            )
+        })?;
+        head.block_hash
+    };
+
+    Ok(block_ref)
+}
+
+/// Rejects a collection that exceeds a size limit.
+fn validate_collection_size(
+    actual_size: usize,
+    max_allowed: usize,
+    field_name: &str,
+) -> Result<(), (StatusCode, ApiErrorResponse)> {
+    if actual_size > max_allowed {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(
+                error_codes::INVALID_REQUEST,
+                format!(
+                    "{} contains {} entries, maximum is {}",
+                    field_name, actual_size, max_allowed
+                ),
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Rejects cursors that exceed size limits.
+pub fn validate_cursor(
+    cursor: &DiscoveryCursor,
+    limits: &ValidationLimits,
+) -> Result<(), (StatusCode, ApiErrorResponse)> {
+    validate_collection_size(
+        cursor.channels.len(),
+        limits.cursor_limits.max_channels,
+        "cursor channels",
+    )?;
+    for channel_cursor in cursor.channels.values() {
+        validate_collection_size(
+            channel_cursor.subchannels.len(),
+            limits.cursor_limits.max_subchannels,
+            "channel subchannels",
+        )?;
+    }
+    Ok(())
+}
+
+/// Rejects recipient sets that exceed size limits.
+#[allow(dead_code)] // Used by outgoing_sync endpoint (next slice)
+pub fn validate_recipients(
+    recipients: &HashSet<Felt>,
+    limits: &ValidationLimits,
+) -> Result<(), (StatusCode, ApiErrorResponse)> {
+    validate_collection_size(
+        recipients.len(),
+        limits.max_outgoing_recipients,
+        "recipients",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain_state::mock::MockChainState;
+    use discovery_core::discovery::ChannelCursor;
+
+    #[tokio::test]
+    async fn test_valid_request_uses_head_as_block_ref() {
+        let backend = MockChainState::new();
+
+        let block_ref = validate_block_ref(None, None, &backend).await.unwrap();
+        assert_ne!(block_ref, Felt::ZERO);
+    }
+
+    #[tokio::test]
+    async fn test_block_ref_used_directly() {
+        let backend = MockChainState::new();
+
+        let block_ref = validate_block_ref(None, Some(Felt::from_hex_unchecked("0xabc")), &backend)
+            .await
+            .unwrap();
+        assert_eq!(block_ref, Felt::from_hex_unchecked("0xabc"));
+    }
+
+    #[tokio::test]
+    async fn test_block_reorged() {
+        let backend = MockChainState::new();
+
+        let result =
+            validate_block_ref(Some(Felt::from_hex_unchecked("0x999")), None, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(error.error.code, error_codes::BLOCK_REORGED);
+    }
+
+    #[tokio::test]
+    async fn test_no_head_available_without_block_ref() {
+        let backend = MockChainState::with_no_head();
+
+        let result = validate_block_ref(None, None, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.error.code, error_codes::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_block_ref_works_without_head() {
+        let backend = MockChainState::with_no_head();
+
+        let block_ref = validate_block_ref(None, Some(Felt::from_hex_unchecked("0xabc")), &backend)
+            .await
+            .unwrap();
+        assert_eq!(block_ref, Felt::from_hex_unchecked("0xabc"));
+    }
+
+    #[tokio::test]
+    async fn test_cursor_too_many_channels() {
+        let limits = ValidationLimits::default();
+        let mut cursor = DiscoveryCursor::default();
+        for channel_index in 0..limits.cursor_limits.max_channels + 1 {
+            cursor.channels.insert(
+                Felt::from(channel_index as u64),
+                ChannelCursor {
+                    channel_key: Felt::ZERO,
+                    subchannel_discovery_complete: false,
+                    last_subchannel_index: None,
+                    subchannels: Default::default(),
+                },
+            );
+        }
+
+        let result = validate_cursor(&cursor, &limits);
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error.code, error_codes::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_too_many_subchannels() {
+        let limits = ValidationLimits::default();
+        let mut cursor = DiscoveryCursor::default();
+        let mut channel_cursor = ChannelCursor {
+            channel_key: Felt::ZERO,
+            subchannel_discovery_complete: false,
+            last_subchannel_index: None,
+            subchannels: Default::default(),
+        };
+        for subchannel_index in 0..limits.cursor_limits.max_subchannels + 1 {
+            channel_cursor
+                .subchannels
+                .insert(Felt::from(subchannel_index as u64), Default::default());
+        }
+        cursor.channels.insert(Felt::ONE, channel_cursor);
+
+        let result = validate_cursor(&cursor, &limits);
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error.code, error_codes::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_validate_recipients_too_many() {
+        let limits = ValidationLimits::default();
+        let recipients: HashSet<Felt> = (0..limits.max_outgoing_recipients + 1)
+            .map(|recipient_index| Felt::from(recipient_index as u64))
+            .collect();
+
+        let result = validate_recipients(&recipients, &limits);
+        assert!(result.is_err());
+
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // RPC error handling is tested via integration tests with real devnet
+}

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -9,6 +9,7 @@
 use std::path::Path;
 use std::time::Duration;
 
+use discovery_core::discovery::CursorLimits;
 use regex::Regex;
 use serde::Deserialize;
 use thiserror::Error;
@@ -107,10 +108,9 @@ impl Default for ApiServerConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct ValidationLimits {
-    /// Maximum number of channels allowed in the cursor.
-    pub max_cursor_channels: usize,
-    /// Maximum number of subchannels allowed per channel in the cursor.
-    pub max_cursor_subchannels_per_channel: usize,
+    /// Limits on cursor size (channels and subchannels per channel).
+    #[serde(flatten)]
+    pub cursor_limits: CursorLimits,
     /// Maximum number of recipients in an outgoing sync filter.
     pub max_outgoing_recipients: usize,
     /// Server-controlled I/O budget per request.
@@ -120,8 +120,7 @@ pub struct ValidationLimits {
 impl Default for ValidationLimits {
     fn default() -> Self {
         Self {
-            max_cursor_channels: 256,
-            max_cursor_subchannels_per_channel: 64,
+            cursor_limits: CursorLimits::default(),
             max_outgoing_recipients: 64,
             server_budget: 100,
         }
@@ -299,7 +298,7 @@ health_max_lag_secs = 10
 level = "debug"
 
 [limits]
-max_cursor_channels = 128
+max_channels = 128
 server_budget = 50
 "#
         )
@@ -313,7 +312,7 @@ server_budget = 50
         assert_eq!(config.api.host, "0.0.0.0:9090");
         assert_eq!(config.api.health_max_lag_secs, 10);
         assert_eq!(config.logging.level.as_deref(), Some("debug"));
-        assert_eq!(config.limits.max_cursor_channels, 128);
+        assert_eq!(config.limits.cursor_limits.max_channels, 128);
         assert_eq!(config.limits.server_budget, 50);
     }
 

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -89,17 +89,13 @@ impl RpcBackend {
 impl StorageBackend for RpcBackend {
     type Snapshot = RpcSnapshot;
 
-    async fn snapshot(
-        &self,
-        contract_address: Felt,
-        block_id: Option<BlockId>,
-    ) -> Result<Self::Snapshot, StorageError> {
+    async fn snapshot(&self, contract_address: Felt, block_id: Option<BlockId>) -> Self::Snapshot {
         let block_id = block_id.unwrap_or(BlockId::Tag(BlockTag::Latest));
-        Ok(RpcSnapshot {
+        RpcSnapshot {
             backend: self.clone(),
             contract_address,
             block_id,
-        })
+        }
     }
 }
 

--- a/crates/discovery-service/tests/common/devnet.rs
+++ b/crates/discovery-service/tests/common/devnet.rs
@@ -15,11 +15,16 @@ use tempfile::NamedTempFile;
 use super::process::{find_free_port, signal_process, wait_for_log_pattern};
 
 /// Metadata from devnet dump, written by SDK during fixture generation.
+#[allow(dead_code)]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct DumpMetadata {
     pub timestamp: u64,
     pub contract_address: Felt,
     pub alice_address: Felt,
+    pub alice_viewing_key: Felt,
+    pub bob_address: Felt,
+    pub bob_viewing_key: Felt,
+    pub strk_token: Felt,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -36,6 +41,7 @@ pub struct DevnetClient {
     _temp_dump: Option<NamedTempFile>,
 }
 
+#[allow(dead_code)]
 impl DevnetClient {
     pub fn spawn(config: DevnetConfig) -> Result<Self> {
         let port = config.port.unwrap_or(find_free_port()?);

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -3,13 +3,17 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use discovery_service::api::{ApiErrorResponse, IncomingSyncRequest, IncomingSyncResponse};
 use nix::sys::signal::Signal;
+use reqwest::StatusCode;
+use serde::Serialize;
+use starknet_types_core::felt::Felt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 
 use super::devnet::DevnetClient;
-use super::process::{find_free_port, signal_process};
+use super::process::signal_process;
 
 /// Default timeout for startup-related waits (API + subscription + reconnection).
 pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -18,34 +22,45 @@ pub const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 pub const DEFAULT_BLOCK_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Wrapper for the discovery-service binary.
+#[allow(dead_code)]
 pub struct IndexerClient {
     /// The process handle for the discovery-service binary.
     process: Child,
     /// A channel to receive logs from the discovery-service binary.
     log_rx: mpsc::Receiver<String>,
+    /// The host:port the API server is listening on.
+    api_host: String,
 }
 
-impl IndexerClient {
-    pub async fn spawn_with_binary(
-        binary: &str,
-        ws_url: &str,
-        api_host: Option<&str>,
-    ) -> Result<Self> {
-        let auto_port;
-        let api_host = match api_host {
-            Some(h) => h,
-            None => {
-                let port = find_free_port()?;
-                auto_port = format!("127.0.0.1:{}", port);
-                &auto_port
-            }
-        };
+/// Configuration for spawning the indexer.
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct IndexerSpawnConfig {
+    pub ws_url: String,
+    pub api_port: Option<u16>,
+    pub contract_address: Option<Felt>,
+    pub rpc_url: Option<String>,
+}
 
-        let mut process = Command::new(binary)
-            .env("WS_URL", ws_url)
-            .env("API_HOST", api_host)
-            .stderr(std::process::Stdio::piped())
-            .spawn()?;
+#[allow(dead_code)]
+impl IndexerClient {
+    pub async fn spawn(binary: &str, config: IndexerSpawnConfig) -> Result<Self> {
+        let port = config
+            .api_port
+            .map(Ok)
+            .unwrap_or_else(super::process::find_free_port)?;
+        let api_host = format!("127.0.0.1:{}", port);
+
+        let mut cmd = Command::new(binary);
+        cmd.env("WS_URL", &config.ws_url)
+            .env("API_HOST", &api_host)
+            .stderr(std::process::Stdio::piped());
+
+        if let Some(rpc_url) = &config.rpc_url {
+            cmd.env("RPC_URL", rpc_url);
+        }
+
+        let mut process = cmd.spawn()?;
 
         let stderr = process.stderr.take().ok_or(anyhow!("No stderr"))?;
         let (log_tx, log_rx) = mpsc::channel(100);
@@ -58,14 +73,16 @@ impl IndexerClient {
             }
         });
 
-        Ok(Self { process, log_rx })
+        Ok(Self {
+            process,
+            log_rx,
+            api_host,
+        })
     }
 
-    /// Wait for a specific log message.
-    pub async fn wait_for_log(&mut self, pattern: &str, timeout: Duration) -> Result<String> {
-        self.wait_for_logs(&[pattern], timeout)
-            .await
-            .map(|v| v.into_values().next().unwrap())
+    /// The `host:port` the API server is bound to.
+    pub fn api_host(&self) -> &str {
+        &self.api_host
     }
 
     /// Wait for all given patterns to appear in logs (in any order).
@@ -110,9 +127,40 @@ impl IndexerClient {
         )
         .await?;
         devnet.create_block().await?;
-        self.wait_for_log("New block #", DEFAULT_BLOCK_TIMEOUT)
+        self.wait_for_logs(&["New block #"], DEFAULT_BLOCK_TIMEOUT)
             .await?;
         Ok(())
+    }
+
+    /// POST JSON to the given endpoint and return status + body text.
+    async fn post_json<Req: Serialize>(
+        &self,
+        endpoint: &str,
+        body: &Req,
+    ) -> Result<(StatusCode, String)> {
+        let url = format!("http://{}/{}", self.api_host, endpoint);
+        let response = reqwest::Client::new().post(&url).json(body).send().await?;
+        let status = response.status();
+        let body_text = response.text().await?;
+        Ok((status, body_text))
+    }
+
+    /// POST `/v1/sync/incoming_state` and return the parsed success response.
+    pub async fn incoming_sync(&self, req: &IncomingSyncRequest) -> Result<IncomingSyncResponse> {
+        let (status, body) = self.post_json("v1/sync/incoming_state", req).await?;
+        if status != StatusCode::OK {
+            return Err(anyhow!("Expected 200, got {}: {}", status, body));
+        }
+        Ok(serde_json::from_str(&body)?)
+    }
+
+    /// POST `/v1/sync/incoming_state` and return status + parsed error body.
+    pub async fn incoming_sync_error(
+        &self,
+        req: &IncomingSyncRequest,
+    ) -> Result<(StatusCode, ApiErrorResponse)> {
+        let (status, body) = self.post_json("v1/sync/incoming_state", req).await?;
+        Ok((status, serde_json::from_str(&body)?))
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/common/mod.rs
+++ b/crates/discovery-service/tests/common/mod.rs
@@ -1,9 +1,52 @@
 #![allow(unused)]
 
+use std::path::Path;
+
 mod devnet;
 mod indexer;
 mod process;
 
 pub use devnet::{DevnetClient, DevnetConfig, DumpMetadata};
-pub use indexer::{IndexerClient, DEFAULT_BLOCK_TIMEOUT, DEFAULT_STARTUP_TIMEOUT};
-pub use process::find_free_port;
+pub use indexer::{
+    IndexerClient, IndexerSpawnConfig, DEFAULT_BLOCK_TIMEOUT, DEFAULT_STARTUP_TIMEOUT,
+};
+
+pub const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+/// Spawn devnet and load dump fixtures.
+/// Returns devnet client and metadata with contract/alice addresses.
+pub async fn setup_devnet_with_dump() -> (DevnetClient, DumpMetadata) {
+    let mut devnet = DevnetClient::spawn(DevnetConfig {
+        seed: 42,
+        accounts: 3,
+        ..Default::default()
+    })
+    .expect("failed to spawn devnet");
+    let metadata = devnet
+        .load_dump(Path::new(FIXTURES_DIR))
+        .await
+        .expect("failed to load dump");
+    (devnet, metadata)
+}
+
+/// Spawn an indexer connected to `devnet`, wait until it is ready (API up + first block processed).
+pub async fn setup_indexer(
+    devnet: &DevnetClient,
+    metadata: Option<&DumpMetadata>,
+) -> IndexerClient {
+    let mut indexer = IndexerClient::spawn(
+        env!("CARGO_BIN_EXE_discovery-service"),
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            rpc_url: metadata.map(|_| devnet.rpc_url()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
+    indexer
+        .wait_until_ready(devnet)
+        .await
+        .expect("Indexer not ready");
+    indexer
+}

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -1,34 +1,24 @@
-//! API server integration tests.
+//! API server tests: health endpoint, incoming sync.
 //!
-//! ## Running tests
-//!
-//! ```sh
-//! cargo test -p discovery-service --test test_api
-//! ```
+//! Run with: `cargo test -p discovery-service --test test_api`
 
 mod common;
 
-use common::{find_free_port, DevnetClient, DevnetConfig, IndexerClient};
-use discovery_service::api::HealthResponse;
-
-const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
+use common::{
+    setup_devnet_with_dump, setup_indexer, DevnetClient, DevnetConfig, IndexerClient,
+    IndexerSpawnConfig, DEFAULT_STARTUP_TIMEOUT,
+};
+use discovery_service::api::{HealthResponse, IncomingSyncRequest};
+use starknet_core::types::Felt;
 
 #[tokio::test]
 async fn test_health_endpoint_returns_ok() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
-    let api_port = find_free_port().expect("Failed to find free port");
-    let api_host = format!("127.0.0.1:{}", api_port);
+    let indexer = setup_indexer(&devnet, None).await;
 
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), Some(&api_host))
-        .await
-        .expect("Failed to spawn indexer");
-
-    indexer.wait_until_ready(&devnet).await.unwrap();
-
-    // Call the health endpoint
     let client = reqwest::Client::new();
     let resp = client
-        .get(format!("http://{}/health", api_host))
+        .get(format!("http://{}/health", indexer.api_host()))
         .send()
         .await
         .expect("Failed to send request");
@@ -39,6 +29,157 @@ async fn test_health_endpoint_returns_ok() {
     assert_eq!(health.status, "OK");
     assert!(health.chain_head.is_some());
     assert!(health.chain_head.unwrap().timestamp > 0);
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    let request = IncomingSyncRequest {
+        contract_address: metadata.contract_address,
+        recipient_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+    };
+
+    let response = indexer.incoming_sync(&request).await.unwrap();
+
+    // block_ref is always present
+    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+
+    // With a large budget, all discovery should complete
+    assert!(
+        response.cursor.is_complete(),
+        "All discovery should be complete"
+    );
+
+    // Alice has at least 1 incoming channel (self-channel from deposit)
+    assert!(
+        !response.channels.is_empty(),
+        "Alice should have at least 1 incoming channel"
+    );
+
+    // Verify result structure
+    for channel in &response.channels {
+        assert!(
+            channel.channel_key != Felt::ZERO,
+            "Channel key should not be zero"
+        );
+    }
+    for subchannel in &response.subchannels {
+        assert!(subchannel.token != Felt::ZERO, "Token should not be zero");
+    }
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_pagination() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // First sync with default budget
+    let request1 = IncomingSyncRequest {
+        contract_address: metadata.contract_address,
+        recipient_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+    };
+
+    let response1 = indexer.incoming_sync(&request1).await.unwrap();
+
+    // Second sync using block_ref and cursor from previous response
+    let request2 = IncomingSyncRequest {
+        contract_address: metadata.contract_address,
+        recipient_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        last_known_block: None,
+        block_ref: Some(response1.block_ref),
+        cursor: response1.cursor.clone(),
+    };
+
+    let response2 = indexer.incoming_sync(&request2).await.unwrap();
+
+    // Should eventually complete
+    assert!(
+        response2.cursor.is_complete(),
+        "Should complete with larger budget"
+    );
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_block_reorged() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // Use a fake block hash that doesn't exist (simulates reorg)
+    let fake_block = Felt::from_hex("0xdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+
+    let request = IncomingSyncRequest {
+        contract_address: metadata.contract_address,
+        recipient_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        last_known_block: Some(fake_block),
+        block_ref: None,
+        cursor: Default::default(),
+    };
+
+    let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
+
+    assert_eq!(status, 409);
+    assert_eq!(error.error.code, "BLOCK_REORGED");
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_incoming_sync_no_head() {
+    let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
+
+    let mut indexer = IndexerClient::spawn(
+        env!("CARGO_BIN_EXE_discovery-service"),
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
+
+    // Wait for API server only (don't create any blocks)
+    indexer
+        .wait_for_logs(&["API server listening"], DEFAULT_STARTUP_TIMEOUT)
+        .await
+        .unwrap();
+
+    // Use any address/key - it doesn't matter since indexer has no head yet
+    let request = IncomingSyncRequest {
+        contract_address: Felt::from_hex("0x123").unwrap(),
+        recipient_address: Felt::from_hex("0x1234").unwrap(),
+        viewing_key: Felt::from_hex("0x5678").unwrap(),
+        last_known_block: None,
+        block_ref: None,
+        cursor: Default::default(),
+    };
+
+    let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
+
+    // Should return 503 SERVICE_UNAVAILABLE since no head is indexed yet
+    assert_eq!(status, 503);
+    assert_eq!(error.error.code, "SERVICE_UNAVAILABLE");
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();

--- a/crates/discovery-service/tests/test_indexer.rs
+++ b/crates/discovery-service/tests/test_indexer.rs
@@ -9,7 +9,8 @@
 mod common;
 
 use common::{
-    DevnetClient, DevnetConfig, IndexerClient, DEFAULT_BLOCK_TIMEOUT, DEFAULT_STARTUP_TIMEOUT,
+    DevnetClient, DevnetConfig, IndexerClient, IndexerSpawnConfig, DEFAULT_BLOCK_TIMEOUT,
+    DEFAULT_STARTUP_TIMEOUT,
 };
 
 const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
@@ -17,9 +18,15 @@ const BINARY: &str = env!("CARGO_BIN_EXE_discovery-service");
 #[tokio::test]
 async fn test_startup_and_shutdown() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer = IndexerClient::spawn(
+        BINARY,
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
 
     indexer
         .wait_for_logs(
@@ -42,19 +49,25 @@ async fn test_startup_and_shutdown() {
 #[tokio::test]
 async fn test_new_block_notification() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer = IndexerClient::spawn(
+        BINARY,
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
+        .wait_for_logs(&["Subscribed to new heads"], DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 
     // Create a block and verify we get notified
     devnet.create_block().await.unwrap();
     indexer
-        .wait_for_log("New block #", DEFAULT_BLOCK_TIMEOUT)
+        .wait_for_logs(&["New block #"], DEFAULT_BLOCK_TIMEOUT)
         .await
         .unwrap();
 
@@ -66,19 +79,25 @@ async fn test_new_block_notification() {
 async fn test_reconnection_on_devnet_restart() {
     let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
     let port = devnet.port();
-    let mut indexer = IndexerClient::spawn_with_binary(BINARY, &devnet.ws_url(), None)
-        .await
-        .expect("Failed to spawn indexer");
+    let mut indexer = IndexerClient::spawn(
+        BINARY,
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer");
 
     indexer
-        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
+        .wait_for_logs(&["Subscribed to new heads"], DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 
     // Kill devnet (simulates connection loss)
     drop(devnet);
     indexer
-        .wait_for_log("will retry", DEFAULT_BLOCK_TIMEOUT)
+        .wait_for_logs(&["will retry"], DEFAULT_BLOCK_TIMEOUT)
         .await
         .unwrap();
 
@@ -89,7 +108,7 @@ async fn test_reconnection_on_devnet_restart() {
     })
     .expect("Failed to respawn devnet");
     indexer
-        .wait_for_log("Subscribed to new heads", DEFAULT_STARTUP_TIMEOUT)
+        .wait_for_logs(&["Subscribed to new heads"], DEFAULT_STARTUP_TIMEOUT)
         .await
         .unwrap();
 

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -53,10 +53,7 @@ async fn test_public_key_lookup() {
     };
     let backend = RpcBackend::new(rpc_config).unwrap();
 
-    let snapshot = backend
-        .snapshot(metadata.contract_address, None)
-        .await
-        .unwrap();
+    let snapshot = backend.snapshot(metadata.contract_address, None).await;
 
     // Alice should have a registered public key
     let alice_pubkey = snapshot


### PR DESCRIPTION
### TL;DR

Added the incoming sync API endpoint to the discovery service, allowing clients to discover channels, subchannels, and notes.

### What changed?

- Added a new `POST /v1/sync/incoming_state` endpoint to the API server
- Implemented request validation, error handling, and response formatting
- Created types for the incoming sync request/response
- Added utility functions to map discovery errors to HTTP responses
- Added integration tests for the incoming sync endpoint

The endpoint allows clients to discover channels, subchannels, and notes directed to them by providing their recipient address and viewing key. It supports pagination through a cursor mechanism to handle large result sets efficiently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/482)
<!-- Reviewable:end -->
