### PR TITLE
feat(sdk): add native ClientAction::Swap support

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -165,6 +165,23 @@ export type FollowupCallAction = {
   call: Call;
 };
 
+export type SwapAction = {
+  /** The SwapExecutor contract address */
+  swapExecutor: StarknetAddressBigint;
+  /** The AMM/DEX contract to call for the swap */
+  swapContract: StarknetAddressBigint;
+  /** The selector of the swap function on the AMM/DEX */
+  swapSelector: bigint;
+  /** The calldata to pass to the swap function */
+  swapCalldata: bigint[];
+  /** The token to swap from (input token) */
+  inToken: StarknetAddressBigint;
+  /** The token to swap to (output token) */
+  outToken: StarknetAddressBigint;
+  /** The amount of input tokens to swap */
+  inAmount: Amount;
+};
+
 /** Actions - context comes from registry */
 export type Actions = {
   setViewingKey?: SetViewingKeyAction;
@@ -176,6 +193,7 @@ export type Actions = {
   withdraws?: WithdrawAction[];
   surpluses?: SurplusAction[];
   followupCall?: FollowupCallAction;
+  swap?: SwapAction;
 };
 
 // ============ Auto-Discovery & Registry Types ============
@@ -296,15 +314,10 @@ export interface SimplePrivateTransfersInterface {
   ): Promise<ExecuteResult>;
 
   /**
-   * will withdraw to the contract in `helperCall` and then deposit to the privacy pool in `toToken`
-   * Note: a noteid will be added to the helper calldata
+   * Swap tokens privately: withdraw inToken to swap executor, execute swap via AMM/DEX,
+   * deposit outToken back as a private note. Uses native ClientAction::Swap.
    */
-  swap(
-    fromToken: StarknetAddress,
-    fromAmount: Amount,
-    toToken: StarknetAddress,
-    helperCall: Call
-  ): Promise<ExecuteResult>;
+  swap(swap: SwapAction): Promise<ExecuteResult>;
 }
 
 /**
@@ -513,6 +526,13 @@ export interface PrivateTransfersBuilder {
 
   /** Add an arbitrary Starknet call that will run on starknet after the private operations are executed */
   call(call: Call): this;
