### PR TITLE
feat(discovery-service): add optional tls termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,8 +598,11 @@ dependencies = [
  "libc",
  "moka",
  "nix",
+ "rcgen",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "starknet-rust-core",
@@ -609,7 +612,9 @@ dependencies = [
  "starknet-types-core",
  "tempfile",
  "thiserror 2.0.18",
+ "tls-listener",
  "tokio",
+ "tokio-rustls",
  "toml",
  "tower",
  "tower-http",
@@ -1661,6 +1666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1901,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,7 +2077,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2066,6 +2096,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2739,6 +2778,21 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls-listener"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
+dependencies = [
+ "axum",
+ "futures-util",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+]
 
 [[package]]
 name = "tokio"
@@ -3678,6 +3732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -29,6 +29,10 @@ url = "2"
 # HTTP
 axum = "0.8"
 reqwest = { version = "0.13", features = ["json"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls-pemfile = "2"
+tls-listener = { version = "0.11", features = ["rustls-ring", "axum"] }
+tokio-rustls = "0.26"
 tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors", "timeout"] }
 
@@ -65,4 +69,5 @@ nix = { version = "0.29", features = ["signal"] }
 serde_json = "1.0"
 starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = { version = "0.2", features = ["serde"] }
+rcgen = "0.13"
 tempfile = "3"

--- a/crates/discovery-service/specs/05-security-considerations.md
+++ b/crates/discovery-service/specs/05-security-considerations.md
@@ -7,6 +7,7 @@ Keys are provided per request and not stored, but additional safeguards are requ
 **Transit security:**
 
 - All API endpoints MUST be served over TLS 1.3+.
+- The service supports optional TLS termination via `[api.tls]` config or `TLS_CERT_PATH`/`TLS_KEY_PATH` env vars. When omitted, a reverse proxy is expected to provide TLS.
 - Clients SHOULD verify server certificates.
 
 **Memory handling:**

--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -28,8 +28,8 @@ All sections and fields are optional. Supports env var expansion: `${VAR}` (requ
 [rpc]
 url = "http://127.0.0.1:5050"
 max_concurrent_requests = 10
-connect_timeout = 30        # seconds
-request_timeout = 60        # seconds
+connect_timeout = 60        # seconds
+request_timeout = 30        # seconds
 max_idle_per_host = 10
 max_batch_size = 256        # max storage slots per JSON-RPC batch request
 event_page_size = 1024      # max events per starknet_getEvents page (spec max: 1024)
@@ -46,6 +46,11 @@ backoff_max_interval = 60
 host = "127.0.0.1:8080"
 health_max_lag_secs = 5
 request_timeout = 30        # seconds
+
+[api.tls]
+cert_path = "/etc/ssl/cert.pem"
+key_path = "/etc/ssl/key.pem"
+handshake_timeout = 10  # seconds, default 10
 
 [logging]
 level = "info"
@@ -71,6 +76,10 @@ These env vars override the corresponding config file values at runtime:
 | `API_HOST` | `api.host` | `127.0.0.1:8080` |
 | `RUST_LOG` | `logging.level` | `info` |
 | `SERVER_BUDGET` | `limits.server_budget` | `10000` |
+| `TLS_CERT_PATH` | `api.tls.cert_path` | — (TLS disabled) |
+| `TLS_KEY_PATH` | `api.tls.key_path` | — (TLS disabled) |
+
+Both `TLS_CERT_PATH` and `TLS_KEY_PATH` must be set together. Setting only one is a configuration error.
 
 RPC pool settings, indexer timeouts, and validation limits (except server budget) have no env var — configurable only via file.
 

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -4,6 +4,8 @@ pub mod handlers;
 pub mod types;
 pub mod validators;
 
+use std::fs::File;
+use std::io::BufReader;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
@@ -43,6 +45,8 @@ pub enum ApiServerError {
     Bind(String),
     #[error("server error: {0}")]
     Serve(String),
+    #[error("TLS configuration error: {0}")]
+    Tls(String),
 }
 
 /// Shared state for the API handlers.
@@ -78,7 +82,6 @@ where
             validation_limits: self.config.validation_limits.clone(),
         });
 
-        // TODO: Add TLS termination (spec 5.1)
         let app = Router::new()
             .route("/health", get(health_handler::<B>))
             .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
@@ -97,20 +100,64 @@ where
             ))
             .with_state(app_state);
 
-        let listener = TcpListener::bind(&self.config.host)
+        let tcp_listener = TcpListener::bind(&self.config.host)
             .await
             .map_err(|e| ApiServerError::Bind(e.to_string()))?;
 
-        info!("API server listening on {}", self.config.host);
-
         let mut rx_shutdown = self.rx_shutdown.resubscribe();
-        axum::serve(listener, app)
-            .with_graceful_shutdown(async move {
-                let _ = rx_shutdown.recv().await;
-                info!("API server shutting down");
-            })
-            .await
-            .map_err(|e| ApiServerError::Serve(e.to_string()))?;
+        let shutdown_signal = async move {
+            let _ = rx_shutdown.recv().await;
+            info!("API server shutting down");
+        };
+
+        if let Some(tls) = &self.config.tls {
+            // Both aws-lc-rs and ring features are enabled transitively, so rustls
+            // cannot auto-detect a provider. Install ring explicitly.
+            let _ = rustls::crypto::ring::default_provider().install_default();
+
+            let certs = rustls_pemfile::certs(&mut BufReader::new(
+                File::open(&tls.cert_path)
+                    .map_err(|e| ApiServerError::Tls(format!("open cert: {e}")))?,
+            ))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| ApiServerError::Tls(format!("parse certs: {e}")))?;
+
+            if certs.is_empty() {
+                return Err(ApiServerError::Tls(
+                    "certificate file contains no certificates".into(),
+                ));
+            }
+
+            let key = rustls_pemfile::private_key(&mut BufReader::new(
+                File::open(&tls.key_path)
+                    .map_err(|e| ApiServerError::Tls(format!("open key: {e}")))?,
+            ))
+            .map_err(|e| ApiServerError::Tls(format!("parse key: {e}")))?
+            .ok_or_else(|| ApiServerError::Tls("no private key found".into()))?;
+
+            let mut server_config = rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(certs, key)
+                .map_err(|e| ApiServerError::Tls(e.to_string()))?;
+            server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+            let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+            let tls_listener = tls_listener::builder(tls_acceptor)
+                .handshake_timeout(tls.handshake_timeout)
+                .listen(tcp_listener);
+
+            info!("API server listening on {} (TLS)", self.config.host);
+            axum::serve(tls_listener, app)
+                .with_graceful_shutdown(shutdown_signal)
+                .await
+                .map_err(|e| ApiServerError::Serve(e.to_string()))?;
+        } else {
+            info!("API server listening on {}", self.config.host);
+            axum::serve(tcp_listener, app)
+                .with_graceful_shutdown(shutdown_signal)
+                .await
+                .map_err(|e| ApiServerError::Serve(e.to_string()))?;
+        }
 
         info!("API server has shut down");
         Ok(())

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -25,6 +25,10 @@ pub enum ConfigError {
         "environment variable '{0}' is required but not set (referenced in config as ${{...}})"
     )]
     EnvVarRequired(String),
