### PR TITLE
feat(discovery-service): add preflight check endpoint

### DIFF
--- a/.claude/specs/discovery-service/06-api-design.md
+++ b/.claude/specs/discovery-service/06-api-design.md
@@ -197,7 +197,53 @@ Uses the same `block_ref`/`last_known_block` reorg-detection pattern and composi
 
 **Completion:** Check `cursor.is_complete()` — when all channel and subchannel discovery is done.
 
-## 6.7 History Endpoint (Not Yet Specified)
+## 6.7 Preflight Check Endpoint
+
+A non-paginated readiness check that reports what on-chain setup exists for a `(sender, recipient, token)` tuple. Performs at most 4 direct storage lookups — no scanning, no budget, no cursor.
+
+`POST /v1/sync/preflight_check`
+
+**Request:**
+
+```json
+{
+  "contract_address": "0x...",
+  "sender_address": "0x...",
+  "viewing_key": "0x...",
+  "recipient": "0x...",
+  "token": "0x..."
+}
+```
+
+- `contract_address`: The privacy pool contract address.
+- `sender_address`: The sender's on-chain address.
+- `viewing_key`: The sender's private viewing key (used to derive channel key).
+- `recipient`: The recipient's on-chain address.
+- `token`: The token address to check subchannel for.
+
+**Response:**
+
+```json
+{
+  "block_ref": "0x...",
+  "sender_registered": true,
+  "channel_exists": true,
+  "subchannel_exists": true
+}
+```
+
+- `block_ref`: Block hash pinning the reads. Clients can use this for consistency.
+- `sender_registered`: Whether the sender has a public key registered on-chain.
+- `channel_exists`: Whether the channel from sender to recipient exists. Always `false` if `sender_registered` is `false`.
+- `subchannel_exists`: Whether the token subchannel exists within the channel. Always `false` if `channel_exists` is `false`.
+
+**Error responses:**
+
+- `503 SERVICE_UNAVAILABLE` — No block indexed yet.
+- `500 INTERNAL_ERROR` — Failed to create RPC snapshot.
+- Standard `DiscoveryError` mapping for storage errors.
+
+## 6.8 History Endpoint (Not Yet Specified)
 
 `POST /v1/discovery/history`
 

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -16,8 +16,9 @@ use discovery_core::privacy_pool::felt_hex;
 use discovery_core::privacy_pool::types::SecretFelt;
 
 use crate::api::types::{
-    ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
-    OutgoingSyncRequest, OutgoingSyncResponse, SyncRequestBase,
+    error_codes, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
+    OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
+    SyncRequestBase,
 };
 use crate::api::validators::{validate_block_ref, validate_cursor, validate_recipients};
 use crate::api::AppState;
@@ -216,5 +217,71 @@ where
         channels: discovery_output.channels,
         subchannels: discovery_output.subchannels,
         cursor: discovery_output.cursor,
+    })
+}
+
+/// Handler for POST /v1/sync/preflight_check.
+pub async fn preflight_check_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<PreflightCheckRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    match preflight_check_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn preflight_check_impl<B>(
+    state: &AppState<B>,
+    request: PreflightCheckRequest,
+) -> Result<PreflightCheckResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: Clone + Send + Sync + 'static,
+{
+    let head = state.backend.get_head().await.ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            ApiErrorResponse::new(error_codes::SERVICE_UNAVAILABLE, "No block indexed yet"),
+        )
+    })?;
+
+    let snapshot = state
+        .backend
+        .snapshot(
+            request.contract_address,
+            Some(BlockId::Hash(head.block_hash)),
+        )
+        .await;
+
+    let viewing_key = SecretFelt::new(request.viewing_key);
+
+    debug!(
+        sender = felt_hex(&request.sender_address),
+        recipient = felt_hex(&request.recipient),
+        token = felt_hex(&request.token),
+        block = %head.block_hash,
+        "preflight_check request"
+    );
+
+    let result = discovery_core::sync::preflight_check::preflight_check(
+        &snapshot,
+        request.sender_address,
+        &viewing_key,
+        request.recipient,
+        request.token,
+    )
+    .await
+    .map_err(crate::api::types::discovery_error_to_response)?;
+
+    Ok(PreflightCheckResponse {
+        block_ref: head.block_hash,
+        sender_registered: result.sender_registered,
+        channel_exists: result.channel_exists,
+        subchannel_exists: result.subchannel_exists,
     })
 }

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -16,10 +16,13 @@ use tracing::info;
 use crate::chain_state::ChainState;
 use crate::config::{ApiServerConfig, ValidationLimits};
 