+
+  /**
+   * Add a swap operation that withdraws inToken to the swap executor, executes the swap via
+   * the AMM/DEX contract, and deposits the output token back into a private note.
+   * This produces a native ClientAction::Swap on the contract (not a FollowupCall).
+   */
+  swap(swap: SwapAction): this;
 
   /**
    * Set the default recipient for any surplus across all tokens.

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -23,6 +23,7 @@ import {
   type TransferOutput,
   type SurplusAction,
   type FollowupCallAction,
+  type SwapAction,
   type Amount,
   Open,
   PrivateTransfersInterface,
@@ -148,6 +149,7 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
   public setViewingKey?: SetViewingKeyAction;
   public openChannels: OpenChannelAction[] = [];
   public followupCall?: FollowupCallAction;
+  public swapAction?: SwapAction;
   public tokenBuilders = new AddressMap<TokenOperationsBuilderImpl>(
     (token) => new TokenOperationsBuilderImpl(this, token)
   );
@@ -178,6 +180,11 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
 
   call(call: Call): this {
     this.followupCall = { call };
+    return this;
+  }
+
+  swap(swap: SwapAction): this {
+    this.swapAction = swap;
     return this;
   }
 
@@ -261,6 +268,7 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
       withdraws,
       surpluses,
       followupCall: this.followupCall,
+      swap: this.swapAction,
     };
 
     // Execute via PrivateTransfers - ActionCompiler will resolve contexts

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -441,6 +441,8 @@ export class ActionCompiler {
         () => `Missing subchannel for swap out_token ${toHex(swap.outToken)}`
       );
 
+      const noteNonce = channel.tokens.get(swap.outToken)!.noteNonce;
+
       const input = {
         type: "Swap",
         input: {
@@ -452,7 +454,9 @@ export class ActionCompiler {
           out_token: swap.outToken,
           in_amount: swap.inAmount,
           channel_key: channel.key as bigint,
-          index: channel.tokens.get(swap.outToken)!.noteNonce,
+          // If an open note was created earlier in this tx, deposit into that latest note index.
+          // Fallback to current nonce for compatibility with legacy mock flows.
+          index: noteNonce > 0 ? noteNonce - 1 : noteNonce,
           random: generateRandom(),
         },
       } as const;

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -53,6 +53,7 @@ type ClientActions = {
   createEncNotes: Extract<ClientAction, { type: "CreateEncNote" }>[];
   createOpenNotes: Extract<ClientAction, { type: "CreateOpenNote" }>[];
   withdraws: Extract<ClientAction, { type: "Withdraw" }>[];
+  swap?: Extract<ClientAction, { type: "Swap" }>;
   followupCall?: Extract<ClientAction, { type: "FollowupCall" }>;
 };
 
@@ -215,6 +216,7 @@ export class ActionCompiler {
       createEncNotes: [],
       createOpenNotes: [],
       withdraws: [],
+      swap: undefined,
       followupCall: undefined,
     };
 
@@ -425,7 +427,39 @@ export class ActionCompiler {
 
     // surpluses were handled in resolveNotes
 
-    // 8. FollowupCall
+    // 8. Swap (native ClientAction::Swap — requires channel context for out_token)
+    if (actions.swap) {
+      const swap = actions.swap;
+      // Ensure the user's self-channel and out_token subchannel exist
+      const channel = transformOpenSubchannel(
+        { recipient: this.userAddress, token: swap.outToken },
+        false
+      );
+      assert(channel, () => `Missing channel context for swap out_token ${toHex(swap.outToken)}`);
+      assert(
+        channel.tokens.has(swap.outToken),
+        () => `Missing subchannel for swap out_token ${toHex(swap.outToken)}`
+      );
+
+      const input = {
+        type: "Swap",
+        input: {
+          swap_executor: swap.swapExecutor,
+          swap_contract: swap.swapContract,
+          swap_selector: swap.swapSelector,
+          swap_calldata: swap.swapCalldata,
+          in_token: swap.inToken,
+          out_token: swap.outToken,
+          in_amount: swap.inAmount,
+          channel_key: channel.key as bigint,
+          index: channel.tokens.get(swap.outToken)!.noteNonce,
+          random: generateRandom(),
+        },
+      } as const;
+      clientActions.swap = execute(input);
+    }
+
+    // 9. FollowupCall
     if (actions.followupCall) {
       const input = {
         type: "FollowupCall",
@@ -561,6 +595,12 @@ export class ActionCompiler {
           update(c.token, -c.amount);
         }
       }
+    }
+
+    // Outputs: Swap (withdraws inAmount of inToken)
+    if (actions.swap) {
+      assert(actions.swap.inAmount > 0n, () => `Swap inAmount must be positive`);
+      update(actions.swap.inToken, -actions.swap.inAmount);
     }
 
     const notesDiscoveryLevel = options?.autoDiscover?.notes;

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -23,6 +23,7 @@ import type {
   OpenChannelInput,
   OpenSubchannelInput,
   SetViewingKeyInput,
+  SwapInput,
   UseNoteInput,
 } from "./client-actions.js";
 import { compute_channel_key, compute_note_id } from "../utils/hashes.js";
@@ -77,6 +78,11 @@ export class PoolSimulator {
 
       case "Withdraw":
         // Withdrawals don't affect tracking state (handled by MockPoolContract)
+        break;
+
+      case "Swap":
+        // Swap creates an open note on out_token — need to increment note nonce
+        this.handleSwap(action.input);
         break;
 
       case "FollowupCall":
@@ -275,6 +281,27 @@ export class PoolSimulator {
       toHex(recipient_addr),
       "token:",
       toHex(token)
+    );
+  }
+
+  private handleSwap(input: SwapInput): void {
+    const { out_token } = input;
+
+    // The contract's swap() internally creates an open note for out_token on the user's
+    // self-channel, so we need to increment the note nonce for out_token.
+    const senderChannel = this.channels.get(this.userAddress);
+    if (senderChannel) {
+      senderChannel.incrementNoteNonce(out_token);
+    }
+
+    debugLog(
+      "pool-simulator",
+      "Swap",
+      toHex(this.userAddress),
+      "in_token:",
+      toHex(input.in_token),
+      "out_token:",
+      toHex(out_token)
     );
   }
 }

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -285,15 +285,6 @@ export class PoolSimulator {
   }
 
   private handleSwap(input: SwapInput): void {
-    const { out_token } = input;
-
-    // The contract's swap() internally creates an open note for out_token on the user's
-    // self-channel, so we need to increment the note nonce for out_token.
-    const senderChannel = this.channels.get(this.userAddress);
-    if (senderChannel) {
-      senderChannel.incrementNoteNonce(out_token);
-    }
-
     debugLog(
       "pool-simulator",
       "Swap",
@@ -301,7 +292,7 @@ export class PoolSimulator {
       "in_token:",
       toHex(input.in_token),
       "out_token:",
-      toHex(out_token)
+      toHex(input.out_token)
     );
   }
 }

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -1,16 +1,15 @@
-import { Call } from "starknet";
 import {
   SimplePrivateTransfersInterface,
   PrivateTransfersInterface,
   Amount,
   Channel,
   Note,
-  Open,
   PrivateRegistry,
   StarknetAddress,
   All,
   ExecuteResult,
-} from "./interfaces.js"; // Assuming you moved interfaces
+  SwapAction,
+} from "./interfaces.js";
 import { AddressMap } from "./utils/maps.js";
 import { isAll } from "./utils/validation.js";
 
@@ -57,20 +56,8 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     return builder.transfer({ recipient, amount }).surplusTo(this.inner.user, false).execute();
   }
 
-  swap(
-    fromToken: StarknetAddress,
-    fromAmount: Amount,
-    toToken: StarknetAddress,
-    helperCall: Call
-  ): Promise<ExecuteResult> {
-    return this.build(fromToken)
-      .withdraw({ recipient: helperCall.contractAddress, amount: fromAmount })
-      .surplusTo(this.inner.user, false) // Keep ACE surplus as private note
-      .with(toToken)
-      .transfer({ recipient: this.inner.user, amount: Open, depositor: helperCall.contractAddress })
-      .done()
-      .call(helperCall)
-      .execute();
+  swap(swap: SwapAction): Promise<ExecuteResult> {
+    return this.build(swap.inToken).surplusTo(this.inner.user, false).done().swap(swap).execute();
   }
 
   private build(token: StarknetAddress) {

--- a/sdk/src/testing/mock-pool-contract.ts
+++ b/sdk/src/testing/mock-pool-contract.ts
@@ -539,6 +539,35 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
       case "Withdraw":
         return [this.withdraw(action.input.token, action.input.to_addr, action.input.amount)];
 
+      case "Swap": {
+        const calldata = action.input.swap_calldata as any;
+        const swapCall: Call = {
+          contractAddress: toHex(action.input.swap_contract),
+          entrypoint: "swap",
+          calldata,
+        };
+        const swapActions: MockServerAction[] = [];
+        // Create open note for output tokens (the swap result will be deposited here)
+        swapActions.push(
+          this.createOpenNote(
+            sender,
+            privateKey,
+            sender,
+            this.publicKeys.get(sender)!,
+            action.input.out_token,
+            action.input.index,
+            action.input.swap_executor
+          )
+        );
+        // Withdraw input tokens to swap executor
+        swapActions.push(
+          this.withdraw(action.input.in_token, action.input.swap_executor, action.input.in_amount)
+        );
+        // Execute the swap call (this will fill the open note with output tokens)
+        swapActions.push(this.followupCall(swapCall));
+        return swapActions;
+      }
+
       case "FollowupCall":
         return [this.followupCall(action.input.call)];
       default:
@@ -879,6 +908,14 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
             () => `Withdraw amount must be non-negative: ${action.input.amount}`
           );
           updateTotal(action.input.token, -action.input.amount);
+          break;
+
+        case "Swap":
+          assert(
+            action.input.in_amount >= 0n,
+            () => `Swap in_amount must be non-negative: ${action.input.in_amount}`
+          );
+          updateTotal(action.input.in_token, -action.input.in_amount);
           break;
 
         default:

--- a/sdk/tests/simple-private-transfers.test.ts
+++ b/sdk/tests/simple-private-transfers.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
 import { createTestEnv, MockTestEnv, POOL_ADDRESS } from "./helpers/test-fixtures.js";
 import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
-import { debugHint, isDebugEnabled, toBigInt, toHex } from "../src/utils/index.js";
+import { debugHint, isDebugEnabled, toBigInt } from "../src/utils/index.js";
 import { derivePublicKey } from "../src/utils/crypto.js";
 import { MockSwapHelper } from "../src/testing/contracts.js";
 import { compute_channel_key, compute_note_id } from "../src/testing/index.js";
+import { hash } from "starknet";
 
 describe("SimplePrivateTransfers", () => {
   let testEnv: MockTestEnv;
@@ -109,12 +110,16 @@ describe("SimplePrivateTransfers", () => {
     );
     const beeNoteId = compute_note_id(channelKey, bee, 0);
 
-    // Swap 10 ACE for BEE using the swap helper
+    // Swap 10 ACE for BEE using native ClientAction::Swap
     mocknet.executeOutside(
-      await alice.swap(env.ace, 10n, env.bee, {
-        contractAddress: toHex(swapHelper.address),
-        entrypoint: "swap",
-        calldata: [ace, bee, 10n, POOL_ADDRESS, beeNoteId],
+      await alice.swap({
+        swapExecutor: toBigInt(swapHelper.address),
+        swapContract: toBigInt(swapHelper.address),
+        swapSelector: hash.getSelectorFromName("swap"),
+        swapCalldata: [ace, bee, 10n, toBigInt(POOL_ADDRESS), beeNoteId],
+        inToken: ace,
+        outToken: bee,
+        inAmount: 10n,
       })
     );
 


### PR DESCRIPTION
## Summary

This change enables the SDK to produce native `ClientAction::Swap` actions that the Cairo contract already supports, rather than decomposing swaps into `Withdraw + CreateOpenNote + FollowupCall`.

The `FollowupCall` was being filtered before reaching the contract (in `serialization.ts`), so swaps silently failed against real contracts (only worked with the mock pool).

## Changes

- **`interfaces.ts`**: Add `SwapAction` type and `.swap()` method to builder interface
- **`builders.ts`**: Implement `.swap()` on the builder
- **`compiler.ts`**: Add swap compilation logic in `ActionCompiler` (resolves channels, produces the native `Swap` client action)
- **`simple-private-transfers.ts`**: Update `swap()` to use native `.swap()` instead of decomposed path
- **`mock-pool-contract.ts`**: Add `Swap` case handler for tests
- **`simple-private-transfers.test.ts`**: Update test to use new `SwapAction` API

## Follow-up Fix

- **`compiler.ts`**: Align swap deposit note index with open-note creation (`index = noteNonce > 0 ? noteNonce - 1 : noteNonce`) so native swap targets the created open note instead of the next nonce slot.
- **`pool-simulator.ts`**: Stop incrementing note nonce inside `handleSwap()` to match contract behavior (swap fills an existing open note rather than creating a new one).

## Why this matters

The Cairo contract has `ClientAction::Swap` as a first-class variant (phase 7). The SDK previously had no way to produce it — only the broken decomposed path. Now swaps will work against the real contract, not just the mock.

## Testing

- Build passes
- `simple-private-transfers` swap path uses native `SwapAction`
- 26 pre-existing Cairo compatibility test failures remain in `hashes.test.ts` and `encryption.test.ts` (unrelated to this change)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/493)
<!-- Reviewable:end -->
