### PR TITLE
feat: assert calldata doesn't contain trailing values after actions

### DIFF
--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -4393,6 +4393,17 @@ fn test_execute_assertions() {
     let result = test.privacy.safe_execute_with_calls(calls: array![invalid_call]);
     assert_panic_with_felt_error(:result, expected_error: errors::INVALID_CALLDATA);
 
+    // Catch INVALID_CALLDATA (trailing data after valid serialization).
+    let mut calldata_with_trailing = array![];
+    user.address.serialize(ref calldata_with_trailing);
+    user.private_key.serialize(ref calldata_with_trailing);
+    let empty_actions: Span<ClientAction> = [].span();
+    empty_actions.serialize(ref calldata_with_trailing);
+    calldata_with_trailing.append(1);
+    let invalid_call = Call { calldata: calldata_with_trailing.span(), ..valid_call };
+    let result = test.privacy.safe_execute_with_calls(calls: array![invalid_call]);
+    assert_panic_with_felt_error(:result, expected_error: errors::INVALID_CALLDATA);
+
     // Catch INVALID_SIGNATURE.
     let mut user_invalid = test.new_user_with_is_valid(is_valid: false);
     let result = user_invalid

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -341,6 +341,7 @@ pub(crate) fn extract_execute_view_inputs(
         (ContractAddress, felt252, Span<ClientAction>),
     >::deserialize(ref :serialized)
         .expect(errors::INVALID_CALLDATA);
+    assert(serialized.is_empty(), errors::INVALID_CALLDATA);
     (user_addr, user_private_key, client_actions)
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/563)
<!-- Reviewable:end -->
