### PR TITLE
feat(discovery-service): add outgoing state sync endpoint

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -2,8 +2,8 @@
 
 **Rust verification checklist:**
 - `cargo fmt --check` - code formatting
-- `cargo clippy` - lints (0 warnings required), including integration tests (all targets)
-- `cargo test` - all tests pass
+- `cargo clippy` - lints (0 warnings required), including integration tests, for all targets
+- `cargo test` - all tests pass, for all targets
 
 **TypeScript verification checklist:**
 - `cd sdk && npm run format:check` - prettier formatting

--- a/.claude/specs/discovery-service/06-api-design.md
+++ b/.claude/specs/discovery-service/06-api-design.md
@@ -138,57 +138,64 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 
 ## 6.6 Outgoing Channel Sync Endpoint
 
-Whenever a user wants to make a private transfer there are several things to determine:
+Discovers all outgoing channels and subchannels for a sender. The server decrypts outgoing channel data using the sender's `viewing_key` to find recipients and their per-token subchannels. An optional `recipients` filter restricts discovery to specific recipients; recipients without an existing on-chain channel are returned with `precomputed: true`.
 
-1. Is the sender registered in the pool?
-2. Is the receiver registered in the pool?
-3. Is there an existing outgoing channel for the destination address?
-4. Is there an existing subchannel for the target token?
-5. What is the latest note index in that subchannel (if it exists)?
+Uses the same `block_ref`/`last_known_block` reorg-detection pattern and composite `DiscoveryCursor` as the incoming sync endpoint (§6.5).
 
-The channel key is computed on the client using the viewing key. This avoids sending additional secrets to the service.
-
-Typically users should have this information cached locally but in case there's a need to recover it, the following method would do all the checks and encrypted note discovery.
-
-`POST /v1/discovery/outgoing/sync`
+`POST /v1/sync/outgoing_state`
 
 **Request:**
 
 ```json
 {
   "contract_address": "0x...",
-  "sender_addr": "0x...",
-  "recipient_addr": "0x...",
-  "channel_key": "0x...",
-  "token_address": "0x...",
+  "sender_address": "0x...",
+  "viewing_key": "0x...",
+  "last_known_block": "0x...",
   "block_ref": "0x...",
-  "cursor": {
-    "start_note_index": 0
-  },
-  "max_reads": 1000
+  "cursor": { ... },
+  "recipients": ["0x...", "0x..."]
 }
 ```
