### PR TITLE
fix(sdk): remove recipient_public_key from open channel input to match cairo contract

### DIFF
--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -62,10 +62,6 @@ export const PrivacyPoolABI = [
         "type": "core::starknet::contract_address::ContractAddress"
       },
       {
-        "name": "recipient_public_key",
-        "type": "core::felt252"
-      },
-      {
         "name": "index",
         "type": "core::integer::u32"
       },
@@ -2350,6 +2346,12 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "event",
+    "name": "openzeppelin_security::reentrancyguard::ReentrancyGuardComponent::Event",
+    "kind": "enum",
+    "variants": []
+  },
+  {
+    "type": "event",
     "name": "privacy::events::ViewingKeySet",
     "kind": "struct",
     "members": [
@@ -2561,6 +2563,11 @@ export const PrivacyPoolABI = [
       {
         "name": "SRC5Event",
         "type": "openzeppelin_introspection::src5::SRC5Component::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "ReentrancyGuardEvent",
+        "type": "openzeppelin_security::reentrancyguard::ReentrancyGuardComponent::Event",
         "kind": "flat"
       },
       {

--- a/sdk/src/internal/client-actions.ts
+++ b/sdk/src/internal/client-actions.ts
@@ -12,7 +12,6 @@ export type SetViewingKeyInput = {
 
 export type OpenChannelInput = {
   recipient_addr: StarknetAddressBigint;
-  recipient_public_key: bigint;
   index: number;
   random: bigint;
   salt: bigint;
@@ -69,7 +68,7 @@ export type InvokeExternalInput = {
 };
 
 /**
- * Union of all client actions (from ABI, including InvokeExternal).
+ * Union of all client actions.
  */
 export type ClientAction =
   | { type: "SetViewingKey"; input: SetViewingKeyInput }

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -291,7 +291,6 @@ export class ActionCompiler {
           type: "OpenChannel",
           input: {
             recipient_addr: action.recipient,
-            recipient_public_key: channel.publicKey as bigint,
             index: pool.getNextChannelIndex(),
             random: generateRandom(),
             salt: generateRandom(),

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -164,19 +164,27 @@ export class PoolSimulator {
   }
 
   private handleOpenChannel(input: OpenChannelInput): void {
-    const { recipient_addr, recipient_public_key } = input;
+    const { recipient_addr } = input;
+
+    // Look up the recipient's public key from the channel set up during setupChannel
+    const existingChannel = this.channels.get(recipient_addr);
+    assert(
+      existingChannel,
+      () =>
+        `Channel not found for recipient ${toHex(recipient_addr)} — setupChannel must be called first`
+    );
+    const recipientPublicKey = existingChannel.publicKey;
 
     // Compute the real channel key using the viewing key from constructor
     const channelKey = compute_channel_key(
       this.userAddress,
       toBigInt(this.userViewingKey),
       recipient_addr,
-      toBigInt(recipient_public_key)
+      toBigInt(recipientPublicKey)
     );
 
-    // Create/update channel
-    const channel = this.channels.get(recipient_addr, () => new Channel(recipient_public_key))!;
-    channel.key = channelKey;
+    // Update channel with computed key
+    existingChannel.key = channelKey;
     this.nextChannelIndex++;
 
     debugLog("pool-simulator", "OpenChannel", toHex(this.userAddress), "->", toHex(recipient_addr));

--- a/sdk/src/testing/mock-pool-contract.ts
+++ b/sdk/src/testing/mock-pool-contract.ts
@@ -480,17 +480,23 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
       case "SetViewingKey":
         return [this.register(sender, privateKey, action.input.random)];
 
-      case "OpenChannel":
+      case "OpenChannel": {
+        const recipientPublicKey = this.publicKeys.get(action.input.recipient_addr);
+        assert(
+          recipientPublicKey !== undefined,
+          () => `Recipient ${toHex(action.input.recipient_addr)} not registered — no public key`
+        );
         return [
           this.setChannel(
             sender,
             privateKey,
             action.input.recipient_addr,
-            action.input.recipient_public_key,
+            recipientPublicKey,
             action.input.index,
             action.input.random
           ),
         ];
+      }
 
       case "OpenSubchannel":
         return [


### PR DESCRIPTION
### TL;DR

Removed `recipient_public_key` parameter from `OpenChannel` action and updated the flow to look up recipient public keys from existing channel data.

### What changed?

- Removed `recipient_public_key` field from `OpenChannelInput` type and PrivacyPool ABI
- Modified `PoolSimulator.handleOpenChannel()` to look up the recipient's public key from existing channels instead of receiving it as a parameter
- Updated `MockPoolContract` to retrieve recipient public keys from its internal registry
- Added reentrancy guard event definitions to the ABI
- Added validation to ensure channels exist before opening them

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/591)
<!-- Reviewable:end -->
