### PR TITLE
feat(discovery-service): add endpoint for paginated transaction history

### DIFF
--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
 use tracing::{debug, trace};
@@ -25,23 +25,8 @@ use crate::io_budget::IoBudget;
 use crate::privacy_pool::decryption::{decrypt_packed_value, OPEN_NOTE_SALT};
 use crate::privacy_pool::felt_hex;
 use crate::privacy_pool::hashes::{compute_note_id, compute_nullifier};
-use crate::privacy_pool::types::SecretFelt;
+use crate::privacy_pool::types::{u128_as_string, SecretFelt};
 use crate::privacy_pool::views::IViews;
-
-/// Serde helper: serializes `u128` as a decimal string to avoid
-/// precision loss in JSON (JS numbers are 53-bit floats).
-mod u128_as_string {
-    use super::*;
-
-    pub fn serialize<S: Serializer>(value: &u128, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&value.to_string())
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u128, D::Error> {
-        let s: &str = Deserialize::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
 
 /// A discovered and decrypted note.
 ///

--- a/crates/discovery-core/src/history/types.rs
+++ b/crates/discovery-core/src/history/types.rs
@@ -1,12 +1,14 @@
 //! Types for the backward history scan.
 
+use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
 use crate::privacy_pool::events::{DepositEvent, OpenNoteDepositedEvent, WithdrawalEvent};
-use crate::privacy_pool::types::SecretFelt;
+use crate::privacy_pool::types::{secret_felt_serde, u128_as_string, SecretFelt};
 
 /// The relationship between the user and a channel.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ChannelKind {
     Incoming,
     Outgoing,
@@ -14,19 +16,21 @@ pub enum ChannelKind {
 }
 
 /// A decrypted note enriched with channel context.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HistoryNote {
     pub channel_kind: ChannelKind,
     pub token: Felt,
     pub note_index: u64,
     pub note_id: Felt,
     pub counterparty: Felt,
+    #[serde(with = "u128_as_string")]
     pub amount: u128,
+    #[serde(with = "u128_as_string")]
     pub salt: u128,
 }
 
 /// A transaction's events grouped and typed for history display.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HistoryTransaction {
     pub block_number: u64,
     pub transaction_hash: Felt,
@@ -50,7 +54,12 @@ impl HistoryTransaction {
 }
 
 /// A single subchannel in the backward history scan (note creation reads only).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistorySubchannel {
+    #[serde(
+        serialize_with = "secret_felt_serde::serialize",
+        deserialize_with = "secret_felt_serde::deserialize"
+    )]
     pub channel_key: SecretFelt,
     pub token: Felt,
     pub channel_kind: ChannelKind,
@@ -60,6 +69,7 @@ pub struct HistorySubchannel {
 }
 
 /// Cursor for paginated backward history scan across multiple subchannels.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HistoryCursor {
     pub subchannels: Vec<HistorySubchannel>,
     /// Inclusive upper bound for event queries — the block where backward scanning begins.
@@ -68,4 +78,62 @@ pub struct HistoryCursor {
     /// `true` = all subchannels exhausted, no more history.
     /// `false` = stopped due to budget or max_transactions limit.
     pub history_complete: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_history_note_serializes_amounts_as_strings() {
+        let note = HistoryNote {
+            channel_kind: ChannelKind::Incoming,
+            token: Felt::from(0x1u64),
+            note_index: 0,
+            note_id: Felt::from(0x42u64),
+            counterparty: Felt::from(0xABCDu64),
+            amount: (1u128 << 53) + 1,
+            salt: u128::MAX,
+        };
+
+        let json = serde_json::to_value(&note).unwrap();
+        assert!(json["amount"].is_string(), "amount must be a JSON string");
+        assert!(json["salt"].is_string(), "salt must be a JSON string");
+
+        let restored: HistoryNote = serde_json::from_value(json).unwrap();
+        assert_eq!(restored, note);
+    }
+
+    #[test]
+    fn test_history_transaction_serializes_event_amounts_as_strings() {
+        let transaction = HistoryTransaction {
+            block_number: 10,
+            transaction_hash: Felt::from(0x999u64),
+            notes: Vec::new(),
+            deposits: vec![DepositEvent {
+                user_address: Felt::from(0xAu64),
+                token: Felt::from(0x1u64),
+                amount: (1u128 << 53) + 1,
+            }],
+            withdrawals: vec![WithdrawalEvent {
+                to_address: Felt::from(0xBu64),
+                token: Felt::from(0x1u64),
+                amount: u128::MAX,
+            }],
+            open_note_deposits: vec![OpenNoteDepositedEvent {
+                depositor: Felt::from(0xCu64),
+                token: Felt::from(0x1u64),
+                note_id: Felt::from(0x42u64),
+                amount: 0,
+            }],
+        };
+
+        let json = serde_json::to_value(&transaction).unwrap();
+        assert!(json["deposits"][0]["amount"].is_string());
+        assert!(json["withdrawals"][0]["amount"].is_string());
+        assert!(json["open_note_deposits"][0]["amount"].is_string());
+
+        let restored: HistoryTransaction = serde_json::from_value(json).unwrap();
+        assert_eq!(restored, transaction);
+    }
 }