+
+- `contract_address`: The privacy pool contract address.
+- `sender_address`: The sender's on-chain address.
+- `viewing_key`: The sender's private viewing key (used for server-side decryption of outgoing channel data).
+- `last_known_block`: Optional. For reorg detection on first request of a new sync session.
+- `block_ref`: Optional. Block hash for consistent reads across paginated requests.
+- `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
+- `recipients`: Optional. When set, only return channels for these recipient addresses.
 
 **Response:**
 
 ```json
 {
-  "head": { "block_number": 123456, "block_hash": "0x..." },
-  "sender_registered": true,
-  "receiver_registered": true,
-  "channel_exists": true,
-  "subchannel_exists": true,
-  "total_n_notes": 57,
-  "cursor": {
-    "start_note_index": 57
-  },
-  "stats": { "reads_used": 100 }
+  "block_ref": "0x...",
+  "channels": [
+    {
+      "recipient_addr": "0x...",
+      "recipient_public_key": "0x...",
+      "channel_key": "0x...",
+      "precomputed": false
+    }
+  ],
+  "subchannels": [
+    {
+      "recipient_addr": "0x...",
+      "token": "0x...",
+      "last_note_index": 0
+    }
+  ],
+  "cursor": { ... }
 }
 ```
 
-**Completion detection:** Client computes done status: `cursor.start_note_index >= total_n_notes`.
+- `block_ref`: Block hash pinning all reads. Pass back as `block_ref` in subsequent requests.
+- `channels`: Discovered outgoing channels (one per recipient). `precomputed: true` for recipients requested via `recipients` filter that don't yet have an on-chain channel.
+- `subchannels`: Discovered subchannels (one per recipient×token pair). `last_note_index` is the last note index in the subchannel, or `null` if no notes exist.
+- `cursor`: Updated cursor for continuation.
 
-**Current limitation:** This endpoint supports a single receiver/token pair per request. Future versions may support batch queries for multiple receivers to enable mass payout scenarios.
+**Completion:** Check `cursor.is_complete()` — when all channel and subchannel discovery is done.
 
 ## 6.7 History Endpoint (Not Yet Specified)
 

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -9,17 +9,20 @@ use axum::response::IntoResponse;
 use axum::Json;
 use discovery_core::io_budget::IoBudget;
 use discovery_core::storage_backend::StorageBackend;
-use starknet_core::types::BlockId;
+use starknet_core::types::{BlockId, Felt};
 use tracing::debug;
 
+use discovery_core::privacy_pool::felt_hex;
 use discovery_core::privacy_pool::types::SecretFelt;
 
 use crate::api::types::{
     ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
+    OutgoingSyncRequest, OutgoingSyncResponse, SyncRequestBase,
 };
-use crate::api::validators::{validate_block_ref, validate_cursor};
+use crate::api::validators::{validate_block_ref, validate_cursor, validate_recipients};
 use crate::api::AppState;
 use crate::chain_state::ChainState;
+use discovery_core::discovery::CursorLimits;
 
 /// Handler for GET /health.
 pub async fn health_handler<B>(State(state): State<Arc<AppState<B>>>) -> impl IntoResponse
@@ -54,6 +57,47 @@ where
     (status_code, Json(response))
 }
 
+/// Validated and resolved shared context for sync handlers.
+struct SyncContext<S> {
+    block_ref: Felt,
+    viewing_key: SecretFelt,
+    snapshot: S,
+    budget: IoBudget,
+    cursor_limits: CursorLimits,
+}
+
+/// Validates the shared request fields and builds the context needed by
+/// both incoming and outgoing sync handlers.
+async fn prepare_sync_context<B>(
+    base: &SyncRequestBase,
+    state: &AppState<B>,
+) -> Result<SyncContext<B::Snapshot>, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    validate_cursor(&base.cursor, &state.validation_limits)?;
+    let block_ref =
+        validate_block_ref(base.last_known_block, base.block_ref, &state.backend).await?;
+    let viewing_key = SecretFelt::new(base.viewing_key);
+
+    let snapshot = state
+        .backend
+        .snapshot(base.contract_address, Some(BlockId::Hash(block_ref)))
+        .await;
+
+    let budget = IoBudget::new(state.validation_limits.server_budget);
+    let cursor_limits = state.validation_limits.cursor_limits;
+
+    Ok(SyncContext {
+        block_ref,
+        viewing_key,
+        snapshot,
+        budget,
+        cursor_limits,
+    })
+}
+
 /// Handler for POST /v1/sync/incoming_state.
 pub async fn incoming_sync_handler<B>(
     State(state): State<Arc<AppState<B>>>,
@@ -77,32 +121,21 @@ where
     B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
     B::Snapshot: Clone + Send + Sync + 'static,
 {
-    validate_cursor(&request.cursor, &state.validation_limits)?;
-    let block_ref =
-        validate_block_ref(request.last_known_block, request.block_ref, &state.backend).await?;
-    let viewing_key = SecretFelt::new(request.viewing_key);
-
-    let snapshot = state
-        .backend
-        .snapshot(request.contract_address, Some(BlockId::Hash(block_ref)))
-        .await;
-
-    let budget = IoBudget::new(state.validation_limits.server_budget);
-    let cursor_limits = state.validation_limits.cursor_limits;
+    let context = prepare_sync_context(&request.base, state).await?;
 
     debug!(
         recipient = %format!("{:#x}", request.recipient_address),
-        block = %block_ref,
+        block = %context.block_ref,
         "incoming_sync request"
     );
 
     let discovery_output = discovery_core::sync::incoming_state::sync_incoming_state(
-        &snapshot,
+        &context.snapshot,
         request.recipient_address,
-        &viewing_key,
-        request.cursor,
-        cursor_limits,
-        &budget,
+        &context.viewing_key,
+        request.base.cursor,
+        context.cursor_limits,
+        &context.budget,
     )
     .await
     .map_err(crate::api::types::discovery_error_to_response)?;
@@ -116,10 +149,72 @@ where
     );
 
     Ok(IncomingSyncResponse {
-        block_ref,
+        block_ref: context.block_ref,
         channels: discovery_output.channels,
         subchannels: discovery_output.subchannels,
         notes: discovery_output.notes,
+        cursor: discovery_output.cursor,
+    })
+}
+
+/// Handler for POST /v1/sync/outgoing_state.
+pub async fn outgoing_sync_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<OutgoingSyncRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    match outgoing_sync_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn outgoing_sync_impl<B>(
+    state: &AppState<B>,
+    request: OutgoingSyncRequest,
+) -> Result<OutgoingSyncResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    if let Some(ref recipients) = request.recipients {
+        validate_recipients(recipients, &state.validation_limits)?;
+    }
+    let context = prepare_sync_context(&request.base, state).await?;
+
+    debug!(
+        sender = felt_hex(&request.sender_address),
+        recipients = ?request.recipients.as_ref().map(|r| r.len()),
+        block = %context.block_ref,
+        "outgoing_sync request"
+    );
+
+    let discovery_output = discovery_core::sync::outgoing_state::sync_outgoing_state(
+        &context.snapshot,
+        request.sender_address,
+        &context.viewing_key,
+        request.base.cursor,
+        context.cursor_limits,
+        &context.budget,
+        request.recipients.as_ref(),
+    )
+    .await
+    .map_err(crate::api::types::discovery_error_to_response)?;
+
+    debug!(
+        channels = discovery_output.channels.len(),
+        subchannels = discovery_output.subchannels.len(),
+        cursor_complete = discovery_output.cursor.is_complete(),
+        "outgoing_sync response"
+    );
+
+    Ok(OutgoingSyncResponse {
+        block_ref: context.block_ref,
+        channels: discovery_output.channels,
+        subchannels: discovery_output.subchannels,
         cursor: discovery_output.cursor,
     })
 }

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -16,9 +16,10 @@ use tracing::info;
 use crate::chain_state::ChainState;
 use crate::config::{ApiServerConfig, ValidationLimits};
 
-pub use handlers::{health_handler, incoming_sync_handler};
+pub use handlers::{health_handler, incoming_sync_handler, outgoing_sync_handler};
 pub use types::{
     ApiErrorBody, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
+    OutgoingSyncRequest, OutgoingSyncResponse, SyncRequestBase,
 };
 
 /// API server for the discovery service.
@@ -70,6 +71,7 @@ where
         let app = Router::new()
             .route("/health", get(health_handler::<B>))
             .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
+            .route("/v1/sync/outgoing_state", post(outgoing_sync_handler::<B>))
             .with_state(app_state);
 
         let listener = TcpListener::bind(&self.config.host)

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -1,12 +1,16 @@
 //! Shared API types: health response, error response, error codes,
 //! and endpoint-specific request/response types.
 
+use std::collections::HashSet;
+
 use axum::http::StatusCode;
 use discovery_core::discovery::incoming_channels::IncomingChannel;
 use discovery_core::discovery::notes::DecryptedNote;
+use discovery_core::discovery::outgoing_channels::OutgoingChannel;
 use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::discovery::DiscoveryError;
 use discovery_core::sync::incoming_state::IncomingSubchannel;
+use discovery_core::sync::outgoing_state::OutgoingSubchannel;
 use serde::{Deserialize, Serialize};
 use starknet_core::types::Felt;
 use tracing::warn;
@@ -95,6 +99,33 @@ pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErr
     }
 }
 
+/// Fields shared by all sync request types.
+///
+/// Each endpoint-specific request embeds this via `#[serde(flatten)]`
+/// so the JSON wire format is unchanged (fields appear at top level).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncRequestBase {
+    /// The privacy pool contract address.
+    pub contract_address: Felt,
+    /// The caller's private viewing key.
+    pub viewing_key: Felt,
+    /// Block hash for reorg detection. Set on first request of a new sync
+    /// session to the `block_hash` from your last completed sync.
+    /// Server returns 409 if this block was reorged out.
+    /// Leave empty on pagination requests or fresh syncs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_known_block: Option<Felt>,
+    /// Block hash to query state at. Ensures consistent reads across
+    /// paginated requests. Leave empty on first request (server uses
+    /// current head). On pagination, use the value from previous response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_ref: Option<Felt>,
+    /// Discovery cursor for pagination. Use the cursor from previous
+    /// response to continue discovery.
+    #[serde(default)]
+    pub cursor: DiscoveryCursor,
+}
+
 /// Request body for POST /v1/sync/incoming_state.
 ///
 /// # Sync Flow
