### PR TITLE
feat(sdk): add indexer discovery provider

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -5,11 +5,10 @@
 - `cargo clippy` - lints (0 warnings required), including integration tests, for all targets
 - `cargo test` - all tests pass, for all targets
 
-**TypeScript verification checklist:**
-- `cd sdk && npm run format:check` - prettier formatting
-- `cd sdk && npm run lint:check` - eslint lints
-- `cd sdk && npm run build` - compiles
-- `cd sdk && npm run test:fast` - tests pass (excludes devnet/parallel-discovery)
+**SDK verification checklist (from `sdk/`):**
+- `npx prettier --check src/ tests/` - code formatting (must include `tests/` — husky pre-commit checks both)
+- `npx eslint src/ tests/` - lints (0 warnings required, must include `tests/`)
+- `npx tsc --noEmit` - type-check passes
 
 ## Cross-layer consistency
 

--- a/.claude/specs/discovery-service/06-api-design.md
+++ b/.claude/specs/discovery-service/06-api-design.md
@@ -42,7 +42,7 @@ For use cases requiring stronger finality, clients should wait for L1 confirmati
 
 ## 6.5 Incoming Notes Discovery Endpoint
 
-`POST /v1/discovery/incoming/sync`
+`POST /v1/sync/incoming_state`
 
 A unified endpoint that discovers channels, subchannels, and notes in one call with a composite cursor. This is the primary endpoint for incoming notes discovery.
 
@@ -53,12 +53,13 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
   "contract_address": "0x...",
   "recipient_address": "0x...",
   "viewing_key": "0x...",
+  "last_known_block": "0x...",
+  "block_ref": "0x...",
   "cursor": {
-    "last_known_block": "0x...",
-    "block_ref": null,
     "last_channel_index": null,
     "channels": {
-      "0x_channel_key": {
+      "0x_sender_addr": {
+        "channel_key": "0x...",
         "last_subchannel_index": null,
         "subchannels": {
           "0x_token_address": {
@@ -67,15 +68,16 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
         }
       }
     }
-  },
-  "max_reads": 2000
+  }
 }
 ```
 
-**Block fields in cursor:**
-
-- `last_known_block`: Block hash from last completed sync session. Used for reorg detection on first request. Server returns `409 BLOCK_REORGED` if this block is no longer canonical. Leave empty on fresh syncs or pagination requests.
-- `block_ref`: Block hash to query state at. Ensures consistent reads across paginated requests. Leave empty on first request (server uses current head and sets it in response cursor).
+- `contract_address`: The privacy pool contract address.
+- `recipient_address`: The recipient's on-chain address.
+- `viewing_key`: The recipient's private viewing key (used for server-side decryption).
+- `last_known_block`: Optional. Block hash from last completed sync session. Used for reorg detection on first request. Server returns `409 BLOCK_REORGED` if this block is no longer canonical. Leave empty on fresh syncs or pagination requests.
+- `block_ref`: Optional. Block hash to query state at. Ensures consistent reads across paginated requests. Leave empty on first request (server uses current head and sets it in response).
+- `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
 
 **Progress fields in cursor:**
 
@@ -87,52 +89,51 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 
 ```json
 {
-  "head": { "block_number": 123456, "block_hash": "0x...", "timestamp": 1234567890 },
-  "channels_done": false,
-  "channels": {
-    "0x_channel_key_1": {
-      "sender_addr": "0x...",
-      "subchannels_done": true,
-      "subchannels": {
-        "0x_token_address_1": {
-          "notes_done": true,
-          "notes": [
-            { "index": 1, "note_id": "0x...", "amount": 1000 }
-          ]
-        }
-      }
-    }
-  },
+  "block_ref": "0x...",
+  "channels": [
+    { "channel_key": "0x...", "sender_addr": "0x..." }
+  ],
+  "subchannels": [
+    { "sender_addr": "0x...", "token": "0x..." }
+  ],
+  "notes": [
+    { "sender_addr": "0x...", "token": "0x...", "index": 1, "note_id": "0x...", "amount": 1000, "salt": 12345 }
+  ],
   "cursor": {
-    "block_ref": "0x...",
+    "channel_discovery_complete": false,
     "last_channel_index": 5,
     "channels": {
-      "0x_channel_key_1": {
+      "0x_sender_addr": {
+        "channel_key": "0x...",
+        "subchannel_discovery_complete": true,
         "last_subchannel_index": 3,
         "subchannels": {
-          "0x_token_address_1": {
+          "0x_token_address": {
+            "note_discovery_complete": true,
             "last_note_index": 10
           }
         }
       }
     }
-  },
-  "stats": { "reads": 2000, "channels_discovered": 1, "subchannels_discovered": 2, "notes_discovered": 5 }
+  }
 }
 ```
 
 **Response fields:**
 
-- `head`: Current chain head. Only present on first request (when `block_ref` not specified). Use `head.block_hash` as `last_known_block` for next sync session.
-- `channels_done`, `subchannels_done`, `notes_done`: Server-computed completion status. When all are `true`, sync is complete.
-- `cursor.block_ref`: Block hash used for queries. Automatically set by server. Pass back as-is on pagination requests.
-- `cursor.last_known_block`: Always cleared in response cursor.
+- `block_ref`: Block hash pinning all reads. Pass back as `block_ref` in subsequent requests.
+- `channels`: Discovered incoming channels (one per sender).
+- `subchannels`: Discovered incoming subchannels (one per sender×token pair).
+- `notes`: Discovered notes with sender and token context.
+- `cursor`: Updated `DiscoveryCursor` for continuation.
+
+**Completion:** Check `cursor.is_complete()` — when `channel_discovery_complete` is true and all channels/subchannels have their discovery complete flags set.
 
 **User flow:**
 
-1. **First request**: Send with `last_known_block` set to previous session's `head.block_hash` (or empty if fresh sync).
-2. **Pagination**: Use response cursor as-is until `channels_done` is `true`.
-3. **Store for next session**: Save final `head.block_hash` as your `last_known_block`.
+1. **First request**: Send with `last_known_block` set to previous session's block hash (or empty if fresh sync).
+2. **Pagination**: Pass back `block_ref` and `cursor` from response until complete.
+3. **Store for next session**: Save final `block_ref` as your `last_known_block`.
 
 **Note filtering:** For each decrypted note, the service derives the nullifier and checks if it exists in contract state. Only unspent notes (those whose nullifier does not exist) are included in the response.
 

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -114,6 +114,7 @@ where
     }
 }
 
+// TODO: support filtering by tokens (see sdk)
 async fn incoming_sync_impl<B>(
     state: &AppState<B>,
     request: IncomingSyncRequest,
@@ -173,6 +174,7 @@ where
     }
 }
 