--- a/crates/discovery-core/src/privacy_pool/events.rs
+++ b/crates/discovery-core/src/privacy_pool/events.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use starknet_core::utils::starknet_keccak;
 use starknet_types_core::felt::Felt;
 
-use super::types::felt_low_u128;
+use super::types::{felt_low_u128, u128_as_string};
 use crate::events_backend::{EmittedEvent, RawEventAccess};
 use crate::storage_backend::StorageError;
 
@@ -36,6 +36,7 @@ pub struct PrivacyPoolEvent {
 pub struct DepositEvent {
     pub user_address: Felt,
     pub token: Felt,
+    #[serde(with = "u128_as_string")]
     pub amount: u128,
 }
 
@@ -45,6 +46,7 @@ pub struct DepositEvent {
 pub struct WithdrawalEvent {
     pub to_address: Felt,
     pub token: Felt,
+    #[serde(with = "u128_as_string")]
     pub amount: u128,
 }
 
@@ -63,6 +65,7 @@ pub struct OpenNoteDepositedEvent {
     pub depositor: Felt,
     pub token: Felt,
     pub note_id: Felt,
+    #[serde(with = "u128_as_string")]
     pub amount: u128,
 }
 

--- a/crates/discovery-core/src/privacy_pool/types.rs
+++ b/crates/discovery-core/src/privacy_pool/types.rs
@@ -58,6 +58,21 @@ impl fmt::Debug for SecretFelt {
     }
 }
 
+/// Serde helper: serializes `u128` as a decimal string to avoid
+/// precision loss in JSON (JS numbers are 53-bit floats).
+pub mod u128_as_string {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &u128, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u128, D::Error> {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 /// Serde helpers for `SecretFelt`. Use with `#[serde(serialize_with, deserialize_with)]`.
 pub mod secret_felt_serde {
     use super::*;
@@ -115,6 +130,27 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: Wrapper = serde_json::from_str(&json).unwrap();
         assert_eq!(*restored.key, *original.key);
+    }
+
+    #[test]
+    fn test_u128_as_string_roundtrip() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            #[serde(with = "u128_as_string")]
+            value: u128,
+        }
+
+        let cases = [0u128, 1, u128::MAX, 1u128 << 53, (1u128 << 53) + 1];
+        for value in cases {
+            let wrapper = Wrapper { value };
+            let json = serde_json::to_string(&wrapper).unwrap();
+            assert!(
+                json.contains(&format!("\"{}\"", value)),
+                "value {value} should be serialized as a string"
+            );
+            let restored: Wrapper = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, wrapper);
+        }
     }
 }
 

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -97,7 +97,7 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
     { "sender_addr": "0x...", "token": "0x..." }
   ],
   "notes": [
-    { "sender_addr": "0x...", "token": "0x...", "index": 1, "note_id": "0x...", "amount": 1000, "salt": 12345 }
+    { "sender_addr": "0x...", "token": "0x...", "index": 1, "note_id": "0x...", "amount": "1000", "salt": "12345" }
   ],
   "cursor": {
     "channel_discovery_complete": false,
@@ -244,14 +244,105 @@ A non-paginated readiness check that reports what on-chain setup exists for a `(
 - `500 INTERNAL_ERROR` — Failed to create RPC snapshot.
 - Standard `DiscoveryError` mapping for storage errors.
 
-## 6.8 History Endpoint (Not Yet Specified)
+## 6.8 History Endpoint
 
-`POST /v1/discovery/history`
+`POST /v1/history`
 
-A planned endpoint for full history retrieval. Unlike the sync endpoints which focus on current unspent notes, this endpoint will provide:
+Retrieves paginated transaction history by scanning backward through note subchannels. Unlike the sync endpoints which discover channels and return current unspent notes, this endpoint operates on already-discovered subchannels and returns full transaction records including deposits, withdrawals, and both spent/unspent notes.
 
-- Full history of all notes (both spent and unspent)
-- Both sent and received notes
-- Historical transaction data for audit/reporting purposes
+**Prerequisites:** The client must first complete incoming and/or outgoing sync to discover channel keys and subchannel metadata. The history cursor is built client-side from those sync results.
 
-**Status:** Not yet specified. This section is a placeholder for future design work.
+**Request:**
+
+```json
+{
+  "contract_address": "0x...",
+  "user_address": "0x...",
+  "max_transactions": 50,
+  "last_known_block": "0x...",
+  "block_ref": "0x...",
+  "cursor": {
+    "subchannels": [
+      {
+        "channel_key": "0x...",
+        "token": "0x...",
+        "channel_kind": "incoming",
+        "counterparty": "0x...",
+        "next_index": 5
+      }
+    ],
+    "begin_block_number": 0,
+    "history_complete": false
+  }
+}
+```
+
+- `contract_address`: The privacy pool contract address.
+- `user_address`: The user's on-chain address (used for withdrawal event filtering).
+- `max_transactions`: Maximum number of transactions to return per page. Capped by server `max_history_transactions` limit.
+- `last_known_block`: Optional. Block hash from last completed sync session. Used for reorg detection on first request.
+- `block_ref`: Optional. Block hash for consistent storage reads across paginated requests. Leave empty on first request.
+- `cursor`: History cursor for pagination.
+  - `subchannels`: List of subchannels to scan. Each contains the `channel_key`, `token`, `channel_kind` (`incoming`, `outgoing`, `self_channel`), `counterparty` address, and `next_index` (next note index to read descending, `null` if exhausted).
+  - `begin_block_number`: Inclusive upper bound for event queries. Set to `0` on first request (server resolves from chain head). On subsequent requests, use the value from the previous response cursor.
+  - `history_complete`: `false` on initial request.
+
+**Response:**
+
+```json
+{
+  "block_ref": "0x...",
+  "transactions": [
+    {
+      "block_number": 100,
+      "transaction_hash": "0x...",
+      "notes": [
+        {
+          "channel_kind": "incoming",
+          "token": "0x...",
+          "note_index": 0,
+          "note_id": "0x...",
+          "counterparty": "0x...",
+          "amount": "1000",
+          "salt": "12345"
+        }
+      ],
+      "deposits": [
+        { "user_address": "0x...", "token": "0x...", "amount": "1000" }
+      ],
+      "withdrawals": [],
+      "open_note_deposits": []
+    }
+  ],
+  "cursor": {
+    "subchannels": [ ... ],
+    "begin_block_number": 50,
+    "history_complete": false
+  }
+}
+```
+
+- `block_ref`: Block hash pinning all storage reads. Pass back as `block_ref` in subsequent requests.
+- `transactions`: Transactions sorted by `block_number` descending. Each contains matched notes, deposits, withdrawals, and open note deposits from the same transaction.
+- `cursor`: Updated cursor for continuation. Pass back in next request.
+
+**Completion:** Check `cursor.history_complete` — `true` when all subchannels are exhausted.
+
+**Cursor lifecycle:**
+
+1. **Build initial cursor:** After completing incoming/outgoing sync, build `HistorySubchannel` entries from discovered channels and subchannels. Set `begin_block_number` to `0` and `history_complete` to `false`.
+2. **First request:** Server resolves `begin_block_number` from chain head. Scans notes backward, fetches block events, groups into transactions.
+3. **Pagination:** Pass back cursor from response. Server continues scanning from where it left off.
+4. **Done:** When `history_complete` is `true`, all history has been retrieved.
+
+**Validation limits:**
+
+- `max_history_subchannels` (default: 256): Maximum number of subchannels in a history cursor.
+- `max_history_transactions` (default: 100): Maximum allowed `max_transactions` value.
+
+**Error responses:**
+
+- `400 INVALID_REQUEST` — Cursor exceeds size limits, or `max_transactions` exceeds server limit.
+- `409 BLOCK_REORGED` — `last_known_block` was reorged out.
+- `503 SERVICE_UNAVAILABLE` — No indexed head available yet.
+- Standard `DiscoveryError` mapping for storage and event errors.

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -7,6 +7,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use discovery_core::events_backend::RawEventAccess;
 use discovery_core::io_budget::IoBudget;
 use discovery_core::storage_backend::StorageBackend;
 use starknet_core::types::{BlockId, Felt};
@@ -15,12 +16,13 @@ use tracing::debug;
 use discovery_core::privacy_pool::felt_hex;
 
 use crate::api::types::{
-    error_codes, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
-    OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
-    SyncRequestBase,
+    error_codes, ApiErrorResponse, HealthResponse, HistoryRequest, HistoryResponse,
+    IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest, OutgoingSyncResponse,
+    PreflightCheckRequest, PreflightCheckResponse, SyncRequestBase,
 };
 use crate::api::validators::{
-    validate_block_ref, validate_cursor, validate_recipients, validate_viewing_key,
+    validate_block_ref, validate_cursor, validate_history_cursor, validate_recipients,
+    validate_viewing_key,
 };
 use crate::api::AppState;
 use crate::chain_state::ChainState;
@@ -301,5 +303,88 @@ where
         sender_registered: result.sender_registered,
         channel_exists: result.channel_exists,
         subchannel_exists: result.subchannel_exists,
+    })
+}
+
+/// Handler for POST /v1/history.
+pub async fn history_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<HistoryRequest>,
+) -> impl IntoResponse
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: RawEventAccess + Clone + Send + Sync + 'static,
+{
+    match history_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn history_impl<B>(
+    state: &AppState<B>,
+    request: HistoryRequest,
+) -> Result<HistoryResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B::Snapshot: RawEventAccess + Clone + Send + Sync + 'static,
+{
+    validate_history_cursor(
+        &request.cursor,
+        request.max_transactions,
+        &state.validation_limits,
+    )?;
+
+    let block_ref =
+        validate_block_ref(request.last_known_block, request.block_ref, &state.backend).await?;
+
+    let snapshot = state
+        .backend
+        .snapshot(request.contract_address, Some(BlockId::Hash(block_ref)))
+        .await;
+
+    let mut cursor = request.cursor;
+    if cursor.begin_block_number == 0 {
+        let head = state.backend.get_head().await.ok_or_else(|| {
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiErrorResponse::new(
+                    error_codes::SERVICE_UNAVAILABLE,
+                    "No indexed head available yet",
+                ),
+            )
+        })?;
+        cursor.begin_block_number = head.block_number;
+    }
+
+    debug!(
+        user = %format!("{:#x}", request.user_address),
+        block = %block_ref,
+        num_subchannels = cursor.subchannels.len(),
+        begin_block = cursor.begin_block_number,
+        "history request"
+    );
+
+    let budget = IoBudget::new(state.validation_limits.server_budget);
+    let transactions = discovery_core::history::transactions::fetch_transactions(
+        &snapshot,
+        request.user_address,
+        &mut cursor,
+        request.max_transactions as usize,
+        &budget,
+    )
+    .await
+    .map_err(crate::api::types::discovery_error_to_response)?;
+
+    debug!(
+        num_transactions = transactions.len(),
+        history_complete = cursor.history_complete,
+        "history response"
+    );
+
+    Ok(HistoryResponse {
+        block_ref,
+        transactions,
+        cursor,
     })
 }

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
+use discovery_core::events_backend::RawEventAccess;
 use discovery_core::storage_backend::StorageBackend;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
@@ -23,12 +24,13 @@ use crate::config::{ApiServerConfig, ValidationLimits};
 use crate::public_key_cache::PublicKeyCache;
 
 pub use handlers::{
-    health_handler, incoming_sync_handler, outgoing_sync_handler, preflight_check_handler,
+    health_handler, history_handler, incoming_sync_handler, outgoing_sync_handler,
+    preflight_check_handler,
 };
 pub use types::{
-    ApiErrorBody, ApiErrorResponse, HealthResponse, IncomingSyncRequest, IncomingSyncResponse,
-    OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
-    SyncRequestBase,
+    ApiErrorBody, ApiErrorResponse, HealthResponse, HistoryRequest, HistoryResponse,
+    IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest, OutgoingSyncResponse,
+    PreflightCheckRequest, PreflightCheckResponse, SyncRequestBase,
 };
 
 /// API server for the discovery service.
@@ -60,7 +62,7 @@ pub struct AppState<B> {
 impl<B> ApiServer<B>
 where
     B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
-    B::Snapshot: Clone + Send + Sync + 'static,
+    B::Snapshot: RawEventAccess + Clone + Send + Sync + 'static,
 {
     /// Creates a new API server.
     pub fn new(config: ApiServerConfig, rx_shutdown: broadcast::Receiver<()>, backend: B) -> Self {
@@ -90,6 +92,7 @@ where
                 "/v1/sync/preflight_check",
                 post(preflight_check_handler::<B>),
             )
+            .route("/v1/history", post(history_handler::<B>))
             .layer(CorsLayer::permissive())
             .layer(DefaultBodyLimit::max(
                 self.config.validation_limits.max_request_body_bytes,

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -9,6 +9,7 @@ use discovery_core::discovery::notes::DecryptedNote;
 use discovery_core::discovery::outgoing_channels::OutgoingChannel;
 use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::discovery::DiscoveryError;
+use discovery_core::history::types::{HistoryCursor, HistoryTransaction};
 use discovery_core::privacy_pool::types::{secret_felt_serde, SecretFelt};
 use discovery_core::sync::incoming_state::IncomingSubchannel;
 use discovery_core::sync::outgoing_state::OutgoingSubchannel;
@@ -296,6 +297,40 @@ pub struct PreflightCheckResponse {
     pub channel_exists: bool,
     /// Whether the token subchannel exists within the channel.
     pub subchannel_exists: bool,
+}
+
+/// Request body for POST /v1/history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryRequest {
+    /// The privacy pool contract address.
+    pub contract_address: Felt,
+    /// The user's on-chain address (used for withdrawal event filtering).
+    pub user_address: Felt,
+    /// Maximum number of transactions to return per page.
+    pub max_transactions: u32,
+    /// Block hash from last completed sync session. Used for reorg detection
+    /// on first request. Leave empty on fresh syncs or pagination requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_known_block: Option<Felt>,
+    /// Block hash for consistent storage reads across paginated requests.
+    /// Leave empty on first request (server uses current head).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_ref: Option<Felt>,
+    /// History cursor for pagination. Use the cursor from previous response
+    /// to continue scanning.
+    #[serde(default)]
+    pub cursor: HistoryCursor,
+}
+
+/// Response body for POST /v1/history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryResponse {
+    /// Block hash pinning all storage reads.
+    pub block_ref: Felt,
+    /// History transactions for the current page.
+    pub transactions: Vec<HistoryTransaction>,
+    /// Updated cursor for continuation.
+    pub cursor: HistoryCursor,
 }
 
 /// Well-known error codes.

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use axum::http::StatusCode;
 use discovery_core::discovery::DiscoveryCursor;
+use discovery_core::history::types::HistoryCursor;
 use discovery_core::storage_backend::{StorageError, StorageSnapshot};
 use starknet_core::types::Felt;
 use tracing::warn;
@@ -172,6 +173,25 @@ pub fn validate_recipients(
         limits.max_outgoing_recipients,
         "recipients",
     )
+}
+
+/// Rejects history cursors that exceed size limits.
+pub fn validate_history_cursor(
+    cursor: &HistoryCursor,
+    max_transactions: u32,
+    limits: &ValidationLimits,
+) -> Result<(), (StatusCode, ApiErrorResponse)> {
+    validate_bound(
+        cursor.subchannels.len(),
+        limits.max_history_subchannels,
+        "history subchannels",
+    )?;
+    validate_bound(
+        max_transactions as usize,
+        limits.max_history_transactions,
+        "max_transactions",
+    )?;
+    Ok(())
 }
 
 /// Validates that the viewing key matches the public key registered on-chain for the given address.
@@ -461,6 +481,67 @@ mod tests {
         cursor.channels.insert(Felt::ONE, channel_cursor);
 
         let result = validate_cursor(&cursor, &limits);
+        assert!(result.is_ok());
+    }
+
+    use discovery_core::history::types::{ChannelKind, HistorySubchannel};
+
+    fn dummy_history_subchannel() -> HistorySubchannel {
+        HistorySubchannel {
+            channel_key: SecretFelt::new(Felt::ZERO),
+            token: Felt::ZERO,
+            channel_kind: ChannelKind::Incoming,
+            counterparty: Felt::ZERO,
+            next_index: None,
+        }
+    }
+
+    #[test]
+    fn test_history_cursor_too_many_subchannels() {
+        let limits = ValidationLimits::default();
+        let subchannels: Vec<_> = (0..limits.max_history_subchannels + 1)
+            .map(|_| dummy_history_subchannel())
+            .collect();
+        let cursor = HistoryCursor {
+            subchannels,
+            begin_block_number: 100,
+            history_complete: false,
+        };
+
+        let result = validate_history_cursor(&cursor, 10, &limits);
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error.code, error_codes::INVALID_REQUEST);
+        assert!(error.error.message.contains("history subchannels"));
+    }
+
+    #[test]
+    fn test_history_cursor_max_transactions_exceeded() {
+        let limits = ValidationLimits::default();
+        let cursor = HistoryCursor::default();
+
+        let result =
+            validate_history_cursor(&cursor, limits.max_history_transactions as u32 + 1, &limits);
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(error.error.message.contains("max_transactions"));
+    }
+
+    #[test]
+    fn test_history_cursor_valid() {
+        let limits = ValidationLimits::default();
+        let subchannels: Vec<_> = (0..5).map(|_| dummy_history_subchannel()).collect();
+        let cursor = HistoryCursor {
+            subchannels,
+            begin_block_number: 100,
+            history_complete: false,
+        };
+
+        let result = validate_history_cursor(&cursor, 50, &limits);
         assert!(result.is_ok());
     }
 

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -153,6 +153,10 @@ pub struct ValidationLimits {
     pub cursor_limits: CursorLimits,
     /// Maximum number of recipients in an outgoing sync filter.
     pub max_outgoing_recipients: usize,
+    /// Maximum number of subchannels in a history cursor.
+    pub max_history_subchannels: usize,
+    /// Maximum number of transactions per history request.
+    pub max_history_transactions: usize,
     /// Server-controlled I/O budget per request.
     pub server_budget: usize,
     /// Maximum request body size in bytes.
@@ -166,6 +170,8 @@ impl Default for ValidationLimits {
         Self {
             cursor_limits: CursorLimits::default(),
             max_outgoing_recipients: 64,
+            max_history_subchannels: 256,
+            max_history_transactions: 100,
             server_budget: 10_000,
             max_request_body_bytes: 102_400,
             public_key_cache_capacity: 10_000,

--- a/crates/discovery-service/tests/common/indexer.rs
+++ b/crates/discovery-service/tests/common/indexer.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use discovery_service::api::{
-    ApiErrorResponse, IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest,
-    OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
+    ApiErrorResponse, HistoryRequest, HistoryResponse, IncomingSyncRequest, IncomingSyncResponse,
+    OutgoingSyncRequest, OutgoingSyncResponse, PreflightCheckRequest, PreflightCheckResponse,
 };
 use nix::sys::signal::Signal;
 use reqwest::StatusCode;
@@ -216,6 +216,11 @@ impl IndexerClient {
         req: &OutgoingSyncRequest,
     ) -> Result<(StatusCode, ApiErrorResponse)> {
         self.sync_err("v1/sync/outgoing_state", req).await
+    }
+
+    /// POST `/v1/history` and return the parsed success response.
+    pub async fn history(&self, req: &HistoryRequest) -> Result<HistoryResponse> {
+        self.sync_ok("v1/history", req).await
     }
 
     /// POST `/v1/sync/preflight_check` and return the parsed success response.

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -8,10 +8,11 @@ use common::{
     setup_devnet_with_dump, setup_indexer, DevnetClient, DevnetConfig, IndexerClient,
     IndexerSpawnConfig, DEFAULT_STARTUP_TIMEOUT,
 };
+use discovery_core::history::types::{ChannelKind, HistoryCursor, HistorySubchannel};
 use discovery_core::privacy_pool::types::SecretFelt;
 use discovery_service::api::{
-    HealthResponse, IncomingSyncRequest, OutgoingSyncRequest, PreflightCheckRequest,
-    SyncRequestBase,
+    HealthResponse, HistoryRequest, IncomingSyncRequest, OutgoingSyncRequest,
+    PreflightCheckRequest, SyncRequestBase,
 };
 use starknet_core::types::Felt;
 
@@ -406,6 +407,81 @@ async fn test_preflight_check_basic() {
         !response.subchannel_exists,
         "No subchannel from unknown sender"
     );
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_history_basic() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    // First, run incoming sync to discover Alice's channels and subchannels.
+    let sync_request = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key.clone(),
+            last_known_block: None,
+            block_ref: None,
+            cursor: Default::default(),
+        },
+    };
+    let sync_response = indexer.incoming_sync(&sync_request).await.unwrap();
+    assert!(sync_response.cursor.is_complete());
+
+    // Build history subchannels from sync results: each (channel, subchannel) pair
+    // becomes a HistorySubchannel with the channel key and the last note index.
+    let mut history_subchannels = Vec::new();
+    for (sender_addr, channel_cursor) in &sync_response.cursor.channels {
+        for (token, subchannel_cursor) in &channel_cursor.subchannels {
+            history_subchannels.push(HistorySubchannel {
+                channel_key: channel_cursor.channel_key.clone(),
+                token: *token,
+                channel_kind: ChannelKind::Incoming,
+                counterparty: *sender_addr,
+                next_index: subchannel_cursor.last_note_index,
+            });
+        }
+    }
+
+    let history_request = HistoryRequest {
+        contract_address: metadata.contract_address,
+        user_address: metadata.alice_address,
+        max_transactions: 50,
+        last_known_block: None,
+        block_ref: Some(sync_response.block_ref),
+        cursor: HistoryCursor {
+            subchannels: history_subchannels,
+            begin_block_number: 0,
+            history_complete: false,
+        },
+    };
+
+    let history_response = indexer.history(&history_request).await.unwrap();
+
+    assert!(
+        history_response.block_ref != Felt::ZERO,
+        "block_ref should be set"
+    );
+    assert!(
+        !history_response.transactions.is_empty(),
+        "Alice should have at least one history transaction"
+    );
+    assert!(
+        history_response.cursor.history_complete,
+        "History should be complete with large budget"
+    );
+
+    // Verify transactions have expected structure
+    for transaction in &history_response.transactions {
+        assert!(transaction.block_number > 0, "block_number should be set");
+        assert!(
+            transaction.transaction_hash != Felt::ZERO,
+            "transaction_hash should be set"
+        );
+    }
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();


### PR DESCRIPTION
### TL;DR

Added a new `/v1/history` endpoint that provides paginated transaction history by scanning backward through note subchannels.

### What changed?

- Added serialization support to history types (`HistoryNote`, `HistoryTransaction`, `HistoryCursor`, etc.) with proper serde derives and custom serialization for `SecretFelt` fields
- Implemented the `/v1/history` POST endpoint with request/response types and validation
- Added history cursor validation with configurable limits for maximum subchannels (256) and transactions per request (100)
- Created a complete API specification for the history endpoint including request/response schemas, error handling, and pagination flow
- Added integration test coverage for the history endpoint functionality

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/630)
<!-- Reviewable:end -->