@@ -121,27 +152,10 @@ pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErr
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingSyncRequest {
-    /// The privacy pool contract address.
-    pub contract_address: Felt,
     /// The recipient's address.
     pub recipient_address: Felt,
-    /// The recipient's private viewing key.
-    pub viewing_key: Felt,
-    /// Block hash for reorg detection. Set on first request of a new sync
-    /// session to the `block_hash` from your last completed sync.
-    /// Server returns 409 if this block was reorged out.
-    /// Leave empty on pagination requests or fresh syncs.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub last_known_block: Option<Felt>,
-    /// Block hash to query state at. Ensures consistent reads across
-    /// paginated requests. Leave empty on first request (server uses
-    /// current head). On pagination, use the value from previous response.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub block_ref: Option<Felt>,
-    /// Discovery cursor for pagination. Use the cursor from previous
-    /// response to continue discovery.
-    #[serde(default)]
-    pub cursor: DiscoveryCursor,
+    #[serde(flatten)]
+    pub base: SyncRequestBase,
 }
 
 /// Response body for POST /v1/sync/incoming_state.
@@ -156,6 +170,59 @@ pub struct IncomingSyncResponse {
     pub subchannels: Vec<IncomingSubchannel>,
     /// Discovered notes with sender and token context.
     pub notes: Vec<DecryptedNote>,
+    /// Updated cursor for continuation. Pass back as `cursor` in next request.
+    pub cursor: DiscoveryCursor,
+}
+
+/// Request body for POST /v1/sync/outgoing_state.
+///
+/// # Sync Flow
+///
+/// **First request** (fresh sync):
+/// ```json
+/// {
+///   "contract_address": "0x...",
+///   "sender_address": "0x...",
+///   "viewing_key": "0x...",
+///   "last_known_block": "0x..."  // Optional: for reorg detection
+/// }
+/// ```
+///
+/// **Subsequent requests** (pagination within same session):
+/// ```json
+/// {
+///   "contract_address": "0x...",
+///   "sender_address": "0x...",
+///   "viewing_key": "0x...",
+///   "block_ref": "0x...",  // From previous response
+///   "cursor": { ... }      // From previous response
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutgoingSyncRequest {
+    /// The sender's address.
+    pub sender_address: Felt,
+    /// Optional filter: only return channels for these recipients.
+    /// Recipients without an existing on-chain channel are returned
+    /// with `precomputed: true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipients: Option<HashSet<Felt>>,
+    #[serde(flatten)]
+    pub base: SyncRequestBase,
+}
+
+/// Response body for POST /v1/sync/outgoing_state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutgoingSyncResponse {
+    /// Block hash pinning all reads in this response. Pass back as
+    /// `block_ref` in subsequent requests for consistency.
+    pub block_ref: Felt,
+    /// Discovered outgoing channels (one per recipient). Includes both
+    /// on-chain channels (`precomputed: false`) and precomputed channels
+    /// for requested recipients (`precomputed: true`).
+    pub channels: Vec<OutgoingChannel>,
+    /// Discovered outgoing subchannels (one per recipient×token pair).
+    pub subchannels: Vec<OutgoingSubchannel>,
     /// Updated cursor for continuation. Pass back as `cursor` in next request.
     pub cursor: DiscoveryCursor,
 }

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -113,7 +113,6 @@ pub fn validate_cursor(
 }
 
 /// Rejects recipient sets that exceed size limits.
