### PR TITLE
feat(demo): transaction builder

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -36,8 +36,8 @@ jobs:
           # Generate vercel.json with rewrites to proxy HTTP backends through
           # the Vercel deployment, avoiding mixed HTTP/HTTPS content errors.
           eval "$(grep '^BACKEND_' ".vercel/.env.preview.local")"
-          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"}]}\n' \
-            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" > vercel.json
+          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"},{"source":"/api/gateway/:path*","destination":"%s/:path*"}]}\n' \
+            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" "$BACKEND_GATEWAY_URL" > vercel.json
 
           npx vercel build
         env:

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -34,7 +34,17 @@ h3 {
   margin: 0 auto;
 }
 
-.pool-selector,
+.pool-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+}
+
 .account-selector {
   display: flex;
   align-items: center;
@@ -46,6 +56,38 @@ h3 {
   border-radius: 4px;
 }
 
+.account-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.account-tab {
+  background: #21262d;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  padding: 4px 12px;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.account-tab.active {
+  background: #238636;
+  border-color: #2ea043;
+  color: #fff;
+}
+
+.account-tab:hover:not(.active) {
+  background: #30363d;
+}
+
+.account-tab-address {
+  font-size: 11px;
+  margin-left: 4px;
+  color: inherit;
+  opacity: 0.7;
+}
+
 select {
   background: #0d1117;
   color: #c9d1d9;
@@ -54,12 +96,6 @@ select {
   padding: 4px 8px;
   font-family: inherit;
   font-size: 13px;
-}
-
-.add-account-form {
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
 }
 
 .main-layout {
@@ -210,4 +246,75 @@ input[type="number"] {
 .chip-no {
   background: #3d1a1a;
   color: #f85149;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.view-toggle button {
+  flex: 1;
+  background: #21262d;
+  border-color: #30363d;
+  color: #8b949e;
+}
+
+.view-toggle button.active {
+  background: #238636;
+  border-color: #2ea043;
+  color: #fff;
+}
+
+.builder-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 0;
+}
+
+.builder-checkbox input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
+.builder-add {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #21262d;
+}
+
+.builder-add select,
+.builder-add input {
+  width: 100%;
+}
+
+.builder-operation {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  border-bottom: 1px solid #21262d;
+  font-size: 12px;
+}
+
+.builder-operation span:nth-child(2) {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.builder-operation .remove-button {
+  background: #3d1a1a;
+  border-color: #f85149;
+  color: #f85149;
+  padding: 1px 6px;
+  font-size: 11px;
+  min-width: auto;
 }

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -34,15 +34,53 @@ h3 {
   margin: 0 auto;
 }
 
-.pool-selector {
-  display: flex;
+.pool-selector-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 8px;
   align-items: center;
-  gap: 8px;
+  margin-top: 12px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 12px 12px 8px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
+}
+
+.pool-selector-label {
+  color: #8b949e;
+  white-space: nowrap;
+}
+
+.pool-selector-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pool-selector-value code {
+  color: #c9d1d9;
+  font-size: 13px;
+  padding-left: 12px;
+}
+
+.pool-selector-value input {
+  width: 540px;
+}
+
+.pool-selector-value > button {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.copy-button {
+  background: #21262d;
+  border-color: #30363d;
+  color: #8b949e;
+}
+
+.copy-button:hover:not(:disabled) {
+  background: #30363d;
 }
 
 .account-selector {
@@ -50,7 +88,7 @@ h3 {
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 8px 12px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
@@ -183,6 +221,9 @@ input[type="number"] {
 
 .action-form button {
   margin-top: 4px;
+  font-size: 12px;
+  padding: 3px 9px;
+  margin-left: 6px;
 }
 
 .status-bar {
@@ -225,7 +266,10 @@ input[type="number"] {
 .subtitle code {
   color: #c9d1d9;
   font-size: 11px;
+  cursor: default;
+  word-break: break-all;
 }
+
 
 .chip {
   display: inline-block;
@@ -317,4 +361,112 @@ input[type="number"] {
   padding: 1px 6px;
   font-size: 11px;
   min-width: auto;
+}
+
+.balances,
+.notes-section,
+.channels-section {
+  margin-top: 16px;
+}
+
+.notes-section h3 {
+  margin-bottom: 12px;
+}
+
+.channel-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+}
+
+.channel-card:last-child {
+  margin-bottom: 0;
+}
+
+.channel-card-header {
+  font-size: 12px;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #21262d;
+  line-height: 1.6;
+}
+
+.channel-card-label {
+  color: #8b949e;
+}
+
+.channel-card-value {
+  color: #c9d1d9;
+}
+
+.channel-card-sep {
+  color: #30363d;
+  margin: 0 6px;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.pagination span {
+  color: #8b949e;
+  font-size: 12px;
+}
+
+.pagination button {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.service-health-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 8px;
+}
+
+.health-indicator {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.health-label {
+  color: #c9d1d9;
+}
+
+.health-detail {
+  color: #8b949e;
+  font-size: 11px;
+}
+
+.app-footer {
+  text-align: center;
+  color: #8b949e;
+  font-size: 12px;
+  padding: 24px 0 12px;
+  border-top: 1px solid #30363d;
+  margin-top: 24px;
+}
+
+.app-footer a {
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.app-footer a:hover {
+  text-decoration: underline;
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { formatChainId, truncateAddress } from "./format.ts";
+import { formatChainId } from "./format.ts";
 import { loadConfig } from "./config.ts";
 import { createProvider, createAccount, createTransfers } from "./starknet.ts";
 import { useAccounts } from "./hooks/useAccounts.ts";
@@ -13,21 +13,30 @@ import { InfoPanel } from "./components/InfoPanel.tsx";
 import { ActionPanel } from "./components/ActionPanel.tsx";
 import { TransactionBuilder } from "./components/TransactionBuilder.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
+import { ServiceHealthBar } from "./components/ServiceHealthBar.tsx";
 import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
+import { useServiceHealth } from "./hooks/useServiceHealth.ts";
 import "./App.css";
 
 const config = loadConfig();
 
 export function App() {
+  const [classHash, setClassHash] = useState(config.poolClassHash);
+
   const { accounts, activeIndex, activeAccount, setActiveIndex } =
     useAccounts(config.accounts);
 
   const provider = useMemo(() => createProvider(config.rpcUrl), []);
 
   const { pools, activePool, selectPool, addPool, loading: poolsLoading } =
-    usePoolSelector(provider, config.poolAddress, config.poolClassHash);
+    usePoolSelector(provider, config.poolAddress, classHash);
 
-  const { deploying, deployError, deploy } = useDeployPool(provider, config);
+  const configWithClassHash = useMemo(
+    () => ({ ...config, poolClassHash: classHash }),
+    [classHash],
+  );
+
+  const { deploying, deployError, deploy } = useDeployPool(provider, configWithClassHash);
 
   const handleDeploy = useCallback(async () => {
     try {
@@ -52,6 +61,7 @@ export function App() {
     provider,
     transfers,
     activeAccount,
+    accounts,
     activePool.address,
     config,
   );
@@ -78,13 +88,16 @@ export function App() {
     refresh,
   );
 
+  const serviceHealth = useServiceHealth(provider, config);
+
   const [activeView, setActiveView] = useState<"actions" | "builder">("actions");
 
   return (
     <div className="app">
       <h1>Privacy Pool Explorer</h1>
       <div className="subtitle">
-        Chain: <code>{formatChainId(config.chainId)}</code> | Pool class: <code>{truncateAddress(config.poolClassHash)}</code>
+        Chain: <code>{formatChainId(config.chainId)}</code>
+        <ServiceHealthBar health={serviceHealth} />
       </div>
       <PoolSelector
         pools={pools}
@@ -92,8 +105,10 @@ export function App() {
         loading={poolsLoading}
         deploying={deploying}
         deployError={deployError}
+        classHash={classHash}
         onSelect={selectPool}
         onDeploy={handleDeploy}
+        onClassHashChange={setClassHash}
       />
       <AccountSelector
         accounts={accounts}
@@ -126,6 +141,7 @@ export function App() {
           {activeView === "actions" ? (
             <ActionPanel
               pending={status.pending}
+              activeAddress={activeAccount!.address}
               otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
               onRegister={register}
               onMint={mint}
@@ -143,6 +159,12 @@ export function App() {
           )}
         </div>
       </div>
+      <footer className="app-footer">
+        Built by Starkware &middot; Docs{" "}
+        <a href="https://github.com/starkware-libs/starknet-privacy" target="_blank" rel="noreferrer">
+          github.com/starkware-libs/starknet-privacy
+        </a>
+      </footer>
     </div>
   );
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { formatChainId, truncateAddress } from "./format.ts";
 import { loadConfig } from "./config.ts";
 import { createProvider, createAccount, createTransfers } from "./starknet.ts";
@@ -11,13 +11,15 @@ import { AccountSelector } from "./components/AccountSelector.tsx";
 import { PoolSelector } from "./components/PoolSelector.tsx";
 import { InfoPanel } from "./components/InfoPanel.tsx";
 import { ActionPanel } from "./components/ActionPanel.tsx";
+import { TransactionBuilder } from "./components/TransactionBuilder.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
+import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
 import "./App.css";
 
 const config = loadConfig();
 
 export function App() {
-  const { accounts, activeIndex, activeAccount, setActiveIndex, addAccount } =
+  const { accounts, activeIndex, activeAccount, setActiveIndex } =
     useAccounts(config.accounts);
 
   const provider = useMemo(() => createProvider(config.rpcUrl), []);
@@ -58,7 +60,7 @@ export function App() {
     refresh();
   }, [refresh]);
 
-  const { status, mint, deposit, withdraw, transfer } = useTransactions(
+  const { status, register, mint, deposit, withdraw, transfer } = useTransactions(
     provider,
     transfers,
     activeAccount?.address,
@@ -66,6 +68,17 @@ export function App() {
     config,
     refresh,
   );
+
+  const { status: builderStatus, executeBatch } = useTransactionBuilder(
+    provider,
+    transfers,
+    activeAccount?.address,
+    activePool.address,
+    config,
+    refresh,
+  );
+
+  const [activeView, setActiveView] = useState<"actions" | "builder">("actions");
 
   return (
     <div className="app">
@@ -86,9 +99,8 @@ export function App() {
         accounts={accounts}
         activeIndex={activeIndex}
         onSelect={setActiveIndex}
-        onAdd={addAccount}
       />
-      <StatusBar status={status} />
+      <StatusBar status={activeView === "actions" ? status : builderStatus} />
       <div className="main-layout">
         <InfoPanel
           state={state}
@@ -96,14 +108,40 @@ export function App() {
           error={error}
           onRefresh={refresh}
         />
-        <ActionPanel
-          pending={status.pending}
-          otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
-          onMint={mint}
-          onDeposit={deposit}
-          onWithdraw={withdraw}
-          onTransfer={transfer}
-        />
+        <div className="action-panel">
+          <div className="view-toggle">
+            <button
+              className={activeView === "actions" ? "active" : ""}
+              onClick={() => setActiveView("actions")}
+            >
+              Actions
+            </button>
+            <button
+              className={activeView === "builder" ? "active" : ""}
+              onClick={() => setActiveView("builder")}
+            >
+              Builder
+            </button>
+          </div>
+          {activeView === "actions" ? (
+            <ActionPanel
+              pending={status.pending}
+              otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
+              onRegister={register}
+              onMint={mint}
+              onDeposit={deposit}
+              onWithdraw={withdraw}
+              onTransfer={transfer}
+            />
+          ) : (
+            <TransactionBuilder
+              pending={builderStatus.pending}
+              activeAddress={activeAccount!.address}
+              otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
+              onExecute={executeBatch}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/demo/src/components/AccountSelector.tsx
+++ b/demo/src/components/AccountSelector.tsx
@@ -1,58 +1,26 @@
-import { useState, type FormEvent } from "react";
 import type { AccountConfig } from "../config.ts";
 
 type Props = {
   accounts: AccountConfig[];
   activeIndex: number;
   onSelect: (index: number) => void;
-  onAdd: (account: AccountConfig) => void;
 };
 
-export function AccountSelector({ accounts, activeIndex, onSelect, onAdd }: Props) {
-  const [showForm, setShowForm] = useState(false);
-  const [name, setName] = useState("");
-  const [address, setAddress] = useState("");
-  const [privateKey, setPrivateKey] = useState("");
-  const [viewingKey, setViewingKey] = useState("");
-
-  function handleSubmit(event: FormEvent) {
-    event.preventDefault();
-    if (!name || !address || !privateKey || !viewingKey) return;
-    onAdd({ name, address, privateKey, viewingKey });
-    setName("");
-    setAddress("");
-    setPrivateKey("");
-    setViewingKey("");
-    setShowForm(false);
-  }
-
+export function AccountSelector({ accounts, activeIndex, onSelect }: Props) {
   return (
     <div className="account-selector">
-      <label>
-        Account:{" "}
-        <select
-          value={activeIndex}
-          onChange={(event) => onSelect(Number(event.target.value))}
-        >
-          {accounts.map((account, index) => (
-            <option key={index} value={index}>
-              {account.name} ({account.address.slice(0, 10)}...)
-            </option>
-          ))}
-        </select>
-      </label>
-      <button type="button" onClick={() => setShowForm(!showForm)}>
-        {showForm ? "Cancel" : "+ Add Account"}
-      </button>
-      {showForm && (
-        <form onSubmit={handleSubmit} className="add-account-form">
-          <input placeholder="Name" value={name} onChange={(event) => setName(event.target.value)} />
-          <input placeholder="Address (0x...)" value={address} onChange={(event) => setAddress(event.target.value)} />
-          <input placeholder="Private Key (0x...)" value={privateKey} onChange={(event) => setPrivateKey(event.target.value)} />
-          <input placeholder="Viewing Key (0x...)" value={viewingKey} onChange={(event) => setViewingKey(event.target.value)} />
-          <button type="submit">Add</button>
-        </form>
-      )}
+      <label>Account:</label>
+      <div className="account-tabs">
+        {accounts.map((account, index) => (
+          <button
+            key={account.address}
+            className={index === activeIndex ? "account-tab active" : "account-tab"}
+            onClick={() => onSelect(index)}
+          >
+            {account.name}<span className="account-tab-address">({account.address.slice(0, 10)}...)</span>
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/demo/src/components/ActionPanel.tsx
+++ b/demo/src/components/ActionPanel.tsx
@@ -3,6 +3,7 @@ import type { AccountConfig } from "../config.ts";
 
 type Props = {
   pending: boolean;
+  activeAddress: string;
   otherAccounts: AccountConfig[];
   onRegister: () => void;
   onMint: (amount: bigint) => void;
@@ -13,6 +14,7 @@ type Props = {
 
 export function ActionPanel({
   pending,
+  activeAddress,
   otherAccounts,
   onRegister,
   onMint,
@@ -66,14 +68,14 @@ export function ActionPanel({
       </form>
 
       <div className="action-form">
-        <h3>Register</h3>
+        <h3>Register in the pool</h3>
         <button type="button" disabled={pending} onClick={onRegister}>
           Register
         </button>
       </div>
 
       <form onSubmit={handleDeposit} className="action-form">
-        <h3>Deposit</h3>
+        <h3>Deposit to self (auto setup)</h3>
         <input
           type="number"
           value={depositAmount}
@@ -87,7 +89,7 @@ export function ActionPanel({
       </form>
 
       <form onSubmit={handleWithdraw} className="action-form">
-        <h3>Withdraw</h3>
+        <h3>Withdraw to self</h3>
         <input
           type="number"
           value={withdrawAmount}
@@ -101,12 +103,15 @@ export function ActionPanel({
       </form>
 
       <form onSubmit={handleTransfer} className="action-form">
-        <h3>Transfer</h3>
+        <h3>Transfer to someone (or sweep)</h3>
         <select
           value={transferRecipient}
           onChange={(event) => setTransferRecipient(event.target.value)}
         >
           <option value="">Select recipient...</option>
+          <option value={activeAddress}>
+            Self ({activeAddress.slice(0, 10)}...)
+          </option>
           {otherAccounts.map((account) => (
             <option key={account.address} value={account.address}>
               {account.name} ({account.address.slice(0, 10)}...)

--- a/demo/src/components/ActionPanel.tsx
+++ b/demo/src/components/ActionPanel.tsx
@@ -4,6 +4,7 @@ import type { AccountConfig } from "../config.ts";
 type Props = {
   pending: boolean;
   otherAccounts: AccountConfig[];
+  onRegister: () => void;
   onMint: (amount: bigint) => void;
   onDeposit: (amount: bigint) => void;
   onWithdraw: (amount: bigint) => void;
@@ -13,6 +14,7 @@ type Props = {
 export function ActionPanel({
   pending,
   otherAccounts,
+  onRegister,
   onMint,
   onDeposit,
   onWithdraw,
@@ -46,11 +48,11 @@ export function ActionPanel({
   }
 
   return (
-    <div className="action-panel">
+    <>
       <h2>Actions</h2>
 
       <form onSubmit={handleMint} className="action-form">
-        <h3>Mint (admin)</h3>
+        <h3>Mint tokens (transparent)</h3>
         <input
           type="number"
           value={mintAmount}
@@ -62,6 +64,13 @@ export function ActionPanel({
           Mint
         </button>
       </form>
+
+      <div className="action-form">
+        <h3>Register</h3>
+        <button type="button" disabled={pending} onClick={onRegister}>
+          Register
+        </button>
+      </div>
 
       <form onSubmit={handleDeposit} className="action-form">
         <h3>Deposit</h3>
@@ -127,6 +136,6 @@ export function ActionPanel({
           Transfer
         </button>
       </form>
-    </div>
+    </>
   );
 }

--- a/demo/src/components/InfoPanel.tsx
+++ b/demo/src/components/InfoPanel.tsx
@@ -1,4 +1,8 @@
+import { useState } from "react";
+import type { ChannelGroup, NoteDisplay } from "../hooks/usePrivateState.ts";
 import type { PrivateState } from "../hooks/usePrivateState.ts";
+
+const NOTES_PER_PAGE = 10;
 
 type Props = {
   state: PrivateState;
@@ -9,6 +13,76 @@ type Props = {
 
 function formatAmount(value: bigint): string {
   return value.toLocaleString("en-US");
+}
+
+function ChannelCard({ group }: { group: ChannelGroup }) {
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.max(1, Math.ceil(group.notes.length / NOTES_PER_PAGE));
+  const clampedPage = Math.min(page, totalPages - 1);
+  const visibleNotes = group.notes.slice(
+    clampedPage * NOTES_PER_PAGE,
+    (clampedPage + 1) * NOTES_PER_PAGE,
+  );
+
+  return (
+    <div className="channel-card">
+      <div className="channel-card-header">
+        <span className="channel-card-label">Sender</span>{" "}
+        <span className="channel-card-value">{group.sender}</span>
+        {group.senderName && <span className="chip">{group.senderName}</span>}
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Token</span>{" "}
+        <span className="channel-card-value">{group.token}</span>
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Channel Key</span>{" "}
+        <span className="channel-card-value">{group.channelKey}</span>
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Unspent Notes</span>{" "}
+        <span className="channel-card-value">{group.notes.length}</span>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Note ID</th>
+            <th>Amount</th>
+            <th>Index</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleNotes.map((note: NoteDisplay) => (
+            <tr key={note.id}>
+              <td>{note.id}</td>
+              <td>{formatAmount(note.amount)}</td>
+              <td>
+                {note.nonce}
+                {note.open && <span className="chip">open</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button
+            disabled={clampedPage === 0}
+            onClick={() => setPage(clampedPage - 1)}
+          >
+            Newer
+          </button>
+          <span>
+            {clampedPage + 1} / {totalPages}
+          </span>
+          <button
+            disabled={clampedPage >= totalPages - 1}
+            onClick={() => setPage(clampedPage + 1)}
+          >
+            Older
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function InfoPanel({ state, loading, error, onRefresh }: Props) {
@@ -54,40 +128,13 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
       </div>
 
       <div className="notes-section">
-        <h3>Notes ({state.notes.length})</h3>
-        {state.notes.length === 0 ? (
+        <h3>Unspent Notes ({state.notes.length})</h3>
+        {state.channelGroups.length === 0 ? (
           <p className="empty">No notes discovered</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Note ID</th>
-                <th>Sender</th>
-                <th>Token</th>
-                <th>Amount</th>
-                <th>Index</th>
-                <th>Channel Key</th>
-              </tr>
-            </thead>
-            <tbody>
-              {state.notes.map((note) => (
-                <tr key={note.id}>
-                  <td>
-                    {note.id}
-                    {note.open && <span className="chip">open</span>}
-                  </td>
-                  <td>
-                    {note.sender}
-                    {note.isSelfSender && <span className="chip">self</span>}
-                  </td>
-                  <td>{note.token}</td>
-                  <td>{formatAmount(note.amount)}</td>
-                  <td>{note.nonce}</td>
-                  <td>{note.channelKey}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          state.channelGroups.map((group) => (
+            <ChannelCard key={group.channelKey} group={group} />
+          ))
         )}
       </div>
 
@@ -101,8 +148,8 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
               <tr>
                 <th>Recipient</th>
                 <th>Token</th>
-                <th>Next Note Index</th>
                 <th>Channel Key</th>
+                <th>Next Note Index</th>
               </tr>
             </thead>
             <tbody>
@@ -110,7 +157,7 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
                 <tr key={index}>
                   <td>
                     {channel.recipient}
-                    {channel.isSelf && <span className="chip">self</span>}
+                    {channel.recipientName && <span className="chip">{channel.recipientName}</span>}
                   </td>
                   <td>
                     {channel.tokens.map((tokenEntry, tokenIndex) => (
@@ -119,8 +166,8 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
                       </div>
                     ))}
                   </td>
-                  <td>{channel.noteNonce}</td>
                   <td>{channel.channelKey}</td>
+                  <td>{channel.noteNonce}</td>
                 </tr>
               ))}
             </tbody>

--- a/demo/src/components/PoolSelector.tsx
+++ b/demo/src/components/PoolSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { PoolEntry } from "../hooks/usePoolSelector.ts";
 
 type Props = {
@@ -6,13 +7,15 @@ type Props = {
   loading: boolean;
   deploying: boolean;
   deployError: string | null;
+  classHash: string;
   onSelect: (address: string) => void;
   onDeploy: () => void;
+  onClassHashChange: (hash: string) => void;
 };
 
-function truncatePoolAddress(address: string): string {
-  if (address.length <= 14) return address;
-  return `${address.slice(0, 8)}...${address.slice(-4)}`;
+function truncateHash(hex: string): string {
+  if (hex.length <= 14) return hex;
+  return `${hex.slice(0, 8)}...${hex.slice(-4)}`;
 }
 
 export function PoolSelector({
@@ -21,28 +24,85 @@ export function PoolSelector({
   loading,
   deploying,
   deployError,
+  classHash,
   onSelect,
   onDeploy,
+  onClassHashChange,
 }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [copied, setCopied] = useState(false);
+
   return (
-    <div className="pool-selector">
-      <label>
-        Pool:{" "}
+    <div className="pool-selector-grid">
+      <span className="pool-selector-label">Class hash:</span>
+      <div className="pool-selector-value">
+        {editing ? (
+          <>
+            <input
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  onClassHashChange(draft);
+                  setEditing(false);
+                }
+                if (event.key === "Escape") setEditing(false);
+              }}
+              autoFocus
+            />
+            <button
+              onClick={() => {
+                onClassHashChange(draft);
+                setEditing(false);
+              }}
+            >
+              Apply
+            </button>
+          </>
+        ) : (
+          <>
+            <code>{truncateHash(classHash)}</code>
+            <button
+              onClick={() => {
+                setDraft(classHash);
+                setEditing(true);
+              }}
+            >
+              Change
+            </button>
+          </>
+        )}
+      </div>
+
+      <span className="pool-selector-label">Address:</span>
+      <div className="pool-selector-value">
         <select
           value={activePool.address}
           onChange={(event) => onSelect(event.target.value)}
         >
           {pools.map((pool) => (
             <option key={pool.address} value={pool.address}>
-              {truncatePoolAddress(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
+              {truncateHash(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
             </option>
           ))}
         </select>
-      </label>
-      <button type="button" disabled={loading || deploying} onClick={onDeploy}>
-        {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
-      </button>
-      {deployError && <span className="error">{deployError}</span>}
+        <button type="button" disabled={loading || deploying} onClick={onDeploy}>
+          {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
+        </button>
+        <button
+          type="button"
+          className="copy-button"
+          onClick={() => {
+            navigator.clipboard.writeText(activePool.address);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+        {deployError && <span className="error">{deployError}</span>}
+      </div>
     </div>
   );
 }

--- a/demo/src/components/ServiceHealthBar.tsx
+++ b/demo/src/components/ServiceHealthBar.tsx
@@ -1,0 +1,30 @@
+import type { HealthStatus, ServiceHealthState, SubsystemHealth } from "../hooks/useServiceHealth.ts";
+
+const STATUS_COLORS: Record<HealthStatus, string> = {
+  healthy: "#3fb950",
+  unhealthy: "#f85149",
+  unknown: "#d29922",
+  checking: "#484f58",
+};
+
+function Indicator({ label, health }: { label: string; health: SubsystemHealth }) {
+  return (
+    <span className="health-indicator">
+      <span className="health-dot" style={{ background: STATUS_COLORS[health.status] }} title={health.detail ?? health.status} />
+      <span className="health-label">{label}</span>
+    </span>
+  );
+}
+
+export function ServiceHealthBar({ health }: { health: ServiceHealthState }) {
+  return (
+    <span className="service-health-bar">
+      | Status:
+      <Indicator label="Discovery" health={health.discovery} />
+      <Indicator label="RPC" health={health.rpc} />
+      {health.proving && <Indicator label="Proving" health={health.proving} />}
+      {health.gateway && <Indicator label="Gateway" health={health.gateway} />}
+      {health.feederGateway && <Indicator label="Feeder GW" health={health.feederGateway} />}
+    </span>
+  );
+}

--- a/demo/src/components/TransactionBuilder.tsx
+++ b/demo/src/components/TransactionBuilder.tsx
@@ -1,0 +1,227 @@
+import { useState, useRef, type FormEvent } from "react";
+import type { AccountConfig } from "../config.ts";
+
+export type OperationType = "deposit" | "transfer" | "withdraw" | "surplus" | "invoke";
+
+const PHASE_ORDER: Record<OperationType, number> = {
+  deposit: 3,
+  transfer: 5,
+  withdraw: 6,
+  surplus: 7,
+  invoke: 8,
+};
+
+const OPERATION_LABELS: Record<OperationType, string> = {
+  deposit: "Deposit",
+  transfer: "Transfer",
+  withdraw: "Withdraw",
+  surplus: "Surplus To",
+  invoke: "Invoke",
+};
+
+export type BuilderOperation = {
+  id: number;
+  operationType: OperationType;
+  amount: string;
+  recipient?: string;
+  withdrawSurplus?: boolean;
+  contractAddress?: string;
+  calldata?: string;
+};
+
+type Props = {
+  pending: boolean;
+  activeAddress: string;
+  otherAccounts: AccountConfig[];
+  onExecute: (operations: BuilderOperation[]) => void;
+};
+
+export function TransactionBuilder({ pending, activeAddress, otherAccounts, onExecute }: Props) {
+  const [operations, setOperations] = useState<BuilderOperation[]>([]);
+  const [selectedType, setSelectedType] = useState<OperationType>("deposit");
+  const [amount, setAmount] = useState("100");
+  const [recipient, setRecipient] = useState("");
+  const [contractAddress, setContractAddress] = useState("");
+  const [calldata, setCalldata] = useState("");
+  const [withdrawSurplus, setWithdrawSurplus] = useState(false);
+  const nextOperationId = useRef(0);
+
+  const hasInvoke = operations.some((op) => op.operationType === "invoke");
+  const hasSurplus = operations.some((op) => op.operationType === "surplus");
+
+  function handleAdd(event: FormEvent) {
+    event.preventDefault();
+    const needsRecipient =
+      selectedType === "transfer" || selectedType === "surplus" ||
+      ((selectedType === "deposit" || selectedType === "withdraw") && recipient);
+
+    const operation: BuilderOperation = {
+      id: nextOperationId.current++,
+      operationType: selectedType,
+      amount,
+      ...(needsRecipient ? { recipient } : {}),
+      ...(selectedType === "surplus" ? { withdrawSurplus } : {}),
+      ...(selectedType === "invoke"
+        ? { contractAddress, calldata }
+        : {}),
+    };
+
+    setOperations((previous) => {
+      const updated = [...previous, operation];
+      updated.sort(
+        (a, b) => PHASE_ORDER[a.operationType] - PHASE_ORDER[b.operationType],
+      );
+      return updated;
+    });
+  }
+
+  function handleRemove(operationId: number) {
+    setOperations((previous) => previous.filter((op) => op.id !== operationId));
+  }
+
+  function handleExecute() {
+    onExecute(operations);
+  }
+
+  function formatOperationDetails(operation: BuilderOperation): string {
+    if (operation.operationType === "invoke") {
+      return `${operation.contractAddress?.slice(0, 10)}...`;
+    }
+    if (operation.operationType === "surplus") {
+      const target = operation.recipient
+        ? `${operation.recipient.slice(0, 10)}...`
+        : "self";
+      return `→ ${target}${operation.withdrawSurplus ? " (withdraw)" : ""}`;
+    }
+    const details = `${operation.amount} STRK`;
+    if (operation.recipient) {
+      return `${details} → ${operation.recipient.slice(0, 10)}...`;
+    }
+    return details;
+  }
+
+  return (
+    <>
+      <h2>Transaction Builder</h2>
+
+      <form onSubmit={handleAdd} className="builder-add">
+        <select
+          value={selectedType}
+          onChange={(event) => setSelectedType(event.target.value as OperationType)}
+        >
+          <option value="deposit">Deposit</option>
+          <option value="transfer">Transfer</option>
+          <option value="withdraw">Withdraw</option>
+          <option value="surplus" disabled={hasSurplus}>Surplus To</option>
+          <option value="invoke" disabled={hasInvoke}>Invoke</option>
+        </select>
+
+        {selectedType !== "invoke" && selectedType !== "surplus" && (
+          <input
+            type="number"
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder="Amount"
+            min="1"
+          />
+        )}
+
+        {(selectedType === "transfer" || selectedType === "surplus" ||
+          selectedType === "deposit" || selectedType === "withdraw") && (
+          <select
+            value={recipient}
+            onChange={(event) => setRecipient(event.target.value)}
+          >
+            {selectedType === "transfer" || selectedType === "surplus" ? (
+              <option value="">Select recipient...</option>
+            ) : (
+              <option value="">None (set surplus recipient)</option>
+            )}
+            <option value={activeAddress}>
+              Self ({activeAddress.slice(0, 10)}...)
+            </option>
+            {otherAccounts.map((account) => (
+              <option key={account.address} value={account.address}>
+                {account.name} ({account.address.slice(0, 10)}...)
+              </option>
+            ))}
+          </select>
+        )}
+
+        {selectedType === "surplus" && (
+          <label className="builder-checkbox">
+            <input
+              type="checkbox"
+              checked={withdrawSurplus}
+              onChange={(event) => setWithdrawSurplus(event.target.checked)}
+            />
+            Withdraw
+          </label>
+        )}
+
+        {selectedType === "invoke" && (
+          <>
+            <input
+              type="text"
+              value={contractAddress}
+              onChange={(event) => setContractAddress(event.target.value)}
+              placeholder="Contract address (0x...)"
+            />
+            <input
+              type="text"
+              value={calldata}
+              onChange={(event) => setCalldata(event.target.value)}
+              placeholder="Calldata (comma-separated)"
+            />
+          </>
+        )}
+
+        <button
+          type="submit"
+          disabled={
+            pending ||
+            (selectedType === "invoke" && hasInvoke) ||
+            (selectedType === "surplus" && hasSurplus) ||
+            ((selectedType === "transfer" || selectedType === "surplus") && !recipient)
+          }
+        >
+          Add
+        </button>
+      </form>
+
+      {operations.length === 0 ? (
+        <p className="empty">No actions added</p>
+      ) : (
+        <div>
+          {operations.map((operation) => (
+            <div key={operation.id} className="builder-operation">
+              <span className="chip">{OPERATION_LABELS[operation.operationType]}</span>
+              <span>{formatOperationDetails(operation)}</span>
+              <button
+                className="remove-button"
+                onClick={() => handleRemove(operation.id)}
+                disabled={pending}
+              >
+                x
+              </button>
+            </div>
+          ))}
+          {!hasSurplus && (
+            <div className="builder-operation" style={{ opacity: 0.5 }}>
+              <span className="chip">Surplus To</span>
+              <span>→ self</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <button
+        onClick={handleExecute}
+        disabled={pending || operations.length === 0}
+        style={{ marginTop: "8px", width: "100%" }}
+      >
+        Execute Transaction ({operations.length} ops)
+      </button>
+    </>
+  );
+}

--- a/demo/src/config.ts
+++ b/demo/src/config.ts
@@ -22,6 +22,8 @@ export type AppConfig = {
   accounts: AccountConfig[];
   /** Proving service URL. If set, uses real prover; otherwise mock. */
   provingServiceUrl?: string;
+  gatewayUrl?: string;
+  feederGatewayUrl?: string;
 };
 
 function requireEnv(key: string): string {
@@ -55,5 +57,7 @@ export function loadConfig(): AppConfig {
     provingServiceUrl: import.meta.env.VITE_PROVING_SERVICE_URL as
       | string
       | undefined,
+    gatewayUrl: import.meta.env.VITE_GATEWAY_URL as string | undefined,
+    feederGatewayUrl: import.meta.env.VITE_FEEDER_GATEWAY_URL as string | undefined,
   };
 }

--- a/demo/src/hooks/useAccounts.ts
+++ b/demo/src/hooks/useAccounts.ts
@@ -1,27 +1,44 @@
 import { useState, useCallback } from "react";
 import type { AccountConfig } from "../config.ts";
 
+const STORAGE_KEY = "activeAccountIndex";
+
+function loadSavedIndex(maxIndex: number): number {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === null) return 0;
+    const parsed = Number(saved);
+    return parsed >= 0 && parsed <= maxIndex ? parsed : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export type UseAccountsResult = {
   accounts: AccountConfig[];
   activeIndex: number;
   activeAccount: AccountConfig | undefined;
   setActiveIndex: (index: number) => void;
-  addAccount: (account: AccountConfig) => void;
 };
 
 export function useAccounts(initialAccounts: AccountConfig[]): UseAccountsResult {
-  const [accounts, setAccounts] = useState<AccountConfig[]>(initialAccounts);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndexState] = useState(() =>
+    loadSavedIndex(initialAccounts.length - 1),
+  );
 
-  const addAccount = useCallback((account: AccountConfig) => {
-    setAccounts((prev) => [...prev, account]);
+  const setActiveIndex = useCallback((index: number) => {
+    setActiveIndexState(index);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(index));
+    } catch {
+      // localStorage unavailable — ignore
+    }
   }, []);
 
   return {
-    accounts,
+    accounts: initialAccounts,
     activeIndex,
-    activeAccount: accounts[activeIndex],
+    activeAccount: initialAccounts[activeIndex],
     setActiveIndex,
-    addAccount,
   };
 }

--- a/demo/src/hooks/usePrivateState.ts
+++ b/demo/src/hooks/usePrivateState.ts
@@ -9,10 +9,11 @@ import { getErc20Balance } from "../starknet.ts";
 
 export type NoteDisplay = {
   id: string;
+  rawId: bigint;
   amount: bigint;
   token: string;
   sender: string;
-  isSelfSender: boolean;
+  senderName: string | null;
   channelKey: string;
   nonce: number;
   open: boolean;
@@ -20,11 +21,19 @@ export type NoteDisplay = {
 
 export type ChannelDisplay = {
   recipient: string;
-  isSelf: boolean;
+  recipientName: string | null;
   publicKey: string;
   channelKey: string;
   noteNonce: number;
   tokens: Array<{ tokenAddress: string }>;
+};
+
+export type ChannelGroup = {
+  channelKey: string;
+  sender: string;
+  senderName: string | null;
+  token: string;
+  notes: NoteDisplay[];
 };
 
 export type PrivateState = {
@@ -33,6 +42,7 @@ export type PrivateState = {
   feeTokenBalance: bigint;
   privateBalance: bigint;
   notes: NoteDisplay[];
+  channelGroups: ChannelGroup[];
   channels: ChannelDisplay[];
 };
 
@@ -42,6 +52,7 @@ const EMPTY_STATE: PrivateState = {
   feeTokenBalance: 0n,
   privateBalance: 0n,
   notes: [],
+  channelGroups: [],
   channels: [],
 };
 
@@ -65,6 +76,7 @@ export function usePrivateState(
   provider: RpcProvider | undefined,
   transfers: PrivateTransfersInterface | undefined,
   account: AccountConfig | undefined,
+  allAccounts: AccountConfig[],
   poolAddress: string,
   config: AppConfig,
 ) {
@@ -110,18 +122,24 @@ export function usePrivateState(
         0n,
       );
 
-      const ownerAddress = BigInt(account.address);
+      const nameByAddress = new Map<bigint, string>();
+      for (const acc of allAccounts) {
+        const accAddress = BigInt(acc.address);
+        nameByAddress.set(accAddress, accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase());
+      }
 
       const tokenAddressBigInt = BigInt(config.tokenAddress);
       const notes: NoteDisplay[] = tokenNotes.map((note: Note) => {
         const witness = readWitness(note.witness);
         const senderBigInt = toBigInt(note.sender);
+        const noteIdBigInt = toBigInt(note.id);
         return {
-          id: formatBigInt(toBigInt(note.id)),
+          id: formatBigInt(noteIdBigInt),
+          rawId: noteIdBigInt,
           amount: note.amount,
           token: truncateAddress(tokenAddressBigInt.toString(16)),
           sender: truncateAddress(senderBigInt.toString(16)),
-          isSelfSender: senderBigInt === ownerAddress,
+          senderName: nameByAddress.get(senderBigInt) ?? null,
           channelKey: formatBigInt(witness.channelKey),
           nonce: witness.nonce,
           open: note.open ?? false,
@@ -138,10 +156,9 @@ export function usePrivateState(
           });
           noteNonce = Math.max(noteNonce, tokenChannel.noteNonce);
         }
-        const isSelf = recipient === ownerAddress;
         channels.push({
           recipient: truncateAddress(recipient.toString(16)),
-          isSelf,
+          recipientName: nameByAddress.get(recipient) ?? null,
           publicKey: formatBigInt(internal.publicKey),
           channelKey: internal.key ? formatBigInt(internal.key) : "N/A",
           noteNonce,
@@ -149,13 +166,37 @@ export function usePrivateState(
         });
       }
 
-      setState({ isRegistered, tokenBalance, feeTokenBalance, privateBalance, notes, channels });
+      const groupsByKey = new Map<string, NoteDisplay[]>();
+      for (const note of notes) {
+        const existing = groupsByKey.get(note.channelKey);
+        if (existing) {
+          existing.push(note);
+        } else {
+          groupsByKey.set(note.channelKey, [note]);
+        }
+      }
+
+      const channelGroups: ChannelGroup[] = [];
+      for (const [channelKey, groupNotes] of groupsByKey) {
+        groupNotes.sort((a, b) => b.nonce - a.nonce);
+        const firstNote = groupNotes[0];
+        channelGroups.push({
+          channelKey,
+          sender: firstNote.sender,
+          senderName: firstNote.senderName,
+          token: firstNote.token,
+          notes: groupNotes,
+        });
+      }
+      channelGroups.sort((a, b) => b.notes[0].nonce - a.notes[0].nonce);
+
+      setState({ isRegistered, tokenBalance, feeTokenBalance, privateBalance, notes, channelGroups, channels });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [provider, transfers, account, poolAddress, config]);
+  }, [provider, transfers, account, allAccounts, poolAddress, config]);
 
   return { state, loading, error, refresh };
 }

--- a/demo/src/hooks/useServiceHealth.ts
+++ b/demo/src/hooks/useServiceHealth.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ProvingService } from "starknet-sdk";
+// @ts-expect-error — deep import into dist, not part of the declared exports
+import { IndexerDiscoveryProvider } from "starknet-sdk/dist/internal/indexer-discovery.js";
+import type { RpcProvider } from "starknet";
+import type { AppConfig } from "../config.ts";
+
+export type HealthStatus = "checking" | "healthy" | "unhealthy" | "unknown";
+
+export type SubsystemHealth = {
+  status: HealthStatus;
+  detail: string | null;
+};
+
+export type ServiceHealthState = {
+  discovery: SubsystemHealth;
+  rpc: SubsystemHealth;
+  proving: SubsystemHealth | null;
+  gateway: SubsystemHealth | null;
+  feederGateway: SubsystemHealth | null;
+};
+
+const POLL_INTERVAL_MS = 30_000;
+const RPC_STALENESS_THRESHOLD_SECS = 120;
+const FETCH_TIMEOUT_MS = 8_000;
+
+function pending(): SubsystemHealth {
+  return { status: "checking", detail: null };
+}
+
+async function checkDiscovery(indexerUrl: string): Promise<SubsystemHealth> {
+  try {
+    const indexer = new IndexerDiscoveryProvider(indexerUrl, "0x0");
+    const health = await indexer.getHealth();
+    if (health.status === "OK") {
+      const detail = health.lag_secs != null ? `lag: ${health.lag_secs}s` : null;
+      return { status: "healthy", detail };
+    }
+    return { status: "unhealthy", detail: `status: ${health.status}` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkRpc(provider: RpcProvider): Promise<SubsystemHealth> {
+  try {
+    const block = await provider.getBlock("latest");
+    const blockTimestamp = block.timestamp;
+    const nowSecs = Math.floor(Date.now() / 1000);
+    const lagSecs = nowSecs - blockTimestamp;
+    if (lagSecs <= RPC_STALENESS_THRESHOLD_SECS) {
+      return { status: "healthy", detail: `lag: ${lagSecs}s` };
+    }
+    return { status: "unhealthy", detail: `stale: ${lagSecs}s behind` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkAliveEndpoint(url: string): Promise<SubsystemHealth> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (response.ok) return { status: "healthy", detail: null };
+    return { status: "unhealthy", detail: `HTTP ${response.status}` };
+  } catch {
+    return { status: "unknown", detail: "unreachable (CORS?)" };
+  }
+}
+
+async function checkProving(provingServiceUrl: string): Promise<SubsystemHealth> {
+  try {
+    const service = new ProvingService({ baseUrl: provingServiceUrl });
+    const healthy = await service.isHealthy();
+    return healthy
+      ? { status: "healthy", detail: null }
+      : { status: "unhealthy", detail: "spec version check failed" };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+function initialState(config: AppConfig): ServiceHealthState {
+  return {
+    discovery: pending(),
+    rpc: pending(),
+    proving: config.provingServiceUrl ? pending() : null,
+    gateway: config.gatewayUrl ? pending() : null,
+    feederGateway: config.feederGatewayUrl ? pending() : null,
+  };
+}
+
+export function useServiceHealth(
+  provider: RpcProvider,
+  config: AppConfig,
+): ServiceHealthState {
+  const [state, setState] = useState<ServiceHealthState>(() => initialState(config));
+  const mountedRef = useRef(true);
+
+  const runChecks = useCallback(() => {
+    const update = (key: keyof ServiceHealthState) => (value: SubsystemHealth) => {
+      if (mountedRef.current) setState((prev) => ({ ...prev, [key]: value }));
+    };
+
+    checkDiscovery(config.indexerUrl).then(update("discovery"));
+    checkRpc(provider).then(update("rpc"));
+
+    if (config.provingServiceUrl) {
+      checkProving(config.provingServiceUrl).then(update("proving"));
+    }
+    if (config.gatewayUrl) {
+      checkAliveEndpoint(`${config.gatewayUrl}/gateway/is_alive`).then(update("gateway"));
+    }
+    if (config.feederGatewayUrl) {
+      checkAliveEndpoint(`${config.feederGatewayUrl}/feeder_gateway/is_alive`).then(
+        update("feederGateway"),
+      );
+    }
+  }, [provider, config]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    runChecks();
+    const intervalId = setInterval(runChecks, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(intervalId);
+    };
+  }, [runChecks]);
+
+  return state;
+}

--- a/demo/src/hooks/useTransactionBuilder.ts
+++ b/demo/src/hooks/useTransactionBuilder.ts
@@ -1,0 +1,139 @@
+import { useState, useCallback, useMemo } from "react";
+import { Account, type RpcProvider } from "starknet";
+import type { PrivateTransfersInterface } from "starknet-sdk";
+import type { AppConfig } from "../config.ts";
+import type { TransactionStatus } from "./useTransactions.ts";
+import type { BuilderOperation } from "../components/TransactionBuilder.tsx";
+import {
+  ERC20_RESOURCE_BOUNDS,
+  POOL_RESOURCE_BOUNDS,
+} from "../starknet.ts";
+
+export function useTransactionBuilder(
+  provider: RpcProvider | undefined,
+  transfers: PrivateTransfersInterface | undefined,
+  activeAddress: string | undefined,
+  poolAddress: string,
+  config: AppConfig,
+  onSuccess: () => void,
+) {
+  const [status, setStatus] = useState<TransactionStatus>({
+    pending: false,
+    lastTxHash: null,
+    lastError: null,
+  });
+
+  const userAccount = useMemo(() => {
+    if (!provider || !activeAddress) return undefined;
+    const accountConfig = config.accounts.find(
+      (account) => account.address === activeAddress,
+    );
+    if (!accountConfig) return undefined;
+    return new Account({
+      provider,
+      address: accountConfig.address,
+      signer: accountConfig.privateKey,
+      cairoVersion: "1",
+    });
+  }, [provider, activeAddress, config.accounts]);
+
+  const executeBatch = useCallback(
+    (operations: BuilderOperation[]) => {
+      const action = "Builder";
+      console.log(`[${action}] starting with ${operations.length} operations...`);
+      setStatus({ pending: true, lastTxHash: null, lastError: null });
+
+      (async () => {
+        try {
+          if (!userAccount || !transfers || !provider || !activeAddress)
+            throw new Error("Not ready");
+
+          // Approve pool for total deposit amount
+          const totalDepositAmount = operations
+            .filter((op) => op.operationType === "deposit")
+            .reduce((sum, op) => sum + BigInt(op.amount), 0n);
+
+          if (totalDepositAmount > 0n) {
+            const approveTx = await userAccount.execute(
+              {
+                contractAddress: config.tokenAddress,
+                entrypoint: "approve",
+                calldata: [poolAddress, totalDepositAmount.toString(), "0"],
+              },
+              { resourceBounds: ERC20_RESOURCE_BOUNDS },
+            );
+            console.log(`[${action}] approve tx: ${approveTx.transaction_hash}`);
+            await provider.waitForTransaction(approveTx.transaction_hash);
+          }
+
+          const surplusOperation = operations.find(
+            (op) => op.operationType === "surplus",
+          );
+
+          const builder = transfers.build({
+            autoRegister: true,
+            autoSetup: true,
+            autoDiscover: { notes: "refresh", channels: "refresh" },
+            autoSelectNotes: "naive",
+          }).surplusTo(
+            surplusOperation?.recipient ?? activeAddress,
+            surplusOperation?.withdrawSurplus,
+          );
+
+          const invokeOperation = operations.find(
+            (op) => op.operationType === "invoke",
+          );
+          if (invokeOperation) {
+            builder.invoke({
+              contractAddress: invokeOperation.contractAddress!,
+              calldata: invokeOperation.calldata
+                ? invokeOperation.calldata.split(",").map((segment) => segment.trim())
+                : [],
+            });
+          }
+
+          const provingBlockId = await provider.getBlockNumber() - 10;
+          const { callAndProof } = await builder
+            .with(config.tokenAddress, (tokenBuilder) => {
+              for (const op of operations) {
+                if (op.operationType === "deposit")
+                  tokenBuilder.deposit({ amount: BigInt(op.amount), recipient: op.recipient || undefined });
+                if (op.operationType === "transfer")
+                  tokenBuilder.transfer({ recipient: op.recipient!, amount: BigInt(op.amount) });
+                if (op.operationType === "withdraw")
+                  tokenBuilder.withdraw({ amount: BigInt(op.amount), recipient: op.recipient || activeAddress });
+              }
+            })
+            .execute({ provingBlockId });
+          console.log(`[${action}] callAndProof built, submitting pool tx...`);
+
+          const executeTx = await userAccount.execute(callAndProof.call, {
+            resourceBounds: POOL_RESOURCE_BOUNDS,
+            ...(callAndProof.proof.proofFacts?.length
+              ? {
+                  proofFacts: callAndProof.proof.proofFacts,
+                  proof: callAndProof.proof.data,
+                }
+              : {}),
+          });
+          console.log(`[${action}] pool tx: ${executeTx.transaction_hash}`);
+          const receipt = await provider.waitForTransaction(executeTx.transaction_hash);
+          if (!receipt.isSuccess()) {
+            throw new Error(`Transaction reverted: ${JSON.stringify(receipt)}`);
+          }
+
+          console.log(`[${action}] confirmed: ${executeTx.transaction_hash}`);
+          setStatus({ pending: false, lastTxHash: executeTx.transaction_hash, lastError: null });
+          onSuccess();
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`[${action}] failed:`, err);
+          setStatus({ pending: false, lastTxHash: null, lastError: `${action}: ${message}` });
+        }
+      })();
+    },
+    [userAccount, transfers, provider, activeAddress, config, poolAddress, onSuccess],
+  );
+
+  return { status, executeBatch };
+}

--- a/demo/src/hooks/useTransactions.ts
+++ b/demo/src/hooks/useTransactions.ts
@@ -70,6 +70,42 @@ export function useTransactions(
     [onSuccess],
   );
 
+  const register = useCallback(
+    () =>
+      execute("Register", async () => {
+        if (!userAccount || !transfers || !provider)
+          throw new Error("Not ready");
+
+        console.log("[Register] registering account in privacy pool...");
+
+        const provingBlockId = await provider.getBlockNumber() - 10;
+        const { callAndProof } = await transfers
+          .build()
+          .register()
+          .execute({ provingBlockId });
+        console.log("[Register] callAndProof built, submitting tx...");
+
+        const executeTx = await userAccount.execute(callAndProof.call, {
+          resourceBounds: POOL_RESOURCE_BOUNDS,
+          ...(callAndProof.proof.proofFacts?.length
+            ? {
+                proofFacts: callAndProof.proof.proofFacts,
+                proof: callAndProof.proof.data,
+              }
+            : {}),
+        });
+        console.log(`[Register] tx: ${executeTx.transaction_hash}`);
+        const receipt = await provider.waitForTransaction(
+          executeTx.transaction_hash,
+        );
+        if (!receipt.isSuccess()) {
+          throw new Error(`Transaction reverted: ${JSON.stringify(receipt)}`);
+        }
+        return executeTx.transaction_hash;
+      }),
+    [userAccount, transfers, provider, execute],
+  );
+
   const mint = useCallback(
     (amount: bigint) =>
       execute("Mint", async () => {
@@ -231,5 +267,5 @@ export function useTransactions(
     [userAccount, transfers, provider, activeAddress, config, execute],
   );
 
-  return { status, mint, deposit, withdraw, transfer };
+  return { status, register, mint, deposit, withdraw, transfer };
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,3 +12,5 @@ export { ProvingServiceProofProvider } from "./internal/proving-service-provider
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";
 export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
+export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
+export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -96,12 +96,39 @@ type ApiOutgoingSyncResponse = {
   cursor: ApiDiscoveryCursor;
 };
 
+export type DiscoveryHealthResponse = {
+  status: string;
+  chain_head?: { block_number: number; block_hash: string; timestamp: number };
+  lag_secs?: number;
+};
+
 export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   constructor(
     private readonly apiUrl: string,
     private readonly contractAddress: StarknetAddress
   ) {
     super();
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.apiUrl}/health`, {
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (!response.ok) return false;
+      const body = (await response.json()) as { status: string };
+      return body.status === "OK";
+    } catch {
+      return false;
+    }
+  }
+
+  async getHealth(): Promise<DiscoveryHealthResponse> {
+    const response = await fetch(`${this.apiUrl}/health`, {
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!response.ok) throw new Error(`Discovery service returned HTTP ${response.status}`);
+    return (await response.json()) as DiscoveryHealthResponse;
   }
 
   async discoverNotes(


### PR DESCRIPTION
### TL;DR

Added a transaction builder interface that allows users to compose and execute multiple privacy pool operations in a single transaction, alongside the existing individual action buttons.

### What changed?

- Added a new `TransactionBuilder` component with support for batching deposit, transfer, withdraw, surplus, and invoke operations
- Implemented `useTransactionBuilder` hook to handle batch transaction execution with automatic approval and proof generation
- Added a view toggle between "Actions" and "Builder" modes in the action panel
- Converted account selector from dropdown to tab-based interface for better UX
- Added a register operation to both action panel and transaction builder
- Enhanced styling with new CSS classes for tabs, builder interface, and operation management
- Implemented localStorage persistence for active account selection
- Removed the ability to add new accounts dynamically from the UI

### How to test?

1. Switch between "Actions" and "Builder" tabs in the right panel
2. In Builder mode, add multiple operations (deposits, transfers, withdrawals) and execute them as a batch
3. Try the new Register button in Actions mode
4. Verify account selection persists across page refreshes
5. Test the new tabbed account selector interface

### Why make this change?

The transaction builder enables more complex privacy pool interactions by allowing users to compose multiple operations into a single transaction, which is more efficient and provides better privacy guarantees. The UI improvements make account management more intuitive and provide a cleaner interface for both simple actions and advanced batch operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/580)
<!-- Reviewable:end -->