+    #[error(
+        "incomplete TLS configuration: both TLS_CERT_PATH and TLS_KEY_PATH must be set together"
+    )]
+    IncompleteTls,
 }
 
 /// Configuration for the RPC backend (flattened, no nested pool section).
@@ -93,6 +97,25 @@ impl Default for IndexerConfig {
     }
 }
 
+/// TLS configuration for the API server.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TlsConfig {
+    /// Path to PEM-encoded certificate file.
+    pub cert_path: String,
+    /// Path to PEM-encoded private key file.
+    pub key_path: String,
+    /// Maximum duration for a TLS handshake before the connection is dropped.
+    #[serde(
+        default = "default_handshake_timeout",
+        deserialize_with = "deserialize_secs"
+    )]
+    pub handshake_timeout: Duration,
+}
+
+fn default_handshake_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
 /// Configuration for the API server.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -102,6 +125,8 @@ pub struct ApiServerConfig {
     /// Maximum duration for an HTTP request before timeout.
     #[serde(deserialize_with = "deserialize_secs")]
     pub request_timeout: Duration,
+    /// Optional TLS configuration. When set, the server terminates TLS directly.
+    pub tls: Option<TlsConfig>,
     /// Populated from the `[limits]` section by `build_configs()`, not deserialized directly.
     #[serde(skip_deserializing)]
     pub validation_limits: ValidationLimits,
@@ -113,6 +138,7 @@ impl Default for ApiServerConfig {
             host: "127.0.0.1:8080".to_string(),
             health_max_lag_secs: 5,
             request_timeout: Duration::from_secs(30),
+            tls: None,
             validation_limits: ValidationLimits::default(),
         }
     }
