### PR TITLE
fix(sdk): update sdk for cairo contract interface changes

### DIFF
--- a/sdk/scripts/generate-pool-interface.ts
+++ b/sdk/scripts/generate-pool-interface.ts
@@ -42,7 +42,7 @@ const INPUT_TYPE_MAP: Record<string, string> = {
 // Type mappings for OUTPUT/RETURN values
 const OUTPUT_TYPE_MAP: Record<string, string> = {
   "core::felt252": "BigNumberish",
-  "core::integer::u128": "bigint",
+  "core::integer::u128": "bigint | number",
   "core::integer::u64": "bigint | number",
   "core::integer::u32": "number",
   "core::starknet::contract_address::ContractAddress": "BigNumberish",

--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -947,56 +947,6 @@ export const PrivacyPoolABI = [
           }
         ],
         "state_mutability": "view"
-      }
-    ]
-  },
-  {
-    "type": "impl",
-    "name": "AuditorImpl",
-    "interface_name": "privacy::interface::IAuditor"
-  },
-  {
-    "type": "interface",
-    "name": "privacy::interface::IAuditor",
-    "items": [
-      {
-        "type": "function",
-        "name": "set_auditor_public_key",
-        "inputs": [
-          {
-            "name": "auditor_public_key",
-            "type": "core::felt252"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      }
-    ]
-  },
-  {
-    "type": "impl",
-    "name": "FeesImpl",
-    "interface_name": "privacy::interface::IFees"
-  },
-  {
-    "type": "interface",
-    "name": "privacy::interface::IFees",
-    "items": [
-      {
-        "type": "function",
-        "name": "set_fee",
-        "inputs": [
-          {
-            "name": "fee_amount",
-            "type": "core::integer::u128"
-          },
-          {
-            "name": "fee_collector",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
       },
       {
         "type": "function",
@@ -1019,6 +969,45 @@ export const PrivacyPoolABI = [
           }
         ],
         "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "AdminImpl",
+    "interface_name": "privacy::interface::IAdmin"
+  },
+  {
+    "type": "interface",
+    "name": "privacy::interface::IAdmin",
+    "items": [
+      {
+        "type": "function",
+        "name": "set_auditor_public_key",
+        "inputs": [
+          {
+            "name": "auditor_public_key",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_fee",
+        "inputs": [
+          {
+            "name": "fee_amount",
+            "type": "core::integer::u128"
+          },
+          {
+            "name": "fee_collector",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
       }
     ]
   },
@@ -1648,14 +1637,6 @@ export const PrivacyPoolABI = [
       {
         "name": "auditor_public_key",
         "type": "core::felt252"
-      },
-      {
-        "name": "fee_amount",
-        "type": "core::integer::u128"
-      },
-      {
-        "name": "fee_collector",
-        "type": "core::starknet::contract_address::ContractAddress"
       }
     ]
   },

--- a/sdk/src/internal/pool-contract-interface.ts
+++ b/sdk/src/internal/pool-contract-interface.ts
@@ -58,4 +58,6 @@ export interface PoolContractInterface {
   get_public_key(userAddr: BigNumberish): BigNumberish | Promise<BigNumberish>;
   get_enc_private_key(userAddr: BigNumberish): EncPrivateKey | Promise<EncPrivateKey>;
   get_auditor_public_key(): BigNumberish | Promise<BigNumberish>;
+  get_fee_amount(): bigint | number | Promise<bigint | number>;
+  get_fee_collector(): BigNumberish | Promise<BigNumberish>;
 }

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -353,15 +353,13 @@ export class Devnet {
     debugLog("devnet", "setup", "class hash:", classHash);
 
     // Deploy the contract
-    // Constructor params: governance_admin, auditor_public_key, fee_amount, fee_collector
+    // Constructor params: governance_admin, auditor_public_key
     const deployResponse = await deployer.deployContract(
       {
         classHash,
         constructorCalldata: [
           deployer.address, // governance_admin
           "0x1", // auditor_public_key (dummy value)
-          "0x0", // fee_amount (disabled for tests)
-          "0x0", // fee_collector
         ],
         salt: "0x0", // Deterministic salt for reproducible contract address
       },

--- a/sdk/src/testing/mock-pool-contract.ts
+++ b/sdk/src/testing/mock-pool-contract.ts
@@ -177,6 +177,14 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
     return 1n;
   }
 
+  get_fee_amount(): bigint | number {
+    return 0n;
+  }
+
+  get_fee_collector(): bigint {
+    return 0n;
+  }
+
   // ============ Helper Methods for Discovery ============
 
   /**

--- a/sdk/tests/fixtures/cairo-reference-data.json
+++ b/sdk/tests/fixtures/cairo-reference-data.json
@@ -22,6 +22,22 @@
     "virtualSnos": "0x5649525455414c5f534e4f53",
     "virtualSnos0": "0x5649525455414c5f534e4f5330"
   },
+  "slots": {
+    "auditorPublicKeyAddress": "0x18223681ac4182236a5f10794ec6fa3530a5cb1a18aff2005fbbed58772ec28",
+    "senderPublicKeyAddress": "0x5935778edf7d690937af7b24298a23b064e54fcfd2e01e181ba011593a848bf",
+    "recipientPublicKeyAddress": "0x703dc5fd86f5987705cf14bd6c50c0e55120f37a0ecac2d8895ccd7e909e62f",
+    "encPrivateKeyAuditorPubKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aac",
+    "encPrivateKeyEphemeralAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aad",
+    "encPrivateKeyEncKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aae",
+    "channelExistsAddress": "0x4f06b03b13f7c07258b1511863de37c23aaeb1788ab31033485214777a2fbee",
+    "recipientChannelsBaseAddress": "0x5039a0f3a2efd831149644f87a421ded13d54721469cd2a552d761d2f523646",
+    "recipientChannelsElementAddress": "0x1964d92b29305036d5487cc7726d73ef02560413e3cb5a8358009f7651eeb6e",
+    "subchannelExistsAddress": "0x3751517ee3ad8e8c32d34b55e6c4997d36ccb713a20a95256b42a3dc387331d",
+    "subchannelTokensSaltAddress": "0x108e08a6481cf28ef8c73e1673e2cadaa0f8ee1ac790d188301786f7d8867ed",
+    "subchannelTokensEncTokenAddress": "0x108e08a6481cf28ef8c73e1673e2cadaa0f8ee1ac790d188301786f7d8867ee",
+    "notesAddress": "0x5d4262aaab99930ce4823d3409f1c043542f144522081296890bcf6b92a025d",
+    "nullifiersAddress": "0xac670230830586718e11a75d0b71104a960532c2e060f8eb0c5afbd3fc4def"
+  },
   "inputs": {
     "sender": "0x123",
     "recipient": "0x456",
@@ -45,22 +61,6 @@
     "subchannelMarker": "0x777b17d81fbb126303906d8076aa8dadaec72a6a25a3e31b51946216edeed7c",
     "noteId": "0x6b098ad0b0b4b1881a77f962eb0650de748f24efcabd5a64ac941e9a05777e8",
     "nullifier": "0x42301c4c2b44b24d874ddfbeacfbbcfe8c54135a4673a390b4128152f3d8afb"
-  },
-  "slots": {
-    "auditorPublicKeyAddress": "0x18223681ac4182236a5f10794ec6fa3530a5cb1a18aff2005fbbed58772ec28",
-    "senderPublicKeyAddress": "0x5935778edf7d690937af7b24298a23b064e54fcfd2e01e181ba011593a848bf",
-    "recipientPublicKeyAddress": "0x703dc5fd86f5987705cf14bd6c50c0e55120f37a0ecac2d8895ccd7e909e62f",
-    "encPrivateKeyAuditorPubKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aac",
-    "encPrivateKeyEphemeralAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aad",
-    "encPrivateKeyEncKeyAddress": "0x440935e6c56281ba4630e9e15910ccb4b8e586b78caa00aee2dab9027248aae",
-    "channelExistsAddress": "0x4f06b03b13f7c07258b1511863de37c23aaeb1788ab31033485214777a2fbee",
-    "recipientChannelsBaseAddress": "0x5039a0f3a2efd831149644f87a421ded13d54721469cd2a552d761d2f523646",
-    "recipientChannelsElementAddress": "0x1964d92b29305036d5487cc7726d73ef02560413e3cb5a8358009f7651eeb6e",
-    "subchannelExistsAddress": "0x3751517ee3ad8e8c32d34b55e6c4997d36ccb713a20a95256b42a3dc387331d",
-    "subchannelTokensSaltAddress": "0x108e08a6481cf28ef8c73e1673e2cadaa0f8ee1ac790d188301786f7d8867ed",
-    "subchannelTokensEncTokenAddress": "0x108e08a6481cf28ef8c73e1673e2cadaa0f8ee1ac790d188301786f7d8867ee",
-    "notesAddress": "0x5d4262aaab99930ce4823d3409f1c043542f144522081296890bcf6b92a025d",
-    "nullifiersAddress": "0xac670230830586718e11a75d0b71104a960532c2e060f8eb0c5afbd3fc4def"
   },
   "outputs": {
     "channelKey": "0x29f111f2674fda971bbee26106be4792a4336860bea7f3c4289d9c8dc16a948",


### PR DESCRIPTION
### TL;DR

Updated the pool contract interface to reflect changes in the contract ABI, specifically around fee management and admin functionality.

### What changed?

- Updated the type mapping for `core::integer::u128` to accept both `bigint` and `number` types
- Reorganized contract ABI by:
  - Moving fee-related functions (`get_fee_amount` and `get_fee_collector`) from the `IFees` interface to the main contract implementation
  - Consolidated `IAuditor` and `IFees` interfaces into a single `IAdmin` interface
- Added new methods to the `PoolContractInterface`:
  - `get_fee_amount()`
  - `get_fee_collector()`
- Updated the contract constructor to remove fee-related parameters
- Implemented the new fee-related methods in the `MockPoolContract` class

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/529)
<!-- Reviewable:end -->
