### PR TITLE
feat(discovery-core): buffered note scanner

### DIFF
--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -66,4 +66,10 @@ pub enum DiscoveryError {
     /// Invalid cursor data provided by client.
     #[error("invalid cursor: {0}")]
     InvalidCursor(String),
+    /// The I/O budget is too small to make progress.
+    #[error("insufficient budget: needed {needed}, available {available}")]
+    InsufficientBudget { needed: usize, available: usize },
+    /// Expected event not found on-chain.
+    #[error("missing event: {0}")]
+    EventError(String),
 }

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -22,7 +22,7 @@ use crate::discovery::cursor::SubchannelCursor;
 use crate::discovery::last_note_index::find_last_note_index;
 use crate::discovery::{DiscoveryError, COST_NOTE, COST_NOTE_PROBING};
 use crate::io_budget::IoBudget;
-use crate::privacy_pool::decryption::{decrypt_note_amount, unpack_note_amount, OPEN_NOTE_SALT};
+use crate::privacy_pool::decryption::{decrypt_packed_value, OPEN_NOTE_SALT};
 use crate::privacy_pool::felt_hex;
 use crate::privacy_pool::hashes::{compute_note_id, compute_nullifier};
 use crate::privacy_pool::types::SecretFelt;
@@ -294,12 +294,7 @@ fn decrypt_note(
     note_id: Felt,
     packed: Felt,
 ) -> DecryptedNote {
-    let (salt, enc_amount) = unpack_note_amount(packed);
-    let amount = if salt == OPEN_NOTE_SALT {
-        enc_amount
-    } else {
-        decrypt_note_amount(enc_amount, salt, channel_key, token, index)
-    };
+    let (amount, salt) = decrypt_packed_value(packed, channel_key, token, index);
     trace!(index, amount, salt, "unspent note found");
     DecryptedNote {
         sender_addr: Felt::ZERO, // set by the sync orchestrator after discovery

--- a/crates/discovery-core/src/history/mod.rs
+++ b/crates/discovery-core/src/history/mod.rs
@@ -1,0 +1,4 @@
+//! Backward history scanner for privacy pool operations.
+
+pub mod notes;
+pub mod types;

--- a/crates/discovery-core/src/history/notes.rs
+++ b/crates/discovery-core/src/history/notes.rs
@@ -1,0 +1,511 @@
+//! Backward history sync: storage-based note reading.
+//!
+//! Reads note values via `get_notes_batch_with_block` (batched storage reads)
+//! instead of scanning `NoteCreated` events. Each note's `last_update_block`
+//! tells us which block it was created in.
+
+use std::collections::HashMap;
+
+use tracing::trace;
+
+use super::types::{HistoryCursor, HistoryNote, HistorySubchannel};
+use crate::discovery::{DiscoveryError, COST_NOTE};
+use crate::io_budget::IoBudget;
+use crate::privacy_pool::decryption::decrypt_packed_value;
+use crate::privacy_pool::hashes::compute_note_id;
+use crate::privacy_pool::views::IViews;
+
+/// Buffered note scanner that yields one block of notes at a time.
+///
+/// Holds the intermediate buffer of fetched-but-not-yet-drained notes.
+/// Each call to [`BufferedNoteScanner::next_block`] fills empty slots, then drains
+/// all notes at the highest block.
+pub struct BufferedNoteScanner {
+    buffered_notes: HashMap<usize, (u64, HistoryNote)>,
+}
+
+impl Default for BufferedNoteScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BufferedNoteScanner {
+    pub fn new() -> Self {
+        Self {
+            buffered_notes: HashMap::new(),
+        }
+    }
+
+    /// Drains the next (highest) block of notes.
+    ///
+    /// 1. Fill empty buffer slots via `get_notes_batch_with_block`.
+    /// 2. Find the highest block among buffered notes.
+    /// 3. Drain all notes at that block, decrement their subchannel indices.
+    ///
+    /// Returns:
+    /// - `Ok(Some((block_number, notes)))` — got a block of notes
+    /// - `Ok(None)` — all subchannels exhausted
+    /// - `Err(InsufficientBudget)` — budget ran out
+    pub async fn next_block<V: IViews>(
+        &mut self,
+        views: &V,
+        cursor: &mut HistoryCursor,
+        budget: &IoBudget,
+    ) -> Result<Option<(u64, Vec<HistoryNote>)>, DiscoveryError> {
+        // Fill-then-drain loop. A single subchannel can have multiple
+        // consecutive notes in the same block; after draining the first and
+        // decrementing `next_index`, the refill may surface another note at
+        // the same block. Looping until no buffered note matches ensures
+        // the block is yielded exactly once.
+        let mut block_notes: Vec<HistoryNote> = Vec::new();
+        let mut block_number: Option<u64> = None;
+        loop {
+            self.fill_buffers(views, &cursor.subchannels, budget)
+                .await?;
+
+            let target_block = match block_number {
+                Some(b) => b,
+                None => match self.buffered_notes.values().map(|(b, _)| *b).max() {
+                    Some(b) => {
+                        block_number = Some(b);
+                        b
+                    }
+                    None => break,
+                },
+            };
+
+            if !self
+                .buffered_notes
+                .values()
+                .any(|(block, _)| *block == target_block)
+            {
+                break;
+            }
+
+            for (subchannel_index, (_, note)) in self
+                .buffered_notes
+                .extract_if(|_, (block, _)| *block == target_block)
+            {
+                block_notes.push(note);
+                let subchannel = &mut cursor.subchannels[subchannel_index];
+                subchannel.next_index = subchannel.next_index.and_then(|i| i.checked_sub(1));
+            }
+        }
+
+        trace!(
+            block_number,
+            drained_notes = block_notes.len(),
+            remaining_buffered = self.buffered_notes.len(),
+            note_ids = ?block_notes.iter().map(|n| format!("{:#x}", n.note_id)).collect::<Vec<_>>(),
+            "next_block: drained"
+        );
+
+        Ok(block_number.map(|block| (block, block_notes)))
+    }
+
+    /// Fills empty buffer slots by reading note storage for all active subchannels,
+    /// then enriching each with channel context and decrypted amount.
+    ///
+    /// Active subchannels are those that have no buffered result yet and haven't been
+    /// exhausted (`next_index` is `Some`).
+    ///
+    /// Returns `Ok(())` on success (including when no active subchannels).
+    /// Returns `Err(InsufficientBudget)` if budget is insufficient.
+    async fn fill_buffers<V: IViews>(
+        &mut self,
+        views: &V,
+        subchannels: &[HistorySubchannel],
+        budget: &IoBudget,
+    ) -> Result<(), DiscoveryError> {
+        let active_subchannels: Vec<_> = subchannels
+            .iter()
+            .enumerate()
+            .filter(|(subchannel_index, _)| !self.buffered_notes.contains_key(subchannel_index))
+            .filter_map(|(subchannel_index, subchannel)| {
+                let next_note_index = subchannel.next_index?;
+                let next_note_id =
+                    compute_note_id(&subchannel.channel_key, subchannel.token, next_note_index);
+                Some((subchannel_index, next_note_id, next_note_index))
+            })
+            .collect();
+
+        let cost = active_subchannels.len() * COST_NOTE;
+        trace!(
+            num_active = active_subchannels.len(),
+            num_buffered = self.buffered_notes.len(),
+            cost,
+            budget_remaining = budget.remaining(),
+            "fill_buffers: preparing batch read"
+        );
+
+        if !active_subchannels.is_empty() && !budget.consume(cost) {
+            trace!(
+                cost,
+                budget_remaining = budget.remaining(),
+                "fill_buffers: budget insufficient"
+            );
+            return Err(DiscoveryError::InsufficientBudget {
+                needed: cost,
+                available: budget.remaining(),
+            });
+        }
+
+        let note_ids: Vec<_> = active_subchannels
+            .iter()
+            .map(|&(_, next_note_id, _)| next_note_id)
+            .collect();
+
+        let storage_results = views.get_notes_batch_with_block(&note_ids).await?;
+
+        for (&(subchannel_index, note_id, next_note_index), result) in
+            active_subchannels.iter().zip(storage_results)
+        {
+            let subchannel = &subchannels[subchannel_index];
+            let (amount, salt) = decrypt_packed_value(
+                result.value,
+                &subchannel.channel_key,
+                subchannel.token,
+                next_note_index,
+            );
+            let note = HistoryNote {
+                channel_kind: subchannel.channel_kind,
+                token: subchannel.token,
+                note_index: next_note_index,
+                note_id,
+                counterparty: subchannel.counterparty,
+                amount,
+                salt,
+            };
+            self.buffered_notes
+                .insert(subchannel_index, (result.last_update_block, note));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starknet_types_core::felt::Felt;
+
+    use super::*;
+    use crate::discovery::DiscoveryError;
+    use crate::history::types::{ChannelKind, HistoryCursor, HistorySubchannel};
+    use crate::privacy_pool::decryption::OPEN_NOTE_SALT;
+    use crate::privacy_pool::hashes::compute_note_id;
+    use crate::privacy_pool::storage_slots;
+    use crate::privacy_pool::types::SecretFelt;
+    use crate::storage_backend::MockBackend;
+
+    fn test_channel_key() -> SecretFelt {
+        SecretFelt::new(Felt::from_hex_unchecked("0xCAFE"))
+    }
+
+    fn test_token() -> Felt {
+        Felt::from_hex_unchecked("0x12345")
+    }
+
+    fn test_counterparty() -> Felt {
+        Felt::from_hex_unchecked("0xBEEF")
+    }
+
+    fn test_subchannel(
+        channel_key: SecretFelt,
+        token: Felt,
+        next_index: Option<u64>,
+    ) -> HistorySubchannel {
+        HistorySubchannel {
+            channel_key,
+            token,
+            channel_kind: ChannelKind::Incoming,
+            counterparty: test_counterparty(),
+            next_index,
+        }
+    }
+
+    fn test_cursor(subchannels: Vec<HistorySubchannel>) -> HistoryCursor {
+        HistoryCursor {
+            subchannels,
+            begin_block_number: u64::MAX,
+            history_complete: false,
+        }
+    }
+
+    fn non_zero_packed() -> Felt {
+        Felt::from(0xDEADu64)
+    }
+
+    fn insert_note(
+        backend: &mut MockBackend,
+        channel_key: &SecretFelt,
+        token: Felt,
+        note_index: u64,
+        packed_value: Felt,
+        block_number: u64,
+    ) {
+        let note_id = compute_note_id(channel_key, token, note_index);
+        let slot = storage_slots::notes(note_id);
+        backend.insert_with_block(slot, packed_value, block_number);
+    }
+
+    #[tokio::test]
+    async fn next_block_empty_subchannels() {
+        let backend = MockBackend::empty();
+        let mut cursor = test_cursor(vec![]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        let result = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_block_single_note() {
+        let channel_key = test_channel_key();
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key, token, 0, packed_value, 10);
+
+        let mut cursor = test_cursor(vec![test_subchannel(channel_key.clone(), token, Some(0))]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(block_number, 10);
+        assert_eq!(notes.len(), 1);
+        assert_eq!(notes[0].note_index, 0);
+        assert_eq!(notes[0].channel_kind, ChannelKind::Incoming);
+        assert_eq!(notes[0].token, token);
+        assert_eq!(notes[0].counterparty, test_counterparty());
+        assert_eq!(
+            notes[0].note_id,
+            compute_note_id(&test_channel_key(), token, 0)
+        );
+        assert!(cursor.subchannels[0].next_index.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_block_returns_highest_block_first() {
+        let channel_key_a = SecretFelt::new(Felt::from_hex_unchecked("0xA1"));
+        let channel_key_b = SecretFelt::new(Felt::from_hex_unchecked("0xB2"));
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key_a, token, 0, packed_value, 100);
+        insert_note(&mut backend, &channel_key_b, token, 0, packed_value, 80);
+
+        let mut cursor = test_cursor(vec![
+            test_subchannel(channel_key_a, token, Some(0)),
+            test_subchannel(channel_key_b, token, Some(0)),
+        ]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        // First drain: highest block (100)
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 100);
+        assert_eq!(notes.len(), 1);
+
+        // Second drain: block 80
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 80);
+        assert_eq!(notes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn next_block_sequential_indices() {
+        let channel_key = test_channel_key();
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key, token, 0, packed_value, 10);
+        insert_note(&mut backend, &channel_key, token, 1, packed_value, 20);
+
+        let mut cursor = test_cursor(vec![test_subchannel(channel_key.clone(), token, Some(1))]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        // First: block 20, note index 1
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 20);
+        assert_eq!(notes[0].note_index, 1);
+        assert_eq!(cursor.subchannels[0].next_index, Some(0));
+
+        // Second: block 10, note index 0
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 10);
+        assert_eq!(notes[0].note_index, 0);
+        assert_eq!(cursor.subchannels[0].next_index, None);
+
+        // Third: exhausted — returns None
+        let result = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_block_zero_budget_returns_error() {
+        let channel_key = test_channel_key();
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key, token, 0, packed_value, 10);
+
+        let mut cursor = test_cursor(vec![test_subchannel(channel_key.clone(), token, Some(0))]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(0);
+
+        let error = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, DiscoveryError::InsufficientBudget { .. }),
+            "expected InsufficientBudget, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn next_block_open_note_returns_plaintext_amount() {
+        let channel_key = test_channel_key();
+        let token = test_token();
+
+        let amount: u128 = 42;
+        let packed = Felt::from(OPEN_NOTE_SALT) * Felt::from(1u128 << 64) * Felt::from(1u128 << 64)
+            + Felt::from(amount);
+
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key, token, 0, packed, 10);
+
+        let mut cursor = test_cursor(vec![test_subchannel(channel_key.clone(), token, Some(0))]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        let (_, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(notes[0].amount, 42);
+        assert_eq!(notes[0].salt, OPEN_NOTE_SALT);
+    }
+
+    #[tokio::test]
+    async fn next_block_completes_block_single_subchannel() {
+        let channel_key = test_channel_key();
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        // Two consecutive notes in the same block within one subchannel.
+        let mut backend = MockBackend::empty();
+        insert_note(&mut backend, &channel_key, token, 0, packed_value, 10);
+        insert_note(&mut backend, &channel_key, token, 1, packed_value, 10);
+
+        let mut cursor = test_cursor(vec![test_subchannel(channel_key.clone(), token, Some(1))]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        // Should yield both notes in a single call.
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(block_number, 10);
+        assert_eq!(notes.len(), 2);
+
+        let mut indices: Vec<u64> = notes.iter().map(|n| n.note_index).collect();
+        indices.sort();
+        assert_eq!(indices, vec![0, 1]);
+
+        // No more notes — exhausted.
+        let result = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_block_completes_block_across_subchannels() {
+        let channel_key_a = SecretFelt::new(Felt::from_hex_unchecked("0xA1"));
+        let channel_key_b = SecretFelt::new(Felt::from_hex_unchecked("0xB2"));
+        let token = test_token();
+        let packed_value = non_zero_packed();
+
+        let mut backend = MockBackend::empty();
+        // Subchannel A: two notes in block 10.
+        insert_note(&mut backend, &channel_key_a, token, 0, packed_value, 10);
+        insert_note(&mut backend, &channel_key_a, token, 1, packed_value, 10);
+        // Subchannel B: one note in block 5.
+        insert_note(&mut backend, &channel_key_b, token, 0, packed_value, 5);
+
+        let mut cursor = test_cursor(vec![
+            test_subchannel(channel_key_a, token, Some(1)),
+            test_subchannel(channel_key_b, token, Some(0)),
+        ]);
+        let mut scanner = BufferedNoteScanner::new();
+        let budget = IoBudget::new(100);
+
+        // First call: block 10 with both of A's notes.
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 10);
+        assert_eq!(notes.len(), 2);
+
+        // Second call: block 5 with B's note.
+        let (block_number, notes) = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(block_number, 5);
+        assert_eq!(notes.len(), 1);
+
+        // Exhausted.
+        let result = scanner
+            .next_block(&backend, &mut cursor, &budget)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/discovery-core/src/history/types.rs
+++ b/crates/discovery-core/src/history/types.rs
@@ -1,0 +1,71 @@
+//! Types for the backward history scan.
+
+use starknet_types_core::felt::Felt;
+
+use crate::privacy_pool::events::{DepositEvent, OpenNoteDepositedEvent, WithdrawalEvent};
+use crate::privacy_pool::types::SecretFelt;
+
+/// The relationship between the user and a channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelKind {
+    Incoming,
+    Outgoing,
+    SelfChannel,
+}
+
+/// A decrypted note enriched with channel context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryNote {
+    pub channel_kind: ChannelKind,
+    pub token: Felt,
+    pub note_index: u64,
+    pub note_id: Felt,
+    pub counterparty: Felt,
+    pub amount: u128,
+    pub salt: u128,
+}
+
+/// A transaction's events grouped and typed for history display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryTransaction {
+    pub block_number: u64,
+    pub transaction_hash: Felt,
+    pub notes: Vec<HistoryNote>,
+    pub deposits: Vec<DepositEvent>,
+    pub withdrawals: Vec<WithdrawalEvent>,
+    pub open_note_deposits: Vec<OpenNoteDepositedEvent>,
+}
+
+impl HistoryTransaction {
+    pub fn new(block_number: u64, transaction_hash: Felt) -> Self {
+        Self {
+            block_number,
+            transaction_hash,
+            notes: Vec::new(),
+            deposits: Vec::new(),
+            withdrawals: Vec::new(),
+            open_note_deposits: Vec::new(),
+        }
+    }
+}
+
+/// A single subchannel in the backward history scan (note creation reads only).
+pub struct HistorySubchannel {
+    pub channel_key: SecretFelt,
+    pub token: Felt,
+    pub channel_kind: ChannelKind,
+    pub counterparty: Felt,
+    /// Next note index to read (descending). None = stream exhausted.
+    pub next_index: Option<u64>,
+}
+
+/// Cursor for paginated backward history scan across multiple subchannels.
+pub struct HistoryCursor {
+    pub subchannels: Vec<HistorySubchannel>,
+    /// Inclusive upper bound for event queries — the block where backward scanning begins.
+    /// Typically set to the latest confirmed block when the scan starts.
+    pub begin_block_number: u64,
+    /// `true` = all subchannels exhausted, no more history.
+    /// `false` = stopped due to budget or max_transactions limit.
+    pub history_complete: bool,
+}

--- a/crates/discovery-core/src/lib.rs
+++ b/crates/discovery-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod discovery;
 pub mod events_backend;
+pub mod history;
 pub mod io_budget;
 pub mod privacy_pool;
 pub mod storage_backend;

--- a/crates/discovery-core/src/privacy_pool/decryption.rs
+++ b/crates/discovery-core/src/privacy_pool/decryption.rs
@@ -106,6 +106,25 @@ pub fn decrypt_note_amount(
     enc_amount.wrapping_sub(pad)
 }
 
+/// Unpacks and decrypts a packed note value into `(amount, salt)`.
+///
+/// Open notes (salt == 1) store their amount in plaintext; encrypted notes
+/// (salt >= 2) require ECDH-based decryption.
+pub fn decrypt_packed_value(
+    packed: Felt,
+    channel_key: &SecretFelt,
+    token: Felt,
+    index: u64,
+) -> (u128, u128) {
+    let (salt, enc_amount) = unpack_note_amount(packed);
+    let amount = if salt == OPEN_NOTE_SALT {
+        enc_amount
+    } else {
+        decrypt_note_amount(enc_amount, salt, channel_key, token, index)
+    };
+    (amount, salt)
+}
+
 /// Decrypts an outgoing channel's encrypted recipient address.
 ///
 /// `recipient_addr = enc_recipient_addr - hash(ENC_RECIPIENT_ADDR_TAG, sender_addr, private_key, index, 0, salt)`

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -111,6 +111,23 @@ pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErr
             StatusCode::BAD_REQUEST,
             ApiErrorResponse::new(error_codes::INVALID_REQUEST, msg),
         ),
+        DiscoveryError::InsufficientBudget { needed, available } => {
+            warn!(
+                "Insufficient I/O budget: needed {}, available {}",
+                needed, available
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
+            )
+        }
+        DiscoveryError::EventError(msg) => {
+            warn!("Event error: {}", msg);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Add backward history scanning for privacy pool notes

This PR introduces a new history scanning module that reads note values directly from storage instead of scanning events, enabling efficient backward traversal of transaction history.

### Key Changes

**New History Module**
- Added `history/` module with `notes.rs` and `types.rs`
- Introduced `BufferedNoteScanner` for batched storage reads via `get_notes_batch_with_block`
- Added `HistoryNote`, `HistoryTransaction`, and `HistoryCursor` types for backward scanning
- Implemented `ChannelKind` enum to distinguish incoming/outgoing/self channels

**Enhanced Error Handling**
- Added `InsufficientBudget` error variant with needed/available budget details
- Added `EventError` variant for missing on-chain events
- Updated API error mapping to handle new error types

**Decryption Refactoring**
- Extracted `decrypt_packed_value()` function to unify note decryption logic
- Refactored existing note decryption to use the new unified function
- Returns `(amount, salt)` tuple for consistent handling of open and encrypted notes

**Testing**
- Comprehensive test coverage for `BufferedNoteScanner` including sequential scanning, budget constraints, and open note handling

The scanner fills a buffer with notes from multiple subchannels, then drains them block-by-block in descending order, making it suitable for displaying transaction history in reverse chronological order.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/615)
<!-- Reviewable:end -->