@@ -174,7 +200,7 @@ impl ServiceConfig {
     }
 
     /// Override config fields with known env vars (applied after file loading).
-    pub fn apply_env_overrides(&mut self) {
+    pub fn apply_env_overrides(&mut self) -> Result<(), ConfigError> {
         if let Ok(v) = std::env::var("RPC_URL") {
             self.rpc.url = v;
         }
@@ -192,6 +218,22 @@ impl ServiceConfig {
                 self.limits.server_budget = n;
             }
         }
+
+        let cert_path = std::env::var("TLS_CERT_PATH").ok();
+        let key_path = std::env::var("TLS_KEY_PATH").ok();
+        match (cert_path, key_path) {
+            (Some(cert_path), Some(key_path)) => {
+                self.api.tls = Some(TlsConfig {
+                    cert_path,
+                    key_path,
+                    handshake_timeout: default_handshake_timeout(),
+                });
+            }
+            (None, None) => {}
+            _ => return Err(ConfigError::IncompleteTls),
+        }
+
+        Ok(())
     }
 
     /// Build component configs from the service config.
@@ -363,7 +405,7 @@ host = "127.0.0.1:8080"
         }
 
         let mut config = ServiceConfig::load(f.path()).unwrap();
-        config.apply_env_overrides();
+        config.apply_env_overrides().unwrap();
 
         assert_eq!(config.api.host, "0.0.0.0:9999");
 
@@ -442,5 +484,58 @@ host = "127.0.0.1:8080"
         assert_eq!(idx.connect_timeout, Duration::from_secs(42));
         assert_eq!(api.host, "0.0.0.0:3000");
         assert_eq!(api.validation_limits.server_budget, 200);
+    }
+
+    #[test]
+    fn test_tls_config() {
+        // SAFETY: test-only, single-threaded access to unique env var names.
+
+        // Both set → TlsConfig populated
+        unsafe {
+            std::env::set_var("TLS_CERT_PATH", "/tmp/cert.pem");
+            std::env::set_var("TLS_KEY_PATH", "/tmp/key.pem");
+        }
+        let mut config = ServiceConfig::default();
+        config.apply_env_overrides().unwrap();
+        let tls = config.api.tls.expect("TLS config should be set");
+        assert_eq!(tls.cert_path, "/tmp/cert.pem");
+        assert_eq!(tls.key_path, "/tmp/key.pem");
+        assert_eq!(tls.handshake_timeout, Duration::from_secs(10));
+
+        // Neither set → None
+        unsafe {
+            std::env::remove_var("TLS_CERT_PATH");
+            std::env::remove_var("TLS_KEY_PATH");
+        }
+        let mut config = ServiceConfig::default();
+        config.apply_env_overrides().unwrap();
+        assert!(config.api.tls.is_none());
+
+        // Only one set → error
+        unsafe {
+            std::env::set_var("TLS_CERT_PATH", "/tmp/cert.pem");
+        }
+        let mut config = ServiceConfig::default();
+        assert!(config.apply_env_overrides().is_err());
+        unsafe {
+            std::env::remove_var("TLS_CERT_PATH");
+        }
+
+        // TOML file
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            f,
+            r#"
+[api.tls]
+cert_path = "/etc/ssl/cert.pem"
+key_path = "/etc/ssl/key.pem"
+"#
+        )
+        .unwrap();
+        let config = ServiceConfig::load(f.path()).unwrap();
+        let tls = config.api.tls.expect("TLS config should be set from TOML");
+        assert_eq!(tls.cert_path, "/etc/ssl/cert.pem");
+        assert_eq!(tls.key_path, "/etc/ssl/key.pem");
+        assert_eq!(tls.handshake_timeout, Duration::from_secs(10));
     }
 }

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -51,7 +51,10 @@ async fn main() {
         }),
         None => ServiceConfig::default(),
     };
-    config.apply_env_overrides();
+    config.apply_env_overrides().unwrap_or_else(|e| {
+        eprintln!("Configuration error: {e}");
+        std::process::exit(1);
+    });
 
     // Extract log level before build_configs() consumes the config
     let log_level = config.logging.level.clone();

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -33,6 +33,8 @@ pub struct IndexerClient {
     log_rx: mpsc::Receiver<String>,
     /// The host:port the API server is listening on.
     api_host: String,
+    /// Whether TLS is enabled for this instance.
+    tls_enabled: bool,
 }
 
 /// Configuration for spawning the indexer.
