### PR TITLE
fix(sdk): strip class_hash prefix from proof output before apply_actions

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -1,5 +1,9 @@
 **MANDATORY:** Before claiming work is complete, fixed, or passing, invoke `/verification-before-completion`. Run fresh verification commands and confirm output before making any success claims. Evidence before assertions, always.
 
+**Cairo verification checklist:**
+- If `snforge` is not in PATH, read `.tool-versions` for the version and use `~/.asdf/installs/starknet-foundry/<version>/bin/snforge`
+- `snforge test` - all tests pass
+
 **Rust verification checklist:**
 - `cargo fmt --check` - code formatting
 - `cargo clippy` - lints (0 warnings required), including integration tests, for all targets

--- a/crates/discovery-core/tests/fixtures/cairo-reference-data.json
+++ b/crates/discovery-core/tests/fixtures/cairo-reference-data.json
@@ -51,6 +51,16 @@
       "0x1",
       "0x6ecbe1e6bce2468d4f9241154bb6c545aed378aa89a661e18f9f8af9a3add9e"
     ],
+    "messagePayloadLength": 7,
+    "messagePayload": [
+      "0x12345",
+      "0x1",
+      "0x0",
+      "0x111",
+      "0x2",
+      "0x222",
+      "0x333"
+    ],
     "virtualSnos": "0x5649525455414c5f534e4f53",
     "virtualSnos0": "0x5649525455414c5f534e4f5330"
   },

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -8,9 +8,6 @@ TOKEN_ADDRESS=0x0
 # Chain ID (hex-encoded felt, e.g. SN_INTEGRATION_SEPOLIA)
 CHAIN_ID=0x534e5f494e544547524154494f4e5f5345504f4c4941
 
