### PR TITLE
feat(discovery): support get_storage_at with last update block

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install starknet-devnet
         run: |
-          curl -L https://github.com/m-kus/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-11/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
+          curl -L https://github.com/starkware-libs/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-19/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
           chmod +x /usr/local/bin/starknet-devnet
 
       - name: Rust test

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install starknet-devnet
         run: |
-          curl -L https://github.com/m-kus/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-11/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
+          curl -L https://github.com/starkware-libs/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-19/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
           chmod +x /usr/local/bin/starknet-devnet
 
       - name: Install npm dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +123,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,12 +209,6 @@ dependencies = [
  "rand 0.8.5",
  "tokio",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -278,8 +283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -303,16 +316,6 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -356,10 +359,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const_format"
@@ -457,11 +479,12 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
 dependencies = [
- "generic-array",
+ "hybrid-array",
+ "num-traits",
  "subtle",
  "zeroize",
 ]
@@ -474,15 +497,6 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -556,9 +570,9 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "starknet-core",
- "starknet-crypto",
- "starknet-providers",
+ "starknet-rust-core",
+ "starknet-rust-crypto",
+ "starknet-rust-providers",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -588,11 +602,10 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "starknet",
- "starknet-core",
- "starknet-crypto",
- "starknet-providers",
- "starknet-tokio-tungstenite",
+ "starknet-rust-core",
+ "starknet-rust-crypto",
+ "starknet-rust-providers",
+ "starknet-rust-tokio-tungstenite",
  "starknet-types-core",
  "tempfile",
  "thiserror 2.0.18",
@@ -629,6 +642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,32 +679,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest",
- "hex",
- "hmac",
- "pbkdf2",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "serde_json",
- "sha2",
- "sha3",
- "thiserror 1.0.69",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "ethbloom"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -696,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+checksum = "f7326303c6c18bb03c7a3c4c22d4032ae60dfe673ca9109602aa4d8154b2637e"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -765,19 +762,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -787,6 +775,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -963,7 +957,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1039,6 +1033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,23 +1078,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1100,7 +1086,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1259,27 +1245,27 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
  "rlp",
 ]
 
 [[package]]
 name = "impl-serde"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
 dependencies = [
  "serde",
 ]
@@ -1319,15 +1305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1340,38 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1524,24 +1533,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.21.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
+ "uuid",
 ]
 
 [[package]]
@@ -1612,48 +1604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1707,15 +1661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,12 +1677,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1781,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -1832,10 +1771,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2005,11 +1945,11 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2019,23 +1959,20 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -2044,7 +1981,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2073,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -2112,8 +2048,8 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2143,11 +2079,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2166,12 +2130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "cipher",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2212,18 +2176,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2",
- "salsa20",
- "sha2",
-]
 
 [[package]]
 name = "security-framework"
@@ -2346,7 +2298,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2463,79 +2415,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "starknet"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ed01c14136e56dcdf21385d20c4a6fdd3509947cb56cca45fc765ef5809add"
+name = "starknet-rust-core"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
- "starknet-accounts",
- "starknet-contract",
- "starknet-core",
- "starknet-core-derive",
- "starknet-crypto",
- "starknet-macros",
- "starknet-providers",
- "starknet-signers",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7c118729bcdcfa1610844047cbdb23090fb1d4172a36bb97a663be8d022d1a"
-dependencies = [
- "async-trait",
- "auto_impl",
- "starknet-core",
- "starknet-crypto",
- "starknet-providers",
- "starknet-signers",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb64331b72caf51c0d8b684b62012f9a771015b4cf5e52cba9bf61be8384ad3"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "starknet-accounts",
- "starknet-core",
- "starknet-providers",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb7212226769766c1c7d79b70f9242ffbd213290a41604ecc7e78faa0ed0deb"
-dependencies = [
- "base64 0.21.7",
+ "base64",
  "crypto-bigint",
  "flate2",
- "foldhash",
+ "foldhash 0.2.0",
  "hex",
  "indexmap 2.13.0",
  "num-traits",
+ "semver",
  "serde",
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-core-derive",
- "starknet-crypto",
+ "starknet-rust-core-derive",
+ "starknet-rust-crypto",
  "starknet-types-core",
 ]
 
 [[package]]
-name = "starknet-core-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
+name = "starknet-rust-core-derive"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2543,12 +2448,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-crypto"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a16c25dc6113c19d4f9d0c19ff97d85804829894bba22c0d0e9e7b249812"
+name = "starknet-rust-crypto"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
+ "blake2",
  "crypto-bigint",
+ "digest",
  "hex",
  "hmac",
  "num-bigint",
@@ -2556,35 +2462,23 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve",
+ "starknet-rust-curve",
  "starknet-types-core",
  "zeroize",
 ]
 
 [[package]]