@@ -43,6 +45,10 @@ pub struct IndexerSpawnConfig {
     pub api_port: Option<u16>,
     pub contract_address: Option<Felt>,
     pub rpc_url: Option<String>,
+    /// Path to PEM-encoded certificate file for TLS.
+    pub tls_cert_path: Option<String>,
+    /// Path to PEM-encoded private key file for TLS.
+    pub tls_key_path: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -62,6 +68,12 @@ impl IndexerClient {
         if let Some(rpc_url) = &config.rpc_url {
             cmd.env("RPC_URL", rpc_url);
         }
+        if let Some(cert_path) = &config.tls_cert_path {
+            cmd.env("TLS_CERT_PATH", cert_path);
+        }
+        if let Some(key_path) = &config.tls_key_path {
+            cmd.env("TLS_KEY_PATH", key_path);
+        }
 
         let mut process = cmd.spawn()?;
 
@@ -76,16 +88,25 @@ impl IndexerClient {
             }
         });
 
+        let tls_enabled = config.tls_cert_path.is_some();
+
         Ok(Self {
             process,
             log_rx,
             api_host,
+            tls_enabled,
         })
     }
 
     /// The `host:port` the API server is bound to.
     pub fn api_host(&self) -> &str {
         &self.api_host
+    }
+
+    /// The base URL for the API server (`http://` or `https://` depending on TLS).
+    pub fn base_url(&self) -> String {
+        let scheme = if self.tls_enabled { "https" } else { "http" };
+        format!("{}://{}", scheme, self.api_host)
     }
 
     /// Wait for all given patterns to appear in logs (in any order).
