### PR TITLE
feat(discovery-service): validate viewing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -213,9 +213,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -273,9 +273,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -295,9 +295,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -424,6 +424,30 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -504,9 +528,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -558,6 +582,7 @@ dependencies = [
  "expect-test",
  "flate2",
  "libc",
+ "moka",
  "nix",
  "regex",
  "reqwest",
@@ -565,6 +590,7 @@ dependencies = [
  "serde_json",
  "starknet",
  "starknet-core",
+ "starknet-crypto",
  "starknet-providers",
  "starknet-tokio-tungstenite",
  "starknet-types-core",
@@ -652,7 +678,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -770,9 +796,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -785,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -795,15 +821,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -812,15 +838,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -829,21 +855,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -853,7 +879,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -895,6 +920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +956,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1178,6 +1225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,9 +1366,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1323,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1365,22 +1418,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1411,9 +1479,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -1443,18 +1511,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
+name = "moka"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid 1.21.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.1.6",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1554,12 +1639,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -1605,6 +1684,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,9 +1723,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1636,6 +1738,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1659,6 +1767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1828,6 +1946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1968,9 +2095,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1981,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
  "ring",
@@ -1999,10 +2126,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -2034,9 +2161,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -2081,6 +2208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scrypt"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,22 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -2120,13 +2240,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2216,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2235,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2549,9 +2675,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2600,6 +2726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,12 +2739,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2669,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2690,9 +2822,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2866,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3035,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -3092,6 +3224,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3134,10 +3277,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3148,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3162,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3172,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3185,18 +3337,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3214,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3461,6 +3647,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -3502,18 +3770,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3582,6 +3850,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/discovery-core/src/storage_backend.rs
+++ b/crates/discovery-core/src/storage_backend.rs
@@ -55,6 +55,9 @@ pub trait StorageBackend: Send + Sync {
 /// Consistent view of storage at a specific block.
 #[async_trait]
 pub trait StorageSnapshot: IViews {
+    /// Returns the contract address this snapshot is bound to.
+    fn contract_address(&self) -> Felt;
+
     /// Returns the block ID this snapshot is bound to.
     fn block_id(&self) -> BlockId;
 }

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -41,6 +41,12 @@ serde_json = "1.0"
 thiserror = "2"
 backoff = { version = "0.4", features = ["tokio"] }
 
+# Crypto
+starknet-crypto = "0.8"
+
+# Cache
+moka = { version = "0.12", features = ["sync"] }
+
 # Configuration
 toml = "0.8"
 regex = "1"

--- a/crates/discovery-service/specs/05-security-considerations.md
+++ b/crates/discovery-service/specs/05-security-considerations.md
@@ -62,7 +62,7 @@ The following request fields are validated by the service:
 - **block_ref:** If provided, used as-is for querying. No separate existence check — an invalid hash surfaces as an RPC error.
 - **cursor:** Structural validation via serde deserialization. Malformed JSON results in `INVALID_REQUEST`. **Note:** cursor HashMap sizes (`channels`, `subchannels`) are NOT validated — an attacker can submit arbitrarily large maps that spawn unbounded concurrent tasks. Size caps MUST be enforced before task spawning.
 - **recipient_address:** Accepted as a Felt value without format validation.
-- **viewing_key:** Deserialized as `SecretFelt` (transparent serde, zeroized on drop). Accepted without format validation.
+- **viewing_key:** Deserialized as `SecretFelt` (transparent serde, zeroized on drop). Validated against the registered public key: the service derives the public key from the viewing key via EC scalar multiplication and checks it against the on-chain registered public key for the request's address. Returns `INVALID_REQUEST` if mismatched. Skipped for unregistered addresses (zero public key).
 
 ## 5.5 Privacy Model
 

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -74,7 +74,7 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 
 - `contract_address`: The privacy pool contract address.
 - `recipient_address`: The recipient's on-chain address.
-- `viewing_key`: The recipient's private viewing key (used for server-side decryption).
+- `viewing_key`: The recipient's private viewing key (used for server-side decryption). Validated against the on-chain public key for the given address.
 - `last_known_block`: Optional. Block hash from last completed sync session. Used for reorg detection on first request. Server returns `409 BLOCK_REORGED` if this block is no longer canonical. Leave empty on fresh syncs or pagination requests.
 - `block_ref`: Optional. Block hash to query state at. Ensures consistent reads across paginated requests. Leave empty on first request (server uses current head and sets it in response).
 - `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
@@ -161,7 +161,7 @@ Uses the same `block_ref`/`last_known_block` reorg-detection pattern and composi
 
 - `contract_address`: The privacy pool contract address.
 - `sender_address`: The sender's on-chain address.
-- `viewing_key`: The sender's private viewing key (used for server-side decryption of outgoing channel data).
+- `viewing_key`: The sender's private viewing key (used for server-side decryption of outgoing channel data). Validated against the on-chain public key for the given address.
 - `last_known_block`: Optional. For reorg detection on first request of a new sync session.
 - `block_ref`: Optional. Block hash for consistent reads across paginated requests.
 - `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
@@ -218,7 +218,7 @@ A non-paginated readiness check that reports what on-chain setup exists for a `(
 
 - `contract_address`: The privacy pool contract address.
 - `sender_address`: The sender's on-chain address.
-- `viewing_key`: The sender's private viewing key (used to derive channel key).
+- `viewing_key`: The sender's private viewing key (used to derive channel key). Validated against the on-chain public key for the given address.
 - `recipient`: The recipient's on-chain address.
 - `token`: The token address to check subchannel for.
 

--- a/crates/discovery-service/specs/12-key-management.md
+++ b/crates/discovery-service/specs/12-key-management.md
@@ -14,6 +14,8 @@
 
 This avoids persistent sensitive material in infrastructure.
 
+Public keys fetched from the contract are cached in a lock-free concurrent cache (moka, default 10K entries) to avoid redundant RPC calls. Keyed by `(contract_address, user_address)`. Public keys are immutable once registered, so cache entries never go stale. Zero (unregistered) values are not cached.
+
 ## 12.2 Persistent Key Storage is an Option, but Not Recommended
 
 Persistent key storage introduces disadvantages:

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -19,7 +19,9 @@ use crate::api::types::{
     OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
     SyncRequestBase,
 };
-use crate::api::validators::{validate_block_ref, validate_cursor, validate_recipients};
+use crate::api::validators::{
+    validate_block_ref, validate_cursor, validate_recipients, validate_viewing_key,
+};
 use crate::api::AppState;
 use crate::chain_state::ChainState;
 use discovery_core::discovery::CursorLimits;
@@ -67,8 +69,12 @@ struct SyncContext<S> {
 
 /// Validates the shared request fields and builds the context needed by
 /// both incoming and outgoing sync handlers.
+///
+/// `user_address` is the address whose public key should match the viewing key
+/// (recipient for incoming, sender for outgoing).
 async fn prepare_sync_context<B>(
     base: &SyncRequestBase,
+    user_address: Felt,
     state: &AppState<B>,
 ) -> Result<SyncContext<B::Snapshot>, (StatusCode, ApiErrorResponse)>
 where
@@ -83,6 +89,14 @@ where
         .backend
         .snapshot(base.contract_address, Some(BlockId::Hash(block_ref)))
         .await;
+
+    validate_viewing_key(
+        &base.viewing_key,
+        user_address,
+        &snapshot,
+        &state.public_key_cache,
+    )
+    .await?;
 
     let budget = IoBudget::new(state.validation_limits.server_budget);
     let cursor_limits = state.validation_limits.cursor_limits;
@@ -119,7 +133,7 @@ where
     B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
     B::Snapshot: Clone + Send + Sync + 'static,
 {
-    let context = prepare_sync_context(&request.base, state).await?;
+    let context = prepare_sync_context(&request.base, request.recipient_address, state).await?;
 
     debug!(
         recipient = %format!("{:#x}", request.recipient_address),
@@ -182,7 +196,7 @@ where
     if let Some(ref recipients) = request.recipients {
         validate_recipients(recipients, &state.validation_limits)?;
     }
-    let context = prepare_sync_context(&request.base, state).await?;
+    let context = prepare_sync_context(&request.base, request.sender_address, state).await?;
 
     debug!(
         sender = felt_hex(&request.sender_address),
@@ -255,6 +269,14 @@ where
             Some(BlockId::Hash(head.block_hash)),
         )
         .await;
+
+    validate_viewing_key(
+        &request.viewing_key,
+        request.sender_address,
+        &snapshot,
+        &state.public_key_cache,
+    )
+    .await?;
 
     debug!(
         sender = felt_hex(&request.sender_address),

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -18,6 +18,7 @@ use tracing::info;
 
 use crate::chain_state::ChainState;
 use crate::config::{ApiServerConfig, ValidationLimits};
+use crate::public_key_cache::PublicKeyCache;
 
 pub use handlers::{
     health_handler, incoming_sync_handler, outgoing_sync_handler, preflight_check_handler,
@@ -49,6 +50,7 @@ pub struct AppState<B> {
     pub backend: B,
     pub health_max_lag_secs: u64,
     pub validation_limits: ValidationLimits,
+    pub public_key_cache: PublicKeyCache,
 }
 
 impl<B> ApiServer<B>
@@ -70,6 +72,9 @@ where
         let app_state = Arc::new(AppState {
             backend: self.backend.clone(),
             health_max_lag_secs: self.config.health_max_lag_secs,
+            public_key_cache: PublicKeyCache::new(
+                self.config.validation_limits.public_key_cache_capacity,
+            ),
             validation_limits: self.config.validation_limits.clone(),
         });
 

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -4,12 +4,14 @@ use std::collections::HashSet;
 
 use axum::http::StatusCode;
 use discovery_core::discovery::DiscoveryCursor;
+use discovery_core::storage_backend::{StorageError, StorageSnapshot};
 use starknet_core::types::Felt;
 use tracing::warn;
 
 use crate::api::types::{error_codes, ApiErrorResponse};
 use crate::chain_state::{ChainState, ChainStateError};
 use crate::config::ValidationLimits;
+use crate::public_key_cache::PublicKeyCache;
 
 /// Validates block reference for sync endpoints.
 ///
@@ -170,6 +172,69 @@ pub fn validate_recipients(
         limits.max_outgoing_recipients,
         "recipients",
     )
+}
+
+/// Validates that the viewing key matches the public key registered on-chain for the given address.
+///
+/// Derives the public key from `viewing_key` via EC scalar multiplication and compares it against
+/// the on-chain registered public key. Skips validation if the user is not registered (zero public
+/// key). Returns `INVALID_REQUEST` on mismatch.
+pub async fn validate_viewing_key<S: StorageSnapshot>(
+    viewing_key: &Felt,
+    user_address: Felt,
+    snapshot: &S,
+    cache: &PublicKeyCache,
+) -> Result<(), (StatusCode, ApiErrorResponse)> {
+    let contract_address = snapshot.contract_address();
+    let registered_public_key = if let Some(cached_key) = cache.get(contract_address, user_address)
+    {
+        cached_key
+    } else {
+        let fetched_key = snapshot
+            .get_public_key(user_address)
+            .await
+            .map_err(|storage_error| match storage_error {
+                StorageError::ContractNotFound => (
+                    StatusCode::NOT_FOUND,
+                    ApiErrorResponse::new(
+                        error_codes::CONTRACT_NOT_FOUND,
+                        "Contract not found at the configured address",
+                    ),
+                ),
+                other => {
+                    warn!("Storage error fetching public key: {}", other);
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        ApiErrorResponse::new(
+                            error_codes::RPC_UNAVAILABLE,
+                            "Upstream RPC is unavailable",
+                        ),
+                    )
+                }
+            })?;
+
+        cache.insert(contract_address, user_address, fetched_key);
+        fetched_key
+    };
+
+    // Skip validation for unregistered users (zero public key).
+    if registered_public_key == Felt::ZERO {
+        return Ok(());
+    }
+
+    let derived_public_key = starknet_crypto::get_public_key(viewing_key);
+
+    if derived_public_key != registered_public_key {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(
+                error_codes::INVALID_REQUEST,
+                "viewing_key does not match the registered public key for the given address",
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -400,4 +465,119 @@ mod tests {
     }
 
     // RPC error handling is tested via integration tests with real devnet
+
+    mod viewing_key_validation {
+        use super::*;
+        use discovery_core::privacy_pool::storage_slots;
+        use discovery_core::storage_backend::MockBackend;
+        use starknet_core::types::BlockId;
+
+        const TEST_VIEWING_KEY: Felt =
+            Felt::from_hex_unchecked("0x1234567890abcdef1234567890abcdef");
+        const CONTRACT_ADDRESS: Felt = Felt::from_hex_unchecked("0xc0ffee");
+        const USER_ADDRESS: Felt = Felt::from_hex_unchecked("0xface");
+
+        /// Thin wrapper around [`MockBackend`] that implements [`StorageSnapshot`].
+        struct MockSnapshot {
+            backend: MockBackend,
+            contract_address: Felt,
+        }
+
+        impl MockSnapshot {
+            fn new(backend: MockBackend, contract_address: Felt) -> Self {
+                Self {
+                    backend,
+                    contract_address,
+                }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl discovery_core::storage_backend::RawStorageAccess for MockSnapshot {
+            async fn read_slot(&self, slot: Felt) -> Result<Felt, StorageError> {
+                self.backend.read_slot(slot).await
+            }
+
+            async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError> {
+                self.backend.read_slots(slots).await
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl StorageSnapshot for MockSnapshot {
+            fn contract_address(&self) -> Felt {
+                self.contract_address
+            }
+
+            fn block_id(&self) -> BlockId {
+                BlockId::Tag(starknet_core::types::BlockTag::Latest)
+            }
+        }
+
+        fn make_mock_with_public_key(public_key: Felt) -> MockSnapshot {
+            let mut backend = MockBackend::empty();
+            let slot = storage_slots::public_key(USER_ADDRESS);
+            backend.insert(slot, public_key);
+            MockSnapshot::new(backend, CONTRACT_ADDRESS)
+        }
+
+        #[tokio::test]
+        async fn test_valid_viewing_key_passes() {
+            let expected_public_key = starknet_crypto::get_public_key(&TEST_VIEWING_KEY);
+            let mock = make_mock_with_public_key(expected_public_key);
+            let cache = PublicKeyCache::new(100);
+
+            let result = validate_viewing_key(&TEST_VIEWING_KEY, USER_ADDRESS, &mock, &cache).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_mismatched_viewing_key_returns_400() {
+            let wrong_key = Felt::from_hex_unchecked("0xdeadbeef");
+            // Register a public key that does NOT match wrong_key
+            let registered_public_key = starknet_crypto::get_public_key(&TEST_VIEWING_KEY);
+            let mock = make_mock_with_public_key(registered_public_key);
+            let cache = PublicKeyCache::new(100);
+
+            let result = validate_viewing_key(&wrong_key, USER_ADDRESS, &mock, &cache).await;
+            assert!(result.is_err());
+
+            let (status, error) = result.unwrap_err();
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(error.error.code, error_codes::INVALID_REQUEST);
+            assert!(error.error.message.contains("viewing_key does not match"));
+        }
+
+        #[tokio::test]
+        async fn test_unregistered_user_skips_validation() {
+            // MockBackend returns Felt::ZERO for missing slots, simulating unregistered user
+            let mock = MockSnapshot::new(MockBackend::empty(), CONTRACT_ADDRESS);
+            let cache = PublicKeyCache::new(100);
+
+            let wrong_key = Felt::from_hex_unchecked("0xdeadbeef");
+            let result = validate_viewing_key(&wrong_key, USER_ADDRESS, &mock, &cache).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_cache_hit_skips_storage_lookup() {
+            let expected_public_key = starknet_crypto::get_public_key(&TEST_VIEWING_KEY);
+
+            // Empty mock — no storage slots populated. If the code hits storage,
+            // it will get Felt::ZERO (unregistered) and skip validation — which would
+            // be wrong. Pre-populate cache so storage is never called.
+            let mock = MockSnapshot::new(MockBackend::empty(), CONTRACT_ADDRESS);
+            let cache = PublicKeyCache::new(100);
+            cache.insert(CONTRACT_ADDRESS, USER_ADDRESS, expected_public_key);
+
+            let result = validate_viewing_key(&TEST_VIEWING_KEY, USER_ADDRESS, &mock, &cache).await;
+            assert!(result.is_ok());
+
+            // Verify: a wrong key should fail even with empty storage, proving
+            // the cache was used (storage would return ZERO → skip validation).
+            let wrong_key = Felt::from_hex_unchecked("0xdeadbeef");
+            let result = validate_viewing_key(&wrong_key, USER_ADDRESS, &mock, &cache).await;
+            assert!(result.is_err());
+        }
+    }
 }

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -122,6 +122,8 @@ pub struct ValidationLimits {
     pub server_budget: usize,
     /// Maximum request body size in bytes.
     pub max_request_body_bytes: usize,
+    /// Maximum number of entries in the public key cache.
+    pub public_key_cache_capacity: u64,
 }
 
 impl Default for ValidationLimits {
@@ -131,6 +133,7 @@ impl Default for ValidationLimits {
             max_outgoing_recipients: 64,
             server_budget: 200,
             max_request_body_bytes: 102_400,
+            public_key_cache_capacity: 10_000,
         }
     }
 }

--- a/crates/discovery-service/src/lib.rs
+++ b/crates/discovery-service/src/lib.rs
@@ -11,5 +11,6 @@ pub mod api;
 pub mod chain_state;
 pub mod config;
 pub mod indexer;
+pub mod public_key_cache;
 pub mod rpc_backend;
 pub mod shutdown;

--- a/crates/discovery-service/src/public_key_cache.rs
+++ b/crates/discovery-service/src/public_key_cache.rs
@@ -1,0 +1,86 @@
+//! Lock-free concurrent cache for on-chain public keys.
+//!
+//! Keyed by `(contract_address, user_address)`. Public keys are immutable
+//! once registered on-chain, so cache entries never go stale. Zero (unregistered)
+//! values are not cached because the user may register later.
+
+use moka::sync::Cache;
+use starknet_core::types::Felt;
+
+/// Concurrent cache for registered public keys fetched from the contract.
+pub struct PublicKeyCache {
+    cache: Cache<(Felt, Felt), Felt>,
+}
+
+impl PublicKeyCache {
+    /// Creates a new cache with the given maximum entry capacity.
+    pub fn new(capacity: u64) -> Self {
+        Self {
+            cache: Cache::new(capacity),
+        }
+    }
+
+    /// Returns the cached public key for `(contract_address, user_address)`, if present.
+    pub fn get(&self, contract_address: Felt, user_address: Felt) -> Option<Felt> {
+        self.cache.get(&(contract_address, user_address))
+    }
+
+    /// Stores a public key. Zero values are skipped (unregistered users may register later).
+    pub fn insert(&self, contract_address: Felt, user_address: Felt, public_key: Felt) {
+        if public_key != Felt::ZERO {
+            self.cache
+                .insert((contract_address, user_address), public_key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert_and_get_round_trip() {
+        let cache = PublicKeyCache::new(100);
+        let contract_address = Felt::from_hex_unchecked("0x1");
+        let user_address = Felt::from_hex_unchecked("0x2");
+        let public_key = Felt::from_hex_unchecked("0xabc");
+
+        cache.insert(contract_address, user_address, public_key);
+        assert_eq!(cache.get(contract_address, user_address), Some(public_key));
+    }
+
+    #[test]
+    fn test_cache_miss_returns_none() {
+        let cache = PublicKeyCache::new(100);
+        let contract_address = Felt::from_hex_unchecked("0x1");
+        let user_address = Felt::from_hex_unchecked("0x2");
+
+        assert_eq!(cache.get(contract_address, user_address), None);
+    }
+
+    #[test]
+    fn test_zero_values_not_cached() {
+        let cache = PublicKeyCache::new(100);
+        let contract_address = Felt::from_hex_unchecked("0x1");
+        let user_address = Felt::from_hex_unchecked("0x2");
+
+        cache.insert(contract_address, user_address, Felt::ZERO);
+        assert_eq!(cache.get(contract_address, user_address), None);
+    }
+
+    #[test]
+    fn test_different_keys_are_independent() {
+        let cache = PublicKeyCache::new(100);
+        let contract_address = Felt::from_hex_unchecked("0x1");
+        let user_a = Felt::from_hex_unchecked("0x2");
+        let user_b = Felt::from_hex_unchecked("0x3");
+        let public_key_a = Felt::from_hex_unchecked("0xaa");
+        let public_key_b = Felt::from_hex_unchecked("0xbb");
+
+        cache.insert(contract_address, user_a, public_key_a);
+        cache.insert(contract_address, user_b, public_key_b);
+
+        assert_eq!(cache.get(contract_address, user_a), Some(public_key_a));
+        assert_eq!(cache.get(contract_address, user_b), Some(public_key_b));
+    }
+}

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -229,6 +229,10 @@ impl ChainState for RpcBackend {
 
 #[async_trait]
 impl StorageSnapshot for RpcSnapshot {
+    fn contract_address(&self) -> Felt {
+        self.contract_address
+    }
+
     fn block_id(&self) -> BlockId {
         self.block_id
     }


### PR DESCRIPTION
### TL;DR

Added viewing key validation to the discovery service API endpoints to verify that provided viewing keys match the registered public keys on-chain.

### What changed?

- Added `starknet-crypto` and `moka` dependencies for cryptographic operations and caching
- Implemented `PublicKeyCache` using a lock-free concurrent cache to store fetched public keys
- Added `validate_viewing_key` function that derives public keys from viewing keys and validates them against on-chain registered keys
- Integrated viewing key validation into all sync endpoints (`incoming_sync`, `outgoing_sync`, `preflight_check`)
- Updated API documentation to reflect that viewing keys are now validated against on-chain public keys
- Added configuration option `public_key_cache_capacity` with a default of 10,000 entries
- Zero (unregistered) public keys skip validation since users may register later

### How to test?

- Test with valid viewing keys that match registered on-chain public keys - should succeed
- Test with invalid viewing keys that don't match registered public keys - should return 400 Bad Request with "INVALID_REQUEST" error code
- Test with unregistered users (zero public key) - should skip validation and succeed
- Verify caching behavior by making repeated requests with the same address
- Test all three endpoints: `incoming_sync`, `outgoing_sync`, and `preflight_check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/566)
<!-- Reviewable:end -->
