### PR TITLE
feat(discovery-core): reconstruct client actions from aggregated note events

### DIFF
--- a/crates/discovery-core/src/events_backend.rs
+++ b/crates/discovery-core/src/events_backend.rs
@@ -1,0 +1,210 @@
+//! Event backend abstraction and mock implementation.
+//!
+//! Mirrors [`crate::storage_backend`] for event access: defines the raw event
+//! access trait and a mock backend for testing.
+
+use async_trait::async_trait;
+use starknet_types_core::felt::Felt;
+
+use crate::storage_backend::StorageError;
+
+/// A raw contract event with block context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmittedEvent {
+    pub block_number: u64,
+    pub transaction_hash: Felt,
+    pub keys: Vec<Felt>,
+    pub data: Vec<Felt>,
+}
+
+/// Low-level event access for reading contract events.
+#[async_trait]
+pub trait RawEventAccess: Send + Sync {
+    /// Fetches events matching the given key filters within a block range (inclusive).
+    ///
+    /// Each element of `keys` is a set of accepted values for that key position.
+    /// An event matches if, for every non-empty filter, the event's key at that
+    /// position is contained in the filter set.
+    async fn get_events(
+        &self,
+        keys: &[Vec<Felt>],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<EmittedEvent>, StorageError>;
+
+    /// Fetches all events emitted in the given transaction.
+    async fn get_transaction_events(
+        &self,
+        transaction_hash: Felt,
+    ) -> Result<Vec<EmittedEvent>, StorageError>;
+}
+
+/// Mock event backend backed by an in-memory `Vec<EmittedEvent>`.
+#[derive(Clone, Default)]
+pub struct MockEventBackend {
+    events: Vec<EmittedEvent>,
+}
+
+impl MockEventBackend {
+    pub fn new(events: Vec<EmittedEvent>) -> Self {
+        Self { events }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl RawEventAccess for MockEventBackend {
+    async fn get_events(
+        &self,
+        keys: &[Vec<Felt>],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<EmittedEvent>, StorageError> {
+        Ok(self
+            .events
+            .iter()
+            .filter(|event| {
+                event.block_number >= from_block
+                    && event.block_number <= to_block
+                    && keys.iter().enumerate().all(|(position, accepted)| {
+                        accepted.is_empty()
+                            || event
+                                .keys
+                                .get(position)
+                                .is_some_and(|key| accepted.contains(key))
+                    })
+            })
+            .cloned()
+            .collect())
+    }
+
+    async fn get_transaction_events(
+        &self,
+        transaction_hash: Felt,
+    ) -> Result<Vec<EmittedEvent>, StorageError> {
+        Ok(self
+            .events
+            .iter()
+            .filter(|event| event.transaction_hash == transaction_hash)
+            .cloned()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_mock_returns_no_events() {
+        let backend = MockEventBackend::empty();
+        let events = backend.get_events(&[], 0, 100).await.unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stored_events_returned_in_block_range() {
+        let backend = MockEventBackend::new(vec![
+            EmittedEvent {
+                block_number: 5,
+                transaction_hash: Felt::from(0x1u64),
+                keys: vec![Felt::from(0xAu64)],
+                data: vec![],
+            },
+            EmittedEvent {
+                block_number: 15,
+                transaction_hash: Felt::from(0x2u64),
+                keys: vec![Felt::from(0xBu64)],
+                data: vec![],
+            },
+            EmittedEvent {
+                block_number: 25,
+                transaction_hash: Felt::from(0x3u64),
+                keys: vec![Felt::from(0xCu64)],
+                data: vec![],
+            },
+        ]);
+
+        let events = backend.get_events(&[], 5, 15).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].block_number, 5);
+        assert_eq!(events[1].block_number, 15);
+    }
+
+    #[tokio::test]
+    async fn key_filtering_matches_correct_events() {
+        let selector_a = Felt::from(0xAAu64);
+        let selector_b = Felt::from(0xBBu64);
+        let user = Felt::from(0x1u64);
+
+        let backend = MockEventBackend::new(vec![
+            EmittedEvent {
+                block_number: 10,
+                transaction_hash: Felt::from(0x1u64),
+                keys: vec![selector_a, user],
+                data: vec![],
+            },
+            EmittedEvent {
+                block_number: 10,
+                transaction_hash: Felt::from(0x2u64),
+                keys: vec![selector_b, user],
+                data: vec![],
+            },
+        ]);
+
+        // Filter by selector_a at position 0
+        let events = backend
+            .get_events(&[vec![selector_a]], 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].keys[0], selector_a);
+
+        // Filter by user at position 1 (any selector)
+        let events = backend
+            .get_events(&[vec![], vec![user]], 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn transaction_event_lookup() {
+        let target_tx = Felt::from(0x42u64);
+        let other_tx = Felt::from(0x99u64);
+
+        let backend = MockEventBackend::new(vec![
+            EmittedEvent {
+                block_number: 10,
+                transaction_hash: target_tx,
+                keys: vec![Felt::ONE],
+                data: vec![Felt::TWO],
+            },
+            EmittedEvent {
+                block_number: 10,
+                transaction_hash: other_tx,
+                keys: vec![Felt::THREE],
+                data: vec![],
+            },
+            EmittedEvent {
+                block_number: 20,
+                transaction_hash: target_tx,
+                keys: vec![Felt::from(0x4u64)],
+                data: vec![],
+            },
+        ]);
+
+        let events = backend.get_transaction_events(target_tx).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|e| e.transaction_hash == target_tx));
+
+        let events = backend
+            .get_transaction_events(Felt::from(0xDEADu64))
+            .await
+            .unwrap();
+        assert!(events.is_empty());
+    }
+}

--- a/crates/discovery-core/src/history/client_actions.rs
+++ b/crates/discovery-core/src/history/client_actions.rs
@@ -1,0 +1,678 @@
+//! Client action reconstruction from aggregated note events.
+//!
+//! Two-pass pipeline:
+//! 1. **Reconstruct** (pure): classify note events per block into [`ClientAction`]s using
+//!    note creation events and on-chain deposit/withdrawal events.
+//! 2. **Enrich** (async, TODO): for `SwapIn` actions, look up `OpenNoteDeposited` events to
+//!    identify the swap counterparty and create `SwapOut`.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+use super::onchain_events::BlockOnChainEvents;
+use super::types::{ChannelKind, CreateNoteEvent, HistoryEvent};
+use crate::discovery::DiscoveryError;
+use crate::privacy_pool::events::{IEvents, PrivacyPoolEventContent};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ClientActionKind {
+    /// `from_address` is populated from the on-chain Deposit event.
+    Deposit {
+        from_address: Option<Felt>,
+    },
+    TransferSent {
+        recipient: Felt,
+    },
+    TransferReceived {
+        sender: Felt,
+    },
+    /// `to_address` is populated from the on-chain Withdrawal event.
+    Withdrawal {
+        to_address: Option<Felt>,
+    },
+    /// Swap input: an open note was created (part of a swap operation).
+    SwapIn,
+    /// Swap output: a withdrawal that co-occurs with a `SwapIn` in the same block.
+    /// `to_address` is populated from the on-chain Withdrawal event.
+    /// TODO: after enrichment via `OpenNoteDeposited`, confirm depositor == to_address.
+    SwapOut {
+        to_address: Option<Felt>,
+    },
+    /// Self-channel notes were found but no matching on-chain deposit or withdrawal event
+    /// exists for this block and token. This can happen when the user's transaction doesn't
+    /// emit standard Deposit/Withdrawal events, or when the on-chain event fetch is incomplete.
+    ///
+    /// TODO: once a `NoteCreated` event exists in the contract, fetch it by `note_id` for all
+    /// blocks with self notes → get `tx_hash` → fetch all events in that tx to discover
+    /// deposits/withdrawals to different addresses.
+    Unknown,
+}
+
+/// One reconstructed action per block+token, with all underlying events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientAction {
+    pub block_number: u64,
+    pub action_kind: ClientActionKind,
+    pub token: Felt,
+    pub amount: u128,
+    pub events: Vec<HistoryEvent>,
+}
+
+/// Reconstructs client actions from note events and on-chain events grouped by block number.
+///
+/// Actions are returned grouped by block number in ascending order. Each block is processed
+/// per-token, and a single block+token may produce multiple actions (e.g. TransferSent + Deposit).
+pub fn reconstruct_client_actions(
+    events_by_block: &BTreeMap<u64, Vec<CreateNoteEvent>>,
+    on_chain_events: &BTreeMap<u64, BlockOnChainEvents>,
+) -> BTreeMap<u64, Vec<ClientAction>> {
+    let mut actions_by_block: BTreeMap<u64, Vec<ClientAction>> = BTreeMap::new();
+    for (&block_number, events) in events_by_block {
+        let block_on_chain = on_chain_events.get(&block_number);
+        let mut block_actions = Vec::new();
+        classify_block_events(block_number, events, block_on_chain, &mut block_actions);
+        if !block_actions.is_empty() {
+            actions_by_block.insert(block_number, block_actions);
+        }
+    }
+    actions_by_block
+}
+
+fn classify_block_events(
+    block_number: u64,
+    events: &[CreateNoteEvent],
+    block_on_chain: Option<&BlockOnChainEvents>,
+    actions: &mut Vec<ClientAction>,
+) {
+    let start = actions.len();
+    let mut by_token: BTreeMap<Felt, Vec<CreateNoteEvent>> = BTreeMap::new();
+    for event in events {
+        by_token.entry(event.token).or_default().push(event.clone());
+    }
+    for (token, token_events) in by_token {
+        classify_token_events(block_number, token, &token_events, block_on_chain, actions);
+    }
+    promote_withdrawals_to_swap_out(&mut actions[start..]);
+}
+
+/// If any `SwapIn` action exists in the block, promote all `Withdrawal` actions to `SwapOut`.
+fn promote_withdrawals_to_swap_out(block_actions: &mut [ClientAction]) {
+    let has_swap_in = block_actions
+        .iter()
+        .any(|a| a.action_kind == ClientActionKind::SwapIn);
+    if !has_swap_in {
+        return;
+    }
+    for action in block_actions.iter_mut() {
+        if let ClientActionKind::Withdrawal { to_address } = action.action_kind {
+            action.action_kind = ClientActionKind::SwapOut { to_address };
+        }
+    }
+}
+
+fn classify_token_events(
+    block_number: u64,
+    token: Felt,
+    events: &[CreateNoteEvent],
+    block_on_chain: Option<&BlockOnChainEvents>,
+    actions: &mut Vec<ClientAction>,
+) {
+    let mut incoming_by_sender: BTreeMap<Felt, Vec<CreateNoteEvent>> = BTreeMap::new();
+    let mut outgoing_by_recipient: BTreeMap<Felt, Vec<CreateNoteEvent>> = BTreeMap::new();
+    let mut open_note_events = Vec::new();
+    let mut self_channel_events = Vec::new();
+
+    for event in events {
+        if event.is_open && event.channel_kind == ChannelKind::SelfChannel {
+            open_note_events.push(event.clone());
+            continue;
+        }
+
+        match event.channel_kind {
+            ChannelKind::Incoming => {
+                incoming_by_sender
+                    .entry(event.counterparty)
+                    .or_default()
+                    .push(event.clone());
+            }
+            ChannelKind::Outgoing => {
+                outgoing_by_recipient
+                    .entry(event.counterparty)
+                    .or_default()
+                    .push(event.clone());
+            }
+            ChannelKind::SelfChannel => {
+                self_channel_events.push(event.clone());
+            }
+        }
+    }
+
+    // Incoming Created → TransferReceived (grouped by sender)
+    for (sender, sender_events) in incoming_by_sender {
+        let amount = sender_events
+            .iter()
+            .map(|e| e.amount)
+            .fold(0u128, u128::saturating_add);
+        let history_events = sender_events
+            .into_iter()
+            .map(HistoryEvent::NoteCreated)
+            .collect();
+        actions.push(ClientAction {
+            block_number,
+            action_kind: ClientActionKind::TransferReceived { sender },
+            token,
+            amount,
+            events: history_events,
+        });
+    }
+
+    // Outgoing Created → TransferSent (grouped by recipient)
+    for (recipient, recipient_events) in outgoing_by_recipient {
+        let amount = recipient_events
+            .iter()
+            .map(|e| e.amount)
+            .fold(0u128, u128::saturating_add);
+        let history_events = recipient_events
+            .into_iter()
+            .map(HistoryEvent::NoteCreated)
+            .collect();
+        actions.push(ClientAction {
+            block_number,
+            action_kind: ClientActionKind::TransferSent { recipient },
+            token,
+            amount,
+            events: history_events,
+        });
+    }
+
+    // On-chain Deposit events (same token) → Deposit action
+    if let Some(on_chain) = block_on_chain {
+        for deposit_event in &on_chain.deposits {
+            let PrivacyPoolEventContent::Deposit {
+                user_address,
+                token: event_token,
+                amount: event_amount,
+            } = &deposit_event.content
+            else {
+                continue;
+            };
+            if *event_token != token {
+                continue;
+            }
+            let mut history_events: Vec<HistoryEvent> = self_channel_events
+                .iter()
+                .cloned()
+                .map(HistoryEvent::NoteCreated)
+                .collect();
+            history_events.push(HistoryEvent::OnChain(deposit_event.clone()));
+            actions.push(ClientAction {
+                block_number,
+                action_kind: ClientActionKind::Deposit {
+                    from_address: Some(*user_address),
+                },
+                token,
+                amount: *event_amount,
+                events: history_events,
+            });
+        }
+
+        // On-chain Withdrawal events (same token) → Withdrawal action
+        for withdrawal_event in &on_chain.withdrawals {
+            let PrivacyPoolEventContent::Withdrawal {
+                to_address,
+                token: event_token,
+                amount: event_amount,
+            } = &withdrawal_event.content
+            else {
+                continue;
+            };
+            if *event_token != token {
+                continue;
+            }
+            let mut history_events: Vec<HistoryEvent> = self_channel_events
+                .iter()
+                .cloned()
+                .map(HistoryEvent::NoteCreated)
+                .collect();
+            history_events.push(HistoryEvent::OnChain(withdrawal_event.clone()));
+            actions.push(ClientAction {
+                block_number,
+                action_kind: ClientActionKind::Withdrawal {
+                    to_address: Some(*to_address),
+                },
+                token,
+                amount: *event_amount,
+                events: history_events,
+            });
+        }
+    }
+
+    // Self-channel notes without matching on-chain deposit/withdrawal → Unknown
+    let has_on_chain_match = block_on_chain.is_some_and(|oc| {
+        oc.deposits
+            .iter()
+            .any(|d| matches!(&d.content, PrivacyPoolEventContent::Deposit { token: t, .. } if *t == token))
+            || oc
+                .withdrawals
+                .iter()
+                .any(|w| matches!(&w.content, PrivacyPoolEventContent::Withdrawal { token: t, .. } if *t == token))
+    });
+    if !self_channel_events.is_empty() && !has_on_chain_match {
+        let amount = self_channel_events
+            .iter()
+            .map(|e| e.amount)
+            .fold(0u128, u128::saturating_add);
+        actions.push(ClientAction {
+            block_number,
+            action_kind: ClientActionKind::Unknown,
+            token,
+            amount,
+            events: self_channel_events
+                .into_iter()
+                .map(HistoryEvent::NoteCreated)
+                .collect(),
+        });
+    }
+
+    // Open notes → SwapIn
+    if !open_note_events.is_empty() {
+        let amount = open_note_events
+            .iter()
+            .map(|e| e.amount)
+            .fold(0u128, u128::saturating_add);
+        actions.push(ClientAction {
+            block_number,
+            action_kind: ClientActionKind::SwapIn,
+            token,
+            amount,
+            events: open_note_events
+                .into_iter()
+                .map(HistoryEvent::NoteCreated)
+                .collect(),
+        });
+    }
+}
+
+/// Enriches swap actions by looking up `OpenNoteDeposited` on-chain events.
+///
+/// TODO: implement. For each SwapIn:
+/// 1. Get the open note's `note_id`
+/// 2. Fetch `OpenNoteDeposited` event by `note_id` key → get `depositor`, `tx_hash`
+/// 3. Fetch all tx events → find Withdrawal where `to_addr == depositor`
+/// 4. Create `SwapOut` with `to_address = depositor`
+pub async fn enrich_swap_actions<E: IEvents>(
+    _actions: &mut BTreeMap<u64, Vec<ClientAction>>,
+    _event_access: &E,
+) -> Result<(), DiscoveryError> {
+    // TODO: implement via OpenNoteDeposited lookup
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::privacy_pool::events::{PrivacyPoolEvent, PrivacyPoolEventContent};
+
+    const TEST_TOKEN: Felt = Felt::from_hex_unchecked("0x1");
+    const SENDER_A: Felt = Felt::from_hex_unchecked("0xA");
+    const SENDER_B: Felt = Felt::from_hex_unchecked("0xB");
+    const RECIPIENT_A: Felt = Felt::from_hex_unchecked("0xCA");
+    const USER_ADDR: Felt = Felt::from_hex_unchecked("0xDEAD");
+    const WITHDRAWAL_TO: Felt = Felt::from_hex_unchecked("0xBEEF");
+    const TX_HASH: Felt = Felt::from_hex_unchecked("0x999");
+
+    fn make_event(channel_kind: ChannelKind, amount: u128, counterparty: Felt) -> CreateNoteEvent {
+        CreateNoteEvent {
+            channel_kind,
+            token: TEST_TOKEN,
+            note_index: 0,
+            note_id: Felt::from(0x100u64),
+            amount,
+            counterparty,
+            is_open: false,
+        }
+    }
+
+    fn incoming_created(amount: u128, sender: Felt) -> CreateNoteEvent {
+        make_event(ChannelKind::Incoming, amount, sender)
+    }
+
+    fn outgoing_created(amount: u128, recipient: Felt) -> CreateNoteEvent {
+        make_event(ChannelKind::Outgoing, amount, recipient)
+    }
+
+    fn self_created(amount: u128) -> CreateNoteEvent {
+        make_event(ChannelKind::SelfChannel, amount, Felt::ZERO)
+    }
+
+    fn make_deposit(
+        block_number: u64,
+        token: Felt,
+        user_addr: Felt,
+        amount: u128,
+    ) -> PrivacyPoolEvent {
+        PrivacyPoolEvent {
+            block_number,
+            transaction_hash: TX_HASH,
+            content: PrivacyPoolEventContent::Deposit {
+                user_address: user_addr,
+                token,
+                amount,
+            },
+        }
+    }
+
+    fn make_withdrawal(
+        block_number: u64,
+        token: Felt,
+        to_addr: Felt,
+        amount: u128,
+    ) -> PrivacyPoolEvent {
+        PrivacyPoolEvent {
+            block_number,
+            transaction_hash: TX_HASH,
+            content: PrivacyPoolEventContent::Withdrawal {
+                to_address: to_addr,
+                token,
+                amount,
+            },
+        }
+    }
+
+    fn empty_on_chain() -> BTreeMap<u64, BlockOnChainEvents> {
+        BTreeMap::new()
+    }
+
+    /// Helper to collect all actions from a BTreeMap into a flat Vec (block-ordered).
+    fn flatten_actions(actions_by_block: &BTreeMap<u64, Vec<ClientAction>>) -> Vec<&ClientAction> {
+        actions_by_block.values().flat_map(|v| v.iter()).collect()
+    }
+
+    // --- Reconstruct tests ---
+
+    #[test]
+    fn empty_events_produce_no_actions() {
+        assert!(reconstruct_client_actions(&BTreeMap::new(), &empty_on_chain()).is_empty());
+    }
+
+    #[test]
+    fn incoming_created_is_transfer_received() {
+        let mut events = BTreeMap::new();
+        events.insert(5, vec![incoming_created(50, SENDER_A)]);
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::TransferReceived { sender: SENDER_A }
+        );
+        assert_eq!(flat[0].amount, 50);
+    }
+
+    #[test]
+    fn outgoing_created_is_transfer_sent() {
+        let mut events = BTreeMap::new();
+        events.insert(15, vec![outgoing_created(200, RECIPIENT_A)]);
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::TransferSent {
+                recipient: RECIPIENT_A
+            }
+        );
+        assert_eq!(flat[0].amount, 200);
+    }
+
+    #[test]
+    fn actions_ordered_by_block_number() {
+        let mut events = BTreeMap::new();
+        events.insert(100, vec![incoming_created(10, SENDER_A)]);
+        events.insert(50, vec![incoming_created(20, SENDER_B)]);
+        events.insert(200, vec![outgoing_created(30, RECIPIENT_A)]);
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 3);
+        assert_eq!(flat[0].block_number, 50);
+        assert_eq!(flat[1].block_number, 100);
+        assert_eq!(flat[2].block_number, 200);
+    }
+
+    #[test]
+    fn incoming_grouped_by_sender() {
+        let mut events = BTreeMap::new();
+        events.insert(
+            10,
+            vec![
+                incoming_created(30, SENDER_A),
+                incoming_created(20, SENDER_B),
+                incoming_created(50, SENDER_A),
+            ],
+        );
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 2);
+        // BTreeMap ordering: SENDER_A (0xA) < SENDER_B (0xB)
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::TransferReceived { sender: SENDER_A }
+        );
+        assert_eq!(flat[0].amount, 80);
+        assert_eq!(flat[0].events.len(), 2);
+        assert_eq!(
+            flat[1].action_kind,
+            ClientActionKind::TransferReceived { sender: SENDER_B }
+        );
+        assert_eq!(flat[1].amount, 20);
+    }
+
+    #[test]
+    fn open_note_created_produces_swap_in() {
+        let open_note = CreateNoteEvent {
+            channel_kind: ChannelKind::SelfChannel,
+            token: TEST_TOKEN,
+            note_index: 0,
+            note_id: Felt::from(0x200u64),
+            amount: 50,
+            counterparty: Felt::ZERO,
+            is_open: true,
+        };
+        let mut events = BTreeMap::new();
+        events.insert(80, vec![open_note]);
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].action_kind, ClientActionKind::SwapIn);
+        assert_eq!(flat[0].amount, 50);
+        assert_eq!(flat[0].block_number, 80);
+    }
+
+    #[test]
+    fn deposit_from_on_chain_event() {
+        let mut events = BTreeMap::new();
+        events.insert(10, vec![self_created(100)]);
+
+        let mut on_chain = BTreeMap::new();
+        on_chain.insert(
+            10,
+            BlockOnChainEvents {
+                deposits: vec![make_deposit(10, TEST_TOKEN, USER_ADDR, 100)],
+                withdrawals: vec![],
+            },
+        );
+
+        let actions = reconstruct_client_actions(&events, &on_chain);
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::Deposit {
+                from_address: Some(USER_ADDR)
+            }
+        );
+        assert_eq!(flat[0].amount, 100);
+        assert_eq!(flat[0].block_number, 10);
+        // Self-channel note + deposit event included
+        assert_eq!(flat[0].events.len(), 2);
+        assert!(matches!(flat[0].events[0], HistoryEvent::NoteCreated(_)));
+        assert!(matches!(flat[0].events[1], HistoryEvent::OnChain(_)));
+    }
+
+    #[test]
+    fn withdrawal_from_on_chain_event() {
+        let mut events = BTreeMap::new();
+        events.insert(20, vec![self_created(50)]);
+
+        let mut on_chain = BTreeMap::new();
+        on_chain.insert(
+            20,
+            BlockOnChainEvents {
+                deposits: vec![],
+                withdrawals: vec![make_withdrawal(20, TEST_TOKEN, WITHDRAWAL_TO, 75)],
+            },
+        );
+
+        let actions = reconstruct_client_actions(&events, &on_chain);
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::Withdrawal {
+                to_address: Some(WITHDRAWAL_TO)
+            }
+        );
+        assert_eq!(flat[0].amount, 75);
+        assert_eq!(flat[0].block_number, 20);
+        // Self-channel note + withdrawal event included
+        assert_eq!(flat[0].events.len(), 2);
+    }
+
+    #[test]
+    fn transfer_with_deposit() {
+        // Transfer to recipient + deposit in the same block
+        let mut events = BTreeMap::new();
+        events.insert(
+            60,
+            vec![outgoing_created(100, RECIPIENT_A), self_created(100)],
+        );
+
+        let mut on_chain = BTreeMap::new();
+        on_chain.insert(
+            60,
+            BlockOnChainEvents {
+                deposits: vec![make_deposit(60, TEST_TOKEN, USER_ADDR, 200)],
+                withdrawals: vec![],
+            },
+        );
+
+        let actions = reconstruct_client_actions(&events, &on_chain);
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 2);
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::TransferSent {
+                recipient: RECIPIENT_A
+            }
+        );
+        assert_eq!(flat[0].amount, 100);
+        assert_eq!(
+            flat[1].action_kind,
+            ClientActionKind::Deposit {
+                from_address: Some(USER_ADDR)
+            }
+        );
+        assert_eq!(flat[1].amount, 200);
+    }
+
+    #[test]
+    fn self_channel_only_produces_unknown() {
+        let mut events = BTreeMap::new();
+        events.insert(30, vec![self_created(100)]);
+
+        // No on-chain events for this block
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].action_kind, ClientActionKind::Unknown);
+        assert_eq!(flat[0].amount, 100);
+        assert_eq!(flat[0].block_number, 30);
+        assert_eq!(flat[0].events.len(), 1);
+    }
+
+    #[test]
+    fn withdrawal_promoted_to_swap_out_with_swap_in() {
+        let open_note = CreateNoteEvent {
+            channel_kind: ChannelKind::SelfChannel,
+            token: TEST_TOKEN,
+            note_index: 1,
+            note_id: Felt::from(0x300u64),
+            amount: 60,
+            counterparty: Felt::ZERO,
+            is_open: true,
+        };
+        let mut events = BTreeMap::new();
+        events.insert(90, vec![self_created(40), open_note]);
+
+        let mut on_chain = BTreeMap::new();
+        on_chain.insert(
+            90,
+            BlockOnChainEvents {
+                deposits: vec![],
+                withdrawals: vec![make_withdrawal(90, TEST_TOKEN, WITHDRAWAL_TO, 100)],
+            },
+        );
+
+        let actions = reconstruct_client_actions(&events, &on_chain);
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 2);
+        // Withdrawal promoted to SwapOut because SwapIn exists in same block
+        assert_eq!(
+            flat[0].action_kind,
+            ClientActionKind::SwapOut {
+                to_address: Some(WITHDRAWAL_TO)
+            }
+        );
+        assert_eq!(flat[0].amount, 100);
+        assert_eq!(flat[1].action_kind, ClientActionKind::SwapIn);
+        assert_eq!(flat[1].amount, 60);
+    }
+
+    #[test]
+    fn on_chain_event_different_token_ignored() {
+        let other_token = Felt::from_hex_unchecked("0x999");
+        let mut events = BTreeMap::new();
+        events.insert(10, vec![self_created(100)]);
+
+        let mut on_chain = BTreeMap::new();
+        on_chain.insert(
+            10,
+            BlockOnChainEvents {
+                deposits: vec![make_deposit(10, other_token, USER_ADDR, 100)],
+                withdrawals: vec![],
+            },
+        );
+
+        // On-chain deposit is for a different token, so self-channel → Unknown
+        let actions = reconstruct_client_actions(&events, &on_chain);
+        let flat = flatten_actions(&actions);
+        assert_eq!(flat.len(), 1);
+        assert_eq!(flat[0].action_kind, ClientActionKind::Unknown);
+    }
+
+    #[test]
+    fn actions_grouped_by_block_in_result() {
+        let mut events = BTreeMap::new();
+        events.insert(10, vec![incoming_created(50, SENDER_A)]);
+        events.insert(20, vec![outgoing_created(100, RECIPIENT_A)]);
+
+        let actions = reconstruct_client_actions(&events, &empty_on_chain());
+        assert_eq!(actions.len(), 2);
+        assert!(actions.contains_key(&10));
+        assert!(actions.contains_key(&20));
+        assert_eq!(actions[&10].len(), 1);
+        assert_eq!(actions[&20].len(), 1);
+    }
+}