-# Privacy pool class hash (already declared on-chain)
-POOL_CLASS_HASH=0x0
-
 # Compliance public key
 COMPLIANCE_PUBLIC_KEY=0x0
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,9 +5,10 @@ End-to-end tests and fixture generation for the privacy pool.
 ## Prerequisites
 
 1. Install the patched starknet-devnet (see [SDK README](../sdk/README.md#starknet-devnet) for instructions)
-2. Build the privacy contract: `scarb build`
+2. Build the privacy contract: `scarb --profile release build`
 3. Build the SDK: `cd sdk && npm run build`
-4. Install e2e dependencies: `npm install`
+4. Build the discovery service: `cargo build -p discovery-service`
+5. Install e2e dependencies: `npm install`
 
 ## Tests
 
@@ -87,9 +88,12 @@ update `POOL_CLASS_HASH` in `.env` to match.
 ## Privacy StarkNet integration (`tests/privacy-starknet-integration.test.ts`)
 
 Tests against a real (non-devnet) StarkNet deployment on integration sepolia.
-Spawns the discovery service indexer, runs preflight and deposit flows via the SDK.
+Declares the contract class from built artifacts (no-op if already declared),
+deploys a fresh pool instance, spawns the discovery service indexer, and runs
+preflight and deposit flows via the SDK.
 
-Requires network access and a `.env` file with account credentials and contract addresses.
+Requires network access, built contract artifacts (`scarb --profile release build`),
+and a `.env` file with account credentials.
 
 ### Setting up `.env`
 

--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -1,12 +1,72 @@
-import { constants } from "starknet";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { constants, hash, type Account } from "starknet";
 import {
   Devnet,
   type DevnetEnvironment,
   CallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "starknet-sdk/testing";
-import { createPrivateTransfers, type PrivateTransfersInterface } from "starknet-sdk";
+import {
+  createPrivateTransfers,
+  type PrivateTransfersInterface,
+} from "starknet-sdk";
 import { IndexerClient, type IndexerSpawnConfig } from "./indexer-client.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "../..");
+
+const CONTRACT_CLASS_PATH = join(
+  repoRoot,
+  "target/release/privacy_Privacy.contract_class.json",
+);
+const COMPILED_CONTRACT_PATH = join(
+  repoRoot,
+  "target/release/privacy_Privacy.compiled_contract_class.json",
+);
+
+/**
+ * Declare the privacy pool contract class on-chain.
+ * Loads sierra + casm artifacts from target/release/, computes the class hash,
+ * and submits DECLARE if not already declared. Returns the class hash.
+ */
+export async function declarePoolClass(
+  adminAccount: Account,
+  resourceBounds?: {
+    l2_gas: { max_amount: bigint; max_price_per_unit: bigint };
+    l1_gas: { max_amount: bigint; max_price_per_unit: bigint };
+    l1_data_gas: { max_amount: bigint; max_price_per_unit: bigint };
+  },
+): Promise<string> {
+  const contractClass = JSON.parse(readFileSync(CONTRACT_CLASS_PATH, "utf8"));
+  const compiledContract = JSON.parse(
+    readFileSync(COMPILED_CONTRACT_PATH, "utf8"),
+  );
+  const classHash = hash.computeContractClassHash(contractClass);
+
+  try {
+    await adminAccount.getClass(classHash);
+    console.log("[declare] class already declared:", classHash);
+    return classHash;
+  } catch {
+    // Not declared yet — proceed
+  }
+
+  console.log("[declare] submitting DECLARE for class hash:", classHash);
+  const response = await adminAccount.declare(
+    { contract: contractClass, casm: compiledContract },
+    { tip: 0n, ...(resourceBounds ? { resourceBounds } : {}) },
+  );
+  const receipt = await adminAccount.waitForTransaction(
+    response.transaction_hash,
+  );
+  if (!receipt.isSuccess()) {
+    throw new Error(`DECLARE failed: ${JSON.stringify(receipt, null, 2)}`);
+  }
+  console.log("[declare] class declared successfully:", classHash);
+  return classHash;
+}
 
 export interface E2eTestEnv {
   devnet: Devnet;
@@ -24,7 +84,7 @@ export interface E2eTestEnvConfig {
 
 export async function createE2eTestEnv(
   devnet: Devnet,
-  config?: E2eTestEnvConfig
+  config?: E2eTestEnvConfig,
 ): Promise<E2eTestEnv> {
   const env = await devnet.initialize();
   const chainId = constants.StarknetChainId.SN_SEPOLIA;
@@ -41,14 +101,20 @@ export async function createE2eTestEnv(
       account: env.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new CallMockProofProvider(env.provider, chainId),
-      discoveryProvider: new IndexerDiscoveryProvider(indexer.apiUrl, env.privacy.address),
+      discoveryProvider: new IndexerDiscoveryProvider(
+        indexer.apiUrl,
+        env.privacy.address,
+      ),
       poolContractAddress: env.privacy.address,
     }),
     bob: createPrivateTransfers({
       account: env.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new CallMockProofProvider(env.provider, chainId),
-      discoveryProvider: new IndexerDiscoveryProvider(indexer.apiUrl, env.privacy.address),
+      discoveryProvider: new IndexerDiscoveryProvider(
+        indexer.apiUrl,
+        env.privacy.address,
+      ),
       poolContractAddress: env.privacy.address,
     }),
   };

--- a/e2e/tests/privacy-starknet-integration.test.ts
+++ b/e2e/tests/privacy-starknet-integration.test.ts
@@ -13,6 +13,7 @@ import {
   SetupRequirement,
 } from "starknet-sdk";
 import { IndexerClient } from "../src/indexer-client.js";
+import { declarePoolClass } from "../src/harness.js";
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -31,13 +32,13 @@ const RPC = requireEnv("RPC_URL");
 const WS = requireEnv("WS_URL");
 const TOKEN = requireEnv("TOKEN_ADDRESS");
 const CHAIN_ID = requireEnv("CHAIN_ID") as constants.StarknetChainId;
-const POOL_CLASS_HASH = requireEnv("POOL_CLASS_HASH");
 const COMPLIANCE_PUBLIC_KEY = requireEnv("COMPLIANCE_PUBLIC_KEY");
-const PROVING_SERVICE_URL = requireEnv("VITE_PROVING_SERVICE_URL")
+const PROVING_SERVICE_URL = requireEnv("VITE_PROVING_SERVICE_URL");
 const accounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
 function findAccount(name: string): AccountEntry {
   const entry = accounts.find((account) => account.name === name);
-  if (!entry) throw new Error(`Account "${name}" not found in ACCOUNTS env var`);
+  if (!entry)
+    throw new Error(`Account "${name}" not found in ACCOUNTS env var`);
   return entry;
 }
 const admin = findAccount("admin");
@@ -51,6 +52,11 @@ const ERC20_RESOURCE_BOUNDS = {
   l2_gas: { max_amount: 2_000_000n, max_price_per_unit: L2_GAS_PRICE },
   l1_gas: { max_amount: 1n, max_price_per_unit: L1_GAS_PRICE },
   l1_data_gas: { max_amount: 640n, max_price_per_unit: L1_DATA_GAS_PRICE },
+};
+const DECLARE_RESOURCE_BOUNDS = {
+  l2_gas: { max_amount: 2_500_000_000n, max_price_per_unit: L2_GAS_PRICE },
+  l1_gas: { max_amount: 1n, max_price_per_unit: L1_GAS_PRICE },
+  l1_data_gas: { max_amount: 25_000n, max_price_per_unit: L1_DATA_GAS_PRICE },
 };
 const DEPLOY_RESOURCE_BOUNDS = {
   l2_gas: { max_amount: 4_000_000n, max_price_per_unit: L2_GAS_PRICE },
@@ -86,22 +92,35 @@ describe("Privacy StarkNet integration", () => {
       cairoVersion: "1",
     });
 
-    // Deploy a fresh privacy pool via UDC v2
+    // Declare the contract class (no-op if already declared), then deploy
+    const poolClassHash = await declarePoolClass(
+      adminAccount,
+      DECLARE_RESOURCE_BOUNDS,
+    );
+
     const deploymentSalt = `0x${Date.now().toString(16)}`;
     const constructorCalldata = [admin.address, COMPLIANCE_PUBLIC_KEY, "450"];
-    console.log("[debug] deploying fresh privacy pool with salt:", deploymentSalt);
+    console.log(
+      "[debug] deploying fresh privacy pool with salt:",
+      deploymentSalt,
+    );
 
     const deployResult = await adminAccount.deployContract(
       {
-        classHash: POOL_CLASS_HASH,
+        classHash: poolClassHash,
         constructorCalldata,
         salt: deploymentSalt,
       },
       { tip: 0n, resourceBounds: DEPLOY_RESOURCE_BOUNDS },
     );
-    const deployReceipt = await provider.waitForTransaction(deployResult.transaction_hash);
+    const deployReceipt = await provider.waitForTransaction(
+      deployResult.transaction_hash,
+    );
     if (!deployReceipt.isSuccess()) {
-      console.error("[debug] deploy FAILED:", JSON.stringify(deployReceipt, null, 2));
+      console.error(
+        "[debug] deploy FAILED:",
+        JSON.stringify(deployReceipt, null, 2),
+      );
       throw new Error("Privacy pool deployment failed");
     }
     poolAddress = deployResult.contract_address;
@@ -129,7 +148,11 @@ describe("Privacy StarkNet integration", () => {
       BigInt(alice.address),
       BigInt(TOKEN),
     );
-    console.log("[debug] preflight requirement:", SetupRequirement[requirement], `(${requirement})`);
+    console.log(
+      "[debug] preflight requirement:",
+      SetupRequirement[requirement],
+      `(${requirement})`,
+    );
     expect(requirement).toBeGreaterThanOrEqual(SetupRequirement.Register);
     expect(requirement).toBeLessThanOrEqual(SetupRequirement.Ready);
   });
@@ -137,7 +160,9 @@ describe("Privacy StarkNet integration", () => {
   it("deposit with auto-register", async () => {
     const transfers = createPrivateTransfers({
       account: aliceAccount,
-      viewingKeyProvider: { getViewingKey: async () => BigInt(alice.viewingKey) },
+      viewingKeyProvider: {
+        getViewingKey: async () => BigInt(alice.viewingKey),
+      },
       provingProvider: new ProvingServiceProofProvider(
         PROVING_SERVICE_URL,
         CHAIN_ID,
@@ -156,8 +181,15 @@ describe("Privacy StarkNet integration", () => {
       },
       { tip: 0n, resourceBounds: ERC20_RESOURCE_BOUNDS },
     );
-    const mintReceipt = await provider.waitForTransaction(mintTx.transaction_hash);
-    console.log("[debug] mint tx:", mintTx.transaction_hash, "status:", mintReceipt.isSuccess() ? "OK" : "FAILED");
+    const mintReceipt = await provider.waitForTransaction(
+      mintTx.transaction_hash,
+    );
+    console.log(
+      "[debug] mint tx:",
+      mintTx.transaction_hash,
+      "status:",
+      mintReceipt.isSuccess() ? "OK" : "FAILED",
+    );
 
     // Approve pool to spend Alice's tokens
     console.log("[debug] approving pool to spend 100 tokens");
@@ -169,8 +201,15 @@ describe("Privacy StarkNet integration", () => {
       },
       { tip: 0n, resourceBounds: ERC20_RESOURCE_BOUNDS },
     );
-    const approveReceipt = await provider.waitForTransaction(approveTx.transaction_hash);
-    console.log("[debug] approve tx:", approveTx.transaction_hash, "status:", approveReceipt.isSuccess() ? "OK" : "FAILED");
+    const approveReceipt = await provider.waitForTransaction(
+      approveTx.transaction_hash,
+    );
+    console.log(
+      "[debug] approve tx:",
+      approveTx.transaction_hash,
+      "status:",
+      approveReceipt.isSuccess() ? "OK" : "FAILED",
+    );
 
     // Deposit 100 tokens — SDK checks state internally and registers if needed
     console.log("[debug] building deposit transaction...");
@@ -191,7 +230,12 @@ describe("Privacy StarkNet integration", () => {
       .surplusTo(alice.address)
       .execute({ provingBlockId });
     console.log("[debug] execute() completed successfully");
-    console.log("[debug] ProofFacts:", callAndProof.proof.proofFacts ? `${callAndProof.proof.proofFacts.length} elements` : "undefined");
+    console.log(
+      "[debug] ProofFacts:",
+      callAndProof.proof.proofFacts
+        ? `${callAndProof.proof.proofFacts.length} elements`
+        : "undefined",
+    );
 
     // Submit via outside execution (admin submits on behalf of Alice).
     // This is required because proofFacts change the tx hash, and the account
@@ -207,13 +251,18 @@ describe("Privacy StarkNet integration", () => {
       callAndProof.call,
       OutsideExecutionVersion.V2,
     );
-    const executeTx = await adminAccount.executeFromOutside(outsideTransaction, {
-      tip: 0n,
-      resourceBounds: POOL_RESOURCE_BOUNDS,
-      proofFacts: callAndProof.proof.proofFacts,
-      proof: callAndProof.proof.data,
-    });
-    const receipt = await provider.waitForTransaction(executeTx.transaction_hash);
+    const executeTx = await adminAccount.executeFromOutside(
+      outsideTransaction,
+      {
+        tip: 0n,
+        resourceBounds: POOL_RESOURCE_BOUNDS,
+        proofFacts: callAndProof.proof.proofFacts,
+        proof: callAndProof.proof.data,
+      },
+    );
+    const receipt = await provider.waitForTransaction(
+      executeTx.transaction_hash,
+    );
     if (!receipt.isSuccess()) {
       console.error("Transaction reverted:", JSON.stringify(receipt, null, 2));
     }

--- a/packages/privacy/src/tests/generate_reference_data.cairo
+++ b/packages/privacy/src/tests/generate_reference_data.cairo
@@ -368,6 +368,14 @@ fn generate_reference_proof_facts() {
         proof_index += 1;
     }
 
+    // The full L2-to-L1 message payload: [class_hash, ...serialized_actions]
+    println!("proofFacts.messagePayloadLength: {}", payload.len());
+    let mut payload_index = 0;
+    for felt in payload {
+        println!("proofFacts.messagePayload.{}: 0x{:x}", payload_index, felt);
+        payload_index += 1;
+    }
+
     // Also print the constants for verification
     println!("proofFacts.virtualSnos: 0x{:x}", VIRTUAL_SNOS);
     println!("proofFacts.virtualSnos0: 0x{:x}", VIRTUAL_SNOS0);

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -74,7 +74,8 @@ export type NoteId = BigNumberish;
 
 export type Proof = {
   readonly data: string;
-  readonly output: string[]; // array of felts
+  /** L2-to-L1 message payload: [class_hash, ...serialized_server_actions]. */
+  readonly output: string[];
   /** Proof facts from the proving service; must be included in the tx when submitting to the chain. */
   readonly proofFacts: string[];
 };

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -71,8 +71,13 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     // Get proof from provider (block id only when provided in options)
     const proof = await this.params.provingProvider.prove(invocation, options?.provingBlockId);
 
+    // proof.output is the L2-to-L1 message payload: [class_hash, ...serialized_actions].
+    // Strip the class_hash prefix — apply_actions expects only Span<ServerAction>.
+    const serverActionsCalldata = proof.output.slice(1);
+
     // Parse and log server actions for debugging
-    const parsedOutput = () => this.params.proofInvocationFactory.parseOutput(proof.output);
+    const parsedOutput = () =>
+      this.params.proofInvocationFactory.parseOutput(serverActionsCalldata);
     debugLog("private-transfers", "execute", "parsed server actions", parsedOutput);
 
     return {
@@ -80,7 +85,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
         call: {
           contractAddress: toHex(this.params.poolContractAddress),
           entrypoint: "apply_actions",
-          calldata: proof.output,
+          calldata: serverActionsCalldata,
         },
         proof,
       },

--- a/sdk/src/internal/proving-service-provider.ts
+++ b/sdk/src/internal/proving-service-provider.ts
@@ -58,7 +58,8 @@ export class ProvingServiceProofProvider implements ProofProviderInterface {
 
     const result = await this.provingService.proveTransaction(blockId, invocation);
 
-    // Server actions for execute_actions: from L2-to-L1 message payload (from_address = pool)
+    // L2-to-L1 message payload from the pool: [class_hash, ...serialized_actions].
+    // The consumer strips the class_hash prefix before calling apply_actions.
     // TODO: Generalize this to support other projects.
     const poolAddressHex = toHex(invocation.sender_address);
     const poolMessage = result.l2_to_l1_messages?.find(

--- a/sdk/src/testing/mock-proof-provider.ts
+++ b/sdk/src/testing/mock-proof-provider.ts
@@ -11,6 +11,7 @@ import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js"
 import type { MockPoolContract } from "./mock-pool-contract.js";
 import { bigintReviver } from "./mock-proof-invocation-factory.js";
 import { constants } from "starknet";
+import { buildMessagePayload } from "../utils/proof-facts.js";
 
 /**
  * Mock proof provider that executes actions on MockPoolContract.
@@ -40,8 +41,9 @@ export class MockProofProvider implements ProofProviderInterface {
 
     return {
       data: "",
-      // Store callbacks in output (duck-typed, will be extracted by MockPublicCallBuilder)
-      output: callbacks as unknown as string[],
+      // L2-to-L1 message payload: [class_hash, ...callbacks].
+      // The consumer strips the class_hash prefix before passing to apply_actions.
+      output: buildMessagePayload("0x0", callbacks as unknown as string[]),
       proofFacts: [],
     };
   }

--- a/sdk/src/testing/mock-proving.ts
+++ b/sdk/src/testing/mock-proving.ts
@@ -9,7 +9,7 @@ import type { constants, ETransactionVersion3, ProviderInterface } from "starkne
 import { EDAMode, encode, hash, num, stark } from "starknet";
 import type { Proof, ProofInvocation, ProofProviderInterface } from "../interfaces.js";
 import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js";
-import { buildProofFacts } from "../utils/proof-facts.js";
+import { buildProofFacts, buildMessagePayload } from "../utils/proof-facts.js";
 import { toBigInt } from "../utils/convert.js";
 import { extractExecuteViewCalldata } from "../internal/proof-invocation-factory.js";
 
@@ -66,9 +66,11 @@ export class CallMockProofProvider implements ProofProviderInterface {
       this.chainId
     );
 
-    // compile_actions returns Span<ServerAction> which is serialized with its length prefix.
-    // apply_actions also expects Span<ServerAction> with the length prefix, so we pass it through as-is.
-    return { output: result, data: undefined!, proofFacts };
+    // Return the full L2-to-L1 message payload: [class_hash, ...serialized_actions].
+    // This matches the real proving service behavior. The consumer must strip the
+    // class_hash prefix before passing to apply_actions.
+    const messagePayload = buildMessagePayload(poolClassHash, result);
+    return { output: messagePayload, data: undefined!, proofFacts };
   }
 
   /**

--- a/sdk/src/utils/proof-facts.ts
+++ b/sdk/src/utils/proof-facts.ts
@@ -18,7 +18,7 @@
 
 import { ec, hash } from "starknet";
 import { shortStringToFelt } from "./crypto.js";
-import { toBigInt } from "./convert.js";
+import { toBigInt, toHex } from "./convert.js";
 import type { BigNumberish } from "starknet";
 
 const PROOF_VERSION = shortStringToFelt("PROOF0");
@@ -53,23 +53,35 @@ function computeVirtualOsConfigHash(
 
 /**
  * Compute the message hash matching Cairo's _compute_message_hash:
- *   `hash([contract_address, 0, payload_len, ...serialized_actions])`
- * where hash = poseidon_hash_span.
+ *   `poseidon([pool_address, 0, payload_len, class_hash, ...serialized_actions])`
  */
 function computeMessageHash(
   poolAddress: BigNumberish,
   poolClassHash: BigNumberish,
   serverActionsCalldata: string[]
 ): bigint {
-  const payloadLen = BigInt(serverActionsCalldata.length + 1);
+  const messagePayload = buildMessagePayload(poolClassHash, serverActionsCalldata);
   const feltValues = [
     toBigInt(poolAddress),
     0n,
-    payloadLen,
-    toBigInt(poolClassHash),
-    ...serverActionsCalldata.map(toBigInt),
+    BigInt(messagePayload.length),
+    ...messagePayload.map(toBigInt),
   ];
   return ec.starkCurve.poseidonHashMany(feltValues);
+}
+
+/**
+ * Build the L2-to-L1 message payload matching Cairo's compute_message_hash:
+ *   `[class_hash, ...serialized_actions]`
+ *
+ * This is what the proving service returns in the L2-to-L1 message payload,
+ * and what the message hash is computed over (after prepending pool_addr, 0, payload_len).
+ */
+export function buildMessagePayload(
+  poolClassHash: BigNumberish,
+  serverActionsCalldata: string[]
+): string[] {
+  return [toHex(poolClassHash), ...serverActionsCalldata];
 }
 
 /**

--- a/sdk/tests/fixtures/cairo-reference-data.json
+++ b/sdk/tests/fixtures/cairo-reference-data.json
@@ -44,6 +44,8 @@
       "0x1",
       "0x6ecbe1e6bce2468d4f9241154bb6c545aed378aa89a661e18f9f8af9a3add9e"
     ],
+    "messagePayloadLength": 7,
+    "messagePayload": ["0x12345", "0x1", "0x0", "0x111", "0x2", "0x222", "0x333"],
     "virtualSnos": "0x5649525455414c5f534e4f53",
     "virtualSnos0": "0x5649525455414c5f534e4f5330"
   },

--- a/sdk/tests/utils/proof-facts.test.ts
+++ b/sdk/tests/utils/proof-facts.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { buildProofFacts } from "../../src/utils/proof-facts.js";
+import { buildProofFacts, buildMessagePayload } from "../../src/utils/proof-facts.js";
 import { shortStringToFelt } from "../../src/utils/crypto.js";
 import { hash, constants } from "starknet";
 import referenceData from "../fixtures/cairo-reference-data.json" with { type: "json" };
@@ -55,6 +55,15 @@ describe("ProofFacts Compatibility with Cairo", () => {
 
     // [6] is starknet_os_config_hash
     expect(proofFacts[6]).toBe(expectedConfigHash);
+  });
+
+  it("buildMessagePayload matches Cairo: [class_hash, ...serialized_actions]", () => {
+    const messagePayload = buildMessagePayload(
+      reference.poolClassHash,
+      reference.serializedActions
+    );
+
+    expect(messagePayload).toEqual(reference.messagePayload);
   });
 
   it("buildProofFacts produces correct layout", () => {


### PR DESCRIPTION
## Summary

  - Fix `proof.output` → `apply_actions` calldata mismatch: the L2-to-L1 message payload is
  `[class_hash, ...serialized_actions]`, but `apply_actions` expects only `Span<ServerAction>`
  - Add `buildMessagePayload()` utility verified against Cairo reference vector, used by both mock
  proof providers
  - Strip the class_hash prefix in `private-transfers.ts` before building `apply_actions` calldata

  ## Context

  The proving service simulates tx execution and returns L2-to-L1 messages. The pool contract's
  `compute_message_hash` serializes the payload as `[class_hash, ...serialized_actions]`.
  Previously, `ProvingServiceProofProvider` passed this full payload as `proof.output`, which
  became `apply_actions` calldata — causing a deserialization failure on-chain.

  The bug was hidden because `CallMockProofProvider` (used in devnet tests) returned
  `compile_actions` output directly (no class_hash prefix), bypassing the real payload format
  entirely.

  ## Test plan

  - [x] `buildMessagePayload` unit test against Cairo fixture (proof-facts.test.ts)
  - [x] Devnet integration test: deposit + transfer succeeds (devnet.test.ts)
  - [x] Mock integration tests: 8 tests pass (integration.test.ts)
  - [x] Full SDK suite: 152 tests pass
  - [x] `npm run lint` clean (prettier + eslint + tsc)
  - [x] E2E with real proving service (requires proving service deployment)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/610)
<!-- Reviewable:end -->
