### PR TITLE
feat(contract): enc note created event

### DIFF
--- a/packages/privacy/src/actions.cairo
+++ b/packages/privacy/src/actions.cairo
@@ -356,6 +356,8 @@ pub enum ServerAction {
     EmitDeposit: events::Deposit,
     /// Emit [`OpenNoteCreated`](privacy::events::OpenNoteCreated) event.
     EmitOpenNoteCreated: events::OpenNoteCreated,
+    /// Emit [`EncNoteCreated`](privacy::events::EncNoteCreated) event.
+    EmitEncNoteCreated: events::EncNoteCreated,
     /// Emit [`NoteUsed`](privacy::events::NoteUsed) event.
     EmitNoteUsed: events::NoteUsed,
     /// Invoke an external contract via the

--- a/packages/privacy/src/events.cairo
+++ b/packages/privacy/src/events.cairo
@@ -77,6 +77,15 @@ pub struct OpenNoteDeposited {
 }
 
 #[derive(Serde, Copy, Debug, Drop, PartialEq, starknet::Event)]
+pub struct EncNoteCreated {
+    /// The note ID.
+    #[key]
+    pub note_id: felt252,
+    /// The packed note value (encodes salt and amount).
+    pub packed_value: felt252,
+}
+
+#[derive(Serde, Copy, Debug, Drop, PartialEq, starknet::Event)]
 pub struct NoteUsed {
     /// The nullifier of the used note.
     #[key]

--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -316,6 +316,8 @@ pub trait IClient<T> {
     /// **For [`CreateEncNote`](privacy::actions::ClientAction::CreateEncNote) action:**
     /// - [`WriteOnce`](privacy::actions::ServerAction::WriteOnce): Writes the encrypted note to
     /// storage.
+    /// - [`EmitEncNoteCreated`](privacy::actions::ServerAction::EmitEncNoteCreated): Emits an
+    /// [`EncNoteCreated`](privacy::events::EncNoteCreated) event.
     ///
     /// **For [`CreateOpenNote`](privacy::actions::ClientAction::CreateOpenNote) action:**
     /// - [`WriteOnce`](privacy::actions::ServerAction::WriteOnce): Writes the open note to
@@ -438,6 +440,8 @@ pub trait IServer<T> {
     ///   [`Deposit`](privacy::events::Deposit) event.
     ///   - [`EmitOpenNoteCreated`](privacy::actions::ServerAction::EmitOpenNoteCreated): Emit an
     ///   [`OpenNoteCreated`](privacy::events::OpenNoteCreated) event.
+    ///   - [`EmitEncNoteCreated`](privacy::actions::ServerAction::EmitEncNoteCreated): Emit an
+    ///   [`EncNoteCreated`](privacy::events::EncNoteCreated) event.
     ///   - [`EmitNoteUsed`](privacy::actions::ServerAction::EmitNoteUsed): Emit a
     ///   [`NoteUsed`](privacy::events::NoteUsed) event.
     ///   - [`Invoke`](privacy::actions::ServerAction::Invoke): Invoke an external contract.
@@ -465,6 +469,9 @@ pub trait IServer<T> {
     /// [`EmitDeposit`](privacy::actions::ServerAction::EmitDeposit) action is executed.
     /// - [`OpenNoteCreated`](privacy::events::OpenNoteCreated): Emitted when
     /// [`EmitOpenNoteCreated`](privacy::actions::ServerAction::EmitOpenNoteCreated) action is
+    /// executed.
+    /// - [`EncNoteCreated`](privacy::events::EncNoteCreated): Emitted when
+    /// [`EmitEncNoteCreated`](privacy::actions::ServerAction::EmitEncNoteCreated) action is
     /// executed.
     /// - [`NoteUsed`](privacy::events::NoteUsed): Emitted when
     /// [`EmitNoteUsed`](privacy::actions::ServerAction::EmitNoteUsed) action is executed.

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -128,6 +128,7 @@ pub mod Privacy {
         Deposit: events::Deposit,
         AuditorPublicKeySet: events::AuditorPublicKeySet,
         OpenNoteCreated: events::OpenNoteCreated,
+        EncNoteCreated: events::EncNoteCreated,
         OpenNoteDeposited: events::OpenNoteDeposited,
         NoteUsed: events::NoteUsed,
         FeeAmountSet: events::FeeAmountSet,
@@ -582,7 +583,7 @@ pub mod Privacy {
             } = input;
 
             // Validate and compute note values.
-            let (channel_key, storage_address, _) = self
+            let (channel_key, storage_address, note_id) = self
                 ._prepare_note_creation(
                     :sender_addr,
                     :sender_private_key,
@@ -600,7 +601,10 @@ pub mod Privacy {
 
             // Only `packed_value` needs to be written to storage, `token` and `depositor` are
             // initialized to zero.
-            array![to_write_once_action(:storage_address, value: packed_value)]
+            array![
+                to_write_once_action(:storage_address, value: packed_value),
+                ServerAction::EmitEncNoteCreated(events::EncNoteCreated { note_id, packed_value }),
+            ]
         }
 
         /// Returns the server action to create an open note.
@@ -704,6 +708,7 @@ pub mod Privacy {
                     ServerAction::EmitWithdrawal(_) => {},
                     ServerAction::EmitDeposit(_) => {},
                     ServerAction::EmitOpenNoteCreated(_) => {},
+                    ServerAction::EmitEncNoteCreated(_) => {},
                     ServerAction::EmitNoteUsed(_) => {},
                 }
             }
@@ -820,6 +825,7 @@ pub mod Privacy {
                     ServerAction::EmitWithdrawal(event) => self.emit(event),
                     ServerAction::EmitDeposit(event) => self.emit(event),
                     ServerAction::EmitOpenNoteCreated(event) => self.emit(event),
+                    ServerAction::EmitEncNoteCreated(event) => self.emit(event),
                     ServerAction::EmitNoteUsed(event) => self.emit(event),
                 };
             };

--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -180,13 +180,12 @@ fn test_transfer() {
     let storage_path_felt_nullifier = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [expected_nullifier].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: storage_path_felt_nullifier, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier }),
-        create_note_input.into_server_action(user: user_1),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input.into_server_actions(user: user_1));
+    assert_eq!(actions, expected_actions.span());
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier));
     assert_eq!(test.privacy.get_note(:note_id), Zero::zero());
 
@@ -225,13 +224,12 @@ fn test_transfer_to_self() {
     let storage_path_felt_nullifier = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [expected_nullifier].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: storage_path_felt_nullifier, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier }),