@@ -141,7 +162,7 @@ impl IndexerClient {
         endpoint: &str,
         body: &Req,
     ) -> Result<(StatusCode, String)> {
-        let url = format!("http://{}/{}", self.api_host, endpoint);
+        let url = format!("{}/{}", self.base_url(), endpoint);
         let response = reqwest::Client::new().post(&url).json(body).send().await?;
         let status = response.status();
         let body_text = response.text().await?;

--- a/crates/discovery-service/tests/test_tls.rs
+++ b/crates/discovery-service/tests/test_tls.rs
@@ -1,0 +1,78 @@
+//! TLS integration test: verify the service can terminate TLS with a self-signed certificate.
+//!
+//! Run with: `cargo test -p discovery-service --test test_tls`
+
+mod common;
+
+use std::time::Duration;
+
+use common::{DevnetClient, DevnetConfig, IndexerClient, IndexerSpawnConfig};
+
+/// Generate a self-signed certificate and key, write them to a temp directory,
+/// and return the (cert_path, key_path) as strings.
+fn generate_self_signed_cert(dir: &std::path::Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let key_pair = rcgen::KeyPair::generate().expect("failed to generate key pair");
+    let cert =
+        rcgen::CertificateParams::new(vec!["127.0.0.1".to_string(), "localhost".to_string()])
+            .expect("failed to create cert params")
+            .self_signed(&key_pair)
+            .expect("failed to self-sign certificate");
+
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+
+    std::fs::write(&cert_path, cert.pem()).expect("failed to write cert");
+    std::fs::write(&key_path, key_pair.serialize_pem()).expect("failed to write key");
+
+    (cert_path, key_path)
+}
+
+#[tokio::test]
+async fn test_tls_health_endpoint() {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let (cert_path, key_path) = generate_self_signed_cert(temp_dir.path());
+
+    let devnet = DevnetClient::spawn(DevnetConfig::default()).expect("Failed to spawn devnet");
+
+    let mut indexer = IndexerClient::spawn(
+        env!("CARGO_BIN_EXE_discovery-service"),
+        IndexerSpawnConfig {
+            ws_url: devnet.ws_url(),
+            tls_cert_path: Some(cert_path.to_str().unwrap().to_string()),
+            tls_key_path: Some(key_path.to_str().unwrap().to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("Failed to spawn indexer with TLS");
+
+    indexer
+        .wait_until_ready(&devnet)
+        .await
+        .expect("Indexer not ready");
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .expect("failed to build HTTPS client");
+
+    let response = client
+        .get(format!("{}/health", indexer.base_url()))
+        .send()
+        .await
+        .expect("failed to reach /health over HTTPS");
+
+    assert_eq!(response.status(), 200);
+
+    // Verify plain HTTP does NOT work on the same port
+    let plain_client = reqwest::Client::new();
+    let plain_result = plain_client
+        .get(format!("http://{}/health", indexer.api_host()))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await;
+    assert!(
+        plain_result.is_err(),
+        "plain HTTP should not work when TLS is enabled"
+    );
+}

--- a/deploy/discovery-service/README.md
+++ b/deploy/discovery-service/README.md
@@ -57,8 +57,45 @@ Precedence: env var > config file > code default.
 | `API_HOST` | `api.host` | `0.0.0.0:8080` (Docker) / `127.0.0.1:8080` (native) |
 | `RUST_LOG` | `logging.level` | `info` |
 | `SERVER_BUDGET` | `limits.server_budget` | `10000` |
+| `TLS_CERT_PATH` | `api.tls.cert_path` | — (TLS disabled) |
+| `TLS_KEY_PATH` | `api.tls.key_path` | — (TLS disabled) |
 
 Other settings (RPC pool, indexer timeouts, cursor limits) can only be configured via the TOML file.
+
+### Config file
+
+For production deployments, mount a TOML config file into the container and pass `--config`:
+
+```bash
+docker run --rm \
+  -v /host/path/config.toml:/etc/discovery-service/config.toml:ro \
+  -p 8080:8080 \
+  discovery-service --config /etc/discovery-service/config.toml
+```
+
+When using TLS via the config file, mount the certificate and key files as well:
+
+```bash
+docker run --rm \
+  -v /host/path/config.toml:/etc/discovery-service/config.toml:ro \
+  -v /host/path/cert.pem:/etc/ssl/cert.pem:ro \
+  -v /host/path/key.pem:/etc/ssl/key.pem:ro \
+  -p 8443:8443 \
+  discovery-service --config /etc/discovery-service/config.toml
+```
+
+The config file references the in-container paths:
+
+```toml
+[api]
+host = "0.0.0.0:8443"
+
+[api.tls]
+cert_path = "/etc/ssl/cert.pem"
+key_path = "/etc/ssl/key.pem"
+```
+
+Env vars override config file values when both are set.
 
 ## Running
 
@@ -76,4 +113,11 @@ docker run --rm \
 
 ```bash
 RPC_URL=http://127.0.0.1:5050 ./target/release/discovery-service
+```
+
+### With TLS
+
+```bash
+TLS_CERT_PATH=/etc/ssl/cert.pem TLS_KEY_PATH=/etc/ssl/key.pem \
+  ./target/release/discovery-service
 ```

--- a/deploy/discovery-service/config.example.toml
+++ b/deploy/discovery-service/config.example.toml
@@ -1,6 +1,7 @@
 # Discovery Service configuration
 # All sections and fields are optional — sensible defaults are used when omitted.
-# Env vars override matching fields: RPC_URL, WS_URL, API_HOST, RUST_LOG, SERVER_BUDGET.
+# Env vars override matching fields: RPC_URL, WS_URL, API_HOST, RUST_LOG, SERVER_BUDGET,
+# TLS_CERT_PATH, TLS_KEY_PATH.
 # Supports env var expansion: ${VAR} (required) or ${VAR:-default} (with fallback).
 #
 # Full spec: crates/discovery-service/specs/18-configuration.md
@@ -26,6 +27,11 @@ backoff_max_interval = 60
 host = "127.0.0.1:8080"
 health_max_lag_secs = 5
 request_timeout = 30
+
+# [api.tls]
+# cert_path = "/etc/ssl/cert.pem"
+# key_path = "/etc/ssl/key.pem"
+# handshake_timeout = 10
 
 [logging]
 level = "info"


### PR DESCRIPTION
# Add TLS termination support to Discovery Service

### TL;DR

Adds native TLS termination to the Discovery Service, allowing it to serve HTTPS directly without requiring a reverse proxy.

### What changed?

- Added TLS configuration options in both TOML config and environment variables
- Integrated `axum-server` with rustls for TLS termination
- Added self-signed certificate generation for testing
- Updated documentation and specs to reflect TLS capabilities
- Added integration test to verify TLS functionality

The service can now be configured to terminate TLS in two ways:
1. Via config file with `[api.tls]` section containing `cert_path` and `key_path`
2. Via environment variables `TLS_CERT_PATH` and `TLS_KEY_PATH`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/511)
<!-- Reviewable:end -->