-name = "starknet-curve"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c898ae81b6409532374cf237f1bd752d068b96c6ad500af9ebbd0d9bb712f6"
+name = "starknet-rust-curve"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
-name = "starknet-macros"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d59e1eb22f4366385b132ba7016faa5a6457f1f23f896f737a06da626455e7b"
-dependencies = [
- "starknet-core",
- "syn",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fc3d94cc008cea64e291b261e8349065424ee7491e5dd0fa9bd688818bece1"
+name = "starknet-rust-providers"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2596,41 +2490,23 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core",
- "thiserror 1.0.69",
+ "starknet-rust-core",
+ "thiserror 2.0.18",
  "url",
 ]
 
 [[package]]
-name = "starknet-signers"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d839b06d899ef3a0de11b1e9a91a14c118b1ed36830ec8e59d9fbc9a1e51976b"
-dependencies = [
- "async-trait",
- "auto_impl",
- "crypto-bigint",
- "eth-keystore",
- "getrandom 0.2.17",
- "rand 0.8.5",
- "starknet-core",
- "starknet-crypto",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-tokio-tungstenite"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394d8339f76ad377a7a3158726b63fee11f008ddb0a598e1ea4dc3ad3c72985c"
+name = "starknet-rust-tokio-tungstenite"
+version = "0.19.0-rc.0"
+source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "futures-util",
  "log",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "starknet-core",
- "starknet-providers",
+ "starknet-rust-core",
+ "starknet-rust-providers",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -2892,16 +2768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2913,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -3129,9 +2995,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3155,9 +3021,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uint"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -3215,16 +3081,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.17",
- "serde",
-]
-
-[[package]]
-name = "uuid"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
@@ -3241,16 +3097,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3399,12 +3259,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3479,6 +3348,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3502,6 +3380,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3539,6 +3432,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3551,6 +3450,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3560,6 +3465,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3587,6 +3498,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3596,6 +3513,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3611,6 +3534,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3620,6 +3549,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/discovery-core/Cargo.toml
+++ b/crates/discovery-core/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 thiserror = "1.0"
 async-trait = "0.1"
 num-traits = "0.2"
-starknet-core = "0.16"
-starknet-crypto = "0.8"
+starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
+starknet-crypto = { package = "starknet-rust-crypto", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = { version = "0.2", features = ["curve", "serde"] }
-starknet-providers = "0.16"
+starknet-providers = { package = "starknet-rust-providers", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 url = "2"

--- a/crates/discovery-core/src/events_backend.rs
+++ b/crates/discovery-core/src/events_backend.rs
@@ -90,6 +90,8 @@ pub fn mock_event(
         block_hash: None,
         block_number: Some(block_number),
         transaction_hash,
+        event_index: 0,
+        transaction_index: 0,
     }
 }
 

--- a/crates/discovery-core/src/privacy_pool/views.rs
+++ b/crates/discovery-core/src/privacy_pool/views.rs
@@ -7,6 +7,7 @@ use starknet_types_core::felt::Felt;
 use super::storage_slots;
 use super::types::{EncChannelInfo, EncOutgoingChannelInfo, EncPrivateKey, EncSubchannelInfo};
 use crate::storage_backend::{RawStorageAccess, StorageError};
+use starknet_core::types::StorageResult;
 
 /// Privacy contract view methods.
 #[async_trait]
@@ -107,6 +108,12 @@ pub trait IViews: Send + Sync {
     ///
     /// Returns a `Vec<bool>` matching the input length. `true` = spent.
     async fn nullifier_exists_batch(&self, nullifiers: &[Felt]) -> Result<Vec<bool>, StorageError>;
+
+    /// Batch-reads note values with their last-update block numbers.
+    async fn get_notes_batch_with_block(
+        &self,
+        note_ids: &[Felt],
+    ) -> Result<Vec<StorageResult>, StorageError>;
 }
 
 /// Blanket implementation of `IViews` for any type implementing `RawStorageAccess`.
@@ -252,5 +259,22 @@ impl<T: RawStorageAccess> IViews for T {
             .collect();
         let values = self.read_slots(slots).await?;
         Ok(values.iter().map(|v| *v != Felt::ZERO).collect())
+    }
+
+    #[tracing::instrument(
+        name = "get_notes_batch_with_block",
+        level = "debug",
+        skip(self, note_ids),
+        fields(count = note_ids.len())
+    )]
+    async fn get_notes_batch_with_block(
+        &self,
+        note_ids: &[Felt],
+    ) -> Result<Vec<StorageResult>, StorageError> {
+        let slots: Vec<_> = note_ids
+            .iter()
+            .map(|&nid| storage_slots::notes(nid))
+            .collect();
+        self.read_slots_with_block(slots).await
     }
 }