--- a/crates/discovery-core/src/history/mod.rs
+++ b/crates/discovery-core/src/history/mod.rs
@@ -1,4 +1,6 @@
 //! Backward history scanner for privacy pool operations.
 
+pub mod client_actions;
 pub mod note_events;
+pub mod onchain_events;
 pub mod types;

--- a/crates/discovery-core/src/history/onchain_events.rs
+++ b/crates/discovery-core/src/history/onchain_events.rs
@@ -1,0 +1,138 @@
+//! On-chain event fetching and block grouping.
+//!
+//! Fetches typed deposit/withdrawal events via [`IEvents`] and groups them by block number.
+
+use std::collections::BTreeMap;
+
+use starknet_types_core::felt::Felt;
+
+use crate::discovery::DiscoveryError;
+use crate::privacy_pool::events::{IEvents, PrivacyPoolEvent};
+
+/// On-chain deposit/withdrawal events for a single block.
+///
+/// Each vec is guaranteed to contain only events of the corresponding variant
+/// (`PrivacyPoolEventContent::Deposit` / `::Withdrawal`).
+#[derive(Debug, Clone, Default)]
+pub struct BlockOnChainEvents {
+    pub deposits: Vec<PrivacyPoolEvent>,
+    pub withdrawals: Vec<PrivacyPoolEvent>,
+}
+
+/// Fetches on-chain Deposit and Withdrawal events for the given block numbers,
+/// filtered by the user's address. Returns events grouped by block number.
+pub async fn fetch_on_chain_events<E: IEvents>(
+    event_access: &E,
+    user_address: Felt,
+    block_numbers: &[u64],
+) -> Result<BTreeMap<u64, BlockOnChainEvents>, DiscoveryError> {
+    if block_numbers.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let min_block = *block_numbers.iter().min().unwrap();
+    let max_block = *block_numbers.iter().max().unwrap();
+
+    let deposit_events = event_access
+        .get_deposit_events(user_address, min_block, max_block)
+        .await?;
+
+    let withdrawal_events = event_access
+        .get_withdrawal_events(user_address, min_block, max_block)
+        .await?;
+
+    let mut result: BTreeMap<u64, BlockOnChainEvents> = BTreeMap::new();
+
+    for event in deposit_events {
+        result
+            .entry(event.block_number)
+            .or_default()
+            .deposits
+            .push(event);
+    }
+
+    for event in withdrawal_events {
+        result
+            .entry(event.block_number)
+            .or_default()
+            .withdrawals
+            .push(event);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events_backend::{EmittedEvent, MockEventBackend};
+    use crate::privacy_pool::events::PrivacyPoolEventContent;
+    use starknet_core::utils::starknet_keccak;
+
+    const USER_ADDR: Felt = Felt::from_hex_unchecked("0xDEAD");
+    const TOKEN: Felt = Felt::from_hex_unchecked("0x1");
+    const TX_HASH: Felt = Felt::from_hex_unchecked("0x999");
+
+    fn make_raw_deposit(block_number: u64, amount: u64) -> EmittedEvent {
+        EmittedEvent {
+            block_number,
+            transaction_hash: TX_HASH,
+            keys: vec![starknet_keccak(b"Deposit"), USER_ADDR, TOKEN],
+            data: vec![Felt::from(amount)],
+        }
+    }
+
+    fn make_raw_withdrawal(block_number: u64, amount: u64) -> EmittedEvent {
+        let to_addr = USER_ADDR; // Withdrawal filtered by to_addr = user_address
+        EmittedEvent {
+            block_number,
+            transaction_hash: TX_HASH,
+            keys: vec![starknet_keccak(b"Withdrawal"), to_addr, TOKEN],
+            data: vec![Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(amount)],
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_blocks_return_empty_map() {
+        let backend = MockEventBackend::empty();
+        let result = fetch_on_chain_events(&backend, USER_ADDR, &[])
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn events_grouped_by_block() {
+        let backend = MockEventBackend::new(vec![
+            make_raw_deposit(10, 100),
+            make_raw_deposit(20, 200),
+            make_raw_withdrawal(10, 50),
+        ]);
+
+        let result = fetch_on_chain_events(&backend, USER_ADDR, &[10, 20])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+
+        let block_10 = &result[&10];
+        assert_eq!(block_10.deposits.len(), 1);
+        assert!(matches!(
+            &block_10.deposits[0].content,
+            PrivacyPoolEventContent::Deposit { amount: 100, .. }
+        ));
+        assert_eq!(block_10.withdrawals.len(), 1);
+        assert!(matches!(
+            &block_10.withdrawals[0].content,
+            PrivacyPoolEventContent::Withdrawal { amount: 50, .. }
+        ));
+
+        let block_20 = &result[&20];
+        assert_eq!(block_20.deposits.len(), 1);
+        assert!(matches!(
+            &block_20.deposits[0].content,
+            PrivacyPoolEventContent::Deposit { amount: 200, .. }
+        ));
+        assert!(block_20.withdrawals.is_empty());
+    }
+}

--- a/crates/discovery-core/src/history/types.rs
+++ b/crates/discovery-core/src/history/types.rs
@@ -3,6 +3,7 @@
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
+use crate::privacy_pool::events::PrivacyPoolEvent;
 use crate::privacy_pool::types::SecretFelt;
 
 /// Direction of the channel from the scanning user's perspective.
@@ -21,8 +22,20 @@ pub struct CreateNoteEvent {
     pub note_index: u64,
     pub note_id: Felt,
     pub amount: u128,
+    /// The other party: sender for Incoming, recipient for Outgoing, self address for SelfChannel.
     pub counterparty: Felt,
+    /// Whether this note is an open note (salt == OPEN_NOTE_SALT). Open notes are part of swaps.
     pub is_open: bool,
+}
+
+/// A unified event in the history timeline.
+///
+/// Groups note creation events with on-chain deposit/withdrawal events
+/// for presentation in client action history.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HistoryEvent {
+    NoteCreated(CreateNoteEvent),
+    OnChain(PrivacyPoolEvent),
 }
 
 /// A single event stream in the backward history scan.
@@ -32,6 +45,7 @@ pub struct HistoryEventSource {
     pub channel_key: SecretFelt,
     pub token: Felt,
     pub channel_kind: ChannelKind,
+    /// The other party: sender for Incoming, recipient for Outgoing, self address for SelfChannel.
     pub counterparty: Felt,
     /// Next note index to read (descending). None = stream exhausted.
     pub next_index: Option<u64>,

--- a/crates/discovery-core/src/lib.rs
+++ b/crates/discovery-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod discovery;
+pub mod events_backend;
 pub mod history;
 pub mod io_budget;
 pub mod privacy_pool;

--- a/crates/discovery-core/src/privacy_pool/events.rs
+++ b/crates/discovery-core/src/privacy_pool/events.rs
@@ -1,0 +1,325 @@
+//! Typed privacy pool events and blanket implementation.
+//!
+//! Mirrors [`super::views`]: defines a unified [`PrivacyPoolEvent`] type with
+//! variant-specific content, and an [`IEvents`] trait with a blanket
+//! implementation over [`RawEventAccess`].
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use starknet_core::utils::starknet_keccak;
+use starknet_types_core::felt::Felt;
+
+use super::types::felt_low_u128;
+use crate::events_backend::RawEventAccess;
+use crate::storage_backend::StorageError;
+
+/// A typed privacy pool contract event with block context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrivacyPoolEvent {
+    pub block_number: u64,
+    pub transaction_hash: Felt,
+    pub content: PrivacyPoolEventContent,
+}
+
+/// Event-specific content for privacy pool contract events.
+///
+/// Each variant corresponds to a Cairo event type with its decoded fields.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrivacyPoolEventContent {
+    /// Cairo `Deposit`: keys = `[selector, user_addr, token]`, data = `[amount]`.
+    Deposit {
+        user_address: Felt,
+        token: Felt,
+        amount: u128,
+    },
+    /// Cairo `Withdrawal`: keys = `[selector, to_addr, token]`, data = `[enc_user_addr(3), amount]`.
+    Withdrawal {
+        to_address: Felt,
+        token: Felt,
+        amount: u128,
+    },
+    /// Cairo `OpenNoteDeposited`: keys = `[selector, depositor, token, note_id]`, data = `[amount]`.
+    OpenNoteDeposited {
+        depositor: Felt,
+        token: Felt,
+        note_id: Felt,
+        amount: u128,
+    },
+}
+
+use crate::events_backend::EmittedEvent;
+
+/// Extracts a required key at `position` from a raw event, or returns `StorageError::Backend`.
+fn required_key(event: &EmittedEvent, position: usize, field: &str) -> Result<Felt, StorageError> {
+    event
+        .keys
+        .get(position)
+        .copied()
+        .ok_or_else(|| StorageError::Backend(format!("missing {field} key").into()))
+}
+
+/// Extracts a `u128` amount from event data at `index`, or returns `StorageError::Backend`.
+fn required_amount(event: &EmittedEvent, index: usize) -> Result<u128, StorageError> {
+    event
+        .data
+        .get(index)
+        .map(|f| felt_low_u128(*f))
+        .ok_or_else(|| StorageError::Backend("missing amount data".into()))
+}
+
+/// Parses raw events into typed [`PrivacyPoolEvent`]s using a content-building closure.
+///
+/// Handles the common wrapping of `block_number` and `transaction_hash`; the closure
+/// only needs to produce the variant-specific [`PrivacyPoolEventContent`].
+fn parse_events(
+    raw_events: Vec<EmittedEvent>,
+    build_content: impl Fn(&EmittedEvent) -> Result<PrivacyPoolEventContent, StorageError>,
+) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
+    raw_events
+        .into_iter()
+        .map(|event| {
+            let content = build_content(&event)?;
+            Ok(PrivacyPoolEvent {
+                block_number: event.block_number,
+                transaction_hash: event.transaction_hash,
+                content,
+            })
+        })
+        .collect()
+}
+
+/// Typed event access for privacy pool contract events.
+#[async_trait]
+pub trait IEvents: Send + Sync {
+    /// Fetches `Deposit` events for the given user address within a block range (inclusive).
+    async fn get_deposit_events(
+        &self,
+        user_address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+
+    /// Fetches `Withdrawal` events for the given recipient address within a block range (inclusive).
+    async fn get_withdrawal_events(
+        &self,
+        to_address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+
+    /// Fetches `OpenNoteDeposited` events for the given note IDs within a block range (inclusive).
+    ///
+    /// Accepts multiple `note_id` values; the RPC key filter matches any of them.
+    async fn get_open_note_deposited_events(
+        &self,
+        note_ids: &[Felt],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+}
+
+#[async_trait]
+impl<T: RawEventAccess> IEvents for T {
+    async fn get_deposit_events(
+        &self,
+        user_address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
+        let selector = starknet_keccak(b"Deposit");
+        let raw_events = self
+            .get_events(&[vec![selector], vec![user_address]], from_block, to_block)
+            .await?;
+
+        parse_events(raw_events, |event| {
+            Ok(PrivacyPoolEventContent::Deposit {
+                user_address: required_key(event, 1, "user_addr")?,
+                token: required_key(event, 2, "token")?,
+                amount: required_amount(event, 0)?,
+            })
+        })
+    }
+
+    async fn get_withdrawal_events(
+        &self,
+        to_address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
+        let selector = starknet_keccak(b"Withdrawal");
+        let raw_events = self
+            .get_events(&[vec![selector], vec![to_address]], from_block, to_block)
+            .await?;
+
+        // data = [enc_user_addr(3 felts), amount] → amount at index 3
+        parse_events(raw_events, |event| {
+            Ok(PrivacyPoolEventContent::Withdrawal {
+                to_address: required_key(event, 1, "to_addr")?,
+                token: required_key(event, 2, "token")?,
+                amount: required_amount(event, 3)?,
+            })
+        })
+    }
+
+    async fn get_open_note_deposited_events(
+        &self,
+        note_ids: &[Felt],
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
+        let selector = starknet_keccak(b"OpenNoteDeposited");
+        // keys = [selector, depositor, token, note_id]
+        // Filter by selector and note_ids at position 3 (multi-key match)
+        let raw_events = self
+            .get_events(
+                &[vec![selector], vec![], vec![], note_ids.to_vec()],
+                from_block,
+                to_block,
+            )
+            .await?;
+
+        parse_events(raw_events, |event| {
+            Ok(PrivacyPoolEventContent::OpenNoteDeposited {
+                depositor: required_key(event, 1, "depositor")?,
+                token: required_key(event, 2, "token")?,
+                note_id: required_key(event, 3, "note_id")?,
+                amount: required_amount(event, 0)?,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events_backend::{EmittedEvent, MockEventBackend};
+
+    const USER: Felt = Felt::from_hex_unchecked("0xABCD");
+    const TOKEN: Felt = Felt::from_hex_unchecked("0x1");
+    const TX_HASH: Felt = Felt::from_hex_unchecked("0x999");
+
+    fn deposit_selector() -> Felt {
+        starknet_keccak(b"Deposit")
+    }
+
+    fn withdrawal_selector() -> Felt {
+        starknet_keccak(b"Withdrawal")
+    }
+
+    fn open_note_deposited_selector() -> Felt {
+        starknet_keccak(b"OpenNoteDeposited")
+    }
+
+    #[tokio::test]
+    async fn parse_deposit_event() {
+        let backend = MockEventBackend::new(vec![EmittedEvent {
+            block_number: 10,
+            transaction_hash: TX_HASH,
+            keys: vec![deposit_selector(), USER, TOKEN],
+            data: vec![Felt::from(100u64)],
+        }]);
+
+        let deposits = backend.get_deposit_events(USER, 0, 100).await.unwrap();
+        assert_eq!(deposits.len(), 1);
+        assert_eq!(deposits[0].block_number, 10);
+        assert_eq!(deposits[0].transaction_hash, TX_HASH);
+        let PrivacyPoolEventContent::Deposit {
+            user_address,
+            token,
+            amount,
+        } = &deposits[0].content
+        else {
+            panic!("expected Deposit");
+        };
+        assert_eq!(*user_address, USER);
+        assert_eq!(*token, TOKEN);
+        assert_eq!(*amount, 100);
+    }
+
+    #[tokio::test]
+    async fn parse_withdrawal_event_extracts_data_index_3() {
+        let to_addr = Felt::from(0xBEEFu64);
+        let backend = MockEventBackend::new(vec![EmittedEvent {
+            block_number: 20,
+            transaction_hash: TX_HASH,
+            keys: vec![withdrawal_selector(), to_addr, TOKEN],
+            // data: [enc_user_addr(3 felts), amount]
+            data: vec![Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(75u64)],
+        }]);
+
+        let withdrawals = backend
+            .get_withdrawal_events(to_addr, 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(withdrawals.len(), 1);
+        let PrivacyPoolEventContent::Withdrawal {
+            to_address,
+            token,
+            amount,
+        } = &withdrawals[0].content
+        else {
+            panic!("expected Withdrawal");
+        };
+        assert_eq!(*to_address, to_addr);
+        assert_eq!(*token, TOKEN);
+        assert_eq!(*amount, 75);
+    }
+
+    #[tokio::test]
+    async fn parse_open_note_deposited_event() {
+        let depositor = Felt::from(0xCAFEu64);
+        let note_id = Felt::from(0x42u64);
+        let backend = MockEventBackend::new(vec![EmittedEvent {
+            block_number: 30,
+            transaction_hash: TX_HASH,
+            keys: vec![open_note_deposited_selector(), depositor, TOKEN, note_id],
+            data: vec![Felt::from(200u64)],
+        }]);
+
+        let events = backend
+            .get_open_note_deposited_events(&[note_id], 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        let PrivacyPoolEventContent::OpenNoteDeposited {
+            depositor: actual_depositor,
+            token,
+            note_id: actual_note_id,
+            amount,
+        } = &events[0].content
+        else {
+            panic!("expected OpenNoteDeposited");
+        };
+        assert_eq!(*actual_depositor, depositor);
+        assert_eq!(*token, TOKEN);
+        assert_eq!(*actual_note_id, note_id);
+        assert_eq!(*amount, 200);
+    }
+
+    #[tokio::test]
+    async fn malformed_deposit_event_returns_error() {
+        let backend = MockEventBackend::new(vec![EmittedEvent {
+            block_number: 10,
+            transaction_hash: TX_HASH,
+            keys: vec![deposit_selector(), USER], // missing token key
+            data: vec![Felt::from(100u64)],
+        }]);
+
+        let result = backend.get_deposit_events(USER, 0, 100).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn malformed_withdrawal_short_data_returns_error() {
+        let to_addr = Felt::from(0xBEEFu64);
+        let backend = MockEventBackend::new(vec![EmittedEvent {
+            block_number: 20,
+            transaction_hash: TX_HASH,
+            keys: vec![withdrawal_selector(), to_addr, TOKEN],
+            data: vec![Felt::ZERO, Felt::ZERO], // only 2 data elements, need 4
+        }]);
+
+        let result = backend.get_withdrawal_events(to_addr, 0, 100).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/discovery-core/src/privacy_pool/mod.rs
+++ b/crates/discovery-core/src/privacy_pool/mod.rs
@@ -3,6 +3,7 @@
 use starknet_types_core::felt::Felt;
 
 pub mod decryption;
+pub mod events;
 pub mod hashes;
 pub mod storage_slots;
 pub mod types;

--- a/crates/discovery-core/src/privacy_pool/storage_slots.rs
+++ b/crates/discovery-core/src/privacy_pool/storage_slots.rs
@@ -151,8 +151,8 @@ pub fn outgoing_channels(outgoing_channel_id: Felt) -> EncOutgoingChannelInfoSlo
     }
 }
 
-/// Storage slot for a note's existence.
-/// Cairo: `notes: LegacyMap<NoteId, bool>`
+/// Storage slot for a note's packed_value (first field of Note struct).
+/// Cairo: `notes: Map<felt252, Note>` where Note = {packed_value, token, depositor}.
 pub fn notes(note_id: Felt) -> Felt {
     slot("notes", &[note_id])
 }

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -244,14 +244,125 @@ A non-paginated readiness check that reports what on-chain setup exists for a `(
 - `500 INTERNAL_ERROR` — Failed to create RPC snapshot.
 - Standard `DiscoveryError` mapping for storage errors.
 
-## 6.8 History Endpoint (Not Yet Specified)
+## 6.8 History Endpoint
 
-`POST /v1/discovery/history`
+`POST /v1/history`
 
-A planned endpoint for full history retrieval. Unlike the sync endpoints which focus on current unspent notes, this endpoint will provide:
+Returns a paginated, backward-ordered list of client actions reconstructed from on-chain note events. Unlike the sync endpoints which focus on current unspent notes, this endpoint provides the full operation history: deposits, transfers, withdrawals, and swaps.
 
-- Full history of all notes (both spent and unspent)
-- Both sent and received notes
-- Historical transaction data for audit/reporting purposes
+### 6.8.1 Overview
 
-**Status:** Not yet specified. This section is a placeholder for future design work.
+The history pipeline has three stages:
+
+1. **Cursor construction** (caller): the caller builds a `HistoryCursor` from previously discovered channels/subchannels, containing one `HistoryEventSource` per subchannel.
+2. **Note event aggregation** (`fetch_aggregated_note_events`): reads note creation events from contract storage, groups them by block number in descending order, and paginates via the cursor.
+3. **On-chain event fetching** (`fetch_on_chain_events`): fetches Deposit and Withdrawal contract events for the block range covered by the aggregated note events.
+4. **Client action reconstruction** (`reconstruct_client_actions`): classifies per-block note events into user-facing actions using both note creation events and on-chain deposit/withdrawal events. Optionally enriched via `enrich_swap_actions` (TODO).
+
+### 6.8.2 Note Event Aggregation
+
+Each `HistoryEventSource` represents one stream of note creation events to scan backward:
+
+| Field | Description |
+|-------|-------------|
+| `channel_key` | Secret channel key (for note ID computation) |
+| `token` | Token address for this subchannel |
+| `channel_kind` | `Incoming`, `Outgoing`, or `SelfChannel` |
+| `counterparty` | Sender (Incoming), recipient (Outgoing), or self address (SelfChannel) |
+| `next_index` | Next note index to read (descending); `None` = exhausted |
+
+Each subchannel produces **one** source (note creation reads only). Spending is not tracked via the backward scanner — deposits and withdrawals are identified from on-chain events instead.
+
+The aggregator reads note values in batch via `get_notes_batch_with_block`. The block number comes from the note's storage write. Events at the same block number are grouped together.
+
+**Pagination**: the caller passes `max_items` (max block groups per call) and an `IoBudget`. The cursor is updated in place — pass it back on subsequent calls.
+
+**Open note detection**: notes with `salt == OPEN_NOTE_SALT (1)` are flagged as `is_open: true` on the `CreateNoteEvent`. The salt is extracted from the packed note value during decryption.
+
+### 6.8.3 Client Action Reconstruction
+
+`reconstruct_client_actions` takes note events (`BTreeMap<block_number, Vec<CreateNoteEvent>>`) and on-chain events (`BTreeMap<block_number, BlockOnChainEvents>`) and produces a `Vec<ClientAction>` in ascending block order.
+
+#### Action types
+
+| Action | Description | Fields |
+|--------|-------------|--------|
+| `Deposit` | Funds entered the pool (from on-chain Deposit event) | `from_address: Option<Felt>` |
+| `TransferSent` | Notes sent to a recipient | `recipient: Felt` |
+| `TransferReceived` | Notes received from a sender | `sender: Felt` |
+| `Withdrawal` | Funds withdrawn from the pool (from on-chain Withdrawal event) | `to_address: Option<Felt>` |
+| `SwapIn` | Open note created as part of a swap | (no fields) |
+| `SwapOut` | Withdrawal co-occurring with a SwapIn | `to_address: Option<Felt>` |
+| `Unknown` | Self-channel notes without matching on-chain event | (no fields) |
+
+Each `ClientAction` contains: `block_number`, `action_kind`, `token`, `amount`, and the underlying `Vec<CreateNoteEvent>`.
+
+#### Classification logic (per block, per token)
+
+Note creation events are partitioned in a single pass:
+
+1. **Open note Created** (`is_open == true` on SelfChannel): collected separately. Produces `SwapIn` action.
+2. **Incoming Created**: grouped by sender. Each sender group produces a `TransferReceived` action.
+3. **Outgoing Created**: grouped by recipient. Each recipient group produces a `TransferSent` action.
+4. **SelfChannel Created** (non-open): collected as context events for deposit/withdrawal/unknown actions.
+
+On-chain events are then matched by block and token:
+
+5. **On-chain Deposit** (same token): produces `Deposit` action with `from_address` from the event's `keys[1]` and `amount` from `data[0]`. Self-channel note events are included as context.
+6. **On-chain Withdrawal** (same token): produces `Withdrawal` action with `to_address` from the event's `keys[1]` and `amount` from `data[3]`. Self-channel note events are included as context.
+7. **Self-channel notes without matching on-chain event**: produces `Unknown` action. TODO: once a `NoteCreated` event exists in the contract, fetch it by `note_id` → get `tx_hash` → fetch all tx events to discover deposits/withdrawals.
+
+**Swap promotion**: after classifying all tokens in a block, if any `SwapIn` action exists, all `Withdrawal` actions in that block are promoted to `SwapOut`.
+
+#### On-chain event layouts (Cairo)
+
+- **Deposit**: keys = `[selector, user_addr, token]`, data = `[amount]`
+- **Withdrawal**: keys = `[selector, to_addr, token]`, data = `[enc_user_addr(3 felts), amount]`
+
+#### Assumptions and known limitations
+
+- **One transaction per block per user**: since note events are aggregated by block without transaction boundaries, multiple transactions from the same user in the same block are merged into a single set of actions. This is acceptable in practice but can produce incorrect classifications in edge cases.
+- **Swap detection is heuristic**: `SwapIn` is detected by open note salt, and all withdrawals in the same block are assumed to be part of the swap. TODO: after enrichment via `OpenNoteDeposited`, confirm `depositor == to_address` before keeping as `SwapOut`.
+- **No spending assumption**: unlike earlier designs, classification does not rely on sequential spending or nullifier scanning. Deposits and withdrawals are identified directly from on-chain events.
+
+### 6.8.4 Enrichment
+
+`enrich_swap_actions` (TODO) will fill in swap counterparty information:
+
+1. For each `SwapIn`, get the open note's `note_id`.
+2. Fetch `OpenNoteDeposited` event by `note_id` key → get `depositor`, `tx_hash`.
+3. Fetch all tx events → find `Withdrawal` where `to_addr == depositor`.
+4. Create `SwapOut` with `to_address = depositor`.
+
+### 6.8.5 Response Shape (Planned)
+
+The HTTP endpoint is not yet implemented. The planned response shape:
+
+```json
+{
+  "block_ref": "0x...",
+  "actions": [
+    {
+      "block_number": 12345,
+      "action_kind": { "Withdrawal": { "to_address": "0x..." } },
+      "token": "0x...",
+      "amount": "1000",
+      "events": [
+        {
+          "channel_kind": "SelfChannel",
+          "token": "0x...",
+          "note_index": 0,
+          "note_id": "0x...",
+          "amount": "1000",
+          "counterparty": "0x...",
+          "is_open": false
+        }
+      ]
+    }
+  ],
+  "cursor": { ... },
+  "has_more": true
+}
+```
+
+The endpoint will use the same `block_ref` / `last_known_block` reorg-detection pattern as the sync endpoints (§6.2, §6.5).


### PR DESCRIPTION
### TL;DR

Added client action reconstruction system that converts note events into high-level user actions like deposits, transfers, and withdrawals.

### What changed?

Added a new `client_actions.rs` module that implements a two-pass pipeline for reconstructing user actions from note events:

1. **Reconstruct phase**: Classifies note events per block into client actions (`Deposit`, `TransferSent`, `TransferReceived`, `NoteSpent`)
2. **Enrich phase**: Distinguishes between `Withdrawal` and `Invoke` actions by querying on-chain events

The module includes:
- `ClientAction` struct representing reconstructed user actions with associated events
- `ClientActionKind` enum defining action types (Deposit, TransferSent, TransferReceived, NoteSpent, Withdrawal, Invoke)
- `OnChainEventAccess` trait for fetching contract events
- `reconstruct_client_actions()` function for the pure reconstruction phase
- `enrich_spent_actions()` async function for enriching spent actions with on-chain data
- Comprehensive test coverage for both reconstruction and enrichment logic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/617)
<!-- Reviewable:end -->