-        create_note_input.into_server_action(user: user_1),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input.into_server_actions(user: user_1));
+    assert_eq!(actions, expected_actions.span());
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier));
     assert_eq!(test.privacy.get_note(:note_id), Zero::zero());
 
@@ -282,14 +280,13 @@ fn test_transfer_one_to_many() {
     let storage_path_felt_nullifier = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [expected_nullifier].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: storage_path_felt_nullifier, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier }),
-        create_note_input_1.into_server_action(user: user_1),
-        create_note_input_2.into_server_action(user: user_1),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input_1.into_server_actions(user: user_1));
+    expected_actions.append_span(create_note_input_2.into_server_actions(user: user_1));
+    assert_eq!(actions, expected_actions.span());
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier));
     assert_eq!(test.privacy.get_note(note_id: note_id_1), Zero::zero());
     assert_eq!(test.privacy.get_note(note_id: note_id_2), Zero::zero());
@@ -347,15 +344,14 @@ fn test_transfer_many_to_one() {
     let storage_path_felt_nullifier_2 = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [expected_nullifier_2].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: storage_path_felt_nullifier_1, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier_1 }),
         to_write_once_action(storage_address: storage_path_felt_nullifier_2, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier_2 }),
-        create_note_input.into_server_action(user: user_1),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input.into_server_actions(user: user_1));
+    assert_eq!(actions, expected_actions.span());
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier_1));
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier_2));
     assert_eq!(test.privacy.get_note(:note_id), Zero::zero());
@@ -419,16 +415,15 @@ fn test_transfer_many_to_many() {
     let storage_path_felt_nullifier_2 = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [expected_nullifier_2].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: storage_path_felt_nullifier_1, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier_1 }),
         to_write_once_action(storage_address: storage_path_felt_nullifier_2, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier: expected_nullifier_2 }),