-#[allow(dead_code)] // Used by outgoing_sync endpoint (next slice)
 pub fn validate_recipients(
     recipients: &HashSet<Felt>,
     limits: &ValidationLimits,

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -3,10 +3,13 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-use discovery_service::api::{ApiErrorResponse, IncomingSyncRequest, IncomingSyncResponse};
+use discovery_service::api::{
+    ApiErrorResponse, IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest,
+    OutgoingSyncResponse,
+};
 use nix::sys::signal::Signal;
 use reqwest::StatusCode;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use starknet_types_core::felt::Felt;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -145,13 +148,32 @@ impl IndexerClient {
         Ok((status, body_text))
     }
 
-    /// POST `/v1/sync/incoming_state` and return the parsed success response.
-    pub async fn incoming_sync(&self, req: &IncomingSyncRequest) -> Result<IncomingSyncResponse> {
-        let (status, body) = self.post_json("v1/sync/incoming_state", req).await?;
+    /// POST a sync endpoint and return the parsed success response.
+    async fn sync_ok<Req: Serialize, Resp: DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        request: &Req,
+    ) -> Result<Resp> {
+        let (status, body) = self.post_json(endpoint, request).await?;
         if status != StatusCode::OK {
             return Err(anyhow!("Expected 200, got {}: {}", status, body));
         }
         Ok(serde_json::from_str(&body)?)
+    }
+
+    /// POST a sync endpoint and return status + parsed error body.
+    async fn sync_err<Req: Serialize>(
+        &self,
+        endpoint: &str,
+        request: &Req,
+    ) -> Result<(StatusCode, ApiErrorResponse)> {
+        let (status, body) = self.post_json(endpoint, request).await?;
+        Ok((status, serde_json::from_str(&body)?))
+    }
+
+    /// POST `/v1/sync/incoming_state` and return the parsed success response.
+    pub async fn incoming_sync(&self, req: &IncomingSyncRequest) -> Result<IncomingSyncResponse> {
+        self.sync_ok("v1/sync/incoming_state", req).await
     }
 
     /// POST `/v1/sync/incoming_state` and return status + parsed error body.
@@ -159,8 +181,20 @@ impl IndexerClient {
         &self,
         req: &IncomingSyncRequest,
     ) -> Result<(StatusCode, ApiErrorResponse)> {
-        let (status, body) = self.post_json("v1/sync/incoming_state", req).await?;
-        Ok((status, serde_json::from_str(&body)?))
+        self.sync_err("v1/sync/incoming_state", req).await
+    }
+
+    /// POST `/v1/sync/outgoing_state` and return the parsed success response.
+    pub async fn outgoing_sync(&self, req: &OutgoingSyncRequest) -> Result<OutgoingSyncResponse> {
+        self.sync_ok("v1/sync/outgoing_state", req).await
+    }
+
+    /// POST `/v1/sync/outgoing_state` and return status + parsed error body.
+    pub async fn outgoing_sync_error(
+        &self,
+        req: &OutgoingSyncRequest,
+    ) -> Result<(StatusCode, ApiErrorResponse)> {
+        self.sync_err("v1/sync/outgoing_state", req).await
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -8,7 +8,9 @@ use common::{
     setup_devnet_with_dump, setup_indexer, DevnetClient, DevnetConfig, IndexerClient,
     IndexerSpawnConfig, DEFAULT_STARTUP_TIMEOUT,
 };
-use discovery_service::api::{HealthResponse, IncomingSyncRequest};
+use discovery_service::api::{
+    HealthResponse, IncomingSyncRequest, OutgoingSyncRequest, SyncRequestBase,
+};
 use starknet_core::types::Felt;
 
 #[tokio::test]
@@ -40,12 +42,14 @@ async fn test_incoming_sync_basic() {
     let indexer = setup_indexer(&devnet, Some(&metadata)).await;
 
     let request = IncomingSyncRequest {
-        contract_address: metadata.contract_address,
         recipient_address: metadata.alice_address,
-        viewing_key: metadata.alice_viewing_key,
-        last_known_block: None,
-        block_ref: None,
-        cursor: Default::default(),
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
     };
 
     let response = indexer.incoming_sync(&request).await.unwrap();
@@ -87,24 +91,28 @@ async fn test_incoming_sync_pagination() {
 
     // First sync with default budget
     let request1 = IncomingSyncRequest {
-        contract_address: metadata.contract_address,
         recipient_address: metadata.alice_address,
-        viewing_key: metadata.alice_viewing_key,
-        last_known_block: None,
-        block_ref: None,
-        cursor: Default::default(),
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
     };
 
     let response1 = indexer.incoming_sync(&request1).await.unwrap();
 
     // Second sync using block_ref and cursor from previous response
     let request2 = IncomingSyncRequest {
-        contract_address: metadata.contract_address,
         recipient_address: metadata.alice_address,
-        viewing_key: metadata.alice_viewing_key,
-        last_known_block: None,
-        block_ref: Some(response1.block_ref),
-        cursor: response1.cursor.clone(),
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: Some(response1.block_ref),
+            cursor: response1.cursor.clone(),
+        },
     };
 
     let response2 = indexer.incoming_sync(&request2).await.unwrap();
@@ -128,12 +136,14 @@ async fn test_incoming_sync_block_reorged() {
     let fake_block = Felt::from_hex("0xdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
 
     let request = IncomingSyncRequest {
-        contract_address: metadata.contract_address,
         recipient_address: metadata.alice_address,
-        viewing_key: metadata.alice_viewing_key,
-        last_known_block: Some(fake_block),
-        block_ref: None,
-        cursor: Default::default(),
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: Some(fake_block),
+            block_ref: None,
+            cursor: Default::default(),
+        },
     };
 
     let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
@@ -167,12 +177,14 @@ async fn test_incoming_sync_no_head() {
 
     // Use any address/key - it doesn't matter since indexer has no head yet
     let request = IncomingSyncRequest {
-        contract_address: Felt::from_hex("0x123").unwrap(),
         recipient_address: Felt::from_hex("0x1234").unwrap(),
-        viewing_key: Felt::from_hex("0x5678").unwrap(),
-        last_known_block: None,
-        block_ref: None,
-        cursor: Default::default(),
+        base: SyncRequestBase {
+            contract_address: Felt::from_hex("0x123").unwrap(),
+            viewing_key: Felt::from_hex("0x5678").unwrap(),
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
     };
 
     let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
@@ -180,6 +192,116 @@ async fn test_incoming_sync_no_head() {
     // Should return 503 SERVICE_UNAVAILABLE since no head is indexed yet
     assert_eq!(status, 503);
     assert_eq!(error.error.code, "SERVICE_UNAVAILABLE");
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_outgoing_sync_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    let request = OutgoingSyncRequest {
+        sender_address: metadata.alice_address,
+        recipients: None,
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
+    };
+
+    let response = indexer.outgoing_sync(&request).await.unwrap();
+
+    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+
+    // Alice has 2 outgoing channels: self-channel (deposit) + Bob (transfer)
+    assert_eq!(
+        response.channels.len(),
+        2,
+        "Alice should have 2 outgoing channels (self + Bob)"
+    );
+
+    // With a large budget, all discovery should complete
+    assert!(
+        response.cursor.is_complete(),
+        "All discovery should be complete"
+    );
+
+    // Each channel should have a matching subchannel with last_note_index = Some(0)
+    assert_eq!(
+        response.subchannels.len(),
+        2,
+        "Each channel should have one subchannel"
+    );
+    for subchannel in &response.subchannels {
+        assert_eq!(
+            subchannel.last_note_index,
+            Some(0),
+            "Each subchannel should have last_note_index=0"
+        );
+    }
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+/// Verifies that passing back a completed cursor is idempotent — the second
+/// call returns no new data and the cursor remains complete.
+#[tokio::test]
+async fn test_outgoing_sync_idempotent() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // First sync discovers everything.
+    let request1 = OutgoingSyncRequest {
+        sender_address: metadata.alice_address,
+        recipients: None,
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
+    };
+
+    let response1 = indexer.outgoing_sync(&request1).await.unwrap();
+    assert!(
+        response1.cursor.is_complete(),
+        "First call should complete all discovery"
+    );
+    assert_eq!(response1.channels.len(), 2, "Alice has 2 outgoing channels");
+
+    // Second sync with completed cursor — should be a no-op.
+    let request2 = OutgoingSyncRequest {
+        sender_address: metadata.alice_address,
+        recipients: None,
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: Some(response1.block_ref),
+            cursor: response1.cursor.clone(),
+        },
+    };
+
+    let response2 = indexer.outgoing_sync(&request2).await.unwrap();
+    assert!(
+        response2.cursor.is_complete(),
+        "Cursor should remain complete"
+    );
+    assert!(
+        response2.channels.is_empty(),
+        "No new channels on second call"
+    );
+    assert!(
+        response2.subchannels.is_empty(),
+        "No new subchannels on second call"
+    );
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();


### PR DESCRIPTION
# Add outgoing channel sync endpoint to discovery service

### TL;DR

Implements the outgoing channel sync endpoint for the discovery service, allowing clients to discover all outgoing channels and subchannels for a sender.

### What changed?

- Added the `/v1/sync/outgoing_state` endpoint implementation in the discovery service
- Updated the API specification in `.claude/specs/discovery-service/06-api-design.md` with detailed documentation for the endpoint
- Added request/response types and validation logic for the new endpoint
- Implemented integration tests for the outgoing sync endpoint

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/483)
<!-- Reviewable:end -->
