### PR TITLE
feat(demo): group notes by channel into card layout

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -36,8 +36,8 @@ jobs:
           # Generate vercel.json with rewrites to proxy HTTP backends through
           # the Vercel deployment, avoiding mixed HTTP/HTTPS content errors.
           eval "$(grep '^BACKEND_' ".vercel/.env.preview.local")"
-          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"}]}\n' \
-            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" > vercel.json
+          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"},{"source":"/api/gateway/:path*","destination":"%s/:path*"}]}\n' \
+            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" "$BACKEND_GATEWAY_URL" > vercel.json
 
           npx vercel build
         env:

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -318,3 +318,82 @@ input[type="number"] {
   font-size: 11px;
   min-width: auto;
 }
+
+.balances,
+.notes-section,
+.channels-section {
+  margin-top: 16px;
+}
+
+.notes-section h3 {
+  margin-bottom: 12px;
+}
+
+.channel-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+}
+
+.channel-card:last-child {
+  margin-bottom: 0;
+}
+
+.channel-card-header {
+  font-size: 12px;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #21262d;
+  line-height: 1.6;
+}
+
+.channel-card-label {
+  color: #8b949e;
+}
+
+.channel-card-value {
+  color: #c9d1d9;
+}
+
+.channel-card-sep {
+  color: #30363d;
+  margin: 0 6px;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.pagination span {
+  color: #8b949e;
+  font-size: 12px;
+}
+
+.pagination button {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.app-footer {
+  text-align: center;
+  color: #8b949e;
+  font-size: 12px;
+  padding: 24px 0 12px;
+  border-top: 1px solid #30363d;
+  margin-top: 24px;
+}
+
+.app-footer a {
+  color: #58a6ff;
+  text-decoration: none;
+}
+
+.app-footer a:hover {
+  text-decoration: underline;
+}

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -34,15 +34,53 @@ h3 {
   margin: 0 auto;
 }
 
-.pool-selector {
-  display: flex;
+.pool-selector-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 8px;
   align-items: center;
-  gap: 8px;
+  margin-top: 12px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 12px 12px 8px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
+}
+
+.pool-selector-label {
+  color: #8b949e;
+  white-space: nowrap;
+}
+
+.pool-selector-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pool-selector-value code {
+  color: #c9d1d9;
+  font-size: 13px;
+  padding-left: 12px;
+}
+
+.pool-selector-value input {
+  width: 540px;
+}
+
+.pool-selector-value > button {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.copy-button {
+  background: #21262d;
+  border-color: #30363d;
+  color: #8b949e;
+}
+
+.copy-button:hover:not(:disabled) {
+  background: #30363d;
 }
 
 .account-selector {
@@ -50,7 +88,7 @@ h3 {
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 8px 12px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
@@ -183,6 +221,9 @@ input[type="number"] {
 
 .action-form button {
   margin-top: 4px;
+  font-size: 12px;
+  padding: 3px 9px;
+  margin-left: 6px;
 }
 
 .status-bar {
@@ -225,7 +266,10 @@ input[type="number"] {
 .subtitle code {
   color: #c9d1d9;
   font-size: 11px;
+  cursor: default;
+  word-break: break-all;
 }
+
 
 .chip {
   display: inline-block;
@@ -378,6 +422,35 @@ input[type="number"] {
 .pagination button {
   font-size: 11px;
   padding: 2px 8px;
+}
+
+.service-health-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 8px;
+}
+
+.health-indicator {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.health-label {
+  color: #c9d1d9;
+}
+
+.health-detail {
+  color: #8b949e;
+  font-size: 11px;
 }
 
 .app-footer {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { formatChainId, truncateAddress } from "./format.ts";
+import { formatChainId } from "./format.ts";
 import { loadConfig } from "./config.ts";
 import { createProvider, createAccount, createTransfers } from "./starknet.ts";
 import { useAccounts } from "./hooks/useAccounts.ts";
@@ -13,21 +13,30 @@ import { InfoPanel } from "./components/InfoPanel.tsx";
 import { ActionPanel } from "./components/ActionPanel.tsx";
 import { TransactionBuilder } from "./components/TransactionBuilder.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
+import { ServiceHealthBar } from "./components/ServiceHealthBar.tsx";
 import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
+import { useServiceHealth } from "./hooks/useServiceHealth.ts";
 import "./App.css";
 
 const config = loadConfig();
 
 export function App() {
+  const [classHash, setClassHash] = useState(config.poolClassHash);
+
   const { accounts, activeIndex, activeAccount, setActiveIndex } =
     useAccounts(config.accounts);
 
   const provider = useMemo(() => createProvider(config.rpcUrl), []);
 
   const { pools, activePool, selectPool, addPool, loading: poolsLoading } =
-    usePoolSelector(provider, config.poolAddress, config.poolClassHash);
+    usePoolSelector(provider, config.poolAddress, classHash);
 
-  const { deploying, deployError, deploy } = useDeployPool(provider, config);
+  const configWithClassHash = useMemo(
+    () => ({ ...config, poolClassHash: classHash }),
+    [classHash],
+  );
+
+  const { deploying, deployError, deploy } = useDeployPool(provider, configWithClassHash);
 
   const handleDeploy = useCallback(async () => {
     try {
@@ -79,13 +88,16 @@ export function App() {
     refresh,
   );
 
+  const serviceHealth = useServiceHealth(provider, config);
+
   const [activeView, setActiveView] = useState<"actions" | "builder">("actions");
 
   return (
     <div className="app">
       <h1>Privacy Pool Explorer</h1>
       <div className="subtitle">
-        Chain: <code>{formatChainId(config.chainId)}</code> | Pool class: <code>{truncateAddress(config.poolClassHash)}</code>
+        Chain: <code>{formatChainId(config.chainId)}</code>
+        <ServiceHealthBar health={serviceHealth} />
       </div>
       <PoolSelector
         pools={pools}
@@ -93,8 +105,10 @@ export function App() {
         loading={poolsLoading}
         deploying={deploying}
         deployError={deployError}
+        classHash={classHash}
         onSelect={selectPool}
         onDeploy={handleDeploy}
+        onClassHashChange={setClassHash}
       />
       <AccountSelector
         accounts={accounts}

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -52,6 +52,7 @@ export function App() {
     provider,
     transfers,
     activeAccount,
+    accounts,
     activePool.address,
     config,
   );
@@ -126,6 +127,7 @@ export function App() {
           {activeView === "actions" ? (
             <ActionPanel
               pending={status.pending}
+              activeAddress={activeAccount!.address}
               otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
               onRegister={register}
               onMint={mint}
@@ -143,6 +145,12 @@ export function App() {
           )}
         </div>
       </div>
+      <footer className="app-footer">
+        Built by Starkware &middot; Docs{" "}
+        <a href="https://github.com/starkware-libs/starknet-privacy" target="_blank" rel="noreferrer">
+          github.com/starkware-libs/starknet-privacy
+        </a>
+      </footer>
     </div>
   );
 }

--- a/demo/src/components/ActionPanel.tsx
+++ b/demo/src/components/ActionPanel.tsx
@@ -3,6 +3,7 @@ import type { AccountConfig } from "../config.ts";
 
 type Props = {
   pending: boolean;
+  activeAddress: string;
   otherAccounts: AccountConfig[];
   onRegister: () => void;
   onMint: (amount: bigint) => void;
@@ -13,6 +14,7 @@ type Props = {
 
 export function ActionPanel({
   pending,
+  activeAddress,
   otherAccounts,
   onRegister,
   onMint,
@@ -66,14 +68,14 @@ export function ActionPanel({
       </form>
 
       <div className="action-form">
-        <h3>Register</h3>
+        <h3>Register in the pool</h3>
         <button type="button" disabled={pending} onClick={onRegister}>
           Register
         </button>
       </div>
 
       <form onSubmit={handleDeposit} className="action-form">
-        <h3>Deposit</h3>
+        <h3>Deposit to self (auto setup)</h3>
         <input
           type="number"
           value={depositAmount}
@@ -87,7 +89,7 @@ export function ActionPanel({
       </form>
 
       <form onSubmit={handleWithdraw} className="action-form">
-        <h3>Withdraw</h3>
+        <h3>Withdraw to self</h3>
         <input
           type="number"
           value={withdrawAmount}
@@ -101,12 +103,15 @@ export function ActionPanel({
       </form>
 
       <form onSubmit={handleTransfer} className="action-form">
-        <h3>Transfer</h3>
+        <h3>Transfer to someone (or sweep)</h3>
         <select
           value={transferRecipient}
           onChange={(event) => setTransferRecipient(event.target.value)}
         >
           <option value="">Select recipient...</option>
+          <option value={activeAddress}>
+            Self ({activeAddress.slice(0, 10)}...)
+          </option>
           {otherAccounts.map((account) => (
             <option key={account.address} value={account.address}>
               {account.name} ({account.address.slice(0, 10)}...)

--- a/demo/src/components/InfoPanel.tsx
+++ b/demo/src/components/InfoPanel.tsx
@@ -1,4 +1,8 @@
+import { useState } from "react";
+import type { ChannelGroup, NoteDisplay } from "../hooks/usePrivateState.ts";
 import type { PrivateState } from "../hooks/usePrivateState.ts";
+
+const NOTES_PER_PAGE = 10;
 
 type Props = {
   state: PrivateState;
@@ -9,6 +13,76 @@ type Props = {
 
 function formatAmount(value: bigint): string {
   return value.toLocaleString("en-US");
+}
+
+function ChannelCard({ group }: { group: ChannelGroup }) {
+  const [page, setPage] = useState(0);
+
+  const totalPages = Math.max(1, Math.ceil(group.notes.length / NOTES_PER_PAGE));
+  const clampedPage = Math.min(page, totalPages - 1);
+  const visibleNotes = group.notes.slice(
+    clampedPage * NOTES_PER_PAGE,
+    (clampedPage + 1) * NOTES_PER_PAGE,
+  );
+
+  return (
+    <div className="channel-card">
+      <div className="channel-card-header">
+        <span className="channel-card-label">Sender</span>{" "}
+        <span className="channel-card-value">{group.sender}</span>
+        {group.senderName && <span className="chip">{group.senderName}</span>}
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Token</span>{" "}
+        <span className="channel-card-value">{group.token}</span>
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Channel Key</span>{" "}
+        <span className="channel-card-value">{group.channelKey}</span>
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Unspent Notes</span>{" "}
+        <span className="channel-card-value">{group.notes.length}</span>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Note ID</th>
+            <th>Amount</th>
+            <th>Index</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleNotes.map((note: NoteDisplay) => (
+            <tr key={note.id}>
+              <td>{note.id}</td>
+              <td>{formatAmount(note.amount)}</td>
+              <td>
+                {note.nonce}
+                {note.open && <span className="chip">open</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="pagination">
+          <button
+            disabled={clampedPage === 0}
+            onClick={() => setPage(clampedPage - 1)}
+          >
+            Newer
+          </button>
+          <span>
+            {clampedPage + 1} / {totalPages}
+          </span>
+          <button
+            disabled={clampedPage >= totalPages - 1}
+            onClick={() => setPage(clampedPage + 1)}
+          >
+            Older
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function InfoPanel({ state, loading, error, onRefresh }: Props) {
@@ -54,40 +128,13 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
       </div>
 
       <div className="notes-section">
-        <h3>Notes ({state.notes.length})</h3>
-        {state.notes.length === 0 ? (
+        <h3>Unspent Notes ({state.notes.length})</h3>
+        {state.channelGroups.length === 0 ? (
           <p className="empty">No notes discovered</p>
         ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Note ID</th>
-                <th>Sender</th>
-                <th>Token</th>
-                <th>Amount</th>
-                <th>Index</th>
-                <th>Channel Key</th>
-              </tr>
-            </thead>
-            <tbody>
-              {state.notes.map((note) => (
-                <tr key={note.id}>
-                  <td>
-                    {note.id}
-                    {note.open && <span className="chip">open</span>}
-                  </td>
-                  <td>
-                    {note.sender}
-                    {note.isSelfSender && <span className="chip">self</span>}
-                  </td>
-                  <td>{note.token}</td>
-                  <td>{formatAmount(note.amount)}</td>
-                  <td>{note.nonce}</td>
-                  <td>{note.channelKey}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          state.channelGroups.map((group) => (
+            <ChannelCard key={group.channelKey} group={group} />
+          ))
         )}
       </div>
 
@@ -101,8 +148,8 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
               <tr>
                 <th>Recipient</th>
                 <th>Token</th>
-                <th>Next Note Index</th>
                 <th>Channel Key</th>
+                <th>Next Note Index</th>
               </tr>
             </thead>
             <tbody>
@@ -110,7 +157,7 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
                 <tr key={index}>
                   <td>
                     {channel.recipient}
-                    {channel.isSelf && <span className="chip">self</span>}
+                    {channel.recipientName && <span className="chip">{channel.recipientName}</span>}
                   </td>
                   <td>
                     {channel.tokens.map((tokenEntry, tokenIndex) => (
@@ -119,8 +166,8 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
                       </div>
                     ))}
                   </td>
-                  <td>{channel.noteNonce}</td>
                   <td>{channel.channelKey}</td>
+                  <td>{channel.noteNonce}</td>
                 </tr>
               ))}
             </tbody>

--- a/demo/src/components/PoolSelector.tsx
+++ b/demo/src/components/PoolSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { PoolEntry } from "../hooks/usePoolSelector.ts";
 
 type Props = {
@@ -6,13 +7,15 @@ type Props = {
   loading: boolean;
   deploying: boolean;
   deployError: string | null;
+  classHash: string;
   onSelect: (address: string) => void;
   onDeploy: () => void;
+  onClassHashChange: (hash: string) => void;
 };
 
-function truncatePoolAddress(address: string): string {
-  if (address.length <= 14) return address;
-  return `${address.slice(0, 8)}...${address.slice(-4)}`;
+function truncateHash(hex: string): string {
+  if (hex.length <= 14) return hex;
+  return `${hex.slice(0, 8)}...${hex.slice(-4)}`;
 }
 
 export function PoolSelector({
@@ -21,28 +24,85 @@ export function PoolSelector({
   loading,
   deploying,
   deployError,
+  classHash,
   onSelect,
   onDeploy,
+  onClassHashChange,
 }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [copied, setCopied] = useState(false);
+
   return (
-    <div className="pool-selector">
-      <label>
-        Pool:{" "}
+    <div className="pool-selector-grid">
+      <span className="pool-selector-label">Class hash:</span>
+      <div className="pool-selector-value">
+        {editing ? (
+          <>
+            <input
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  onClassHashChange(draft);
+                  setEditing(false);
+                }
+                if (event.key === "Escape") setEditing(false);
+              }}
+              autoFocus
+            />
+            <button
+              onClick={() => {
+                onClassHashChange(draft);
+                setEditing(false);
+              }}
+            >
+              Apply
+            </button>
+          </>
+        ) : (
+          <>
+            <code>{truncateHash(classHash)}</code>
+            <button
+              onClick={() => {
+                setDraft(classHash);
+                setEditing(true);
+              }}
+            >
+              Change
+            </button>
+          </>
+        )}
+      </div>
+
+      <span className="pool-selector-label">Address:</span>
+      <div className="pool-selector-value">
         <select
           value={activePool.address}
           onChange={(event) => onSelect(event.target.value)}
         >
           {pools.map((pool) => (
             <option key={pool.address} value={pool.address}>
-              {truncatePoolAddress(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
+              {truncateHash(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
             </option>
           ))}
         </select>
-      </label>
-      <button type="button" disabled={loading || deploying} onClick={onDeploy}>
-        {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
-      </button>
-      {deployError && <span className="error">{deployError}</span>}
+        <button type="button" disabled={loading || deploying} onClick={onDeploy}>
+          {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
+        </button>
+        <button
+          type="button"
+          className="copy-button"
+          onClick={() => {
+            navigator.clipboard.writeText(activePool.address);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+        {deployError && <span className="error">{deployError}</span>}
+      </div>
     </div>
   );
 }

--- a/demo/src/components/ServiceHealthBar.tsx
+++ b/demo/src/components/ServiceHealthBar.tsx
@@ -1,0 +1,30 @@
+import type { HealthStatus, ServiceHealthState, SubsystemHealth } from "../hooks/useServiceHealth.ts";
+
+const STATUS_COLORS: Record<HealthStatus, string> = {
+  healthy: "#3fb950",
+  unhealthy: "#f85149",
+  unknown: "#d29922",
+  checking: "#484f58",
+};
+
+function Indicator({ label, health }: { label: string; health: SubsystemHealth }) {
+  return (
+    <span className="health-indicator">
+      <span className="health-dot" style={{ background: STATUS_COLORS[health.status] }} title={health.detail ?? health.status} />
+      <span className="health-label">{label}</span>
+    </span>
+  );
+}
+
+export function ServiceHealthBar({ health }: { health: ServiceHealthState }) {
+  return (
+    <span className="service-health-bar">
+      | Status:
+      <Indicator label="Discovery" health={health.discovery} />
+      <Indicator label="RPC" health={health.rpc} />
+      {health.proving && <Indicator label="Proving" health={health.proving} />}
+      {health.gateway && <Indicator label="Gateway" health={health.gateway} />}
+      {health.feederGateway && <Indicator label="Feeder GW" health={health.feederGateway} />}
+    </span>
+  );
+}

--- a/demo/src/config.ts
+++ b/demo/src/config.ts
@@ -22,6 +22,8 @@ export type AppConfig = {
   accounts: AccountConfig[];
   /** Proving service URL. If set, uses real prover; otherwise mock. */
   provingServiceUrl?: string;
+  gatewayUrl?: string;
+  feederGatewayUrl?: string;
 };
 
 function requireEnv(key: string): string {
@@ -55,5 +57,7 @@ export function loadConfig(): AppConfig {
     provingServiceUrl: import.meta.env.VITE_PROVING_SERVICE_URL as
       | string
       | undefined,
+    gatewayUrl: import.meta.env.VITE_GATEWAY_URL as string | undefined,
+    feederGatewayUrl: import.meta.env.VITE_FEEDER_GATEWAY_URL as string | undefined,
   };
 }

--- a/demo/src/hooks/usePrivateState.ts
+++ b/demo/src/hooks/usePrivateState.ts
@@ -9,10 +9,11 @@ import { getErc20Balance } from "../starknet.ts";
 
 export type NoteDisplay = {
   id: string;
+  rawId: bigint;
   amount: bigint;
   token: string;
   sender: string;
-  isSelfSender: boolean;
+  senderName: string | null;
   channelKey: string;
   nonce: number;
   open: boolean;
@@ -20,11 +21,19 @@ export type NoteDisplay = {
 
 export type ChannelDisplay = {
   recipient: string;
-  isSelf: boolean;
+  recipientName: string | null;
   publicKey: string;
   channelKey: string;
   noteNonce: number;
   tokens: Array<{ tokenAddress: string }>;
+};
+
+export type ChannelGroup = {
+  channelKey: string;
+  sender: string;
+  senderName: string | null;
+  token: string;
+  notes: NoteDisplay[];
 };
 
 export type PrivateState = {
@@ -33,6 +42,7 @@ export type PrivateState = {
   feeTokenBalance: bigint;
   privateBalance: bigint;
   notes: NoteDisplay[];
+  channelGroups: ChannelGroup[];
   channels: ChannelDisplay[];
 };
 
@@ -42,6 +52,7 @@ const EMPTY_STATE: PrivateState = {
   feeTokenBalance: 0n,
   privateBalance: 0n,
   notes: [],
+  channelGroups: [],
   channels: [],
 };
 
@@ -65,6 +76,7 @@ export function usePrivateState(
   provider: RpcProvider | undefined,
   transfers: PrivateTransfersInterface | undefined,
   account: AccountConfig | undefined,
+  allAccounts: AccountConfig[],
   poolAddress: string,
   config: AppConfig,
 ) {
@@ -110,18 +122,24 @@ export function usePrivateState(
         0n,
       );
 
-      const ownerAddress = BigInt(account.address);
+      const nameByAddress = new Map<bigint, string>();
+      for (const acc of allAccounts) {
+        const accAddress = BigInt(acc.address);
+        nameByAddress.set(accAddress, accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase());
+      }
 
       const tokenAddressBigInt = BigInt(config.tokenAddress);
       const notes: NoteDisplay[] = tokenNotes.map((note: Note) => {
         const witness = readWitness(note.witness);
         const senderBigInt = toBigInt(note.sender);
+        const noteIdBigInt = toBigInt(note.id);
         return {
-          id: formatBigInt(toBigInt(note.id)),
+          id: formatBigInt(noteIdBigInt),
+          rawId: noteIdBigInt,
           amount: note.amount,
           token: truncateAddress(tokenAddressBigInt.toString(16)),
           sender: truncateAddress(senderBigInt.toString(16)),
-          isSelfSender: senderBigInt === ownerAddress,
+          senderName: nameByAddress.get(senderBigInt) ?? null,
           channelKey: formatBigInt(witness.channelKey),
           nonce: witness.nonce,
           open: note.open ?? false,
@@ -138,10 +156,9 @@ export function usePrivateState(
           });
           noteNonce = Math.max(noteNonce, tokenChannel.noteNonce);
         }
-        const isSelf = recipient === ownerAddress;
         channels.push({
           recipient: truncateAddress(recipient.toString(16)),
-          isSelf,
+          recipientName: nameByAddress.get(recipient) ?? null,
           publicKey: formatBigInt(internal.publicKey),
           channelKey: internal.key ? formatBigInt(internal.key) : "N/A",
           noteNonce,
@@ -149,13 +166,37 @@ export function usePrivateState(
         });
       }
 
-      setState({ isRegistered, tokenBalance, feeTokenBalance, privateBalance, notes, channels });
+      const groupsByKey = new Map<string, NoteDisplay[]>();
+      for (const note of notes) {
+        const existing = groupsByKey.get(note.channelKey);
+        if (existing) {
+          existing.push(note);
+        } else {
+          groupsByKey.set(note.channelKey, [note]);
+        }
+      }
+
+      const channelGroups: ChannelGroup[] = [];
+      for (const [channelKey, groupNotes] of groupsByKey) {
+        groupNotes.sort((a, b) => b.nonce - a.nonce);
+        const firstNote = groupNotes[0];
+        channelGroups.push({
+          channelKey,
+          sender: firstNote.sender,
+          senderName: firstNote.senderName,
+          token: firstNote.token,
+          notes: groupNotes,
+        });
+      }
+      channelGroups.sort((a, b) => b.notes[0].nonce - a.notes[0].nonce);
+
+      setState({ isRegistered, tokenBalance, feeTokenBalance, privateBalance, notes, channelGroups, channels });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
-  }, [provider, transfers, account, poolAddress, config]);
+  }, [provider, transfers, account, allAccounts, poolAddress, config]);
 
   return { state, loading, error, refresh };
 }

--- a/demo/src/hooks/useServiceHealth.ts
+++ b/demo/src/hooks/useServiceHealth.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ProvingService } from "starknet-sdk";
+// @ts-expect-error — deep import into dist, not part of the declared exports
+import { IndexerDiscoveryProvider } from "starknet-sdk/dist/internal/indexer-discovery.js";
+import type { RpcProvider } from "starknet";
+import type { AppConfig } from "../config.ts";
+
+export type HealthStatus = "checking" | "healthy" | "unhealthy" | "unknown";
+
+export type SubsystemHealth = {
+  status: HealthStatus;
+  detail: string | null;
+};
+
+export type ServiceHealthState = {
+  discovery: SubsystemHealth;
+  rpc: SubsystemHealth;
+  proving: SubsystemHealth | null;
+  gateway: SubsystemHealth | null;
+  feederGateway: SubsystemHealth | null;
+};
+
+const POLL_INTERVAL_MS = 30_000;
+const RPC_STALENESS_THRESHOLD_SECS = 120;
+const FETCH_TIMEOUT_MS = 8_000;
+
+function pending(): SubsystemHealth {
+  return { status: "checking", detail: null };
+}
+
+async function checkDiscovery(indexerUrl: string): Promise<SubsystemHealth> {
+  try {
+    const indexer = new IndexerDiscoveryProvider(indexerUrl, "0x0");
+    const health = await indexer.getHealth();
+    if (health.status === "OK") {
+      const detail = health.lag_secs != null ? `lag: ${health.lag_secs}s` : null;
+      return { status: "healthy", detail };
+    }
+    return { status: "unhealthy", detail: `status: ${health.status}` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkRpc(provider: RpcProvider): Promise<SubsystemHealth> {
+  try {
+    const block = await provider.getBlock("latest");
+    const blockTimestamp = block.timestamp;
+    const nowSecs = Math.floor(Date.now() / 1000);
+    const lagSecs = nowSecs - blockTimestamp;
+    if (lagSecs <= RPC_STALENESS_THRESHOLD_SECS) {
+      return { status: "healthy", detail: `lag: ${lagSecs}s` };
+    }
+    return { status: "unhealthy", detail: `stale: ${lagSecs}s behind` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkAliveEndpoint(url: string): Promise<SubsystemHealth> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (response.ok) return { status: "healthy", detail: null };
+    return { status: "unhealthy", detail: `HTTP ${response.status}` };
+  } catch {
+    return { status: "unknown", detail: "unreachable (CORS?)" };
+  }
+}
+
+async function checkProving(provingServiceUrl: string): Promise<SubsystemHealth> {
+  try {
+    const service = new ProvingService({ baseUrl: provingServiceUrl });
+    const healthy = await service.isHealthy();
+    return healthy
+      ? { status: "healthy", detail: null }
+      : { status: "unhealthy", detail: "spec version check failed" };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+function initialState(config: AppConfig): ServiceHealthState {
+  return {
+    discovery: pending(),
+    rpc: pending(),
+    proving: config.provingServiceUrl ? pending() : null,
+    gateway: config.gatewayUrl ? pending() : null,
+    feederGateway: config.feederGatewayUrl ? pending() : null,
+  };
+}
+
+export function useServiceHealth(
+  provider: RpcProvider,
+  config: AppConfig,
+): ServiceHealthState {
+  const [state, setState] = useState<ServiceHealthState>(() => initialState(config));
+  const mountedRef = useRef(true);
+
+  const runChecks = useCallback(() => {
+    const update = (key: keyof ServiceHealthState) => (value: SubsystemHealth) => {
+      if (mountedRef.current) setState((prev) => ({ ...prev, [key]: value }));
+    };
+
+    checkDiscovery(config.indexerUrl).then(update("discovery"));
+    checkRpc(provider).then(update("rpc"));
+
+    if (config.provingServiceUrl) {
+      checkProving(config.provingServiceUrl).then(update("proving"));
+    }
+    if (config.gatewayUrl) {
+      checkAliveEndpoint(`${config.gatewayUrl}/gateway/is_alive`).then(update("gateway"));
+    }
+    if (config.feederGatewayUrl) {
+      checkAliveEndpoint(`${config.feederGatewayUrl}/feeder_gateway/is_alive`).then(
+        update("feederGateway"),
+      );
+    }
+  }, [provider, config]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    runChecks();
+    const intervalId = setInterval(runChecks, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(intervalId);
+    };
+  }, [runChecks]);
+
+  return state;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,3 +12,5 @@ export { ProvingServiceProofProvider } from "./internal/proving-service-provider
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";
 export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
+export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
+export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -96,12 +96,39 @@ type ApiOutgoingSyncResponse = {
   cursor: ApiDiscoveryCursor;
 };
 
+export type DiscoveryHealthResponse = {
+  status: string;
+  chain_head?: { block_number: number; block_hash: string; timestamp: number };
+  lag_secs?: number;
+};
+
 export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   constructor(
     private readonly apiUrl: string,
     private readonly contractAddress: StarknetAddress
   ) {
     super();
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.apiUrl}/health`, {
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (!response.ok) return false;
+      const body = (await response.json()) as { status: string };
+      return body.status === "OK";
+    } catch {
+      return false;
+    }
+  }
+
+  async getHealth(): Promise<DiscoveryHealthResponse> {
+    const response = await fetch(`${this.apiUrl}/health`, {
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!response.ok) throw new Error(`Discovery service returned HTTP ${response.status}`);
+    return (await response.json()) as DiscoveryHealthResponse;
   }
 
   async discoverNotes(


### PR DESCRIPTION
### TL;DR

Reorganized the notes display to group unspent notes by channel with pagination support and improved the visual layout with card-based design.

### What changed?

- Replaced the flat notes table with a card-based layout that groups notes by channel key
- Added pagination to channel cards showing 10 notes per page with "Newer"/"Older" navigation
- Introduced `ChannelGroup` type to organize notes by sender, token, and channel key
- Reordered table columns in the channels section to show Channel Key before Next Note Index
- Added sorting logic to display channel groups and notes by most recent first
- Enhanced styling with new CSS classes for channel cards, pagination controls, and improved spacing

### How to test?

1. Load the demo application with multiple notes across different channels
2. Verify that notes are grouped by channel key in separate cards
3. Test pagination controls when a channel has more than 10 notes
4. Confirm that channel groups are sorted by most recent activity
5. Check that the "self" and "open" chips display correctly within the card layout

### Why make this change?

This change improves the user experience by organizing notes in a more logical and visually appealing way. Grouping by channels makes it easier to understand note relationships, while pagination prevents performance issues and UI clutter when dealing with large numbers of notes. The card-based design provides better visual separation and makes the interface more scannable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/584)
<!-- Reviewable:end -->
