### PR TITLE
fix(discovery): serialize u128 as string to avoid precision loss

### DIFF
--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use starknet_types_core::felt::Felt;
 
 use tracing::{debug, trace};
@@ -28,7 +28,26 @@ use crate::privacy_pool::hashes::{compute_note_id, compute_nullifier};
 use crate::privacy_pool::types::SecretFelt;
 use crate::privacy_pool::views::IViews;
 
+/// Serde helper: serializes `u128` as a decimal string to avoid
+/// precision loss in JSON (JS numbers are 53-bit floats).
+mod u128_as_string {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(value: &u128, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u128, D::Error> {
+        let s: &str = Deserialize::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 /// A discovered and decrypted note.
+///
+/// `amount` and `salt` are serialized as decimal strings to avoid
+/// precision loss when transported via JSON (JavaScript numbers are
+/// IEEE 754 doubles with only 53 bits of mantissa).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecryptedNote {
     /// The sender's address. Set by the sync orchestrator after discovery.
@@ -42,8 +61,10 @@ pub struct DecryptedNote {
     /// The note ID (storage key).
     pub note_id: Felt,
     /// The decrypted amount.
+    #[serde(with = "u128_as_string")]
     pub amount: u128,
     /// The salt used for encryption.
+    #[serde(with = "u128_as_string")]
     pub salt: u128,
 }
 

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -64,8 +64,8 @@ type ApiIncomingNoteInfo = {
   token: string;
   index: number;
   note_id: string;
-  amount: number;
-  salt: number;
+  amount: string;
+  salt: string;
 };
 
 type ApiOutgoingChannel = {
@@ -578,7 +578,7 @@ export function convertIncomingNotes(
       amount: BigInt(n.amount),
       witness: new Witness(channelKey, n.index, BigInt(n.salt)),
       sender,
-      open: n.salt === 1,
+      open: n.salt === "1",
     });
   }
   return result;

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -104,8 +104,8 @@ function noteEntry(overrides: Partial<Record<string, unknown>> = {}) {
     token: TOKEN_ADDR,
     index: 0,
     note_id: "0xde1",
-    amount: 100,
-    salt: 42,
+    amount: "100",
+    salt: "42",
     ...overrides,
   };
 }
@@ -170,7 +170,7 @@ describe("IndexerDiscoveryProvider", () => {
         {
           body: incomingSyncResponse({
             channels: [{ channel_key: CHANNEL_KEY_1, sender_addr: SENDER_ADDR }],
-            notes: [noteEntry({ amount: 50, salt: 10 })],
+            notes: [noteEntry({ amount: "50", salt: "10" })],
             cursor: incompleteCursor({
               [SENDER_ADDR]: { channel_key: CHANNEL_KEY_1 },
             }),
@@ -178,7 +178,7 @@ describe("IndexerDiscoveryProvider", () => {
         },
         {
           body: incomingSyncResponse({
-            notes: [noteEntry({ index: 1, note_id: "0xde2", amount: 75, salt: 20 })],
+            notes: [noteEntry({ index: 1, note_id: "0xde2", amount: "75", salt: "20" })],
             cursor: completeCursor({
               [SENDER_ADDR]: {
                 channel_key: CHANNEL_KEY_1,
@@ -210,8 +210,8 @@ describe("IndexerDiscoveryProvider", () => {
         body: incomingSyncResponse({
           channels: [{ channel_key: CHANNEL_KEY_1, sender_addr: SENDER_ADDR }],
           notes: [
-            noteEntry({ amount: 50, salt: 1 }),
-            noteEntry({ token: TOKEN_ADDR_2, note_id: "0xde2", amount: 75, salt: 2 }),
+            noteEntry({ amount: "50", salt: "1" }),
+            noteEntry({ token: TOKEN_ADDR_2, note_id: "0xde2", amount: "75", salt: "2" }),
           ],
           cursor: completeCursor({
             [SENDER_ADDR]: {
@@ -525,8 +525,8 @@ describe("IndexerDiscoveryProvider", () => {
 
     it("convertIncomingNotes filters by token", () => {
       const apiNotes = [
-        noteEntry({ note_id: "0xe1", salt: 5 }),
-        noteEntry({ token: TOKEN_ADDR_2, note_id: "0xe2", amount: 200, salt: 6 }),
+        noteEntry({ note_id: "0xe1", salt: "5" }),
+        noteEntry({ token: TOKEN_ADDR_2, note_id: "0xe2", amount: "200", salt: "6" }),
       ];
       const channelKeyMap = new Map<string, bigint>([[SENDER_ADDR, 0xcc1n]]);
       const existingChannels = new AddressMap<IncomingChannelCursor>();


### PR DESCRIPTION
### TL;DR

Fixed precision loss for large numbers when serializing notes to JSON by converting `u128` fields to strings.

### What changed?

- Added custom serde serialization for `amount` and `salt` fields in `DecryptedNote` to serialize as decimal strings instead of numbers
- Updated TypeScript types to expect `amount` and `salt` as strings rather than numbers
- Modified the salt comparison logic to check against string `"1"` instead of number `1`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/612)
<!-- Reviewable:end -->