-pub use handlers::{health_handler, incoming_sync_handler, outgoing_sync_handler};
+pub use handlers::{
+    health_handler, incoming_sync_handler, outgoing_sync_handler, preflight_check_handler,
+};
 pub use types::{
     ApiErrorBody, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
-    OutgoingSyncRequest, OutgoingSyncResponse, SyncRequestBase,
+    OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
+    SyncRequestBase,
 };
 
 /// API server for the discovery service.
@@ -72,6 +75,10 @@ where
             .route("/health", get(health_handler::<B>))
             .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
             .route("/v1/sync/outgoing_state", post(outgoing_sync_handler::<B>))
+            .route(
+                "/v1/sync/preflight_check",
+                post(preflight_check_handler::<B>),
+            )
             .with_state(app_state);
 
         let listener = TcpListener::bind(&self.config.host)

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -227,6 +227,37 @@ pub struct OutgoingSyncResponse {
     pub cursor: DiscoveryCursor,
 }
 
+/// Request body for POST /v1/sync/preflight_check.
+///
+/// A non-paginated readiness check for a `(sender, recipient, token)` tuple.
+/// Returns boolean flags indicating what on-chain setup exists.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreflightCheckRequest {
+    /// The privacy pool contract address.
+    pub contract_address: Felt,
+    /// The sender's address.
+    pub sender_address: Felt,
+    /// The sender's private viewing key.
+    pub viewing_key: Felt,
+    /// The recipient's address.
+    pub recipient: Felt,
+    /// The token address.
+    pub token: Felt,
+}
+
+/// Response body for POST /v1/sync/preflight_check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreflightCheckResponse {
+    /// Block hash pinning the reads in this response.
+    pub block_ref: Felt,
+    /// Whether the sender has a public key registered on-chain.
+    pub sender_registered: bool,
+    /// Whether the channel from sender to recipient exists.
+    pub channel_exists: bool,
+    /// Whether the token subchannel exists within the channel.
+    pub subchannel_exists: bool,
+}
+
 /// Well-known error codes.
 pub mod error_codes {
     pub const INVALID_REQUEST: &str = "INVALID_REQUEST";

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use discovery_service::api::{
     ApiErrorResponse, IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest,
-    OutgoingSyncResponse,
+    OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
 };
 use nix::sys::signal::Signal;
 use reqwest::StatusCode;
@@ -195,6 +195,14 @@ impl IndexerClient {
         req: &OutgoingSyncRequest,
     ) -> Result<(StatusCode, ApiErrorResponse)> {
         self.sync_err("v1/sync/outgoing_state", req).await
+    }
+
+    /// POST `/v1/sync/preflight_check` and return the parsed success response.
+    pub async fn preflight_check(
+        &self,
+        req: &PreflightCheckRequest,
+    ) -> Result<PreflightCheckResponse> {
+        self.sync_ok("v1/sync/preflight_check", req).await
     }
 
     /// Send SIGINT for graceful shutdown.

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -9,7 +9,8 @@ use common::{
     IndexerSpawnConfig, DEFAULT_STARTUP_TIMEOUT,
 };
 use discovery_service::api::{
-    HealthResponse, IncomingSyncRequest, OutgoingSyncRequest, SyncRequestBase,
+    HealthResponse, IncomingSyncRequest, OutgoingSyncRequest, PreflightCheckRequest,
+    SyncRequestBase,
 };
 use starknet_core::types::Felt;
 
@@ -301,6 +302,81 @@ async fn test_outgoing_sync_idempotent() {
     assert!(
         response2.subchannels.is_empty(),
         "No new subchannels on second call"
+    );
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_preflight_check_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // Scenario 1: Alice → Bob STRK — all flags true
+    let request = PreflightCheckRequest {
+        contract_address: metadata.contract_address,
+        sender_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        recipient: metadata.bob_address,
+        token: metadata.strk_token,
+    };
+
+    let response = indexer.preflight_check(&request).await.unwrap();
+    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+    assert!(response.sender_registered, "Alice should be registered");
+    assert!(response.channel_exists, "Alice→Bob channel should exist");
+    assert!(
+        response.subchannel_exists,
+        "Alice→Bob STRK subchannel should exist"
+    );
+
+    // Scenario 2: Alice → unknown recipient — sender registered, no channel/subchannel
+    let unknown_recipient = Felt::from_hex("0xdeadbeef").unwrap();
+    let request_unknown_recipient = PreflightCheckRequest {
+        contract_address: metadata.contract_address,
+        sender_address: metadata.alice_address,
+        viewing_key: metadata.alice_viewing_key,
+        recipient: unknown_recipient,
+        token: metadata.strk_token,
+    };
+
+    let response = indexer
+        .preflight_check(&request_unknown_recipient)
+        .await
+        .unwrap();
+    assert!(response.sender_registered, "Alice should be registered");
+    assert!(
+        !response.channel_exists,
+        "Channel to unknown recipient should not exist"
+    );
+    assert!(
+        !response.subchannel_exists,
+        "Subchannel to unknown recipient should not exist"
+    );
+
+    // Scenario 3: Unknown sender → Bob — all flags false
+    let unknown_sender = Felt::from_hex("0xbaddecaf").unwrap();
+    let request_unknown_sender = PreflightCheckRequest {
+        contract_address: metadata.contract_address,
+        sender_address: unknown_sender,
+        viewing_key: Felt::from_hex("0x1234").unwrap(),
+        recipient: metadata.bob_address,
+        token: metadata.strk_token,
+    };
+
+    let response = indexer
+        .preflight_check(&request_unknown_sender)
+        .await
+        .unwrap();
+    assert!(
+        !response.sender_registered,
+        "Unknown sender should not be registered"
+    );
+    assert!(!response.channel_exists, "No channel from unknown sender");
+    assert!(
+        !response.subchannel_exists,
+        "No subchannel from unknown sender"
     );
 
     indexer.signal_shutdown().unwrap();

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -15,9 +15,7 @@
 
 mod common;
 
-use std::path::Path;
-
-use common::{DevnetClient, DevnetConfig, DumpMetadata};
+use common::setup_devnet_with_dump;
 use discovery_core::privacy_pool::views::IViews;
 use discovery_core::storage_backend::StorageBackend;
 use discovery_service::config::RpcConfig;
@@ -25,27 +23,9 @@ use discovery_service::rpc_backend::RpcBackend;
 use expect_test::expect;
 use starknet_core::types::Felt;
 
-const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
-
-async fn setup_devnet() -> (DevnetClient, DumpMetadata) {
-    let mut devnet = DevnetClient::spawn(DevnetConfig {
-        seed: 42,
-        accounts: 3,
-        ..Default::default()
-    })
-    .expect("failed to spawn devnet");
-
-    let metadata = devnet
-        .load_dump(Path::new(FIXTURES_DIR))
-        .await
-        .expect("failed to load dump");
-
-    (devnet, metadata)
-}
-
 #[tokio::test]
 async fn test_public_key_lookup() {
-    let (devnet, metadata) = setup_devnet().await;
+    let (devnet, metadata) = setup_devnet_with_dump().await;
 
     let rpc_config = RpcConfig {
         url: devnet.rpc_url(),


### PR DESCRIPTION
### TL;DR

Added a new preflight check endpoint to the Discovery Service API that quickly checks if a sender-recipient-token combination is ready for private transfers.

### What changed?

- Added a new `POST /v1/sync/preflight_check` endpoint to the Discovery Service API
- Implemented the handler, request/response types, and supporting logic
- Updated API documentation with detailed specifications for the new endpoint
- Added integration tests to verify the endpoint's behavior in different scenarios

The preflight check performs at most 4 direct storage lookups to determine:
- If the sender has registered a public key
- If a channel exists between sender and recipient
- If a subchannel exists for the specified token

The response includes boolean flags for each condition and a block reference for consistency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/484)
<!-- Reviewable:end -->
