### PR TITLE
fix(ci): update proving API spec path after sequencer crate rename

### DIFF
--- a/sdk/scripts/fetch-proving-api-spec.ts
+++ b/sdk/scripts/fetch-proving-api-spec.ts
@@ -18,7 +18,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const SPEC_PATH_IN_REPO =
-  "crates/starknet_os_runner/resources/proving_api_openrpc.json";
+  "crates/starknet_transaction_prover/resources/proving_api_openrpc.json";
 const REF = process.env.SEQUENCER_SPEC_REF ?? "main";
 const URL = `https://raw.githubusercontent.com/starkware-libs/sequencer/${REF}/${SPEC_PATH_IN_REPO}`;
 const OUT_PATH = join(__dirname, "..", "tests", "fixtures", "proving_api_openrpc.json");

--- a/sdk/tests/fixtures/proving_api_openrpc.json
+++ b/sdk/tests/fixtures/proving_api_openrpc.json
@@ -2,8 +2,8 @@
   "openrpc": "1.0.0-rc1",
   "info": {
     "version": "0.10.0",
-    "title": "Starknet OS Runner Proving API",
-    "description": "JSON-RPC API for proving Starknet transactions via the Starknet OS Runner.",
+    "title": "Starknet Transaction Prover API",
+    "description": "JSON-RPC API for proving Starknet transactions via the Starknet Transaction Prover.",
     "license": {
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
@@ -87,7 +87,7 @@
       },
       "BLOCK_ID": {
         "title": "Block id",
-        "description": "Identifies a block by hash, number, or tag.",
+        "description": "Identifies a finalized block by hash, number, or the \"latest\" tag.",
         "oneOf": [
           {
             "title": "Block hash",
@@ -115,7 +115,7 @@
           {
             "title": "Block tag",
             "type": "string",
-            "enum": ["latest", "pending"]
+            "enum": ["latest"]
           }
         ]
       },

--- a/sdk/tests/internal/proving-service-openrpc.test.ts
+++ b/sdk/tests/internal/proving-service-openrpc.test.ts
@@ -274,7 +274,8 @@ describe("ProvingService (proving-service.ts) vs OpenRPC spec", () => {
       const validate = compileSchemaForRef(spec!, "components/schemas/BLOCK_ID");
 
       expect(validate("latest")).toBe(true);
-      expect(validate("pending")).toBe(true);
+      // "pending" was removed from BLOCK_ID in the proving API spec.
+      expect(validate("pending")).toBe(false);
       expect(validate({ block_number: 42 })).toBe(true);
       expect(validate({ block_number: 0 })).toBe(true);
       expect(validate({ block_hash: "0x123" })).toBe(true);


### PR DESCRIPTION
The starknet_os_runner crate was renamed to starknet_transaction_prover in starkware-libs/sequencer, breaking the spec fetch in CI.

- Update SPEC_PATH_IN_REPO to new crate path
- Pin SEQUENCER_SPEC_REF to commit SHA instead of branch name
- Update BLOCK_ID schema test: "pending" removed from spec

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/614)
<!-- Reviewable:end -->
