### PR TITLE
feat(demo): add subsystem health indicators to explorer

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -36,8 +36,8 @@ jobs:
           # Generate vercel.json with rewrites to proxy HTTP backends through
           # the Vercel deployment, avoiding mixed HTTP/HTTPS content errors.
           eval "$(grep '^BACKEND_' ".vercel/.env.preview.local")"
-          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"}]}\n' \
-            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" > vercel.json
+          printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"},{"source":"/api/gateway/:path*","destination":"%s/:path*"}]}\n' \
+            "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" "$BACKEND_GATEWAY_URL" > vercel.json
 
           npx vercel build
         env:

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -380,6 +380,35 @@ input[type="number"] {
   padding: 2px 8px;
 }
 
+.service-health-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: 8px;
+}
+
+.health-indicator {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.health-label {
+  color: #c9d1d9;
+}
+
+.health-detail {
+  color: #8b949e;
+  font-size: 11px;
+}
+
 .app-footer {
   text-align: center;
   color: #8b949e;

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -34,15 +34,53 @@ h3 {
   margin: 0 auto;
 }
 
-.pool-selector {
-  display: flex;
+.pool-selector-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 8px;
   align-items: center;
-  gap: 8px;
+  margin-top: 12px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 12px 12px 8px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
+}
+
+.pool-selector-label {
+  color: #8b949e;
+  white-space: nowrap;
+}
+
+.pool-selector-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pool-selector-value code {
+  color: #c9d1d9;
+  font-size: 13px;
+  padding-left: 12px;
+}
+
+.pool-selector-value input {
+  width: 540px;
+}
+
+.pool-selector-value > button {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+.copy-button {
+  background: #21262d;
+  border-color: #30363d;
+  color: #8b949e;
+}
+
+.copy-button:hover:not(:disabled) {
+  background: #30363d;
 }
 
 .account-selector {
@@ -50,7 +88,7 @@ h3 {
   align-items: center;
   gap: 8px;
   margin-bottom: 12px;
-  padding: 8px;
+  padding: 8px 12px;
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
@@ -183,6 +221,9 @@ input[type="number"] {
 
 .action-form button {
   margin-top: 4px;
+  font-size: 12px;
+  padding: 3px 9px;
+  margin-left: 6px;
 }
 
 .status-bar {
@@ -225,7 +266,10 @@ input[type="number"] {
 .subtitle code {
   color: #c9d1d9;
   font-size: 11px;
+  cursor: default;
+  word-break: break-all;
 }
+
 
 .chip {
   display: inline-block;

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { formatChainId, truncateAddress } from "./format.ts";
+import { formatChainId } from "./format.ts";
 import { loadConfig } from "./config.ts";
 import { createProvider, createAccount, createTransfers } from "./starknet.ts";
 import { useAccounts } from "./hooks/useAccounts.ts";
@@ -21,15 +21,22 @@ import "./App.css";
 const config = loadConfig();
 
 export function App() {
+  const [classHash, setClassHash] = useState(config.poolClassHash);
+
   const { accounts, activeIndex, activeAccount, setActiveIndex } =
     useAccounts(config.accounts);
 
   const provider = useMemo(() => createProvider(config.rpcUrl), []);
 
   const { pools, activePool, selectPool, addPool, loading: poolsLoading } =
-    usePoolSelector(provider, config.poolAddress, config.poolClassHash);
+    usePoolSelector(provider, config.poolAddress, classHash);
 
-  const { deploying, deployError, deploy } = useDeployPool(provider, config);
+  const configWithClassHash = useMemo(
+    () => ({ ...config, poolClassHash: classHash }),
+    [classHash],
+  );
+
+  const { deploying, deployError, deploy } = useDeployPool(provider, configWithClassHash);
 
   const handleDeploy = useCallback(async () => {
     try {
@@ -89,7 +96,7 @@ export function App() {
     <div className="app">
       <h1>Privacy Pool Explorer</h1>
       <div className="subtitle">
-        Chain: <code>{formatChainId(config.chainId)}</code> | Pool class: <code>{truncateAddress(config.poolClassHash)}</code>
+        Chain: <code>{formatChainId(config.chainId)}</code>
         <ServiceHealthBar health={serviceHealth} />
       </div>
       <PoolSelector
@@ -98,8 +105,10 @@ export function App() {
         loading={poolsLoading}
         deploying={deploying}
         deployError={deployError}
+        classHash={classHash}
         onSelect={selectPool}
         onDeploy={handleDeploy}
+        onClassHashChange={setClassHash}
       />
       <AccountSelector
         accounts={accounts}

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -13,7 +13,9 @@ import { InfoPanel } from "./components/InfoPanel.tsx";
 import { ActionPanel } from "./components/ActionPanel.tsx";
 import { TransactionBuilder } from "./components/TransactionBuilder.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
+import { ServiceHealthBar } from "./components/ServiceHealthBar.tsx";
 import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
+import { useServiceHealth } from "./hooks/useServiceHealth.ts";
 import "./App.css";
 
 const config = loadConfig();
@@ -79,6 +81,8 @@ export function App() {
     refresh,
   );
 
+  const serviceHealth = useServiceHealth(provider, config);
+
   const [activeView, setActiveView] = useState<"actions" | "builder">("actions");
 
   return (
@@ -86,6 +90,7 @@ export function App() {
       <h1>Privacy Pool Explorer</h1>
       <div className="subtitle">
         Chain: <code>{formatChainId(config.chainId)}</code> | Pool class: <code>{truncateAddress(config.poolClassHash)}</code>
+        <ServiceHealthBar health={serviceHealth} />
       </div>
       <PoolSelector
         pools={pools}

--- a/demo/src/components/PoolSelector.tsx
+++ b/demo/src/components/PoolSelector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { PoolEntry } from "../hooks/usePoolSelector.ts";
 
 type Props = {
@@ -6,13 +7,15 @@ type Props = {
   loading: boolean;
   deploying: boolean;
   deployError: string | null;
+  classHash: string;
   onSelect: (address: string) => void;
   onDeploy: () => void;
+  onClassHashChange: (hash: string) => void;
 };
 
-function truncatePoolAddress(address: string): string {
-  if (address.length <= 14) return address;
-  return `${address.slice(0, 8)}...${address.slice(-4)}`;
+function truncateHash(hex: string): string {
+  if (hex.length <= 14) return hex;
+  return `${hex.slice(0, 8)}...${hex.slice(-4)}`;
 }
 
 export function PoolSelector({
@@ -21,28 +24,85 @@ export function PoolSelector({
   loading,
   deploying,
   deployError,
+  classHash,
   onSelect,
   onDeploy,
+  onClassHashChange,
 }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [copied, setCopied] = useState(false);
+
   return (
-    <div className="pool-selector">
-      <label>
-        Pool:{" "}
+    <div className="pool-selector-grid">
+      <span className="pool-selector-label">Class hash:</span>
+      <div className="pool-selector-value">
+        {editing ? (
+          <>
+            <input
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  onClassHashChange(draft);
+                  setEditing(false);
+                }
+                if (event.key === "Escape") setEditing(false);
+              }}
+              autoFocus
+            />
+            <button
+              onClick={() => {
+                onClassHashChange(draft);
+                setEditing(false);
+              }}
+            >
+              Apply
+            </button>
+          </>
+        ) : (
+          <>
+            <code>{truncateHash(classHash)}</code>
+            <button
+              onClick={() => {
+                setDraft(classHash);
+                setEditing(true);
+              }}
+            >
+              Change
+            </button>
+          </>
+        )}
+      </div>
+
+      <span className="pool-selector-label">Address:</span>
+      <div className="pool-selector-value">
         <select
           value={activePool.address}
           onChange={(event) => onSelect(event.target.value)}
         >
           {pools.map((pool) => (
             <option key={pool.address} value={pool.address}>
-              {truncatePoolAddress(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
+              {truncateHash(pool.address)}{pool.isDefault ? " (default)" : pool.isNewest ? " (newest)" : ""}
             </option>
           ))}
         </select>
-      </label>
-      <button type="button" disabled={loading || deploying} onClick={onDeploy}>
-        {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
-      </button>
-      {deployError && <span className="error">{deployError}</span>}
+        <button type="button" disabled={loading || deploying} onClick={onDeploy}>
+          {loading ? "Loading..." : deploying ? "Deploying..." : "Deploy New Pool"}
+        </button>
+        <button
+          type="button"
+          className="copy-button"
+          onClick={() => {
+            navigator.clipboard.writeText(activePool.address);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+        {deployError && <span className="error">{deployError}</span>}
+      </div>
     </div>
   );
 }

--- a/demo/src/components/ServiceHealthBar.tsx
+++ b/demo/src/components/ServiceHealthBar.tsx
@@ -1,0 +1,30 @@
+import type { HealthStatus, ServiceHealthState, SubsystemHealth } from "../hooks/useServiceHealth.ts";
+
+const STATUS_COLORS: Record<HealthStatus, string> = {
+  healthy: "#3fb950",
+  unhealthy: "#f85149",
+  unknown: "#d29922",
+  checking: "#484f58",
+};
+
+function Indicator({ label, health }: { label: string; health: SubsystemHealth }) {
+  return (
+    <span className="health-indicator">
+      <span className="health-dot" style={{ background: STATUS_COLORS[health.status] }} title={health.detail ?? health.status} />
+      <span className="health-label">{label}</span>
+    </span>
+  );
+}
+
+export function ServiceHealthBar({ health }: { health: ServiceHealthState }) {
+  return (
+    <span className="service-health-bar">
+      | Status:
+      <Indicator label="Discovery" health={health.discovery} />
+      <Indicator label="RPC" health={health.rpc} />
+      {health.proving && <Indicator label="Proving" health={health.proving} />}
+      {health.gateway && <Indicator label="Gateway" health={health.gateway} />}
+      {health.feederGateway && <Indicator label="Feeder GW" health={health.feederGateway} />}
+    </span>
+  );
+}

--- a/demo/src/config.ts
+++ b/demo/src/config.ts
@@ -22,6 +22,8 @@ export type AppConfig = {
   accounts: AccountConfig[];
   /** Proving service URL. If set, uses real prover; otherwise mock. */
   provingServiceUrl?: string;
+  gatewayUrl?: string;
+  feederGatewayUrl?: string;
 };
 
 function requireEnv(key: string): string {
@@ -55,5 +57,7 @@ export function loadConfig(): AppConfig {
     provingServiceUrl: import.meta.env.VITE_PROVING_SERVICE_URL as
       | string
       | undefined,
+    gatewayUrl: import.meta.env.VITE_GATEWAY_URL as string | undefined,
+    feederGatewayUrl: import.meta.env.VITE_FEEDER_GATEWAY_URL as string | undefined,
   };
 }

--- a/demo/src/hooks/useServiceHealth.ts
+++ b/demo/src/hooks/useServiceHealth.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ProvingService } from "starknet-sdk";
+// @ts-expect-error — deep import into dist, not part of the declared exports
+import { IndexerDiscoveryProvider } from "starknet-sdk/dist/internal/indexer-discovery.js";
+import type { RpcProvider } from "starknet";
+import type { AppConfig } from "../config.ts";
+
+export type HealthStatus = "checking" | "healthy" | "unhealthy" | "unknown";
+
+export type SubsystemHealth = {
+  status: HealthStatus;
+  detail: string | null;
+};
+
+export type ServiceHealthState = {
+  discovery: SubsystemHealth;
+  rpc: SubsystemHealth;
+  proving: SubsystemHealth | null;
+  gateway: SubsystemHealth | null;
+  feederGateway: SubsystemHealth | null;
+};
+
+const POLL_INTERVAL_MS = 30_000;
+const RPC_STALENESS_THRESHOLD_SECS = 120;
+const FETCH_TIMEOUT_MS = 8_000;
+
+function pending(): SubsystemHealth {
+  return { status: "checking", detail: null };
+}
+
+async function checkDiscovery(indexerUrl: string): Promise<SubsystemHealth> {
+  try {
+    const indexer = new IndexerDiscoveryProvider(indexerUrl, "0x0");
+    const health = await indexer.getHealth();
+    if (health.status === "OK") {
+      const detail = health.lag_secs != null ? `lag: ${health.lag_secs}s` : null;
+      return { status: "healthy", detail };
+    }
+    return { status: "unhealthy", detail: `status: ${health.status}` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkRpc(provider: RpcProvider): Promise<SubsystemHealth> {
+  try {
+    const block = await provider.getBlock("latest");
+    const blockTimestamp = block.timestamp;
+    const nowSecs = Math.floor(Date.now() / 1000);
+    const lagSecs = nowSecs - blockTimestamp;
+    if (lagSecs <= RPC_STALENESS_THRESHOLD_SECS) {
+      return { status: "healthy", detail: `lag: ${lagSecs}s` };
+    }
+    return { status: "unhealthy", detail: `stale: ${lagSecs}s behind` };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+async function checkAliveEndpoint(url: string): Promise<SubsystemHealth> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (response.ok) return { status: "healthy", detail: null };
+    return { status: "unhealthy", detail: `HTTP ${response.status}` };
+  } catch {
+    return { status: "unknown", detail: "unreachable (CORS?)" };
+  }
+}
+
+async function checkProving(provingServiceUrl: string): Promise<SubsystemHealth> {
+  try {
+    const service = new ProvingService({ baseUrl: provingServiceUrl });
+    const healthy = await service.isHealthy();
+    return healthy
+      ? { status: "healthy", detail: null }
+      : { status: "unhealthy", detail: "spec version check failed" };
+  } catch (error) {
+    return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
+  }
+}
+
+function initialState(config: AppConfig): ServiceHealthState {
+  return {
+    discovery: pending(),
+    rpc: pending(),
+    proving: config.provingServiceUrl ? pending() : null,
+    gateway: config.gatewayUrl ? pending() : null,
+    feederGateway: config.feederGatewayUrl ? pending() : null,
+  };
+}
+
+export function useServiceHealth(
+  provider: RpcProvider,
+  config: AppConfig,
+): ServiceHealthState {
+  const [state, setState] = useState<ServiceHealthState>(() => initialState(config));
+  const mountedRef = useRef(true);
+
+  const runChecks = useCallback(() => {
+    const update = (key: keyof ServiceHealthState) => (value: SubsystemHealth) => {
+      if (mountedRef.current) setState((prev) => ({ ...prev, [key]: value }));
+    };
+
+    checkDiscovery(config.indexerUrl).then(update("discovery"));
+    checkRpc(provider).then(update("rpc"));
+
+    if (config.provingServiceUrl) {
+      checkProving(config.provingServiceUrl).then(update("proving"));
+    }
+    if (config.gatewayUrl) {
+      checkAliveEndpoint(`${config.gatewayUrl}/gateway/is_alive`).then(update("gateway"));
+    }
+    if (config.feederGatewayUrl) {
+      checkAliveEndpoint(`${config.feederGatewayUrl}/feeder_gateway/is_alive`).then(
+        update("feederGateway"),
+      );
+    }
+  }, [provider, config]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    runChecks();
+    const intervalId = setInterval(runChecks, POLL_INTERVAL_MS);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(intervalId);
+    };
+  }, [runChecks]);
+
+  return state;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,3 +12,5 @@ export { ProvingServiceProofProvider } from "./internal/proving-service-provider
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";
 export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
+export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
+export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -96,12 +96,39 @@ type ApiOutgoingSyncResponse = {
   cursor: ApiDiscoveryCursor;
 };
 
+export type DiscoveryHealthResponse = {
+  status: string;
+  chain_head?: { block_number: number; block_hash: string; timestamp: number };
+  lag_secs?: number;
+};
+
 export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   constructor(
     private readonly apiUrl: string,
     private readonly contractAddress: StarknetAddress
   ) {
     super();
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const response = await fetch(`${this.apiUrl}/health`, {
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (!response.ok) return false;
+      const body = (await response.json()) as { status: string };
+      return body.status === "OK";
+    } catch {
+      return false;
+    }
+  }
+
+  async getHealth(): Promise<DiscoveryHealthResponse> {
+    const response = await fetch(`${this.apiUrl}/health`, {
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!response.ok) throw new Error(`Discovery service returned HTTP ${response.status}`);
+    return (await response.json()) as DiscoveryHealthResponse;
   }
 
   async discoverNotes(


### PR DESCRIPTION
### TL;DR

Added a service health monitoring system to the demo application that displays real-time status indicators for all backend services.

### What changed?

- Added a new `ServiceHealthBar` component that displays colored status dots for Discovery, RPC, Proving, Gateway, and Feeder Gateway services
- Created a `useServiceHealth` hook that periodically checks the health of each service using appropriate endpoints and methods
- Extended the Vercel deployment configuration to proxy Gateway API requests through `/api/gateway/`
- Exported `IndexerDiscoveryProvider` and `DiscoveryHealthResponse` from the SDK to enable health checking
- Added `getHealth()` and `isHealthy()` methods to the `IndexerDiscoveryProvider` class
- Updated the app configuration to support optional Gateway and Feeder Gateway URLs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/600)
<!-- Reviewable:end -->