+// TODO: support "total-only" mode (see sdk)
 async fn outgoing_sync_impl<B>(
     state: &AppState<B>,
     request: OutgoingSyncRequest,

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -21,6 +21,17 @@ pub async fn validate_block_ref<B: ChainState>(
     block_ref: Option<Felt>,
     backend: &B,
 ) -> Result<Felt, (StatusCode, ApiErrorResponse)> {
+    // last_known_block is for first requests, block_ref is for pagination — never both.
+    if last_known_block.is_some() && block_ref.is_some() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(
+                error_codes::INVALID_REQUEST,
+                "last_known_block and block_ref are mutually exclusive",
+            ),
+        ));
+    }
+
     // 1. If last_known_block provided, check is_canonical
     if let Some(last_known) = last_known_block {
         match backend.is_canonical(last_known).await {
@@ -244,6 +255,24 @@ mod tests {
 
         let (status, _) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_both_block_ref_and_last_known_block_rejected() {
+        let backend = MockChainState::new();
+
+        let result = validate_block_ref(
+            Some(Felt::from_hex_unchecked("0x111")),
+            Some(Felt::from_hex_unchecked("0x222")),
+            &backend,
+        )
+        .await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error.code, error_codes::INVALID_REQUEST);
+        assert!(error.error.message.contains("mutually exclusive"));
     }
 
     // RPC error handling is tested via integration tests with real devnet

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -37,6 +37,7 @@ import type { BigNumberish } from "starknet";
 import { generateRandom, generateRandom120 } from "../utils/crypto.js";
 import { debugLog } from "../utils/logging.js";
 import { toHex } from "../utils/convert.js";
+import { ReorgError } from "./indexer-discovery.js";
 
 export type CompileResult = {
   clientActions: ClientAction[];
@@ -88,6 +89,24 @@ export class ActionCompiler {
    * Compile actions by resolving contexts, updating the registry, and producing ClientAction[].
    */
   async compile(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
+    try {
+      return await this.compileOnce(actions, options);
+    } catch (e) {
+      if (e instanceof ReorgError) {
+        debugLog("compiler", "compile", "reorg detected", e);
+        // Reorg detected: clear stale registry state and retry from scratch.
+        if (options?.registry) {
+          options.registry.notes.clear();
+          options.registry.channels.clear();
+          delete options.registry.cursor;
+        }
+        return await this.compileOnce(actions, options);
+      }
+      throw e;
+    }
+  }
+
+  private async compileOnce(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
     const registry_ = options?.registry ?? createEmptyRegistry();
     const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
     const recipientsNeeded = this.getRecipientsNeeded(actions);

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -1,0 +1,558 @@
+import type { BlockIdentifier } from "starknet";
+import {
+  SetupRequirement,
+  type Channel as ChannelInterface,
+  type Note,
+  type StarknetAddress,
+  type StarknetAddressBigint,
+  type ViewingKey,
+} from "../interfaces.js";
+import { toBigInt } from "../utils/crypto.js";
+import { toHex } from "../utils/convert.js";
+import { AddressMap } from "../utils/maps.js";
+import { AbstractDiscoveryProvider } from "./abstract-discovery.js";
+import { Channel, Witness } from "./channel.js";
+import type {
+  ChannelCursor,
+  IncomingChannelCursor,
+  NotesCursor,
+  RecipientsFilter,
+} from "./channel.js";
+
+/** Thrown when the indexer reports a block reorg (HTTP 409, BLOCK_REORGED). */
+export class ReorgError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReorgError";
+  }
+}
+
+// API JSON wire types
+
+type ApiSubchannelCursor = {
+  note_discovery_complete?: boolean;
+  last_note_index?: number;
+  max_note_index?: number;
+};
+
+type ApiChannelCursor = {
+  channel_key?: string;
+  subchannel_discovery_complete?: boolean;
+  last_subchannel_index?: number;
+  subchannels?: Record<string, ApiSubchannelCursor>;
+};
+
+type ApiDiscoveryCursor = {
+  channel_discovery_complete?: boolean;
+  total_n_channels?: number;
+  last_channel_index?: number;
+  channels?: Record<string, ApiChannelCursor>;
+};
+
+type ApiIncomingChannel = {
+  channel_key: string;
+  sender_addr: string;
+};
+
+type ApiIncomingSubchannelInfo = {
+  sender_addr: string;
+  token: string;
+};
+
+type ApiIncomingNoteInfo = {
+  sender_addr: string;
+  token: string;
+  index: number;
+  note_id: string;
+  amount: number;
+  salt: number;
+};
+
+type ApiOutgoingChannel = {
+  recipient_addr: string;
+  recipient_public_key: string;
+  channel_key: string;
+  precomputed?: boolean;
+};
+
+type ApiOutgoingSubchannelInfo = {
+  recipient_addr: string;
+  token: string;
+  last_note_index: number | null;
+};
+
+type ApiIncomingSyncResponse = {
+  block_ref: string;
+  channels: ApiIncomingChannel[];
+  subchannels: ApiIncomingSubchannelInfo[];
+  notes: ApiIncomingNoteInfo[];
+  cursor: ApiDiscoveryCursor;
+};
+
+type ApiOutgoingSyncResponse = {
+  block_ref: string;
+  channels: ApiOutgoingChannel[];
+  subchannels: ApiOutgoingSubchannelInfo[];
+  cursor: ApiDiscoveryCursor;
+};
+
+export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
+  constructor(
+    private readonly apiUrl: string,
+    private readonly contractAddress: StarknetAddress
+  ) {
+    super();
+  }
+
+  async discoverNotes(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }
+  ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
+    const tokenFilter = params?.tokens ? new Set(params.tokens.map((t) => toBigInt(t))) : null;
+    const cursor = params?.cursor;
+    let apiCursor: ApiDiscoveryCursor = cursor ? notesCursorToApiCursor(cursor, tokenFilter) : {};
+
+    // last_known_block is sent once on the first request for reorg detection.
+    // block_ref (from the first response) pins subsequent pagination requests.
+    const lastKnownBlock = cursor?.blockId as string | undefined;
+    let blockRef: string | undefined;
+
+    const allNotes = new AddressMap<Note[]>(() => []);
+    const incomingChannels = new AddressMap<IncomingChannelCursor>();
+
+    let complete = false;
+    do {
+      const body: Record<string, unknown> = {
+        contract_address: toHex(this.contractAddress),
+        recipient_address: toHex(address),
+        viewing_key: toHex(viewingKey),
+        cursor: apiCursor,
+      };
+      if (blockRef) {
+        body.block_ref = blockRef;
+      } else if (lastKnownBlock) {
+        body.last_known_block = lastKnownBlock;
+      }
+
+      const resp = await this.post<ApiIncomingSyncResponse>("/v1/sync/incoming_state", body);
+
+      blockRef = resp.block_ref;
+
+      const channelKeyMap = new Map<string, bigint>();
+      for (const ch of resp.channels) {
+        channelKeyMap.set(ch.sender_addr, BigInt(ch.channel_key));
+      }
+
+      const notesByToken = convertIncomingNotes(
+        resp.notes,
+        channelKeyMap,
+        incomingChannels,
+        tokenFilter
+      );
+      for (const [token, tokenNotes] of notesByToken) {
+        allNotes.get(token)!.push(...tokenNotes);
+      }
+
+      const updatedCursor = apiCursorToNotesCursor(resp.cursor, resp.block_ref);
+      for (const [sender, icc] of updatedCursor.incomingChannels) {
+        incomingChannels.set(sender, icc);
+      }
+
+      apiCursor = resp.cursor;
+      complete = isApiCursorComplete(resp.cursor);
+    } while (!complete);
+
+    // FIXME: The incoming sync API filters out spent notes (nullifier exists).
+    // When a note is spent and removed from the response, we lose information
+    // about its index. The constructed noteIndexes[token] is
+    // max(surviving_note.index) + 1, which may be lower than the true last
+    // discovered index if the highest-index notes were spent. This causes
+    // suboptimal incremental updates — the next call re-scans already-discovered
+    // (but now spent) note indices.
+
+    return {
+      timestamp: blockRef!,
+      notes: allNotes,
+      cursor: { blockId: blockRef!, incomingChannels },
+    };
+  }
+
+  async discoverChannels(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    recipients: RecipientsFilter,
+    params?: { cursor?: ChannelCursor }
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<ChannelInterface>;
+    total?: number;
+  }> {
+    if (recipients === "total-only") {
+      // For total-only, do a minimal outgoing sync to get the total channel count
+      const body: Record<string, unknown> = {
+        contract_address: toHex(this.contractAddress),
+        sender_address: toHex(address),
+        viewing_key: toHex(viewingKey),
+        cursor: { channel_discovery_complete: false },
+      };
+      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
+      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels };
+    }
+
+    const cursorMap = params?.cursor?.channels;
+    let apiCursor: ApiDiscoveryCursor;
+
+    if (recipients === "all") {
+      apiCursor = channelMapToApiCursor(cursorMap, false);
+    } else {
+      let allResolved = true;
+      const resolved = new Map<bigint, { key: bigint; publicKey: bigint }>();
+      for (const r of recipients) {
+        const rb = toBigInt(r);
+        const existing = cursorMap?.get(rb);
+        if (existing?.key) {
+          resolved.set(rb, { key: existing.key, publicKey: toBigInt(existing.publicKey) });
+        } else {
+          allResolved = false;
+        }
+      }
+
+      if (allResolved) {
+        // Targeted scan: skip channel discovery, only refresh subchannels
+        apiCursor = { channel_discovery_complete: true, channels: {} };
+        for (const [rb, info] of resolved) {
+          const existing = cursorMap?.get(rb);
+          const subchannels = existing
+            ? buildSubchannelCursors(
+                [...existing.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
+                null
+              )
+            : {};
+          apiCursor.channels![toHex(rb)] = {
+            channel_key: toHex(info.key),
+            subchannel_discovery_complete: false,
+            subchannels,
+          };
+        }
+      } else {
+        apiCursor = { channel_discovery_complete: false, channels: {} };
+      }
+    }
+
+    // Accumulate channel/subchannel data across all pagination pages.
+    const createdChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
+    const subchannelsByRecipient = new Map<
+      string,
+      Map<string, { token: bigint; lastIndex: number | null }>
+    >();
+    const nonCreatedChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
+    let blockRef: string | undefined;
+
+    let complete = false;
+    do {
+      const body: Record<string, unknown> = {
+        contract_address: toHex(this.contractAddress),
+        sender_address: toHex(address),
+        viewing_key: toHex(viewingKey),
+        cursor: apiCursor,
+      };
+      if (blockRef) {
+        body.block_ref = blockRef;
+      }
+      if (recipients !== "all") {
+        body.recipients = recipients.map((r) => toHex(r));
+      }
+
+      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
+
+      blockRef = resp.block_ref;
+
+      accumulateOutgoingResponse(
+        resp,
+        createdChannelMap,
+        subchannelsByRecipient,
+        nonCreatedChannelMap
+      );
+
+      apiCursor = resp.cursor;
+      complete = isApiCursorComplete(resp.cursor);
+      if (!complete) pruneCompleteCursor(apiCursor);
+    } while (!complete);
+
+    // Build the final channel map from all accumulated data
+    const channels = buildChannelMap(
+      createdChannelMap,
+      subchannelsByRecipient,
+      nonCreatedChannelMap
+    );
+
+    if (recipients !== "all") {
+      const requested = new Set(recipients.map((r) => toBigInt(r)));
+      for (const key of [...channels.keys()]) {
+        if (!requested.has(key)) channels.delete(key);
+      }
+    }
+
+    return { timestamp: blockRef!, channels };
+  }
+
+  async discoverRequirement(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    recipient: StarknetAddressBigint,
+    token: StarknetAddressBigint
+  ): Promise<SetupRequirement> {
+    const resp = await this.post<{
+      block_ref: string;
+      sender_registered: boolean;
+      channel_exists: boolean;
+      subchannel_exists: boolean;
+    }>("/v1/sync/preflight_check", {
+      contract_address: toHex(this.contractAddress),
+      sender_address: toHex(address),
+      viewing_key: toHex(viewingKey),
+      recipient: toHex(recipient),
+      token: toHex(token),
+    });
+    if (!resp.sender_registered) return SetupRequirement.Register;
+    if (!resp.channel_exists) return SetupRequirement.SetupChannel;
+    if (!resp.subchannel_exists) return SetupRequirement.SetupToken;
+    return SetupRequirement.Ready;
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const resp = await fetch(`${this.apiUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      if (resp.status === 409) {
+        throw new ReorgError(`Block reorged during ${path}: ${text}`);
+      }
+      throw new Error(`Indexer API ${path} failed (${resp.status}): ${text}`);
+    }
+    return resp.json() as Promise<T>;
+  }
+}
+
+/** Mirrors Rust `DiscoveryCursor::is_complete()`. */
+function isApiCursorComplete(cursor: ApiDiscoveryCursor): boolean {
+  if (!cursor.channel_discovery_complete) return false;
+  if (!cursor.channels) return true;
+  return Object.values(cursor.channels).every(
+    (ch) =>
+      ch.subchannel_discovery_complete &&
+      (!ch.subchannels || Object.values(ch.subchannels).every((sc) => !!sc.note_discovery_complete))
+  );
+}
+
+/** Builds `Record<string, ApiSubchannelCursor>` from token→noteIndex pairs, optionally filtered. */
+export function buildSubchannelCursors(
+  noteIndexes: Iterable<[StarknetAddressBigint, number]>,
+  tokenFilter: Set<bigint> | null
+): Record<string, ApiSubchannelCursor> {
+  const subchannels: Record<string, ApiSubchannelCursor> = {};
+  for (const [token, noteIndex] of noteIndexes) {
+    if (tokenFilter && !tokenFilter.has(toBigInt(token))) continue;
+    subchannels[toHex(token)] = {
+      last_note_index: noteIndex > 0 ? noteIndex - 1 : undefined,
+    };
+  }
+  return subchannels;
+}
+
+/** Converts SDK `NotesCursor` -> API cursor for an incoming sync request. */
+export function notesCursorToApiCursor(
+  cursor: NotesCursor,
+  tokenFilter: Set<bigint> | null
+): ApiDiscoveryCursor {
+  const apiCursor: ApiDiscoveryCursor = {
+    channel_discovery_complete: false,
+    last_channel_index:
+      cursor.incomingChannels.size > 0 ? cursor.incomingChannels.size - 1 : undefined,
+    channels: {},
+  };
+  for (const [sender, icc] of cursor.incomingChannels) {
+    const subchannels = buildSubchannelCursors(icc.noteIndexes, tokenFilter);
+    apiCursor.channels![toHex(sender)] = {
+      channel_key: toHex(icc.channelKey),
+      subchannel_discovery_complete:
+        tokenFilter != null && tokenFilter.size === Object.keys(subchannels).length,
+      last_subchannel_index: icc.subchannelIdIndex > 0 ? icc.subchannelIdIndex - 1 : undefined,
+      subchannels,
+    };
+  }
+  return apiCursor;
+}
+
+/** Converts API cursor from an incoming sync response → SDK `NotesCursor`. */
+export function apiCursorToNotesCursor(
+  apiCursor: ApiDiscoveryCursor,
+  blockRef: string
+): NotesCursor {
+  const incomingChannels = new AddressMap<IncomingChannelCursor>();
+  if (apiCursor.channels) {
+    for (const [senderHex, ch] of Object.entries(apiCursor.channels)) {
+      const channelKey = ch.channel_key ? BigInt(ch.channel_key) : 0n;
+      const noteIndexes = new AddressMap<number>();
+      if (ch.subchannels) {
+        for (const [tokenHex, sc] of Object.entries(ch.subchannels)) {
+          noteIndexes.set(BigInt(tokenHex), (sc.last_note_index ?? -1) + 1);
+        }
+      }
+      incomingChannels.set(BigInt(senderHex), {
+        channelKey,
+        subchannelIdIndex: (ch.last_subchannel_index ?? -1) + 1,
+        noteIndexes,
+      });
+    }
+  }
+  return { blockId: blockRef, incomingChannels };
+}
+
+/** Converts SDK `AddressMap<Channel>` → API cursor for an outgoing sync request. */
+export function channelMapToApiCursor(
+  channels: AddressMap<ChannelInterface> | undefined,
+  channelDiscoveryComplete: boolean
+): ApiDiscoveryCursor {
+  const apiCursor: ApiDiscoveryCursor = {
+    channel_discovery_complete: channelDiscoveryComplete,
+    channels: {},
+  };
+  if (channels) {
+    for (const [recipient, channel] of channels) {
+      if (!channel.key) continue;
+      const subchannels = buildSubchannelCursors(
+        [...channel.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
+        null
+      );
+      apiCursor.channels![toHex(recipient)] = {
+        channel_key: toHex(channel.key),
+        subchannel_discovery_complete: false,
+        subchannels,
+      };
+    }
+  }
+  return apiCursor;
+}
+
+/** Accumulates outgoing sync response data into maps across multiple pages. */
+function accumulateOutgoingResponse(
+  resp: ApiOutgoingSyncResponse,
+  createdChannelMap: Map<string, { publicKey: bigint; channelKey: bigint }>,
+  subchannelsByRecipient: Map<string, Map<string, { token: bigint; lastIndex: number | null }>>,
+  nonCreatedChannelMap: Map<string, { publicKey: bigint; channelKey: bigint }>
+): void {
+  for (const ch of resp.channels) {
+    const info = { publicKey: BigInt(ch.recipient_public_key), channelKey: BigInt(ch.channel_key) };
+    if (ch.precomputed) {
+      // Precomputed channels may duplicate a real channel discovered in a
+      // later pagination step. The created map takes precedence.
+      if (!createdChannelMap.has(ch.recipient_addr)) {
+        nonCreatedChannelMap.set(ch.recipient_addr, info);
+      }
+    } else {
+      createdChannelMap.set(ch.recipient_addr, info);
+      // Promote: if we previously saw a precomputed entry, the real one wins.
+      nonCreatedChannelMap.delete(ch.recipient_addr);
+    }
+  }
+
+  for (const sc of resp.subchannels) {
+    let tokenMap = subchannelsByRecipient.get(sc.recipient_addr);
+    if (!tokenMap) {
+      tokenMap = new Map();
+      subchannelsByRecipient.set(sc.recipient_addr, tokenMap);
+    }
+    const existing = tokenMap.get(sc.token);
+    // Keep the most informative value: non-null overrides null
+    if (!existing || sc.last_note_index !== null) {
+      tokenMap.set(sc.token, { token: BigInt(sc.token), lastIndex: sc.last_note_index });
+    }
+  }
+}
+
+/** Builds the final SDK channel map from accumulated outgoing sync data. */
+function buildChannelMap(
+  createdChannelMap: Map<string, { publicKey: bigint; channelKey: bigint }>,
+  subchannelsByRecipient: Map<string, Map<string, { token: bigint; lastIndex: number | null }>>,
+  nonCreatedChannelMap: Map<string, { publicKey: bigint; channelKey: bigint }>
+): AddressMap<ChannelInterface> {
+  const channels = new AddressMap<ChannelInterface>();
+
+  for (const [recipientHex, info] of createdChannelMap) {
+    const tokens = new AddressMap<{ tokenIndex: number; noteNonce: number }>();
+    const subs = subchannelsByRecipient.get(recipientHex);
+    if (subs) {
+      let tokenIndex = 0;
+      for (const [, sub] of subs) {
+        tokens.set(sub.token, {
+          tokenIndex: tokenIndex++,
+          noteNonce: sub.lastIndex !== null ? sub.lastIndex + 1 : 0,
+        });
+      }
+    }
+    channels.set(
+      BigInt(recipientHex),
+      new Channel(info.publicKey, info.channelKey, tokens.entries())
+    );
+  }
+
+  for (const [recipientHex, info] of nonCreatedChannelMap) {
+    const addr = BigInt(recipientHex);
+    if (!channels.has(addr)) {
+      channels.set(addr, new Channel(info.publicKey));
+    }
+  }
+
+  return channels;
+}
+
+/** Prunes complete channels/subchannels from an API cursor to reduce payload size. */
+function pruneCompleteCursor(cursor: ApiDiscoveryCursor): void {
+  if (!cursor.channels) return;
+  for (const [addr, ch] of Object.entries(cursor.channels)) {
+    if (ch.subchannel_discovery_complete && ch.subchannels) {
+      for (const [token, sc] of Object.entries(ch.subchannels)) {
+        if (sc.note_discovery_complete) {
+          delete ch.subchannels[token];
+        }
+      }
+      if (Object.keys(ch.subchannels).length === 0) {
+        delete cursor.channels[addr];
+      }
+    }
+  }
+}
+
+/** Converts API incoming notes → SDK `Note` objects grouped by token. */
+export function convertIncomingNotes(
+  apiNotes: ApiIncomingNoteInfo[],
+  channelKeyMap: Map<string, bigint>,
+  existingChannels: AddressMap<IncomingChannelCursor>,
+  tokenFilter: Set<bigint> | null
+): AddressMap<Note[]> {
+  const result = new AddressMap<Note[]>(() => []);
+  for (const n of apiNotes) {
+    const token = BigInt(n.token);
+    if (tokenFilter && !tokenFilter.has(token)) continue;
+    const sender = BigInt(n.sender_addr);
+    const channelKey = channelKeyMap.get(n.sender_addr) ?? existingChannels.get(sender)?.channelKey;
+    if (channelKey == null) {
+      throw new Error(
+        `Missing channel_key for sender ${n.sender_addr}: not found in current response or previous pages`
+      );
+    }
+    result.get(token)!.push({
+      id: n.note_id,
+      amount: BigInt(n.amount),
+      witness: new Witness(channelKey, n.index, BigInt(n.salt)),
+      sender,
+      open: n.salt === 1,
+    });
+  }
+  return result;
+}

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ActionCompiler } from "../../src/internal/compiler.js";
+import { ReorgError } from "../../src/internal/indexer-discovery.js";
+import { createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
+import type { DiscoveryProviderInterface, Note } from "../../src/interfaces.js";
+import { AddressMap } from "../../src/utils/maps.js";
+import { Channel } from "../../src/internal/channel.js";
+
+const USER_ADDRESS = 0xa11cen;
+const VIEWING_KEY = 0xbeefn;
+const RECIPIENT_ADDR = 0xb0b1n;
+const TOKEN_ADDR = 0xace1n;
+
+function createMockProvider(overrides: Partial<DiscoveryProviderInterface> = {}) {
+  return {
+    discoverNotes: vi.fn().mockResolvedValue({
+      timestamp: "0xblock",
+      notes: new AddressMap<Note[]>(),
+      cursor: { blockId: "0xblock", incomingChannels: new AddressMap() },
+    }),
+    discoverChannels: vi.fn().mockResolvedValue({
+      timestamp: "0xblock",
+      channels: new AddressMap<Channel>([
+        [USER_ADDRESS, new Channel(0xaa1n, 0xcc1n)],
+        [RECIPIENT_ADDR, new Channel(0xaa2n, 0xcc2n)],
+      ]),
+    }),
+    discoverRequirement: vi.fn().mockResolvedValue(SetupRequirement.Ready),
+    ...overrides,
+  } satisfies DiscoveryProviderInterface;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ActionCompiler reorg handling", () => {
+  it("clears registry and retries on ReorgError", async () => {
+    const mockProvider = createMockProvider({
+      discoverChannels: vi
+        .fn()
+        .mockRejectedValueOnce(new ReorgError("block reorged"))
+        .mockResolvedValue({
+          timestamp: "0xblock2",
+          channels: new AddressMap<Channel>([
+            [USER_ADDRESS, new Channel(0xaa1n, 0xcc1n)],
+            [RECIPIENT_ADDR, new Channel(0xaa2n, 0xcc2n)],
+          ]),
+        }),
+    });
+
+    const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, mockProvider);
+
+    const registry = createEmptyRegistry();
+    registry.notes.set(TOKEN_ADDR, [
+      {
+        id: "0xstale",
+        amount: 100n,
+        witness: { channelKey: 0xc0n, nonce: 0, r: 1n },
+        sender: 0xaaan,
+      },
+    ]);
+    registry.channels.set(RECIPIENT_ADDR, new Channel(0xa1dn, 0xa1cn));
+    registry.cursor = { blockId: "0xoldblock", incomingChannels: new AddressMap() };
+
+    const result = await compiler.compile(
+      { openChannels: [{ recipient: RECIPIENT_ADDR }] },
+      { registry, autoDiscover: { channels: "refresh" } }
+    );
+
+    expect(mockProvider.discoverChannels).toHaveBeenCalledTimes(2);
+    // Stale note was cleared before the retry repopulated the registry
+    expect(registry.notes.has(TOKEN_ADDR)).toBe(false);
+    expect(result.clientActions).toBeDefined();
+  });
+
+  it("propagates non-ReorgError without retry", async () => {
+    const mockProvider = createMockProvider({
+      discoverChannels: vi.fn().mockRejectedValue(new Error("network failure")),
+    });
+
+    const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, mockProvider);
+
+    await expect(
+      compiler.compile(
+        { openChannels: [{ recipient: RECIPIENT_ADDR }] },
+        { registry: createEmptyRegistry(), autoDiscover: { channels: "refresh" } }
+      )
+    ).rejects.toThrow("network failure");
+
+    expect(mockProvider.discoverChannels).toHaveBeenCalledOnce();
+  });
+});

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -1,0 +1,658 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import {
+  IndexerDiscoveryProvider,
+  ReorgError,
+  notesCursorToApiCursor,
+  apiCursorToNotesCursor,
+  convertIncomingNotes,
+  buildSubchannelCursors,
+} from "../../src/internal/indexer-discovery.js";
+import { SetupRequirement } from "../../src/interfaces.js";
+import { AddressMap } from "../../src/utils/maps.js";
+import type { IncomingChannelCursor, NotesCursor } from "../../src/internal/channel.js";
+
+const API_URL = "http://test-indexer:8080";
+const USER_ADDRESS = 0xa11cen;
+const VIEWING_KEY = 0xbeefn;
+const BLOCK_REF = "0xb10c1";
+const SENDER_ADDR = "0xaaa1";
+const TOKEN_ADDR = "0xace1";
+const TOKEN_ADDR_2 = "0xace2";
+const RECIPIENT_ADDR = "0xbbb1";
+const RECIPIENT_ADDR_2 = "0xbbb2";
+const CHANNEL_KEY_1 = "0xcc1";
+const CHANNEL_KEY_2 = "0xcc2";
+const PUBLIC_KEY_1 = "0xaa1";
+const PUBLIC_KEY_2 = "0xaa2";
+
+function mockFetchJson(...responses: { body: unknown; status?: number }[]) {
+  const mockFn = vi.fn();
+  for (const resp of responses) {
+    const status = resp.status ?? 200;
+    mockFn.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(resp.body),
+      text: () => Promise.resolve(JSON.stringify(resp.body)),
+    });
+  }
+  globalThis.fetch = mockFn;
+  return mockFn;
+}
+
+function createProvider(): IndexerDiscoveryProvider {
+  return new IndexerDiscoveryProvider(API_URL, "0x123");
+}
+
+/** A complete cursor with no channels -- signals "nothing left to discover". */
+const EMPTY_COMPLETE_CURSOR = { channel_discovery_complete: true, channels: {} } as const;
+
+/** Builds a complete API cursor with fully-discovered channels and subchannels. */
+function completeCursor(
+  channels: Record<string, { channel_key: string; subchannels?: Record<string, unknown> }>
+): Record<string, unknown> {
+  const apiChannels: Record<string, unknown> = {};
+  for (const [addr, ch] of Object.entries(channels)) {
+    apiChannels[addr] = {
+      channel_key: ch.channel_key,
+      subchannel_discovery_complete: true,
+      subchannels: ch.subchannels ?? {},
+    };
+  }
+  return { channel_discovery_complete: true, channels: apiChannels };
+}
+
+/** Builds an incomplete API cursor (channel discovery still in progress). */
+function incompleteCursor(
+  channels: Record<string, { channel_key: string; subchannels?: Record<string, unknown> }>
+): Record<string, unknown> {
+  const apiChannels: Record<string, unknown> = {};
+  for (const [addr, ch] of Object.entries(channels)) {
+    apiChannels[addr] = {
+      channel_key: ch.channel_key,
+      subchannel_discovery_complete: false,
+      subchannels: ch.subchannels ?? {},
+    };
+  }
+  return { channel_discovery_complete: false, channels: apiChannels };
+}
+
+function incomingSyncResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    block_ref: BLOCK_REF,
+    channels: [],
+    subchannels: [],
+    notes: [],
+    cursor: EMPTY_COMPLETE_CURSOR,
+    ...overrides,
+  };
+}
+
+function outgoingSyncResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    block_ref: BLOCK_REF,
+    channels: [],
+    subchannels: [],
+    cursor: EMPTY_COMPLETE_CURSOR,
+    ...overrides,
+  };
+}
+
+function noteEntry(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    sender_addr: SENDER_ADDR,
+    token: TOKEN_ADDR,
+    index: 0,
+    note_id: "0xde1",
+    amount: 100,
+    salt: 42,
+    ...overrides,
+  };
+}
+
+function channelEntry(
+  recipientAddr: string,
+  publicKey: string,
+  channelKey: string,
+  extra: Record<string, unknown> = {}
+) {
+  return {
+    recipient_addr: recipientAddr,
+    recipient_public_key: publicKey,
+    channel_key: channelKey,
+    ...extra,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("IndexerDiscoveryProvider", () => {
+  describe("discoverNotes", () => {
+    it("returns notes from a single complete page", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: incomingSyncResponse({
+          channels: [{ channel_key: CHANNEL_KEY_1, sender_addr: SENDER_ADDR }],
+          notes: [noteEntry()],
+          cursor: completeCursor({
+            [SENDER_ADDR]: {
+              channel_key: CHANNEL_KEY_1,
+              subchannels: {
+                [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 0 },
+              },
+            },
+          }),
+        }),
+      });
+
+      const result = await provider.discoverNotes(USER_ADDRESS, VIEWING_KEY);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(result.timestamp).toBe(BLOCK_REF);
+
+      const tokenNotes = result.notes.get(BigInt(TOKEN_ADDR));
+      expect(tokenNotes).toHaveLength(1);
+      const note = tokenNotes![0];
+      expect(note.id).toBe("0xde1");
+      expect(note.amount).toBe(100n);
+      expect(note.witness.channelKey).toBe(BigInt(CHANNEL_KEY_1));
+      expect(note.witness.nonce).toBe(0);
+      expect(note.sender).toBe(BigInt(SENDER_ADDR));
+      expect(note.open).toBe(false);
+      expect(result.cursor.blockId).toBe(BLOCK_REF);
+    });
+
+    it("paginates across 2 pages and merges notes", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson(
+        {
+          body: incomingSyncResponse({
+            channels: [{ channel_key: CHANNEL_KEY_1, sender_addr: SENDER_ADDR }],
+            notes: [noteEntry({ amount: 50, salt: 10 })],
+            cursor: incompleteCursor({
+              [SENDER_ADDR]: { channel_key: CHANNEL_KEY_1 },
+            }),
+          }),
+        },
+        {
+          body: incomingSyncResponse({
+            notes: [noteEntry({ index: 1, note_id: "0xde2", amount: 75, salt: 20 })],
+            cursor: completeCursor({
+              [SENDER_ADDR]: {
+                channel_key: CHANNEL_KEY_1,
+                subchannels: {
+                  [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 1 },
+                },
+              },
+            }),
+          }),
+        }
+      );
+
+      const result = await provider.discoverNotes(USER_ADDRESS, VIEWING_KEY);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      const secondCallBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(secondCallBody.block_ref).toBe(BLOCK_REF);
+
+      const tokenNotes = result.notes.get(BigInt(TOKEN_ADDR));
+      expect(tokenNotes).toHaveLength(2);
+      expect(tokenNotes![0].id).toBe("0xde1");
+      expect(tokenNotes![1].id).toBe("0xde2");
+    });
+
+    it("filters notes by token when tokens param is provided", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: incomingSyncResponse({
+          channels: [{ channel_key: CHANNEL_KEY_1, sender_addr: SENDER_ADDR }],
+          notes: [
+            noteEntry({ amount: 50, salt: 1 }),
+            noteEntry({ token: TOKEN_ADDR_2, note_id: "0xde2", amount: 75, salt: 2 }),
+          ],
+          cursor: completeCursor({
+            [SENDER_ADDR]: {
+              channel_key: CHANNEL_KEY_1,
+              subchannels: {
+                [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 0 },
+                [TOKEN_ADDR_2]: { note_discovery_complete: true, last_note_index: 0 },
+              },
+            },
+          }),
+        }),
+      });
+
+      const result = await provider.discoverNotes(USER_ADDRESS, VIEWING_KEY, {
+        tokens: [BigInt(TOKEN_ADDR)],
+      });
+
+      const token1Notes = result.notes.get(BigInt(TOKEN_ADDR));
+      expect(token1Notes).toHaveLength(1);
+      expect(token1Notes![0].id).toBe("0xde1");
+      expect(token1Notes![0].open).toBe(true); // salt === 1
+
+      const token2Notes = result.notes.get(BigInt(TOKEN_ADDR_2));
+      expect(token2Notes ?? []).toHaveLength(0);
+    });
+
+    it("throws ReorgError on HTTP 409", async () => {
+      const provider = createProvider();
+      mockFetchJson({ body: { error: "BLOCK_REORGED" }, status: 409 });
+
+      await expect(provider.discoverNotes(USER_ADDRESS, VIEWING_KEY)).rejects.toThrow(ReorgError);
+    });
+  });
+
+  describe("discoverChannels", () => {
+    it("returns channels for 'all' recipients on a single page", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: outgoingSyncResponse({
+          channels: [channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1)],
+          subchannels: [{ recipient_addr: RECIPIENT_ADDR, token: TOKEN_ADDR, last_note_index: 2 }],
+          cursor: completeCursor({
+            [RECIPIENT_ADDR]: {
+              channel_key: CHANNEL_KEY_1,
+              subchannels: {
+                [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 2 },
+              },
+            },
+          }),
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(result.timestamp).toBe(BLOCK_REF);
+
+      const channel = result.channels!.get(BigInt(RECIPIENT_ADDR));
+      expect(channel).toBeDefined();
+      expect(channel!.key).toBe(BigInt(CHANNEL_KEY_1));
+      expect(channel!.publicKey).toBe(BigInt(PUBLIC_KEY_1));
+
+      const tokenNonces = channel!.tokens.get(BigInt(TOKEN_ADDR));
+      expect(tokenNonces).toBeDefined();
+      expect(tokenNonces!.noteNonce).toBe(3); // last_note_index 2 + 1
+    });
+
+    it("paginates 'all' recipients across 2 pages and merges", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson(
+        {
+          body: outgoingSyncResponse({
+            channels: [channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1)],
+            cursor: incompleteCursor({
+              [RECIPIENT_ADDR]: { channel_key: CHANNEL_KEY_1 },
+            }),
+          }),
+        },
+        {
+          body: outgoingSyncResponse({
+            channels: [channelEntry(RECIPIENT_ADDR_2, PUBLIC_KEY_2, CHANNEL_KEY_2)],
+            subchannels: [
+              { recipient_addr: RECIPIENT_ADDR, token: TOKEN_ADDR, last_note_index: 0 },
+            ],
+            cursor: completeCursor({
+              [RECIPIENT_ADDR]: {
+                channel_key: CHANNEL_KEY_1,
+                subchannels: {
+                  [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 0 },
+                },
+              },
+              [RECIPIENT_ADDR_2]: { channel_key: CHANNEL_KEY_2 },
+            }),
+          }),
+        }
+      );
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
+      expect(result.channels!.has(BigInt(RECIPIENT_ADDR_2))).toBe(true);
+      expect(result.channels!.get(BigInt(RECIPIENT_ADDR_2))!.key).toBe(BigInt(CHANNEL_KEY_2));
+    });
+
+    it("sends recipients array in request body for specific recipients", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: outgoingSyncResponse({
+          channels: [
+            channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1),
+            channelEntry(RECIPIENT_ADDR_2, PUBLIC_KEY_2, CHANNEL_KEY_2),
+          ],
+          cursor: completeCursor({
+            [RECIPIENT_ADDR]: { channel_key: CHANNEL_KEY_1 },
+            [RECIPIENT_ADDR_2]: { channel_key: CHANNEL_KEY_2 },
+          }),
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, [
+        BigInt(RECIPIENT_ADDR),
+        BigInt(RECIPIENT_ADDR_2),
+      ]);
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.recipients).toBeDefined();
+      expect(requestBody.recipients).toHaveLength(2);
+
+      expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
+      expect(result.channels!.has(BigInt(RECIPIENT_ADDR_2))).toBe(true);
+    });
+
+    it("does not send recipients field for 'all' filter", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: outgoingSyncResponse(),
+      });
+
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.recipients).toBeUndefined();
+    });
+
+    it("returns total for 'total-only' recipients filter", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          cursor: {
+            channel_discovery_complete: false,
+            total_n_channels: 5,
+          },
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+
+      expect(result.total).toBe(5);
+      expect(result.channels).toBeUndefined();
+    });
+
+    it("prefers real channels over precomputed channels for the same recipient", async () => {
+      const provider = createProvider();
+      const PRECOMPUTED_KEY = "0xdd1";
+      const REAL_KEY = "0xee1";
+      const PRECOMPUTED_PK = "0xff1";
+      const REAL_PK = "0xff2";
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          channels: [
+            channelEntry(RECIPIENT_ADDR, PRECOMPUTED_PK, PRECOMPUTED_KEY, { precomputed: true }),
+            channelEntry(RECIPIENT_ADDR, REAL_PK, REAL_KEY),
+          ],
+          cursor: completeCursor({
+            [RECIPIENT_ADDR]: { channel_key: REAL_KEY },
+          }),
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+
+      const channel = result.channels!.get(BigInt(RECIPIENT_ADDR));
+      expect(channel).toBeDefined();
+      expect(channel!.key).toBe(BigInt(REAL_KEY));
+      expect(channel!.publicKey).toBe(BigInt(REAL_PK));
+    });
+  });
+
+  describe("discoverRequirement", () => {
+    it.each([
+      {
+        name: "Register when sender not registered",
+        response: { sender_registered: false, channel_exists: false, subchannel_exists: false },
+        expected: SetupRequirement.Register,
+      },
+      {
+        name: "SetupChannel when registered but no channel",
+        response: { sender_registered: true, channel_exists: false, subchannel_exists: false },
+        expected: SetupRequirement.SetupChannel,
+      },
+      {
+        name: "SetupToken when channel exists but no subchannel",
+        response: { sender_registered: true, channel_exists: true, subchannel_exists: false },
+        expected: SetupRequirement.SetupToken,
+      },
+      {
+        name: "Ready when everything exists",
+        response: { sender_registered: true, channel_exists: true, subchannel_exists: true },
+        expected: SetupRequirement.Ready,
+      },
+    ])("returns $expected for $name", async ({ response, expected }) => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: { block_ref: BLOCK_REF, ...response },
+      });
+
+      const result = await provider.discoverRequirement(
+        USER_ADDRESS,
+        VIEWING_KEY,
+        BigInt(RECIPIENT_ADDR),
+        BigInt(TOKEN_ADDR)
+      );
+
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe("request body validation", () => {
+    it("includes contract_address and viewing_key in discoverNotes requests", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({ body: incomingSyncResponse() });
+
+      await provider.discoverNotes(USER_ADDRESS, VIEWING_KEY);
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.contract_address).toBe("0x123");
+      expect(requestBody.viewing_key).toBe("0xbeef");
+      expect(requestBody.decryption_key).toBeUndefined();
+    });
+
+    it("includes contract_address and viewing_key in discoverChannels requests", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({ body: outgoingSyncResponse() });
+
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.contract_address).toBe("0x123");
+      expect(requestBody.viewing_key).toBe("0xbeef");
+      expect(requestBody.decryption_key).toBeUndefined();
+    });
+
+    it("includes contract_address and viewing_key in discoverRequirement requests", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: {
+          block_ref: BLOCK_REF,
+          sender_registered: true,
+          channel_exists: true,
+          subchannel_exists: true,
+        },
+      });
+
+      await provider.discoverRequirement(
+        USER_ADDRESS,
+        VIEWING_KEY,
+        BigInt(RECIPIENT_ADDR),
+        BigInt(TOKEN_ADDR)
+      );
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.contract_address).toBe("0x123");
+      expect(requestBody.viewing_key).toBe("0xbeef");
+      expect(requestBody.decryption_key).toBeUndefined();
+    });
+  });
+
+  describe("exported helpers", () => {
+    it("round-trips notesCursorToApiCursor → apiCursorToNotesCursor", () => {
+      const senderAddress = 0xabn;
+      const tokenAddress = 0xcdn;
+      const channelKey = 0x999n;
+
+      const noteIndexes = new AddressMap<number>();
+      noteIndexes.set(tokenAddress, 5);
+
+      const incomingChannels = new AddressMap<IncomingChannelCursor>();
+      incomingChannels.set(senderAddress, {
+        channelKey,
+        subchannelIdIndex: 3,
+        noteIndexes,
+      });
+
+      const originalCursor: NotesCursor = {
+        blockId: BLOCK_REF,
+        incomingChannels,
+      };
+
+      const apiCursor = notesCursorToApiCursor(originalCursor, null);
+      const roundTripped = apiCursorToNotesCursor(apiCursor, BLOCK_REF);
+
+      expect(roundTripped.blockId).toBe(BLOCK_REF);
+
+      const rtChannel = roundTripped.incomingChannels.get(senderAddress);
+      expect(rtChannel).toBeDefined();
+      expect(rtChannel!.channelKey).toBe(channelKey);
+      expect(rtChannel!.subchannelIdIndex).toBe(3);
+      expect(rtChannel!.noteIndexes.get(tokenAddress)).toBe(5);
+    });
+
+    it("convertIncomingNotes filters by token", () => {
+      const apiNotes = [
+        noteEntry({ note_id: "0xe1", salt: 5 }),
+        noteEntry({ token: TOKEN_ADDR_2, note_id: "0xe2", amount: 200, salt: 6 }),
+      ];
+      const channelKeyMap = new Map<string, bigint>([[SENDER_ADDR, 0xcc1n]]);
+      const existingChannels = new AddressMap<IncomingChannelCursor>();
+      const tokenFilter = new Set([BigInt(TOKEN_ADDR)]);
+
+      const result = convertIncomingNotes(apiNotes, channelKeyMap, existingChannels, tokenFilter);
+
+      const token1Notes = result.get(BigInt(TOKEN_ADDR));
+      expect(token1Notes).toHaveLength(1);
+      expect(token1Notes![0].id).toBe("0xe1");
+
+      const token2Notes = result.get(BigInt(TOKEN_ADDR_2));
+      expect(token2Notes ?? []).toHaveLength(0);
+    });
+
+    it("convertIncomingNotes throws when sender has no channel key", () => {
+      const unknownSender = "0xdead";
+      const apiNotes = [noteEntry({ sender_addr: unknownSender })];
+      const channelKeyMap = new Map<string, bigint>();
+      const existingChannels = new AddressMap<IncomingChannelCursor>();
+
+      expect(() => convertIncomingNotes(apiNotes, channelKeyMap, existingChannels, null)).toThrow(
+        `Missing channel_key for sender ${unknownSender}`
+      );
+    });
+
+    describe("buildSubchannelCursors", () => {
+      it("builds cursors from token-noteIndex pairs", () => {
+        const entries: [bigint, number][] = [
+          [BigInt(TOKEN_ADDR), 5],
+          [BigInt(TOKEN_ADDR_2), 0],
+        ];
+        const result = buildSubchannelCursors(entries, null);
+
+        expect(Object.keys(result)).toHaveLength(2);
+        expect(result[TOKEN_ADDR]).toEqual({ last_note_index: 4 });
+        expect(result[TOKEN_ADDR_2]).toEqual({ last_note_index: undefined });
+      });
+
+      it("filters by token when tokenFilter is provided", () => {
+        const entries: [bigint, number][] = [
+          [BigInt(TOKEN_ADDR), 3],
+          [BigInt(TOKEN_ADDR_2), 7],
+        ];
+        const tokenFilter = new Set([BigInt(TOKEN_ADDR)]);
+        const result = buildSubchannelCursors(entries, tokenFilter);
+
+        expect(Object.keys(result)).toHaveLength(1);
+        expect(result[TOKEN_ADDR]).toEqual({ last_note_index: 2 });
+        expect(result[TOKEN_ADDR_2]).toBeUndefined();
+      });
+
+      it("returns empty record for empty input", () => {
+        const result = buildSubchannelCursors([], null);
+        expect(Object.keys(result)).toHaveLength(0);
+      });
+    });
+
+    describe("notesCursorToApiCursor subchannel_discovery_complete", () => {
+      it("sets subchannel_discovery_complete false when filtered token is missing from noteIndexes", () => {
+        const senderAddress = 0xabn;
+        const knownToken = BigInt(TOKEN_ADDR);
+        const unknownToken = BigInt(TOKEN_ADDR_2);
+
+        const noteIndexes = new AddressMap<number>();
+        noteIndexes.set(knownToken, 3);
+
+        const incomingChannels = new AddressMap<IncomingChannelCursor>();
+        incomingChannels.set(senderAddress, {
+          channelKey: 0x999n,
+          subchannelIdIndex: 1,
+          noteIndexes,
+        });
+
+        const cursor: NotesCursor = { blockId: BLOCK_REF, incomingChannels };
+        const tokenFilter = new Set([knownToken, unknownToken]);
+
+        const apiCursor = notesCursorToApiCursor(cursor, tokenFilter);
+        const senderChannel = apiCursor.channels!["0xab"];
+
+        expect(senderChannel.subchannel_discovery_complete).toBe(false);
+      });
+
+      it("sets subchannel_discovery_complete true when all filtered tokens exist in noteIndexes", () => {
+        const senderAddress = 0xabn;
+        const token1 = BigInt(TOKEN_ADDR);
+        const token2 = BigInt(TOKEN_ADDR_2);
+
+        const noteIndexes = new AddressMap<number>();
+        noteIndexes.set(token1, 3);
+        noteIndexes.set(token2, 1);
+
+        const incomingChannels = new AddressMap<IncomingChannelCursor>();
+        incomingChannels.set(senderAddress, {
+          channelKey: 0x999n,
+          subchannelIdIndex: 2,
+          noteIndexes,
+        });
+
+        const cursor: NotesCursor = { blockId: BLOCK_REF, incomingChannels };
+        const tokenFilter = new Set([token1, token2]);
+
+        const apiCursor = notesCursorToApiCursor(cursor, tokenFilter);
+        const senderChannel = apiCursor.channels!["0xab"];
+
+        expect(senderChannel.subchannel_discovery_complete).toBe(true);
+      });
+
+      it("sets subchannel_discovery_complete false when tokenFilter is null", () => {
+        const senderAddress = 0xabn;
+        const noteIndexes = new AddressMap<number>();
+        noteIndexes.set(BigInt(TOKEN_ADDR), 3);
+
+        const incomingChannels = new AddressMap<IncomingChannelCursor>();
+        incomingChannels.set(senderAddress, {
+          channelKey: 0x999n,
+          subchannelIdIndex: 1,
+          noteIndexes,
+        });
+
+        const cursor: NotesCursor = { blockId: BLOCK_REF, incomingChannels };
+        const apiCursor = notesCursorToApiCursor(cursor, null);
+        const senderChannel = apiCursor.channels!["0xab"];
+
+        expect(senderChannel.subchannel_discovery_complete).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### TL;DR

Add IndexerDiscoveryProvider to support discovery via the indexer API, with reorg handling and cursor-based pagination.

### What changed?

- Added `IndexerDiscoveryProvider` implementation that communicates with the discovery service API
- Implemented reorg detection and recovery in the `ActionCompiler`
- Updated API endpoint paths to match the latest discovery service spec
- Added cursor conversion utilities between SDK and API formats
- Added comprehensive tests for the indexer discovery provider
- Updated verification checklist to include SDK checks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/485)
<!-- Reviewable:end -->
