### PR TITLE
fix(e2e): add declare-class script and fix outgoing sync

### DIFF
--- a/crates/discovery-core/src/discovery/cursor.rs
+++ b/crates/discovery-core/src/discovery/cursor.rs
@@ -43,6 +43,7 @@ pub struct DiscoveryCursor {
 
     /// Total number of channels (cached from `get_num_of_channels` for incoming).
     /// Used as optimization to avoid redundant RPC calls.
+    // TODO: rename to total_n_incoming_channels to avoid confusion on the SDK side.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_n_channels: Option<u64>,
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -63,6 +63,23 @@ This writes fixtures directly to:
 
 After regenerating, run `cargo test` from the repo root to confirm Rust tests still pass.
 
+## Declaring a new contract class
+
+When the Cairo contract changes (new constructor param, logic update, etc.), the class hash
+changes and must be re-declared on the target network before deploying new instances.
+
+```bash
+# 1. Rebuild the contract (release profile — no debug info, full inlining)
+scarb --profile release build
+
+# 2. Declare (reads RPC_URL and ACCOUNTS from .env)
+npm run declare-class
+```
+
+The script computes the class hash locally, checks whether it's already declared on-chain,
+and submits a DECLARE v3 transaction if needed. On success it prints the new class hash —
+update `POOL_CLASS_HASH` in `.env` to match.
+
 ## Privacy StarkNet integration (`tests/privacy-starknet-integration.test.ts`)
 
 Tests against a real (non-devnet) StarkNet deployment on integration sepolia.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "vitest run",
     "test:e2e": "vitest run",
+    "declare-class": "tsx --env-file=.env scripts/declare-class.ts",
     "generate-dump": "tsx scripts/generate-dump.ts",
     "lint": "eslint src tests scripts --fix",
     "lint:check": "eslint src tests scripts",

--- a/e2e/scripts/declare-class.ts
+++ b/e2e/scripts/declare-class.ts
@@ -1,0 +1,131 @@
+/**
+ * Declare the privacy pool contract class on a live network (e.g. Sepolia).
+ *
+ * Reads env vars:
+ *   RPC_URL   — JSON-RPC endpoint
+ *   ACCOUNTS  — JSON array; uses the "admin" entry for signing
+ *
+ * Loads sierra + casm artifacts from target/dev/ and submits a DECLARE v3 tx.
+ *
+ * Usage: npm run declare-class   (from e2e/, with .env populated)
+ */
+
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { Account, RpcProvider, hash } from "starknet";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "../..");
+
+const CONTRACT_CLASS_PATH = join(
+  repoRoot,
+  "target/release/privacy_Privacy.contract_class.json",
+);
+const COMPILED_CONTRACT_PATH = join(
+  repoRoot,
+  "target/release/privacy_Privacy.compiled_contract_class.json",
+);
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+}
+
+interface AccountEntry {
+  name: string;
+  address: string;
+  privateKey: string;
+  viewingKey: string;
+}
+
+// Resource bounds for DECLARE on Sepolia — the sierra payload is large (~25k felts),
+// so l1_data_gas needs a generous allowance.
+const L2_GAS_PRICE = 16_000_000_000n;
+const L1_GAS_PRICE = 1_000_000_000_000n;
+const L1_DATA_GAS_PRICE = 2_000n;
+const DECLARE_RESOURCE_BOUNDS = {
+  l2_gas: { max_amount: 4_000_000_000n, max_price_per_unit: L2_GAS_PRICE },
+  l1_gas: { max_amount: 1n, max_price_per_unit: L1_GAS_PRICE },
+  l1_data_gas: { max_amount: 25_000n, max_price_per_unit: L1_DATA_GAS_PRICE },
+};
+
+const rpcUrl = requireEnv("RPC_URL");
+const accounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
+const admin = accounts.find((account) => account.name === "admin");
+if (!admin) throw new Error('No "admin" entry found in ACCOUNTS env var');
+
+const provider = new RpcProvider({ nodeUrl: rpcUrl });
+const adminAccount = new Account({
+  provider,
+  address: admin.address,
+  signer: admin.privateKey,
+  cairoVersion: "1",
+});
+
+console.log("Loading contract artifacts...");
+const contractClass = JSON.parse(readFileSync(CONTRACT_CLASS_PATH, "utf8"));
+const compiledContract = JSON.parse(
+  readFileSync(COMPILED_CONTRACT_PATH, "utf8"),
+);
+
+const classHash = hash.computeContractClassHash(contractClass);
+console.log("Class hash:", classHash);
+
+// Check if already declared before sending a tx
+try {
+  await provider.getClass(classHash);
+  console.log("Class already declared on-chain — nothing to do.");
+  console.log("Update POOL_CLASS_HASH in .env to:", classHash);
+  process.exit(0);
+} catch {
+  // getClass throws when the class doesn't exist — proceed with declaration
+}
+
+console.log("Submitting DECLARE transaction...");
+try {
+  const response = await adminAccount.declare(
+    { contract: contractClass, casm: compiledContract },
+    { resourceBounds: DECLARE_RESOURCE_BOUNDS, tip: 0n },
+  );
+
+  console.log("Transaction hash:", response.transaction_hash);
+  console.log("Waiting for acceptance...");
+
+  const receipt = await provider.waitForTransaction(response.transaction_hash);
+  if (!receipt.isSuccess()) {
+    console.error("DECLARE failed:", JSON.stringify(receipt, null, 2));
+    process.exit(1);
+  }
+
+  console.log("Class declared successfully!");
+  console.log("Class hash:", response.class_hash);
+} catch (error: unknown) {
+  // RpcError dumps the full sierra payload — extract just the useful info
+  if (error instanceof Error && "code" in error) {
+    const rpcError = error as Error & {
+      code: number;
+      data?: unknown;
+      baseError?: unknown;
+    };
+    if (rpcError.code === 51) {
+      console.log("Class already declared — nothing to do.");
+      console.log("Update POOL_CLASS_HASH in .env to:", classHash);
+    } else {
+      console.error("RPC error code:", rpcError.code);
+      console.error(
+        "RPC error message:",
+        rpcError.message.split(" with params")[0],
+      );
+      if (rpcError.data)
+        console.error("RPC error data:", JSON.stringify(rpcError.data));
+      if (rpcError.baseError)
+        console.error("RPC base error:", JSON.stringify(rpcError.baseError));
+      process.exit(1);
+    }
+  } else {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+}

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -197,7 +197,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
         cursor: { channel_discovery_complete: false },
       };
       const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels };
+      return { timestamp: resp.block_ref, total: (resp.cursor.last_channel_index ?? -1) + 1 };
     }
 
     const cursorMap = params?.cursor?.channels;

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -180,6 +180,8 @@ export class Devnet {
       "1",
       "--dump-on",
       "request", // Enable devnet_dump RPC (no-op unless explicitly called)
+      "--chain-id",
+      "TESTNET",
     ];
 
     // Spawn a devnet instance on a random free port using the system-installed binary

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -363,7 +363,7 @@ describe("IndexerDiscoveryProvider", () => {
         body: outgoingSyncResponse({
           cursor: {
             channel_discovery_complete: false,
-            total_n_channels: 5,
+            last_channel_index: 4,
           },
         }),
       });


### PR DESCRIPTION
### TL;DR

Added a script to declare Cairo contract classes on live networks and fixed indexer discovery channel counting logic.

### What changed?

- Added `declare-class.ts` script that handles declaring privacy pool contract classes on StarkNet networks
- Added npm script `declare-class` to run the declaration script
- Updated devnet configuration to use TESTNET chain ID
- Fixed indexer discovery provider to calculate total channels using `last_channel_index + 1` instead of `total_n_channels`
- Added documentation for the contract class declaration process

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/555)
<!-- Reviewable:end -->
