### PR TITLE
chore(discovery-service): adjust default config

### DIFF
--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -51,7 +51,7 @@ level = "info"
 max_cursor_channels = 256
 max_cursor_subchannels_per_channel = 64
 max_outgoing_recipients = 64
-server_budget = 100
+server_budget = 10000
 max_request_body_bytes = 102400
 batch_budget = 16
 ```
@@ -68,7 +68,7 @@ These env vars override the corresponding config file values at runtime:
 | `WS_URL` | `indexer.ws_url` | `ws://127.0.0.1:5050/ws` |
 | `API_HOST` | `api.host` | `127.0.0.1:8080` |
 | `RUST_LOG` | `logging.level` | `info` |
-| `SERVER_BUDGET` | `limits.server_budget` | `100` |
+| `SERVER_BUDGET` | `limits.server_budget` | `10000` |
 | `BATCH_BUDGET` | `limits.batch_budget` | `16` |
 
 RPC pool settings, indexer timeouts, and validation limits (except server/batch budget) have no env var — configurable only via file.

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -51,7 +51,7 @@ impl Default for RpcConfig {
             connect_timeout: Duration::from_secs(30),
             request_timeout: Duration::from_secs(60),
             max_idle_per_host: 10,
-            max_batch_size: 50,
+            max_batch_size: 100,
         }
     }
 }
@@ -131,7 +131,7 @@ impl Default for ValidationLimits {
         Self {
             cursor_limits: CursorLimits::default(),
             max_outgoing_recipients: 64,
-            server_budget: 200,
+            server_budget: 10_000,
             max_request_body_bytes: 102_400,
             public_key_cache_capacity: 10_000,
         }


### PR DESCRIPTION
### TL;DR

Increased server budget and RPC batch size limits in the discovery service configuration.

### What changed?

- Increased `server_budget` from 100/200 to 10,000 in both the default configuration and documentation
- Increased RPC `max_batch_size` from 50 to 100 in the default configuration
- Updated the configuration documentation to reflect the new `SERVER_BUDGET` environment variable default value

### Why make this change?

These limit increases allow the discovery service to handle higher throughput scenarios by processing larger batches and supporting more concurrent operations within the server budget constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/585)
<!-- Reviewable:end -->