--- a/crates/discovery-core/src/storage_backend.rs
+++ b/crates/discovery-core/src/storage_backend.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use starknet_core::types::BlockId;
+use starknet_core::types::{BlockId, StorageResult};
 use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
@@ -39,6 +39,12 @@ pub trait RawStorageAccess: Send + Sync {
     ///
     /// The returned `Vec` must have the same length as `slots`.
     async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError>;
+
+    /// Reads multiple storage slots with their last-update block numbers.
+    async fn read_slots_with_block(
+        &self,
+        slots: Vec<Felt>,
+    ) -> Result<Vec<StorageResult>, StorageError>;
 }
 
 /// Factory for creating storage snapshots bound to a specific block.
@@ -68,24 +74,35 @@ pub trait StorageSnapshot: IViews {
 #[derive(Clone)]
 pub struct MockBackend {
     slots: HashMap<Felt, Felt>,
+    last_update_blocks: HashMap<Felt, u64>,
 }
 
 impl MockBackend {
     /// Creates a new mock backend with the given slot->value mapping.
     pub fn new(slots: HashMap<Felt, Felt>) -> Self {
-        Self { slots }
+        Self {
+            slots,
+            last_update_blocks: HashMap::new(),
+        }
     }
 
     /// Creates an empty mock backend.
     pub fn empty() -> Self {
         Self {
             slots: HashMap::new(),
+            last_update_blocks: HashMap::new(),
         }
     }
 
     /// Inserts or replaces a slot->value pair into the mock storage.
     pub fn insert(&mut self, slot: Felt, value: Felt) {
         self.slots.insert(slot, value);
+    }
+
+    /// Inserts a slot->value pair with an associated last-update block number.
+    pub fn insert_with_block(&mut self, slot: Felt, value: Felt, last_update_block: u64) {
+        self.slots.insert(slot, value);
+        self.last_update_blocks.insert(slot, last_update_block);
     }
 }
 
@@ -99,6 +116,19 @@ impl RawStorageAccess for MockBackend {
         Ok(slots
             .iter()
             .map(|s| self.slots.get(s).copied().unwrap_or(Felt::ZERO))
+            .collect())
+    }
+
+    async fn read_slots_with_block(
+        &self,
+        slots: Vec<Felt>,
+    ) -> Result<Vec<StorageResult>, StorageError> {
+        Ok(slots
+            .iter()
+            .map(|s| StorageResult {
+                value: self.slots.get(s).copied().unwrap_or(Felt::ZERO),
+                last_update_block: self.last_update_blocks.get(s).copied().unwrap_or(0),
+            })
             .collect())
     }
 }
@@ -158,5 +188,43 @@ mod tests {
             backend.read_slot(Felt::ONE).await.unwrap(),
             Felt::from(100u64)
         );
+    }
+
+    #[tokio::test]
+    async fn test_read_slots_with_block_default() {
+        let mut slots = HashMap::new();
+        slots.insert(Felt::ONE, Felt::from(42u64));
+        let backend = MockBackend::new(slots);
+
+        let results = backend
+            .read_slots_with_block(vec![Felt::ONE, Felt::TWO])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].value, Felt::from(42u64));
+        assert_eq!(results[0].last_update_block, 0);
+        assert_eq!(results[1].value, Felt::ZERO);
+        assert_eq!(results[1].last_update_block, 0);
+    }
+
+    #[tokio::test]
+    async fn test_read_slots_with_block_with_data() {
+        let mut backend = MockBackend::empty();
+        backend.insert_with_block(Felt::ONE, Felt::from(42u64), 100);
+        backend.insert_with_block(Felt::TWO, Felt::from(99u64), 200);
+
+        let results = backend
+            .read_slots_with_block(vec![Felt::ONE, Felt::TWO, Felt::THREE])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].value, Felt::from(42u64));
+        assert_eq!(results[0].last_update_block, 100);
+        assert_eq!(results[1].value, Felt::from(99u64));
+        assert_eq!(results[1].last_update_block, 200);
+        assert_eq!(results[2].value, Felt::ZERO);
+        assert_eq!(results[2].last_update_block, 0);
     }
 }

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -20,16 +20,15 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "process", "io-util"] }
 
 # StarkNet