-        create_note_input_1.into_server_action(user: user_3),
-        create_note_input_2.into_server_action(user: user_3),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input_1.into_server_actions(user: user_3));
+    expected_actions.append_span(create_note_input_2.into_server_actions(user: user_3));
+    assert_eq!(actions, expected_actions.span());
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier_1));
     assert!(!test.privacy.nullifier_exists(nullifier: expected_nullifier_2));
     assert_eq!(test.privacy.get_note(note_id: note_id_1), Zero::zero());
@@ -3698,17 +3693,16 @@ fn test_execute_deposit_create_note() {
     let actions = user_1.execute(:client_actions);
     let (note_id, expected_note) = user_1.compute_enc_note(:create_note_input);
     let expected_event = events::Deposit { user_addr: user_1.address, token: token_addr, amount };
-    let expected_actions = array![
+    let mut expected_actions = array![
         ServerAction::TransferFrom(
             TransferFromInput {
                 from_addr: user_1.address, token: token_addr, amount: amount.into(),
             },
         ),
         ServerAction::EmitDeposit(expected_event),
-        create_note_input.into_server_action(user: user_1),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input.into_server_actions(user: user_1));
+    assert_eq!(actions, expected_actions.span());
     let view_actions = user_1.compile_actions(:client_actions);
     assert_eq!(view_actions, actions);
     let panic_data_actions = user_1.compile_and_panic(:client_actions);
@@ -3761,13 +3755,12 @@ fn test_execute_use_note_create_note() {
     let nullifier_storage_path = map_entry_address(
         map_selector: selector!("nullifiers"), keys: [nullifier].span(),
     );
-    let expected_actions = array![
+    let mut expected_actions = array![
         to_write_once_action(storage_address: nullifier_storage_path, value: true),
         ServerAction::EmitNoteUsed(events::NoteUsed { nullifier }),
-        create_note_input_2.into_server_action(user: user_2),
-    ]
-        .span();
-    assert_eq!(actions, expected_actions);
+    ];
+    expected_actions.append_span(create_note_input_2.into_server_actions(user: user_2));
+    assert_eq!(actions, expected_actions.span());
     let mut spy = spy_events();
     let view_actions = user_2.compile_actions(:client_actions);
     let compile_actions_events = spy
@@ -5227,7 +5220,7 @@ fn test_client_apply_writes() {
         user_addr: address, public_key, enc_private_key,
     };
     let expected_event_deposit = events::Deposit { user_addr: address, token: token_addr, amount };
-    let expected_server_actions = [
+    let mut expected_server_actions = array![
         // Set viewing key.
         to_write_once_action(storage_address: public_key_storage_path, value: public_key),
         to_write_once_action(storage_address: enc_private_key_storage_path, value: enc_private_key),
@@ -5247,10 +5240,11 @@ fn test_client_apply_writes() {
         ServerAction::TransferFrom(
             TransferFromInput { from_addr: address, token: token_addr, amount },
         ),
-        ServerAction::EmitDeposit(expected_event_deposit), // Create note.
-        create_enc_note_input.into_server_action(:user),
-    ]
-        .span();
+        ServerAction::EmitDeposit(expected_event_deposit),
+    ];
+    // Create note.
+    expected_server_actions.append_span(create_enc_note_input.into_server_actions(:user));
+    let expected_server_actions = expected_server_actions.span();
     // Assert server actions.
     assert_eq!(server_actions, expected_server_actions);
     let events = spy_events.get_events().emitted_by(contract_address: test.privacy.address).events;
@@ -5356,14 +5350,14 @@ fn test_client_transfers_dont_execute() {
         salt,
     };
     let expected_event = events::Deposit { user_addr: user.address, token: token_addr, amount };
-    let expected_server_actions = array![
+    let mut expected_server_actions = array![
         ServerAction::TransferFrom(
             TransferFromInput { from_addr: user.address, token: token_addr, amount: amount.into() },
         ),
-        ServerAction::EmitDeposit(expected_event), create_note_input.into_server_action(:user),
-    ]
-        .span();
-    assert_eq!(server_actions, expected_server_actions);
+        ServerAction::EmitDeposit(expected_event),
+    ];
+    expected_server_actions.append_span(create_note_input.into_server_actions(:user));
+    assert_eq!(server_actions, expected_server_actions.span());
     let result = test.privacy.safe_apply_actions(actions: server_actions);
     assert_panic_with_error(:result, expected_error: Erc20Error::INSUFFICIENT_BALANCE.describe());
 

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -576,6 +576,25 @@ fn test_apply_emit_open_note_created() {
 }
 
 #[test]
+fn test_apply_emit_enc_note_created() {
+    let mut test: Test = Default::default();
+    let note_id = 'NOTE_ID';
+    let packed_value = 'PACKED_VALUE';
+    let expected_event = events::EncNoteCreated { note_id, packed_value };
+    let actions = array![ServerAction::EmitEncNoteCreated(expected_event)];
+    let mut spy = spy_events();
+    test.privacy.apply_actions(actions.span());
+    let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
+    assert_eq!(events.len(), 1);
+    assert_expected_event_emitted(
+        spied_event: events[0],
+        :expected_event,
+        expected_event_selector: @selector!("EncNoteCreated"),
+        expected_event_name: "EncNoteCreated",
+    );
+}
+
+#[test]
 fn test_apply_emit_note_used() {
     let mut test: Test = Default::default();
     let nullifier = test.mock_new_nullifier();

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -87,16 +87,18 @@ pub(crate) impl InvokeExternalInputIntoServerActionImpl of InvokeExternalInputIn
 
 #[generate_trait]
 pub(crate) impl CreateEncNoteInputIntoServerActionImpl of CreateEncNoteInputIntoServerActionTrait {
-    fn into_server_action(self: @CreateEncNoteInput, user: User) -> ServerAction {
+    fn into_server_actions(self: @CreateEncNoteInput, user: User) -> Span<ServerAction> {
         let (note_id, note) = user.compute_enc_note(create_note_input: *self);
         let storage_path = map_entry_address(
             map_selector: selector!("notes"), keys: [note_id].span(),
         );
-        to_write_once_action(storage_address: storage_path, value: note.packed_value)
-    }
-
-    fn into_server_actions(self: @CreateEncNoteInput, user: User) -> Span<ServerAction> {
-        [self.into_server_action(:user)].span()
+        [
+            to_write_once_action(storage_address: storage_path, value: note.packed_value),
+            ServerAction::EmitEncNoteCreated(
+                events::EncNoteCreated { note_id, packed_value: note.packed_value },
+            ),
+        ]
+            .span()
     }
 }
 
@@ -1139,16 +1141,18 @@ pub(crate) impl UserImpl of UserTrait {
         self: @User, token: Token, amount: u128, create_note_input: CreateEncNoteInput,
     ) {
         self.approve(:token, amount: amount.into());
-        let actions = [
-            create_note_input.into_server_action(user: *self),
-            ServerAction::TransferFrom(
-                TransferFromInput {
-                    from_addr: *self.address, token: token.contract_address(), amount,
-                },
-            ),
-        ]
-            .span();
-        self.privacy.apply_actions(:actions);
+        let mut actions: Array<ServerAction> = create_note_input
+            .into_server_actions(user: *self)
+            .into();
+        actions
+            .append(
+                ServerAction::TransferFrom(
+                    TransferFromInput {
+                        from_addr: *self.address, token: token.contract_address(), amount,
+                    },
+                ),
+            );
+        self.privacy.apply_actions(actions: actions.span());
     }
 
     /// Cheat withdraw in the server side (no client side).


### PR DESCRIPTION
## Add NoteCreated event emission for all note creation operations

This change introduces a new `NoteCreated` event that is emitted whenever a note is created, providing a unified way to track note creation across the privacy system.

### Changes

- **New Event Structure**: Added `NoteCreated` event with `note_id` (keyed) and `packed_value` fields
- **Server Action Integration**: Added `EmitNoteCreated` variant to `ServerAction` enum with proper documentation
- **Event Emission**: Modified note creation functions to emit `NoteCreated` events:
  - `create_enc_note()` now emits the event alongside storage writes
  - `create_open_note()` emits both `OpenNoteCreated` and `NoteCreated` events
- **Event Handling**: Updated `apply_actions()` to handle the new event emission
- **Test Updates**: Updated all test cases to expect the additional `NoteCreated` event emissions and verify correct event data

The `NoteCreated` event provides a consistent interface for tracking note creation regardless of whether the note is encrypted or open, complementing the existing specialized events.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" alt="Reviewable">](https://reviewable.io/reviews/starkware-libs/starknet-privacy/624)

<!-- Reviewable:end -->