### PR TITLE
fix(discovery-core): handle note probing gap

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -20,6 +20,10 @@ pub struct CursorLimits {
     pub max_channels: usize,
     /// Maximum number of subchannels per channel in the cursor at once.
     pub max_subchannels: usize,
+    /// Maximum exponent for note index probe offsets.
+    /// Offsets: `[0, 1, 3, 7, ..., 2^max_note_log_index - 1]`.
+    /// Default 30 → 31 probes covering ~1 billion indices.
+    pub max_note_log_index: u32,
 }
 
 impl Default for CursorLimits {
@@ -27,6 +31,7 @@ impl Default for CursorLimits {
         Self {
             max_channels: 256,
             max_subchannels: 64,
+            max_note_log_index: 30,
         }
     }
 }
@@ -113,9 +118,6 @@ impl ChannelCursor {
 }
 
 /// Cursor state for a single subchannel (shared by incoming and outgoing).
-///
-/// For incoming (linear scan): only `last_note_index` is used.
-/// For outgoing (exponential search): `last_note_index` = lo, `max_note_index` = hi.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SubchannelCursor {
     /// All notes in this subchannel have been discovered. Set when the
@@ -123,19 +125,17 @@ pub struct SubchannelCursor {
     #[serde(default)]
     pub note_discovery_complete: bool,
 
-    /// Last note index where a note exists.
-    /// - Incoming: last scanned index.
-    /// - Outgoing: lower bound (lo) for exponential search.
+    /// Last scanned note index (incoming scan progress only).
+    /// Outgoing flow does not use this — it reads `last_existing_index()`
+    /// from `total_n_notes`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_note_index: Option<u64>,
 
-    /// - Incoming: last index confirmed to exist by exponential probe. Linear
-    ///   scan reads notes up to this index. Kept after scan — used to bound the
-    ///   next exponential probe range (`max_note_index * 2`). Re-probe triggers
-    ///   when `last_note_index == max_note_index`.
-    /// - Outgoing: first index confirmed empty (hi); `Some` = bisection phase.
+    /// Cached total number of notes in this subchannel (from boundary finding).
+    /// Analogous to `total_n_channels` at the channel level.
+    /// `None` = not yet probed. `Some(0)` = empty. `Some(n)` = notes at indices 0..n-1.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_note_index: Option<u64>,
+    pub total_n_notes: Option<u64>,
 }
 
 impl SubchannelCursor {
@@ -145,5 +145,11 @@ impl SubchannelCursor {
     /// scanned). If `None`, returns 0 (fresh cursor).
     pub fn start_index(&self) -> u64 {
         self.last_note_index.map_or(0, |i| i + 1)
+    }
+
+    /// Returns the last existing note index, derived from the cached total.
+    /// `None` if not yet probed or subchannel is empty.
+    pub fn last_existing_index(&self) -> Option<u64> {
+        self.total_n_notes.and_then(|n| n.checked_sub(1))
     }
 }

--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -1,13 +1,13 @@
-//! Note index boundary probing.
+//! Note index boundary finding.
 //!
-//! Finds the last note index in a subchannel via exponential search + bisection.
+//! Finds the last note index in a subchannel via exponential probe + bisection.
 //! No decryption, no nullifier checks — just probes note existence.
 //!
-//! [`exponential_probe`] is shared between notes discovery (finds `max_note_index`
-//! for a linear scan) and [`find_last_note_index_paginated`] (outgoing channels).
+//! [`find_last_note_index`] is the unified entry point: runs an atomic probe + bisect
+//! cycle, shared by both incoming (notes discovery) and outgoing (last-note-index)
+//! flows.
 
 use std::collections::HashMap;
-use std::future::Future;
 
 use starknet_types_core::felt::Felt;
 
@@ -18,205 +18,166 @@ use crate::io_budget::IoBudget;
 use crate::privacy_pool::hashes::compute_note_id;
 use crate::privacy_pool::views::IViews;
 
-/// Default max probe offset for notes discovery. Caps the jump distance to
-/// avoid overshooting into sparse index space (offsets: 0, 1, 3, 7, …, 1023).
-pub const DEFAULT_MAX_PROBE_OFFSET: u64 = 1024;
-
-/// Result of a batched exponential probe.
-pub struct ExponentialProbeResult {
-    /// Probed notes that exist: index → (note_id, packed_amount).
-    /// Used as a cache during the linear scan to avoid re-fetching amounts.
-    pub cache: HashMap<u64, (Felt, Felt)>,
-    /// Last index confirmed to exist.
-    /// `None` if the first probe missed (empty subchannel) or budget exhausted.
-    pub last_found_index: Option<u64>,
-    /// First index where no note exists (`None` if all probes hit = need more).
-    /// Used by [`find_last_note_index_paginated`] to set the bisection upper bound.
-    pub first_empty_index: Option<u64>,
-    /// Whether the probe conclusively found the boundary (sentinel or start-of-empty).
-    /// `false` when the batch was truncated by budget before reaching a boundary.
-    pub probe_complete: bool,
+/// Maximum budget for a single [`find_boundary`] call.
+///
+/// `max_note_log_index + 1` probe offsets + up to `max_note_log_index` bisect
+/// steps, each costing `COST_NOTE_PROBING`.
+pub fn boundary_budget(max_note_log_index: u32) -> usize {
+    let max_note_log_index: usize = max_note_log_index
+        .try_into()
+        .expect("max_note_log_index is a config value that must fit in usize");
+    (2 * max_note_log_index + 1) * COST_NOTE_PROBING
 }
 
-/// Finds the last note index via [`exponential_probe`] + [`bisect_boundary`].
+/// Finds the last note index via atomic exponential probe + bisection.
 ///
-/// Runs in two phases, resumable via cursor:
-/// 1. **Ascending**: batched exponential probing to find bounds (`lo`, `hi`).
-/// 2. **Bisection**: sequential binary search for exact boundary.
+/// When `cursor.total_n_notes` is already cached, returns immediately.
+/// Otherwise, budget is allocated atomically: consumes [`boundary_budget`]
+/// upfront, then reclaims unused units after completion. Either completes
+/// fully or makes no progress (budget too small).
 ///
-/// Returns `(last_index, has_more)`. When `has_more` is `false`, the search is complete.
-pub async fn find_last_note_index_paginated<S: IViews>(
+/// Returns `(probe_cache, has_more)`:
+/// - `probe_cache`: index → (note_id, packed_amount) from probe hits (for incoming scan).
+/// - `has_more`: `true` if budget was insufficient and another call is needed.
+///
+/// On success, sets `cursor.total_n_notes`. Callers read the result via
+/// `cursor.last_existing_index()`.
+pub async fn find_last_note_index<S: IViews>(
     pool: &S,
     channel_key: Felt,
     token: Felt,
     cursor: &mut SubchannelCursor,
+    max_note_log_index: u32,
     budget: &IoBudget,
-) -> Result<(Option<u64>, bool), DiscoveryError> {
-    // Phase 1: Ascending (find bounds)
-    if cursor.max_note_index.is_none() {
-        let start = cursor.start_index();
-        let result = exponential_probe(pool, channel_key, token, start, None, None, budget).await?;
-
-        if let Some(last_found_index) = result.last_found_index {
-            cursor.last_note_index = Some(last_found_index);
-        }
-        if let Some(index) = result.first_empty_index {
-            cursor.max_note_index = Some(index);
-        }
-
-        // Budget exhausted, all probes hit, or empty subchannel — nothing to bisect yet.
-        if cursor.max_note_index.is_none() || cursor.last_note_index.is_none() {
-            let has_more = !result.probe_complete;
-            return Ok((cursor.last_note_index, has_more));
-        }
+) -> Result<(HashMap<u64, (Felt, Felt)>, bool), DiscoveryError> {
+    if cursor.total_n_notes.is_some() {
+        return Ok((HashMap::new(), false));
     }
 
-    // Phase 2: Bisection (narrow down to exact boundary, sequential)
-    // Probe returns `(Option<u64>, bool)`:
-    //   `Some(idx)` = note exists at idx, `None` = absent.
-    //   `bool` = budget exhausted (true = stop early).
-    let probe = |idx: u64| {
-        let budget = budget.clone();
-        async move {
-            if !budget.consume(COST_NOTE_PROBING) {
-                return Ok((None, true));
-            }
-            let note_id = compute_note_id(channel_key, token, idx);
-            if pool.get_note(note_id).await? != Felt::ZERO {
-                Ok((Some(idx), false))
-            } else {
-                Ok((None, false))
-            }
-        }
+    let max_budget = boundary_budget(max_note_log_index);
+    if !budget.consume(max_budget) {
+        return Ok((HashMap::new(), true));
+    }
+
+    let start_index = cursor.start_index();
+    let max_bisect_steps: usize = max_note_log_index
+        .try_into()
+        .expect("max_note_log_index is a config value that must fit in usize");
+    let mut cache = HashMap::new();
+
+    let Some((lower_bound, upper_bound)) = exponential_probe(
+        pool,
+        channel_key,
+        token,
+        start_index,
+        max_note_log_index,
+        &mut cache,
+    )
+    .await?
+    else {
+        // Empty subchannel.
+        budget.reclaim(max_bisect_steps * COST_NOTE_PROBING);
+        cursor.total_n_notes = Some(0);
+        return Ok((cache, false));
     };
-    let complete = bisect_boundary(&probe, cursor).await?;
-    Ok((cursor.last_note_index, !complete))
+
+    let (boundary, bisect_step_count) = bisect_boundary(
+        pool,
+        channel_key,
+        token,
+        lower_bound,
+        upper_bound,
+        &mut cache,
+    )
+    .await?;
+    budget.reclaim((max_bisect_steps - bisect_step_count) * COST_NOTE_PROBING);
+    cursor.total_n_notes = Some(boundary + 1);
+    Ok((cache, false))
 }
 
-/// Binary search between `lo` (exists) and `hi` (absent) to find
-/// the exact last occupied index.
+/// Binary search between `lower_bound` (exists) and `upper_bound` (absent) to
+/// find the exact last occupied index. Hits are inserted into `cache`.
 ///
-/// Requires both `cursor.last_note_index` (lo) and `cursor.max_note_index` (hi)
-/// to be `Some`. The probe closure returns `(Option<u64>, bool)` — see
-/// [`find_last_note_index_paginated`] for the contract.
-///
-/// Updates cursor in place. Returns `true` if complete, `false` if budget exhausted.
-async fn bisect_boundary<F, Fut>(
-    probe: F,
-    cursor: &mut SubchannelCursor,
-) -> Result<bool, DiscoveryError>
-where
-    F: Fn(u64) -> Fut,
-    Fut: Future<Output = Result<(Option<u64>, bool), DiscoveryError>>,
-{
-    let (mut lo, mut hi) = match (cursor.last_note_index, cursor.max_note_index) {
-        (Some(lo), Some(hi)) => (lo, hi),
-        _ => unreachable!("bisect_boundary called without both lo and hi"),
-    };
-
-    while lo + 1 < hi {
-        let mid = lo + (hi - lo) / 2;
-        match probe(mid).await? {
-            (Some(_), _) => lo = mid,
-            (None, false) => hi = mid,
-            (None, true) => {
-                cursor.last_note_index = Some(lo);
-                cursor.max_note_index = Some(hi);
-                return Ok(false);
-            }
+/// Budget is pre-allocated by the caller. Returns
+/// `(last_existing_index, step_count)`.
+async fn bisect_boundary<S: IViews>(
+    pool: &S,
+    channel_key: Felt,
+    token: Felt,
+    mut lower_bound: u64,
+    mut upper_bound: u64,
+    cache: &mut HashMap<u64, (Felt, Felt)>,
+) -> Result<(u64, usize), DiscoveryError> {
+    let mut step_count = 0;
+    while lower_bound + 1 < upper_bound {
+        let mid = lower_bound + (upper_bound - lower_bound) / 2;
+        let note_id = compute_note_id(channel_key, token, mid);
+        step_count += 1;
+        let packed = pool.get_note(note_id).await?;
+        if packed != Felt::ZERO {
+            cache.insert(mid, (note_id, packed));
+            lower_bound = mid;
+        } else {
+            upper_bound = mid;
         }
     }
-
-    cursor.last_note_index = Some(lo);
-    cursor.max_note_index = Some(hi);
-    Ok(true)
+    Ok((lower_bound, step_count))
 }
 
 /// Probes note existence at exponentially increasing indices in a single batch.
+/// Hits are inserted into the caller-provided `cache`.
 ///
-/// From `start`, probes at offsets `0, 1, 3, 7, 15, ..., 2^k - 1` capped at
-/// `max_probe_offset`. The `2^k - 1` pattern is denser at the start than
-/// powers of 2, yielding more cache hits for small subchannels.
+/// From `start`, probes at offsets `[0, 1, 3, 7, 15, ..., 2^max_note_log_index - 1]`
+/// (`max_note_log_index + 1` offsets total). The `2^k - 1` pattern is denser at the
+/// start than powers of 2, yielding more cache hits for small subchannels.
 ///
-/// `prior_max_index` narrows the search when a previous probe already found a bound:
-/// - `None` (first discovery): offsets up to `max_probe_offset`
-/// - `Some(m)` (re-probe after scan): range capped at `m * 2`
+/// Returns:
+/// - `Ok(None)` — empty subchannel (first probe missed); no bisection needed.
+/// - `Ok(Some((lower_bound, upper_bound)))` — `lower_bound` is the last index
+///   confirmed to exist (bisection lower bound), `upper_bound` is the first
+///   index confirmed empty (bisection upper bound).
+/// - `Err` — all probes hit, `max_note_log_index` too small.
 ///
-/// `max_probe_offset` caps the maximum offset per batch. Use
-/// `Some(`[`DEFAULT_MAX_PROBE_OFFSET`]`)` for notes discovery or `None` for
-/// unbounded probing (e.g. last-note-index search).
-///
-/// All probed notes that exist are cached in the result for use by the
-/// linear scan phase.
-///
-/// Issues exactly one batch of probes via `pool.get_notes_batch()`. Callers
-/// handle iteration via cursor-based pagination.
-pub async fn exponential_probe<S: IViews>(
+/// Budget is pre-allocated by [`find_last_note_index`] — this function issues
+/// the full batch unconditionally.
+async fn exponential_probe<S: IViews>(
     pool: &S,
     channel_key: Felt,
     token: Felt,
     start_index: u64,
-    prior_max_index: Option<u64>,
-    max_probe_offset: Option<u64>,
-    budget: &IoBudget,
-) -> Result<ExponentialProbeResult, DiscoveryError> {
-    let max_index = match prior_max_index {
-        None => start_index.saturating_add(max_probe_offset.unwrap_or(u64::MAX)),
-        Some(prior_max) => prior_max.saturating_mul(2).max(start_index),
-    };
-    let max_probe_offset = max_index.saturating_sub(start_index);
-
-    // Offsets: [0, 1, 3, 7, 15, ..., 2^k - 1] where 2^k - 1 <= max_probe_offset.
-    let offsets: Vec<u64> = std::iter::once(0)
-        .chain(
-            (1..64)
-                .map(|exp| (1u64 << exp) - 1)
-                .take_while(|&offset| offset <= max_probe_offset),
-        )
+    max_note_log_index: u32,
+    cache: &mut HashMap<u64, (Felt, Felt)>,
+) -> Result<Option<(u64, u64)>, DiscoveryError> {
+    // Offsets: [0, 1, 3, 7, 15, ..., 2^k - 1] where k = max_note_log_index.
+    let offsets: Vec<u64> = (0..=max_note_log_index)
+        .map(|k| if k == 0 { 0 } else { (1u64 << k) - 1 })
         .collect();
 
-    // Consume as many probes as budget allows.
-    let (batch_size, budget_exhausted) = budget.consume_up_to(offsets.len(), COST_NOTE_PROBING);
-    if batch_size == 0 {
-        return Ok(ExponentialProbeResult {
-            cache: HashMap::new(),
-            last_found_index: None,
-            first_empty_index: None,
-            probe_complete: !budget_exhausted,
-        });
-    }
-
-    let note_ids: Vec<_> = offsets[..batch_size]
+    let note_ids: Vec<_> = offsets
         .iter()
         .map(|&off| compute_note_id(channel_key, token, start_index + off))
         .collect();
     let results = pool.get_notes_batch(&note_ids).await?;
 
-    let mut cache = HashMap::new();
-    let mut last_found_index: Option<u64> = None;
-    let mut first_empty_index: Option<u64> = None;
+    let mut lower_bound: Option<u64> = None;
 
     for (i, &packed) in results.iter().enumerate() {
         let idx = start_index + offsets[i];
         if packed != Felt::ZERO {
             cache.insert(idx, (note_ids[i], packed));
-            last_found_index = Some(idx);
+            lower_bound = Some(idx);
         } else {
-            first_empty_index = Some(idx);
-            break;
+            return Ok(lower_bound.map(|lower_bound| (lower_bound, idx)));
         }
     }
-    // Probe is complete when we found a sentinel, or when no notes exist at all
-    // (first probe missed and budget wasn't the limiting factor).
-    let probe_complete =
-        first_empty_index.is_some() || (!budget_exhausted && last_found_index.is_none());
 
-    Ok(ExponentialProbeResult {
-        cache,
-        last_found_index,
-        first_empty_index,
-        probe_complete,
-    })
+    // All probes hit — subchannel has more notes than the probe range
+    // covers (>2^max_note_log_index). Config too small.
+    Err(DiscoveryError::InvalidCursor(format!(
+        "note boundary exceeds max_note_log_index={max_note_log_index} \
+         (>{} notes from start_index={start_index})",
+        1u64.checked_shl(max_note_log_index).unwrap_or(u64::MAX)
+    )))
 }
 
 #[cfg(test)]
@@ -229,6 +190,7 @@ mod tests {
 
     const CK: Felt = Felt::from_hex_unchecked("0x12345");
     const TK: Felt = Felt::from_hex_unchecked("0x67890");
+    const DEFAULT_MAX_LOG: u32 = 30;
 
     /// Creates a mock backend with notes at indices 0..=last_index.
     fn mock_with_notes(last_index: Option<u64>) -> MockBackend {
@@ -246,132 +208,184 @@ mod tests {
     #[tokio::test]
     async fn test_exponential_probe_empty() {
         let backend = mock_with_notes(None);
-        let budget = IoBudget::new(100);
-        let result = exponential_probe(
-            &backend,
-            CK,
-            TK,
-            0,
-            None,
-            Some(DEFAULT_MAX_PROBE_OFFSET),
-            &budget,
-        )
-        .await
-        .unwrap();
+        let mut cache = HashMap::new();
+        let result = exponential_probe(&backend, CK, TK, 0, DEFAULT_MAX_LOG, &mut cache)
+            .await
+            .unwrap();
 
-        assert_eq!(result.last_found_index, None);
-        assert!(result.cache.is_empty());
-        assert!(result.probe_complete);
+        assert!(result.is_none(), "empty subchannel returns None");
+        assert!(cache.is_empty());
     }
 
     #[tokio::test]
     async fn test_exponential_probe_one_element() {
         // Elements at 0 only. Probes: offset 0→0 (hit), 1→1 (miss).
         let backend = mock_with_notes(Some(0));
-        let budget = IoBudget::new(100);
-        let result = exponential_probe(
-            &backend,
-            CK,
-            TK,
-            0,
-            None,
-            Some(DEFAULT_MAX_PROBE_OFFSET),
-            &budget,
-        )
-        .await
-        .unwrap();
+        let mut cache = HashMap::new();
+        let (lower_bound, upper_bound) =
+            exponential_probe(&backend, CK, TK, 0, DEFAULT_MAX_LOG, &mut cache)
+                .await
+                .unwrap()
+                .expect("non-empty subchannel");
 
-        assert_eq!(result.last_found_index, Some(0));
-        assert_eq!(result.cache.len(), 1);
-        assert!(result.probe_complete);
+        assert_eq!(lower_bound, 0);
+        assert_eq!(upper_bound, 1);
+        assert_eq!(cache.len(), 1);
     }
 
     #[tokio::test]
     async fn test_exponential_probe_multiple_elements() {
         // Elements at 0..=4. Probes: offset 0→0 (hit), 1→1 (hit),
-        // 3→3 (hit), 7→7 (miss)
+        // 3→3 (hit), 7→7 (miss). Sentinel found.
+        let backend = mock_with_notes(Some(4));
+        let mut cache = HashMap::new();
+        let (lower_bound, upper_bound) =
+            exponential_probe(&backend, CK, TK, 0, DEFAULT_MAX_LOG, &mut cache)
+                .await
+                .unwrap()
+                .expect("non-empty subchannel");
+
+        assert_eq!(lower_bound, 3);
+        assert_eq!(upper_bound, 7);
+        assert_eq!(cache.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_exponential_probe_gap_between_last_hit_and_sentinel() {
+        // Notes at 0..=2. Probe offsets [0, 1, 3, ...]:
+        //   0→hit, 1→hit, 3→miss (sentinel). Gap at index 2 is unprobed.
+        let backend = mock_with_notes(Some(2));
+        let mut cache = HashMap::new();
+        let (lower_bound, upper_bound) =
+            exponential_probe(&backend, CK, TK, 0, DEFAULT_MAX_LOG, &mut cache)
+                .await
+                .unwrap()
+                .expect("non-empty subchannel");
+
+        assert_eq!(lower_bound, 1);
+        assert_eq!(upper_bound, 3);
+        assert_eq!(cache.len(), 2, "probed indices 0 and 1");
+    }
+
+    #[tokio::test]
+    async fn test_exponential_probe_all_hit_errors() {
+        // 10 notes at 0..=9. With max_note_log_index=3, probe offsets are
+        // [0, 1, 3, 7] — all hit. Should error.
+        let backend = mock_with_notes(Some(9));
+        let mut cache = HashMap::new();
+        let result = exponential_probe(&backend, CK, TK, 0, 3, &mut cache).await;
+
+        assert!(result.is_err(), "all probes hit should error");
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("max_note_log_index=3"),
+            "error should mention the config: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_empty_subchannel() {
+        let backend = mock_with_notes(None);
+        let budget = IoBudget::new(100);
+        let mut cursor = SubchannelCursor::default();
+        let (cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
+
+        assert!(cache.is_empty());
+        assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(0));
+        assert_eq!(cursor.last_existing_index(), None);
+        // Probe cost only (31 offsets), bisect budget reclaimed.
+        assert_eq!(
+            budget.remaining(),
+            100 - boundary_budget(DEFAULT_MAX_LOG) + DEFAULT_MAX_LOG as usize
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_one_note() {
+        let backend = mock_with_notes(Some(0));
+        let budget = IoBudget::new(100);
+        let mut cursor = SubchannelCursor::default();
+        let (cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
+
+        assert_eq!(cache.len(), 1);
+        assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(1));
+        assert_eq!(cursor.last_existing_index(), Some(0));
+        // Adjacent boundary (lo=0, hi=1) — no bisection, bisect budget reclaimed.
+        let num_probe_offsets = DEFAULT_MAX_LOG as usize + 1;
+        assert_eq!(budget.remaining(), 100 - num_probe_offsets);
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_with_gap() {
+        // 3 notes at 0..=2. Probe hits 0, 1, misses 3.
+        // Bisection: mid=2, hit → lo=2. lo+1==hi(3) → done. 1 bisect step.
+        let backend = mock_with_notes(Some(2));
+        let budget = IoBudget::new(100);
+        let mut cursor = SubchannelCursor::default();
+        let (cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
+
+        assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(3));
+        assert_eq!(cache.len(), 3, "probe cached 0,1 + bisect cached 2");
+        let num_probe_offsets = DEFAULT_MAX_LOG as usize + 1;
+        let bisect_steps = 1;
+        assert_eq!(
+            budget.remaining(),
+            100 - num_probe_offsets - bisect_steps,
+            "31 probe + 1 bisect step"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_five_notes() {
+        // 5 notes at 0..=4. Probe hits 0, 1, 3, misses at 7.
+        // Bisection: lo=3, hi=7 → mid=5 (miss)→hi=5 → mid=4 (hit)→lo=4.
+        // lo+1==hi(5) → done. 2 bisect steps.
         let backend = mock_with_notes(Some(4));
         let budget = IoBudget::new(100);
-        let result = exponential_probe(
-            &backend,
-            CK,
-            TK,
-            0,
-            None,
-            Some(DEFAULT_MAX_PROBE_OFFSET),
-            &budget,
-        )
-        .await
-        .unwrap();
+        let mut cursor = SubchannelCursor::default();
+        let (_cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
 
-        assert_eq!(result.last_found_index, Some(3));
-        assert_eq!(result.cache.len(), 3);
-        assert!(result.probe_complete);
+        assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(5));
+        let num_probe_offsets = DEFAULT_MAX_LOG as usize + 1;
+        let bisect_steps = 2;
+        assert_eq!(budget.remaining(), 100 - num_probe_offsets - bisect_steps);
     }
 
     #[tokio::test]
-    async fn test_exponential_ascend_probe_incomplete() {
+    async fn test_find_last_note_index_budget_insufficient() {
         let backend = mock_with_notes(Some(100));
-        // Budget for only 2 probes: offsets 0, 1
-        let budget = IoBudget::new(2 * COST_NOTE_PROBING);
-        let result = exponential_probe(
-            &backend,
-            CK,
-            TK,
-            0,
-            None,
-            Some(DEFAULT_MAX_PROBE_OFFSET),
-            &budget,
-        )
-        .await
-        .unwrap();
+        let mut cursor = SubchannelCursor::default();
+        // Budget below the minimum for boundary finding.
+        let budget = IoBudget::new(boundary_budget(DEFAULT_MAX_LOG) - 1);
+        let (cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
 
-        assert_eq!(result.last_found_index, Some(1));
-        assert_eq!(result.cache.len(), 2);
-        assert!(!result.probe_complete);
-    }
-
-    /// Helper: mock bisection probe.
-    fn mock_probe(
-        last_index: Option<u64>,
-    ) -> impl Fn(u64) -> std::future::Ready<Result<(Option<u64>, bool), DiscoveryError>> {
-        move |idx| {
-            let exists = last_index.is_some_and(|last| idx <= last);
-            std::future::ready(Ok(if exists {
-                (Some(idx), false)
-            } else {
-                (None, false)
-            }))
-        }
-    }
-
-    #[tokio::test]
-    async fn test_bisect_boundary_adjacent() {
-        let mut cursor = SubchannelCursor {
-            note_discovery_complete: false,
-            last_note_index: Some(0),
-            max_note_index: Some(1),
-        };
-        let complete = bisect_boundary(mock_probe(Some(0)), &mut cursor)
-            .await
-            .unwrap();
-        assert!(complete);
-        assert_eq!(cursor.last_note_index, Some(0));
-    }
-
-    #[tokio::test]
-    async fn test_bisect_boundary_gap() {
-        let mut cursor = SubchannelCursor {
-            note_discovery_complete: false,
-            last_note_index: Some(3),
-            max_note_index: Some(7),
-        };
-        let complete = bisect_boundary(mock_probe(Some(4)), &mut cursor)
-            .await
-            .unwrap();
-        assert!(complete);
-        assert_eq!(cursor.last_note_index, Some(4));
-        assert_eq!(cursor.max_note_index, Some(5));
+        assert!(cache.is_empty());
+        assert!(has_more, "budget insufficient — no boundary found");
+        assert!(cursor.total_n_notes.is_none());
+        assert_eq!(
+            budget.remaining(),
+            boundary_budget(DEFAULT_MAX_LOG) - 1,
+            "budget unchanged on insufficient allocation"
+        );
     }
 
     #[tokio::test]
@@ -394,36 +408,35 @@ mod tests {
         let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
 
-        let (last_index, has_more) =
-            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+        let (_cache, has_more) =
+            find_last_note_index(&backend, channel_key, token, &mut cursor, 30, &budget)
                 .await
                 .unwrap();
 
         // Alice has 1 note at index 0
-        assert_eq!(last_index, Some(0));
         assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(1));
+        assert_eq!(cursor.last_existing_index(), Some(0));
     }
 
     #[tokio::test]
-    async fn test_find_last_note_index_empty() {
+    async fn test_find_last_note_index_empty_fixture() {
         let backend = MockBackend::empty();
-        let channel_key = Felt::from_hex_unchecked("0x12345");
-        let token = Felt::from_hex_unchecked("0x67890");
 
         let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
 
-        let (last_index, has_more) =
-            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
-                .await
-                .unwrap();
+        let (_cache, has_more) = find_last_note_index(&backend, CK, TK, &mut cursor, 30, &budget)
+            .await
+            .unwrap();
 
-        assert_eq!(last_index, None);
         assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(0));
+        assert_eq!(cursor.last_existing_index(), None);
     }
 
     #[tokio::test]
-    async fn test_find_last_note_index_budget_exhausted_ascending() {
+    async fn test_find_last_note_index_budget_insufficient_then_resume() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
@@ -441,27 +454,54 @@ mod tests {
 
         let mut cursor = SubchannelCursor::default();
 
-        // Budget for 1 probe: batch gets offset 0 only (note at 0 exists),
-        // but no first_empty found — budget_exhausted (all probes hit).
-        let budget = IoBudget::new(COST_NOTE_PROBING);
-        let (last_index, has_more) =
-            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+        // Budget below minimum — can't start boundary finding.
+        let budget = IoBudget::new(boundary_budget(30) - 1);
+        let (_cache, has_more) =
+            find_last_note_index(&backend, channel_key, token, &mut cursor, 30, &budget)
                 .await
                 .unwrap();
 
-        assert_eq!(last_index, Some(0));
-        assert!(has_more, "budget exhausted during ascending");
-        assert_eq!(cursor.last_note_index, Some(0));
-        assert!(cursor.max_note_index.is_none(), "sentinel not found yet");
+        assert!(has_more, "budget insufficient");
+        assert!(cursor.total_n_notes.is_none(), "boundary not cached yet");
 
-        // Resume with more budget
+        // Resume with sufficient budget.
         let budget = IoBudget::new(100);
-        let (last_index, has_more) =
-            find_last_note_index_paginated(&backend, channel_key, token, &mut cursor, &budget)
+        let (_cache, has_more) =
+            find_last_note_index(&backend, channel_key, token, &mut cursor, 30, &budget)
                 .await
                 .unwrap();
 
-        assert_eq!(last_index, Some(0));
         assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(1));
+        assert_eq!(cursor.last_existing_index(), Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_find_last_note_index_skips_when_cached() {
+        let backend = mock_with_notes(Some(4));
+        let mut cursor = SubchannelCursor::default();
+
+        // First call: finds boundary.
+        let budget = IoBudget::new(100);
+        let (_cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
+        assert!(!has_more);
+        assert_eq!(cursor.total_n_notes, Some(5));
+        let remaining_after_first = budget.remaining();
+
+        // Second call: cached, returns immediately without consuming budget.
+        let (cache, has_more) =
+            find_last_note_index(&backend, CK, TK, &mut cursor, DEFAULT_MAX_LOG, &budget)
+                .await
+                .unwrap();
+        assert!(!has_more);
+        assert!(cache.is_empty(), "no probe needed — cached");
+        assert_eq!(
+            budget.remaining(),
+            remaining_after_first,
+            "no budget consumed"
+        );
     }
 }

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -1,11 +1,11 @@
 //! Notes discovery for a subchannel (channel_key + token pair).
 //!
 //! Two-phase algorithm:
-//! 1. **Exponential probe**: batched probes at exponentially increasing indices
-//!    to find `max_note_index` (the last index confirmed to exist).
-//! 2. **Linear scan**: nullifier-first batches for all notes in
-//!    `start..=max_note_index`. Spent notes skip the amount fetch; cached
-//!    amounts from the probe phase skip it too.
+//! 1. **Boundary finding**: atomic exponential probe + bisection via
+//!    [`find_boundary`] to determine the exact last note index.
+//! 2. **Linear scan**: nullifier-first batches for all notes in the range.
+//!    Spent notes skip the amount fetch; cached amounts from the probe phase
+//!    skip it too.
 //!
 //! Parallelization is possible at higher levels:
 //! - Multiple subchannel scans (for notes) can run in parallel
@@ -19,9 +19,7 @@ use starknet_types_core::felt::Felt;
 use tracing::{debug, trace};
 
 use crate::discovery::cursor::SubchannelCursor;
-use crate::discovery::last_note_index::{
-    exponential_probe, ExponentialProbeResult, DEFAULT_MAX_PROBE_OFFSET,
-};
+use crate::discovery::last_note_index::find_last_note_index;
 use crate::discovery::{DiscoveryError, COST_NOTE, COST_NOTE_PROBING};
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::{decrypt_note_amount, unpack_note_amount};
@@ -66,20 +64,18 @@ pub struct NotesDiscoveryResult {
 /// Discovers notes with cursor-based pagination using batched RPC calls.
 ///
 /// Two-phase algorithm:
-/// 1. **Exponential probe** (when `max_note_index` is unknown or scan caught up):
-///    batched probes to find the last existing note index. All probe hits are
-///    cached for use by the linear scan.
-/// 2. **Linear scan** (when `last_note_index < max_note_index`): nullifier-first
-///    batches that skip amount fetches for spent and cached notes.
-///
-/// `max_note_index` is kept after scan — used to bound the next exponential
-/// probe range. Re-probe triggers when `last_note_index == max_note_index`.
+/// 1. **Boundary finding** (when `total_n_notes` is unknown): atomic exponential
+///    probe + bisection via [`find_boundary`] to determine the exact last note index.
+///    All probe hits are cached for use by the linear scan.
+/// 2. **Linear scan** (when notes remain to scan): nullifier-first batches that
+///    skip amount fetches for spent and cached notes.
 pub async fn discover_notes_paginated<S: IViews>(
     pool: &S,
     channel_key: Felt,
     token: Felt,
     cursor: &mut SubchannelCursor,
     private_key: &SecretFelt,
+    max_note_log_index: u32,
     budget: &IoBudget,
 ) -> Result<Vec<DecryptedNote>, DiscoveryError> {
     let start_index = cursor.start_index();
@@ -87,21 +83,26 @@ pub async fn discover_notes_paginated<S: IViews>(
     debug!(
         token = felt_hex(&token),
         start_index,
-        max_note_index = ?cursor.max_note_index,
+        total_n_notes = ?cursor.total_n_notes,
         budget = budget.remaining(),
         "discover_notes_paginated start"
     );
 
+    // Phase 1: Find boundary if not yet known.
     let (probe_cache, probe_has_more) =
-        probe_note_boundary(pool, channel_key, token, cursor, budget).await?;
+        find_last_note_index(pool, channel_key, token, cursor, max_note_log_index, budget).await?;
+    if probe_has_more {
+        // Not enough budget to find the boundary.
+        return Ok(Vec::new());
+    }
 
-    // None means empty subchannel (first probe missed) or budget exhausted
-    // before any probe ran — either way, nothing to scan.
-    let Some(max_note_index) = cursor.max_note_index else {
-        cursor.note_discovery_complete = !probe_has_more;
+    // Empty subchannel or scan already past the end.
+    let Some(max_note_index) = cursor.last_existing_index() else {
+        cursor.note_discovery_complete = true;
         return Ok(Vec::new());
     };
 
+    // Phase 2: Linear scan.
     let NotesDiscoveryResult {
         notes,
         last_index,
@@ -121,67 +122,21 @@ pub async fn discover_notes_paginated<S: IViews>(
     if let Some(last_index) = last_index {
         cursor.last_note_index = Some(last_index);
     }
-    let has_more = scan_has_more || probe_has_more;
-    cursor.note_discovery_complete = !has_more;
+
+    if !scan_has_more {
+        // Scan complete — no more notes to discover.
+        cursor.note_discovery_complete = true;
+    }
 
     debug!(
         unspent = notes.len(),
         last_scanned = ?last_index,
-        has_more,
+        has_more = scan_has_more,
         budget = budget.remaining(),
         "discover_notes_paginated done"
     );
 
     Ok(notes)
-}
-
-/// Probes for the note boundary, updating `cursor.max_note_index`.
-///
-/// Skips probing when the cursor already has a valid bound beyond `start_index`
-/// (resume-after-budget-exhaustion). Re-probing mid-scan would overwrite
-/// `max_note_index` with a smaller value, losing the known bound.
-///
-/// Returns `(probe_cache, probe_has_more)`:
-/// - `probe_cache`: index -> (note_id, packed_amount) for probe hits.
-/// - `probe_has_more`: `true` when the probe couldn't conclusively find the
-///   boundary (budget exhausted or all probes hit). When `true`, the subchannel
-///   must not be pruned even if the scan reaches `max_note_index`.
-async fn probe_note_boundary<S: IViews>(
-    pool: &S,
-    channel_key: Felt,
-    token: Felt,
-    cursor: &mut SubchannelCursor,
-    budget: &IoBudget,
-) -> Result<(HashMap<u64, (Felt, Felt)>, bool), DiscoveryError> {
-    let start_index = cursor.start_index();
-
-    if cursor
-        .max_note_index
-        .is_some_and(|max_note_index| start_index < max_note_index)
-    {
-        return Ok((HashMap::new(), false));
-    }
-
-    let ExponentialProbeResult {
-        cache,
-        last_found_index,
-        probe_complete,
-        ..
-    } = exponential_probe(
-        pool,
-        channel_key,
-        token,
-        start_index,
-        cursor.max_note_index,
-        Some(DEFAULT_MAX_PROBE_OFFSET),
-        budget,
-    )
-    .await?;
-
-    // Clears max_note_index when no notes found, so the caller skips the linear scan.
-    cursor.max_note_index = last_found_index;
-
-    Ok((cache, !probe_complete))
 }
 
 /// Linear scan of notes in `start_index..=end_index`.
@@ -199,7 +154,7 @@ async fn discover_notes<S: IViews>(
     budget: &IoBudget,
     probe_cache: &HashMap<u64, (Felt, Felt)>,
 ) -> Result<NotesDiscoveryResult, DiscoveryError> {
-    let num_remaining_notes = usize::try_from(end_index - start_index + 1)
+    let num_remaining_notes = usize::try_from((end_index + 1).saturating_sub(start_index))
         .map_err(|_| DiscoveryError::InvalidCursor("note range too large".into()))?;
     let (batch_size, budget_exhausted) = budget.consume_up_to(num_remaining_notes, COST_NOTE);
     if batch_size == 0 {
@@ -324,8 +279,13 @@ fn decrypt_note(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::discovery::last_note_index::boundary_budget;
     use crate::storage_backend::MockBackend;
     use crate::test_fixtures::{get_channel_key, get_subchannel_token, load_devnet_fixture};
+
+    const DEFAULT_MAX_LOG: u32 = 30;
+    /// Number of probe offsets: [0, 1, 3, 7, ..., 2^30-1] = 31 offsets.
+    const NUM_PROBE_OFFSETS: usize = (DEFAULT_MAX_LOG + 1) as usize;
 
     /// Helper: runs discover_notes_paginated with a fresh default cursor and
     /// returns the result along with the cursor for inspection.
@@ -343,6 +303,7 @@ mod tests {
             token,
             &mut cursor,
             private_key,
+            DEFAULT_MAX_LOG,
             budget,
         )
         .await
@@ -448,20 +409,65 @@ mod tests {
         let budget = IoBudget::new(100);
         let key = SecretFelt::new(fixture.constants.alice_viewing_key);
         let mut cursor = SubchannelCursor::default();
-        let notes =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
-                .await
-                .unwrap();
+        let notes = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget,
+        )
+        .await
+        .unwrap();
         assert_eq!(notes.len(), 1, "1 unspent change note");
         assert!(cursor.note_discovery_complete);
 
-        // Incremental discovery — should find 0 new notes (sentinel at index 1)
-        let notes2 =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
-                .await
-                .unwrap();
+        // Incremental discovery — total_n_notes was cleared on completion,
+        // re-probes and finds sentinel at index 1. Returns immediately.
+        let notes2 = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget,
+        )
+        .await
+        .unwrap();
         assert_eq!(notes2.len(), 0);
         assert!(cursor.note_discovery_complete);
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_three_notes_with_bisection() {
+        // 3 notes at indices 0, 1, 2. Exponential probe offsets [0, 1, 3, ...]
+        // hit at 0 and 1, miss at 3. Bisection finds note at 2. Total = 3.
+        // All 3 notes discovered in a single call (atomic boundary finding).
+        use crate::privacy_pool::{hashes::compute_note_id, storage_slots};
+
+        let channel_key = Felt::from_hex_unchecked("0x12345");
+        let token = Felt::from_hex_unchecked("0x67890");
+        let zero_key = SecretFelt::new(Felt::ZERO);
+
+        let mut backend = MockBackend::empty();
+        for index in 0..=2u64 {
+            let note_id = compute_note_id(channel_key, token, index);
+            let slot = storage_slots::notes(note_id);
+            backend.insert(slot, Felt::ONE);
+        }
+
+        let budget = IoBudget::new(200);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, channel_key, token, &zero_key, &budget).await;
+
+        assert!(cursor.note_discovery_complete);
+        assert_eq!(notes.len(), 3, "all 3 notes discovered in one call");
+        let indices: Vec<u64> = notes.iter().map(|n| n.index).collect();
+        assert!(indices.contains(&0));
+        assert!(indices.contains(&1));
+        assert!(indices.contains(&2));
     }
 
     #[tokio::test]
@@ -495,10 +501,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_exponential_probe_empty_subchannel() {
+    async fn test_boundary_finding_empty_subchannel() {
         // Empty subchannel: exponential probe finds sentinel at offset 0.
-        // Offsets: [0, 1, 3, 7, ..., 1023] = 11 probes at COST_NOTE_PROBING=1 each.
-        // All return empty (Felt::ZERO), so sentinel is found at offset 0.
+        // 31 offsets probed at COST_NOTE_PROBING=1 each.
         let backend = MockBackend::empty();
         let channel_key = Felt::from_hex_unchecked("0x12345");
         let token = Felt::from_hex_unchecked("0x67890");
@@ -513,8 +518,11 @@ mod tests {
             cursor.note_discovery_complete,
             "sentinel found, not budget exhaustion"
         );
-        // 11 exponential offsets probed: [0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023]
-        assert_eq!(budget.remaining(), 89);
+        assert_eq!(
+            budget.remaining(),
+            100 - NUM_PROBE_OFFSETS,
+            "31 probe offsets consumed"
+        );
     }
 
     #[tokio::test]
@@ -534,10 +542,17 @@ mod tests {
         let mut cursor = SubchannelCursor::default();
         let budget = IoBudget::new(100);
         let key = SecretFelt::new(fixture.constants.bob_viewing_key);
-        let notes =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
-                .await
-                .unwrap();
+        let notes = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget,
+        )
+        .await
+        .unwrap();
 
         // Bob's note is spent → filtered out
         assert_eq!(notes.len(), 0, "Bob's note is spent");
@@ -545,7 +560,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_budget_exhaustion_then_resume_skips_initial_probe() {
+    async fn test_budget_exhaustion_then_resume_skips_boundary_finding() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
@@ -563,26 +578,40 @@ mod tests {
 
         // First call with enough budget to discover notes.
         let budget = IoBudget::new(100);
-        let notes =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
-                .await
-                .unwrap();
+        let notes = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget,
+        )
+        .await
+        .unwrap();
         assert_eq!(notes.len(), 1);
         assert!(cursor.note_discovery_complete);
 
-        // Now resume — cursor.last_note_index is Some(0), so start_index = 1.
-        // It should find sentinel at index 1 and return immediately.
+        // Resume — total_n_notes was cleared, re-probes from start_index=1.
+        // Finds sentinel immediately → empty, complete.
         let budget2 = IoBudget::new(100);
-        let notes2 =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget2)
-                .await
-                .unwrap();
+        let notes2 = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget2,
+        )
+        .await
+        .unwrap();
         assert_eq!(notes2.len(), 0);
         assert!(cursor.note_discovery_complete);
     }
 
     #[tokio::test]
-    async fn test_paginated_budget_limited() {
+    async fn test_paginated_budget_insufficient_for_boundary() {
         let fixture = load_devnet_fixture();
         let backend = MockBackend::new(fixture.slots);
 
@@ -597,25 +626,34 @@ mod tests {
 
         let mut cursor = SubchannelCursor::default();
         let key = SecretFelt::new(fixture.constants.bob_viewing_key);
-        // Bob has 1 note at index 0.
-        // Exponential probe: 11 offsets [0..1023], all probed at COST_NOTE_PROBING=1.
-        //   Offset 0 hits, offset 1 is empty sentinel. Cost = 11.
-        // Scan: budget exhausted (0 remaining) → has_more = true.
-        let budget = IoBudget::new(11);
-        let notes =
-            discover_notes_paginated(&backend, channel_key, token, &mut cursor, &key, &budget)
-                .await
-                .unwrap();
+        // Budget below the minimum for atomic boundary finding.
+        // Boundary finding requires boundary_budget(30) = 61 upfront.
+        let budget = IoBudget::new(boundary_budget(DEFAULT_MAX_LOG) - 1);
+        let notes = discover_notes_paginated(
+            &backend,
+            channel_key,
+            token,
+            &mut cursor,
+            &key,
+            DEFAULT_MAX_LOG,
+            &budget,
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(notes.len(), 0, "no budget left for scan");
-        assert_eq!(
-            cursor.max_note_index,
-            Some(0),
-            "probe found note at index 0"
+        assert_eq!(notes.len(), 0, "can't start boundary finding");
+        assert!(
+            cursor.total_n_notes.is_none(),
+            "boundary not found — budget insufficient"
         );
         assert!(
             !cursor.note_discovery_complete,
-            "scan budget exhausted is not complete"
+            "budget insufficient is not complete"
+        );
+        assert_eq!(
+            budget.remaining(),
+            boundary_budget(DEFAULT_MAX_LOG) - 1,
+            "budget unchanged — atomic allocation failed"
         );
     }
 
@@ -645,14 +683,12 @@ mod tests {
         assert_eq!(notes.len(), 1, "1 unspent note");
         assert!(cursor.note_discovery_complete);
         assert_eq!(cursor.last_note_index, Some(0));
-        // Probe: 11 probes (offsets 0, 1, 3, 7, ..., 1023) = 11 budget.
-        //   Hit at 0, miss at 1 → cache has index 0.
+        // Probe: 31 offsets consumed. Hit at 0, miss at 1 → cache has index 0.
         // Scan: pre-consume 2 (COST_NOTE), nullifier → unspent, cached → reclaim 1.
-        //   Net scan cost = 1. Total = 12.
-        // Without cache, scan would cost 2 (nullifier + amount fetch). Saves 1.
+        //   Net scan cost = 1. Total = 32.
         assert_eq!(
             budget.remaining(),
-            88,
+            100 - NUM_PROBE_OFFSETS - COST_NOTE + COST_NOTE_PROBING,
             "cache saves 1 budget unit vs no-cache"
         );
     }

--- a/crates/discovery-core/src/sync/incoming_state.rs
+++ b/crates/discovery-core/src/sync/incoming_state.rs
@@ -127,6 +127,7 @@ pub async fn sync_incoming_state<S: IViews>(
                 ch_cursor,
                 viewing_key,
                 cursor_limits.max_subchannels,
+                cursor_limits.max_note_log_index,
                 budget,
             )
         })
@@ -169,6 +170,7 @@ async fn process_channel<S: IViews>(
     mut cursor: ChannelCursor,
     viewing_key: &SecretFelt,
     max_cursor_subchannels: usize,
+    max_note_log_index: u32,
     budget: &IoBudget,
 ) -> Result<ProcessChannelResult, DiscoveryError> {
     let channel_key = cursor.channel_key;
@@ -188,7 +190,15 @@ async fn process_channel<S: IViews>(
         .subchannels
         .extract_if(|_, sc| !sc.note_discovery_complete)
         .map(|(token, sc_cursor)| {
-            process_subchannel(pool, channel_key, token, sc_cursor, viewing_key, budget)
+            process_subchannel(
+                pool,
+                channel_key,
+                token,
+                sc_cursor,
+                viewing_key,
+                max_note_log_index,
+                budget,
+            )
         })
         .collect();
 
@@ -229,6 +239,7 @@ async fn process_subchannel<S: IViews>(
     token: Felt,
     mut cursor: SubchannelCursor,
     viewing_key: &SecretFelt,
+    max_note_log_index: u32,
     budget: &IoBudget,
 ) -> Result<ProcessSubchannelResult, DiscoveryError> {
     if cursor.note_discovery_complete {
@@ -239,9 +250,16 @@ async fn process_subchannel<S: IViews>(
         });
     }
 
-    let notes =
-        discover_notes_paginated(pool, channel_key, token, &mut cursor, viewing_key, budget)
-            .await?;
+    let notes = discover_notes_paginated(
+        pool,
+        channel_key,
+        token,
+        &mut cursor,
+        viewing_key,
+        max_note_log_index,
+        budget,
+    )
+    .await?;
 
     Ok(ProcessSubchannelResult {
         token,
@@ -253,9 +271,8 @@ async fn process_subchannel<S: IViews>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::discovery::{
-        COST_CHANNEL_INFO, COST_NOTE, COST_NOTE_PROBING, COST_NUM_CHANNELS, COST_SUBCHANNEL_INFO,
-    };
+    use crate::discovery::last_note_index::boundary_budget;
+    use crate::discovery::{COST_CHANNEL_INFO, COST_NUM_CHANNELS, COST_SUBCHANNEL_INFO};
     use crate::storage_backend::MockBackend;
     use crate::test_fixtures::load_devnet_fixture;
 
@@ -273,7 +290,7 @@ mod tests {
     /// | 2    | 3      | Channel 0 discovered                              |
     /// | 3    | 2      | Subchannel 0 (STRK) discovered                    |
     /// | 4    | 2      | Subchannel sentinel → total cached                |
-    /// | 5    | 4+     | Subchannels skipped + batched note scan → all done |
+    /// | 5    | 61     | Atomic boundary finding + note scan → all done    |
     #[tokio::test]
     async fn test_sync_incoming_state_step_by_step_pagination() {
         let f = load_devnet_fixture();
@@ -293,6 +310,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
         )
@@ -317,6 +335,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
         )
@@ -348,6 +367,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
         )
@@ -376,7 +396,7 @@ mod tests {
         // Step 4: budget = COST_SUBCHANNEL_INFO (2)
         // Channel discovery skipped (cursor.channels non-empty). Reads
         // subchannel index 1 → sentinel (salt=0). Budget=0, note discovery
-        // fails (needs COST_NOTE_PROBING=1 for initial probe).
+        // fails (needs boundary_budget(30)=61 for atomic boundary finding).
         let budget = IoBudget::new(COST_SUBCHANNEL_INFO);
         let out = sync_incoming_state(
             &backend,
@@ -386,6 +406,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
         )
@@ -404,11 +425,10 @@ mod tests {
         );
 
         // Step 5: Subchannels skipped (total cached). Notes discovery:
-        // Exponential probe: 11 offsets [0,1,3,7,...,1023] consumed greedily,
-        // but breaks at offset 1 (empty). Hit at 0, miss at 1. Cost = 11.
-        // Linear scan: 1 note at index 0 → COST_NOTE (2: get_note + nullifier).
-        // Bob's note is spent → filtered. Total = 13.
-        let budget = IoBudget::new(11 * COST_NOTE_PROBING + COST_NOTE);
+        // Atomic boundary finding: consumes boundary_budget(30) = 61 upfront.
+        // Probe: hit at 0, miss at 1 (adjacent). No bisection. Reclaim 30.
+        // Net boundary cost = 31. Scan: 1 note (spent), net cost = 1. Total = 32.
+        let budget = IoBudget::new(boundary_budget(30));
         let out = sync_incoming_state(
             &backend,
             recipient,
@@ -417,6 +437,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
         )

--- a/crates/discovery-core/src/sync/outgoing_state.rs
+++ b/crates/discovery-core/src/sync/outgoing_state.rs
@@ -13,7 +13,7 @@ use starknet_types_core::felt::Felt;
 
 use tracing::{debug, instrument, trace};
 
-use crate::discovery::last_note_index::find_last_note_index_paginated;
+use crate::discovery::last_note_index::find_last_note_index;
 use crate::discovery::outgoing_channels::{
     discover_outgoing_channels_paginated, precompute_channels, OutgoingChannel,
 };
@@ -134,6 +134,7 @@ pub async fn sync_outgoing_state<S: IViews>(
                 recipient_addr,
                 ch_cursor,
                 cursor_limits.max_subchannels,
+                cursor_limits.max_note_log_index,
                 budget,
             )
         })
@@ -185,6 +186,7 @@ async fn process_outgoing_channel<S: IViews>(
     recipient_addr: Felt,
     mut cursor: ChannelCursor,
     max_cursor_subchannels: usize,
+    max_note_log_index: u32,
     budget: &IoBudget,
 ) -> Result<ProcessChannelResult, DiscoveryError> {
     let channel_key = cursor.channel_key;
@@ -204,7 +206,14 @@ async fn process_outgoing_channel<S: IViews>(
         .subchannels
         .extract_if(|_, sc| !sc.note_discovery_complete)
         .map(|(token, sc_cursor)| {
-            process_outgoing_subchannel(pool, channel_key, token, sc_cursor, budget)
+            process_outgoing_subchannel(
+                pool,
+                channel_key,
+                token,
+                sc_cursor,
+                max_note_log_index,
+                budget,
+            )
         })
         .collect();
 
@@ -237,24 +246,32 @@ async fn process_outgoing_subchannel<S: IViews>(
     channel_key: Felt,
     token: Felt,
     mut cursor: SubchannelCursor,
+    max_note_log_index: u32,
     budget: &IoBudget,
 ) -> Result<ProcessSubchannelResult, DiscoveryError> {
     if cursor.note_discovery_complete {
         return Ok(ProcessSubchannelResult {
             token,
-            last_note_index: cursor.last_note_index,
+            last_note_index: cursor.last_existing_index(),
             cursor,
         });
     }
 
-    let (last_index, has_more) =
-        find_last_note_index_paginated(pool, channel_key, token, &mut cursor, budget).await?;
+    let (_cache, has_more) = find_last_note_index(
+        pool,
+        channel_key,
+        token,
+        &mut cursor,
+        max_note_log_index,
+        budget,
+    )
+    .await?;
 
     cursor.note_discovery_complete = !has_more;
 
     Ok(ProcessSubchannelResult {
         token,
-        last_note_index: last_index,
+        last_note_index: cursor.last_existing_index(),
         cursor,
     })
 }
@@ -275,7 +292,7 @@ mod tests {
         let viewing_key = SecretFelt::new(f.constants.alice_viewing_key);
 
         let cursor = DiscoveryCursor::default();
-        let budget = IoBudget::new(100);
+        let budget = IoBudget::new(200);
 
         let out = sync_outgoing_state(
             &backend,
@@ -285,6 +302,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
             None,
@@ -354,6 +372,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
             None,
@@ -380,7 +399,8 @@ mod tests {
 
         // Step 2: generous budget. Channel discovery skipped (cursor.channels
         // non-empty). Finishes subchannel + note discovery for both channels.
-        let budget = IoBudget::new(100);
+        // Needs budget for 2 concurrent boundary-finding operations (61 each).
+        let budget = IoBudget::new(200);
         let out2 = sync_outgoing_state(
             &backend,
             f.constants.alice_address,
@@ -389,6 +409,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &budget,
             None,
@@ -426,8 +447,9 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
-            &IoBudget::new(100),
+            &IoBudget::new(200),
             Some(&recipients),
         )
         .await
@@ -462,6 +484,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &IoBudget::new(1000),
             None,
@@ -513,6 +536,7 @@ mod tests {
             CursorLimits {
                 max_channels: 1024,
                 max_subchannels: 1024,
+                ..Default::default()
             },
             &IoBudget::new(1000),
             None,

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -122,7 +122,7 @@ impl Default for ValidationLimits {
         Self {
             cursor_limits: CursorLimits::default(),
             max_outgoing_recipients: 64,
-            server_budget: 100,
+            server_budget: 200,
         }
     }
 }

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -80,5 +80,22 @@ describe("E2E Smoke", () => {
 
     const req = await aliceIndexer.discoverRequirement(de.bob.address, de.strk);
     expect(req).toBe(SetupRequirement.Ready);
+
+    // --- Bob's incoming discovery ---
+    const bobIndexer = createPrivateTransfers({
+      account: de.bob,
+      viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
+      provingProvider: new CallMockProofProvider(de.provider, constants.StarknetChainId.SN_SEPOLIA),
+      discoveryProvider: indexerDiscovery,
+      poolContractAddress: de.privacy.address,
+    });
+
+    // Bob should discover 1 incoming note: 50 STRK from Alice
+    const { notes: bobNotes } = await bobIndexer.discoverNotes();
+    expect(bobNotes.size).toBeGreaterThanOrEqual(1);
+    const bobStrkNotes = bobNotes.get(BigInt(de.strk));
+    expect(bobStrkNotes).toBeDefined();
+    expect(bobStrkNotes!.length).toBe(1);
+    expect(bobStrkNotes![0].amount).toBe(50n);
   });
 });


### PR DESCRIPTION
### TL;DR

Replaced paginated exponential probing with atomic boundary finding to eliminate gaps in note discovery and simplify the cursor state model.

### What changed?

**Boundary Finding Algorithm**
- Replaced two-phase exponential probe + bisection with atomic boundary finding that consumes budget upfront
- Added `max_note_log_index` configuration parameter to limit probe range (default 30 → ~1B indices)
- Exponential probe now errors if all offsets hit, indicating insufficient configuration

**Cursor State Simplification**
- Replaced `max_note_index` field with `total_n_notes` in `SubchannelCursor`
- Added `last_existing_index()` helper method to derive the last note index from total count
- Removed complex probe resumption logic that could miss notes in gaps

**Budget Management**
- Boundary finding now allocates `boundary_budget()` atomically and reclaims unused bisection steps
- Increased default server budget from 100 to 200 to accommodate atomic allocation requirements
- Added budget validation to ensure sufficient allocation before starting boundary finding

**Test Coverage**
- Added comprehensive tests for gap scenarios, empty subchannels, and budget edge cases
- Updated existing tests to reflect atomic boundary finding behavior
- Added end-to-end test verifying Bob can discover incoming notes from Alice

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/554)
<!-- Reviewable:end -->