-starknet = "0.17"
-starknet-core = "0.16"
-starknet-providers = "0.16"
+starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
+starknet-providers = { package = "starknet-rust-providers", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = "0.2"
-starknet-tokio-tungstenite = "0.3"
+starknet-tokio-tungstenite = { package = "starknet-rust-tokio-tungstenite", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 url = "2"
 
 # HTTP
 axum = "0.8"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.13", features = ["json"] }
 tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors", "timeout"] }
 
@@ -42,7 +41,7 @@ thiserror = "2"
 backoff = { version = "0.4", features = ["tokio"] }
 
 # Crypto
-starknet-crypto = "0.8"
+starknet-crypto = { package = "starknet-rust-crypto", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 
 # Cache
 moka = { version = "0.12", features = ["sync"] }
@@ -64,6 +63,6 @@ flate2 = "1.0"
 libc = "0.2"
 nix = { version = "0.29", features = ["signal"] }
 serde_json = "1.0"
-starknet-core = "0.16"
+starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = { version = "0.2", features = ["serde"] }
 tempfile = "3"

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -501,6 +501,13 @@ mod tests {
             async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError> {
                 self.backend.read_slots(slots).await
             }
+
+            async fn read_slots_with_block(
+                &self,
+                slots: Vec<Felt>,
+            ) -> Result<Vec<starknet_core::types::StorageResult>, StorageError> {
+                self.backend.read_slots_with_block(slots).await
+            }
         }
 
         #[async_trait::async_trait]

--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -2,7 +2,7 @@
 
 use backoff::ExponentialBackoffBuilder;
 use backoff::{backoff::Backoff, ExponentialBackoff};
-use starknet::core::types::ConfirmedBlockId;
+use starknet_core::types::ConfirmedBlockId;
 use starknet_tokio_tungstenite::{NewHeadsUpdate, TungsteniteStream};
 use thiserror::Error;
 use tokio::sync::broadcast;

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -8,8 +8,9 @@ use discovery_core::storage_backend::{
     RawStorageAccess, StorageBackend, StorageError, StorageSnapshot,
 };
 use starknet_core::types::{
-    requests::GetStorageAtRequest, BlockId, BlockTag, EmittedEvent, EventFilter, Felt,
-    MaybePreConfirmedBlockWithTxHashes, StarknetError,
+    requests::GetStorageAtRequest, AddressFilter, BlockId, BlockTag, EmittedEvent, EventFilter,
+    Felt, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey,
+    StorageResponseFlag, StorageResult,
 };
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
@@ -118,8 +119,13 @@ pub struct RpcSnapshot {
 }
 
 impl RpcSnapshot {
-    /// Executes a single JSON-RPC batch request for the given slots.
-    async fn batch_read(&self, slots: &[Felt]) -> Result<Vec<Felt>, StorageError> {
+    /// Builds and sends a batch `get_storage_at` request for the given slots,
+    /// optionally including response flags (e.g. `IncludeLastUpdateBlock`).
+    async fn send_batch_storage_request(
+        &self,
+        slots: &[Felt],
+        response_flags: Option<Vec<StorageResponseFlag>>,
+    ) -> Result<Vec<ProviderResponseData>, StorageError> {
         let contract_address = self.contract_address;
 
         let requests: Vec<ProviderRequestData> = slots
@@ -127,14 +133,14 @@ impl RpcSnapshot {
             .map(|&slot| {
                 ProviderRequestData::GetStorageAt(GetStorageAtRequest {
                     contract_address,
-                    key: slot,
+                    key: StorageKey(format!("{slot:#x}")),
                     block_id: self.block_id,
+                    response_flags: response_flags.clone(),
                 })
             })
             .collect();
 
-        let responses = self
-            .backend
+        self.backend
             .inner
             .provider
             .batch_requests(&requests)
@@ -144,12 +150,34 @@ impl RpcSnapshot {
                     StorageError::ContractNotFound
                 }
                 _ => StorageError::from(RpcBackendError::Request(e.to_string())),
-            })?;
+            })
+    }
 
-        responses
+    /// Executes a batch `get_storage_at` request (values only).
+    async fn batch_read(&self, slots: &[Felt]) -> Result<Vec<Felt>, StorageError> {
+        self.send_batch_storage_request(slots, None)
+            .await?
             .into_iter()
             .map(|resp| match resp {
-                ProviderResponseData::GetStorageAt(value) => Ok(value),
+                ProviderResponseData::GetStorageAt(result) => Ok(result.value()),
+                _ => Err(RpcBackendError::UnexpectedResponseType.into()),
+            })
+            .collect()
+    }
+
+    /// Executes a batch `get_storage_at` request with `IncludeLastUpdateBlock` flag.
+    async fn batch_read_with_block(
+        &self,
+        slots: &[Felt],
+    ) -> Result<Vec<StorageResult>, StorageError> {
+        let flags = vec![StorageResponseFlag::IncludeLastUpdateBlock];
+        self.send_batch_storage_request(slots, Some(flags))
+            .await?
+            .into_iter()
+            .map(|resp| match resp {
+                ProviderResponseData::GetStorageAt(GetStorageAtResult::ValueWithMetadata(
+                    result,
+                )) => Ok(result),
                 _ => Err(RpcBackendError::UnexpectedResponseType.into()),
             })
             .collect()
@@ -162,8 +190,9 @@ impl RawStorageAccess for RpcSnapshot {
         self.backend
             .inner
             .provider
-            .get_storage_at(self.contract_address, slot, self.block_id)
+            .get_storage_at(self.contract_address, slot, self.block_id, None)
             .await
+            .map(|result| result.value())
             .map_err(|e| match &e {
                 ProviderError::StarknetError(StarknetError::ContractNotFound) => {
                     StorageError::ContractNotFound
@@ -181,9 +210,24 @@ impl RawStorageAccess for RpcSnapshot {
         }
 
         let mut results = Vec::with_capacity(slots.len());
-        // TODO: consider provessing chunks concurrently
         for chunk in slots.chunks(self.backend.inner.max_batch_size) {
             let chunk_results = self.batch_read(chunk).await?;
+            results.extend(chunk_results);
+        }
+        Ok(results)
+    }
+
+    async fn read_slots_with_block(
+        &self,
+        slots: Vec<Felt>,
+    ) -> Result<Vec<StorageResult>, StorageError> {
+        if slots.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut results = Vec::with_capacity(slots.len());
+        for chunk in slots.chunks(self.backend.inner.max_batch_size) {
+            let chunk_results = self.batch_read_with_block(chunk).await?;
             results.extend(chunk_results);
         }
         Ok(results)
@@ -222,7 +266,7 @@ impl RawEventAccess for RpcSnapshot {
         let filter = EventFilter {
             from_block: Some(BlockId::Number(from_block)),
             to_block: Some(BlockId::Number(to_block)),
-            address: Some(self.contract_address),
+            address: Some(AddressFilter::Single(self.contract_address)),
             keys: if trimmed_keys.is_empty() {
                 None
             } else {

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -17,8 +17,9 @@ mod common;
 
 use common::setup_devnet_with_dump;
 use discovery_core::privacy_pool::events::{IEvents, PrivacyPoolEventContent};
+use discovery_core::privacy_pool::storage_slots;
 use discovery_core::privacy_pool::views::IViews;
-use discovery_core::storage_backend::StorageBackend;
+use discovery_core::storage_backend::{RawStorageAccess, StorageBackend};
 use discovery_service::chain_state::ChainState;
 use discovery_service::config::RpcConfig;
 use discovery_service::rpc_backend::RpcBackend;
@@ -145,4 +146,40 @@ async fn test_withdrawal_events_empty_for_non_recipient() {
         .unwrap();
 
     assert!(withdrawals.is_empty());
+}
+
+#[tokio::test]
+async fn test_read_slots_with_block() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+
+    let rpc_config = RpcConfig {
+        url: devnet.rpc_url(),
+        ..Default::default()
+    };
+    let backend = RpcBackend::new(rpc_config).unwrap();
+    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+
+    // Query a slot known to be written during fixture generation (Alice's public key)
+    let alice_pubkey_slot = storage_slots::public_key(metadata.alice_address);
+    // Query a slot that was never written (random address)
+    let unset_slot = storage_slots::public_key(Felt::from_hex("0xdeadbeef").unwrap());
+
+    let results = snapshot
+        .read_slots_with_block(vec![alice_pubkey_slot, unset_slot])
+        .await
+        .unwrap();
+
+    // Written slot: non-zero value and block_number > 0
+    expect![[r#"
+        0x07913e4dbbc06e873598f6e0bb0076449079fbdd951650c7f7a258d1c6b6a82d
+    "#]]
+    .assert_eq(&format!("{:#066x}\n", results[0].value));
+    assert!(
+        results[0].last_update_block > 0,
+        "written slot should have non-zero last_update_block"
+    );
+
+    // Unset slot: zero value and last_update_block == 0
+    assert_eq!(results[1].value, Felt::ZERO);
+    assert_eq!(results[1].last_update_block, 0);
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -414,7 +414,7 @@ sequenceDiagram
 
 ## Starknet Devnet
 
-SDK tests use a [custom fork of starknet-devnet](https://github.com/m-kus/starknet-devnet) that includes a blockifier version supporting the new transaction version with proofs. Install from the `APOLLO-PRE-PROOF-DEMO-11` release:
+SDK tests use a [custom fork of starknet-devnet](https://github.com/starkware-libs/starknet-devnet) that includes a blockifier version supporting the new transaction version with proofs. Install from the `APOLLO-PRE-PROOF-DEMO-19` release:
 
 If you have a previous asdf installation of starknet-devnet, remove it first:
 
@@ -426,13 +426,13 @@ Then install from the release:
 
 ```bash
 # macOS (Apple Silicon)
-curl -L https://github.com/m-kus/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-11/starknet-devnet-aarch64-apple-darwin.tar.gz -o /tmp/starknet-devnet.tar.gz
+curl -L https://github.com/starkware-libs/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-19/starknet-devnet-aarch64-apple-darwin.tar.gz -o /tmp/starknet-devnet.tar.gz
 sudo tar -xzf /tmp/starknet-devnet.tar.gz -C /usr/local/bin
 sudo chmod +x /usr/local/bin/starknet-devnet
 rm /tmp/starknet-devnet.tar.gz
 
 # Linux (x86_64)
-curl -L https://github.com/m-kus/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-11/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz -o /tmp/starknet-devnet.tar.gz
+curl -L https://github.com/starkware-libs/starknet-devnet/releases/download/APOLLO-PRE-PROOF-DEMO-19/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz -o /tmp/starknet-devnet.tar.gz
 sudo tar -xzf /tmp/starknet-devnet.tar.gz -C /usr/local/bin
 sudo chmod +x /usr/local/bin/starknet-devnet
 rm /tmp/starknet-devnet.tar.gz


### PR DESCRIPTION
- StorageValueWithBlock type + read_slots_with_block() on RawStorageAccess — new trait method that
returns storage values paired with their last-update block number, with a default impl that delegates to
read_slots (block_number=0)
- get_notes_batch_with_block() on IViews — convenience method that maps note IDs to storage slots and
calls read_slots_with_block
- RpcSnapshot::batch_read_with_block() — RPC implementation that sends IncludeLastUpdateBlock flag via
the patched starknet-rs fork
- MockBackend extended with block_numbers map and insert_with_block() for testing
- InsufficientBudget error variant added to DiscoveryError with API response mapping
- [patch.crates-io] in workspace Cargo.toml pointing starknet-core/providers to
m-kus/starknet-rs@get-storage-at-flags
- CI devnet bumped from APOLLO-PRE-PROOF-DEMO-11 to APOLLO-PRE-PROOF-DEMO-19 in both rust-ci and
typescript-ci workflows
- Integration test test_read_slots_with_block verifying the end-to-end flow against devnet (written slot
returns value + block > 0; unset slot returns zero + block 0)
- Unit tests for MockBackend's read_slots_with_block (default and with-data paths)

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" alt="Reviewable">](https://reviewable.io/reviews/starkware-libs/starknet-privacy/613)

<!-- Reviewable:end -->