### PR TITLE
refactor(sdk): consistent cursors in private registry and discovery

### DIFF
--- a/e2e/tests/reorg-recovery.test.ts
+++ b/e2e/tests/reorg-recovery.test.ts
@@ -64,7 +64,7 @@ describe("E2E Reorg Recovery", () => {
     // NotesCursor fields are @internal (stripped from .d.ts), so we cast through `any`.
     const registry = createEmptyRegistry();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    registry.cursor = { blockId: "0xdeadbeef", incomingChannels: new AddressMap() } as any;
+    registry.notesCursor = { blockId: "0xdeadbeef", incomingChannels: new AddressMap() } as any;
 
     // Second operation: withdraw triggers a deficit, forcing note discovery.
     // Note discovery sends the fake cursor → indexer returns 409 →
@@ -82,10 +82,10 @@ describe("E2E Reorg Recovery", () => {
 
     // Verify recovery succeeded:
     // - No error thrown (reorg was handled internally)
-    // - Registry cursor was cleared and re-populated with a valid blockId
-    expect(updatedRegistry.cursor).toBeDefined();
+    // - Registry notesCursor was cleared and re-populated with a valid blockId
+    expect(updatedRegistry.notesCursor).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((updatedRegistry.cursor as any).blockId).not.toBe("0xdeadbeef");
+    expect((updatedRegistry.notesCursor as any).blockId).not.toBe("0xdeadbeef");
     // - Notes were re-discovered (Alice has a 50 STRK change note)
     expect(updatedRegistry.notes.size).toBeGreaterThanOrEqual(1);
   });

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -205,9 +205,42 @@ const result = await transfers.build({
 | `autoSetup` | `boolean` | Automatically open channels and token subchannels as needed |
 | `autoSelectNotes` | `"all" \| "naive"` | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum) |
 | `autoDiscover` | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`) |
-| `registry` | `PrivateRegistry` | User's private state (channels, notes, cursor) |
+| `registry` | `PrivateRegistry` | User's private state (notes, discovery cursors) |
 | `registryConst` | `boolean` | If true, returns a new registry instead of mutating the provided one |
 | `provingBlockId` | `ProvingBlockId` | Block identifier to use for proving |
+
+## Registry management
+
+The `PrivateRegistry` holds the user's private state: unspent notes and discovery cursors. Create one with `createEmptyRegistry()` and pass it through `ExecuteOptions`.
+
+```typescript
+import { createEmptyRegistry } from "starknet-sdk";
+
+const registry = createEmptyRegistry();
+
+// The registry is updated in-place after each execute()
+const result = await transfers.build({
+  registry,
+  autoDiscover: { notes: "refresh", channels: "refresh" },
+  autoSetup: true,
+  autoSelectNotes: "naive",
+}).with(STRK, (t) => t
+  .deposit({ amount: 100n }))
+.surplusTo(self)
+.execute();
+
+// result.registry === registry (same object, mutated)
+// Use registryConst: true to get a new object instead
+```
+
+The registry contains:
+- **`notes`** — `AddressMap<Note[]>`: unspent notes keyed by token address
+- **`notesCursor`** — pagination cursor for incoming notes discovery (incremental sync)
+- **`channelCursor`** — pagination cursor for outgoing channels discovery (incremental sync, includes `blockId` for reorg detection)
+
+Discovery cursors are internal to the registry flow. When `autoDiscover` is set, the SDK uses them automatically for incremental syncing. You don't need to manage them directly.
+
+**Optimistic updates:** After `execute()`, the registry is updated optimistically — spent notes are removed and new notes/channels are added before the transaction is confirmed on-chain. If the transaction reverts, the registry becomes stale. Handle this by re-discovering from scratch (`autoDiscover: "refresh"`) or by snapshotting the registry before `execute()` (use `registryConst: true`) and restoring on revert.
 
 ## Discovery
 
@@ -223,7 +256,6 @@ const requirement = await transfers.discoverRequirement(recipient, token);
 ```typescript
 const { notes, timestamp } = await transfers.discoverNotes({
   tokens: [STRK],
-  cursor: previousCursor,
 });
 // notes: AddressMap<Note[]> — unspent notes keyed by token address
 ```
@@ -231,9 +263,7 @@ const { notes, timestamp } = await transfers.discoverNotes({
 ### Discover channels
 
 ```typescript
-const { timestamp, channels, total } = await transfers.discoverChannels("all", {
-  cursor: previousCursor,
-});
+const { timestamp, channels, total } = await transfers.discoverChannels("all");
 // channels: AddressMap<Channel> — channels keyed by recipient address
 ```
 
@@ -257,7 +287,7 @@ The wallet sends `callAndProof` in a transaction to the contract's `execute_acti
 
 **`Channel`** — A communication channel to a recipient, holding a shared key and per-token nonces.
 
-**`PrivateRegistry`** — The user's local state: discovered channels, unspent notes, and a pagination cursor. Create with `createEmptyRegistry()`.
+**`PrivateRegistry`** — The user's local state: unspent notes and discovery cursors for incremental sync. Create with `createEmptyRegistry()`.
 
 **`AddressMap<V>`** — A `Map` that normalizes Starknet addresses for consistent key lookup.
 

--- a/sdk/src/factory.ts
+++ b/sdk/src/factory.ts
@@ -18,7 +18,7 @@ import {
   type ProofInvocationFactoryInterface,
 } from "./internal/proof-invocation-factory.js";
 import { ProvingServiceProofProvider } from "./internal/proving-service-provider.js";
-import { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
+import { IndexerDiscoveryProvider } from "./internal/indexer/index.js";
 
 function isProofProviderConfig(
   x: ProofProviderInterface | ProofProviderConfig

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -13,5 +13,5 @@ export { ProvingServiceProofProvider } from "./internal/proving-service-provider
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";
 export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
-export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
-export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";
+export { IndexerDiscoveryProvider } from "./internal/indexer/index.js";
+export type { DiscoveryHealthResponse } from "./internal/indexer/index.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -57,6 +57,7 @@ import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./internal/ch
 import type { INVOKE_TXN_V3 } from "@starknet-io/starknet-types-010";
 export { Witness, Channel };
 export type { NotesCursor as DiscoveryCursor };
+export type { NotesCursor, ChannelCursor };
 
 export type Note = {
   readonly id: NoteId;
@@ -243,22 +244,21 @@ export type AutoDiscoveryOptions = {
 export type AutoSelectionStrategy = "all" | "naive" /*| "exact"*/; //
 
 /**
- * Registry holding the user's private state: channels and notes.
+ * Registry holding the user's private state: cursors and notes.
  * Passed to execute() for context resolution and updated with new state.
  */
 export type PrivateRegistry = {
-  /** Channels by recipient address */
-  channels: AddressMap<Channel>;
+  /** Cursor for incoming notes discovery */
+  notesCursor?: NotesCursor;
+  /** Cursor for outgoing channels discovery */
+  channelCursor?: ChannelCursor;
   /** Notes by token address */
   notes: AddressMap<Note[]>;
-  /** Cursor for discovery */
-  cursor?: NotesCursor;
 };
 
 /** Create an empty private registry */
 export function createEmptyRegistry(): PrivateRegistry {
   return {
-    channels: new AddressMap<Channel>(),
     notes: new AddressMap<Note[]>(() => []),
   };
 }
@@ -409,7 +409,11 @@ export interface PrivateTransfersInterface {
   discoverChannels(
     recipients: RecipientsFilter<StarknetAddress>,
     params?: { cursor?: ChannelCursor }
-  ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<Channel>;
+    total?: number;
+  }>;
 
   /**
    * Execute raw actions. The implementation:
@@ -650,7 +654,12 @@ export interface DiscoveryProviderInterface {
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
     params?: { cursor?: ChannelCursor }
-  ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<Channel>;
+    total?: number;
+    cursor: ChannelCursor;
+  }>;
 
   /**
    * Check the setup requirements for a recipient.

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -31,7 +31,12 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
     params?: { cursor?: ChannelCursor }
-  ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<Channel>;
+    total?: number;
+    cursor: ChannelCursor;
+  }>;
 
   // Default implementation provided by the abstract class
   async discoverRequirement(

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -67,7 +67,11 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   async discoverChannels(
     recipients: RecipientsFilter<StarknetAddress>,
     params?: { cursor?: ChannelCursor }
-  ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }> {
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<Channel>;
+    total?: number;
+  }> {
     return this.discoveryProvider.discoverChannels(
       this.user,
       await this.getViewingKey(),

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -74,6 +74,7 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
 export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all" | "total-only";
 
 export type ChannelCursor = {
+  /** @internal */ blockId?: BlockIdentifier;
   /** @internal */ channels?: AddressMap<Channel>;
   /** @internal */ total?: number;
 };
@@ -86,6 +87,7 @@ export function cloneChannelCursor(cursor?: ChannelCursor): ChannelCursor {
   }
 
   return {
+    blockId: cursor.blockId,
     channels: cursor.channels
       ? new AddressMap<Channel>(
           [...cursor.channels.entries()].map(([k, v]): [StarknetAddressBigint, Channel] => [

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -39,7 +39,7 @@ import { generateRandom, generateRandom120 } from "../utils/crypto.js";
 import { debugLog } from "../utils/logging.js";
 import { toHex } from "../utils/convert.js";
 import { compute_note_id } from "../utils/hashes.js";
-import { ReorgError } from "./indexer-discovery.js";
+import { ReorgError } from "./indexer/index.js";
 
 export type CompileResult = {
   clientActions: ClientAction[];
@@ -100,8 +100,8 @@ export class ActionCompiler {
         // Reorg detected: clear stale registry state and retry from scratch.
         if (options?.registry) {
           options.registry.notes.clear();
-          options.registry.channels.clear();
-          delete options.registry.cursor;
+          delete options.registry.notesCursor;
+          delete options.registry.channelCursor;
         }
         return await this.compileOnce(actions, options);
       }
@@ -199,9 +199,9 @@ export class ActionCompiler {
       pool.setupChannel(addr, channel);
     }
 
-    debugLog("compiler", "setup registry channels", registry?.channels);
+    debugLog("compiler", "setup registry channels", registry?.channelCursor?.channels);
 
-    for (const [addr, channel] of registry?.channels?.entries() ?? []) {
+    for (const [addr, channel] of registry?.channelCursor?.channels?.entries() ?? []) {
       if (channels?.has(addr)) continue; // skip channels that were already set up in the previous step
       pool.setupChannel(addr, channel);
     }
@@ -512,7 +512,9 @@ export class ActionCompiler {
       recipientsToDiscover = [...recipientsNeeded.keys()];
     } else {
       // None or 'missing': only discover recipients not in registry
-      recipientsToDiscover = [...recipientsNeeded.keys()].filter((r) => !registry.channels.has(r));
+      recipientsToDiscover = [...recipientsNeeded.keys()].filter(
+        (r) => !registry.channelCursor?.channels?.has(r)
+      );
     }
 
     if (recipientsToDiscover.length === 0) {
@@ -636,14 +638,14 @@ export class ActionCompiler {
         const { notes, cursor } = await this.discoveryProvider.discoverNotes(
           this.userAddress,
           this.userViewingKey,
-          { cursor: registry.cursor, tokens: tokensToDiscover }
+          { cursor: registry.notesCursor, tokens: tokensToDiscover }
         );
 
         // Replace registry notes (don't merge - some may have been spent)
         for (const [token, discoveredNotes] of notes.entries()) {
           registry.notes.set(token, discoveredNotes);
         }
-        registry.cursor = cursor;
+        registry.notesCursor = cursor;
       }
     }
 
@@ -707,19 +709,17 @@ export class ActionCompiler {
   }
 
   private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {
-    // Clone channels
-    const clonedChannels = new AddressMap<Channel>();
-    for (const [addr, channel] of registry.channels.entries()) {
-      clonedChannels.set(addr, channel);
-    }
-
     // Clone notes
     const clonedNotes = new AddressMap<Note[]>(() => []);
     for (const [addr, notes] of registry.notes.entries()) {
       clonedNotes.set(addr, [...notes]);
     }
 
-    return { channels: clonedChannels, notes: clonedNotes };
+    return {
+      notesCursor: registry.notesCursor,
+      channelCursor: registry.channelCursor,
+      notes: clonedNotes,
+    };
   }
 
   private allOpen(

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -253,6 +253,7 @@ class ChannelsDiscovery {
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
+    cursor: ChannelCursor;
   }> {
     if (this.recipients == "all" || this.recipients == "total-only") {
       void scan(
@@ -296,7 +297,12 @@ class ChannelsDiscovery {
       }
     }
     await this.tracker.wait();
-    return { timestamp: 0, channels: this.channels, total: this.total };
+    return {
+      timestamp: 0,
+      channels: this.channels,
+      total: this.total,
+      cursor: { channels: this.channels, total: this.total, blockId: 0 },
+    };
   }
 
   private async discoverChannel(recipient: StarknetAddressBigint): Promise<void> {
@@ -412,7 +418,12 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
     params?: { cursor?: ChannelCursor }
-  ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }> {
+  ): Promise<{
+    timestamp: BlockIdentifier;
+    channels?: AddressMap<Channel>;
+    total?: number;
+    cursor: ChannelCursor;
+  }> {
     const discovery = new ChannelsDiscovery(
       address,
       toBigInt(viewingKey),

--- a/sdk/src/internal/indexer/discovery.ts
+++ b/sdk/src/internal/indexer/discovery.ts
@@ -6,18 +6,18 @@ import {
   type StarknetAddress,
   type StarknetAddressBigint,
   type ViewingKey,
-} from "../interfaces.js";
-import { toBigInt } from "../utils/crypto.js";
-import { toHex } from "../utils/convert.js";
-import { AddressMap } from "../utils/maps.js";
-import { AbstractDiscoveryProvider } from "./abstract-discovery.js";
-import { Channel, Witness } from "./channel.js";
+} from "../../interfaces.js";
+import { toBigInt } from "../../utils/crypto.js";
+import { toHex } from "../../utils/convert.js";
+import { AddressMap } from "../../utils/maps.js";
+import { AbstractDiscoveryProvider } from "../abstract-discovery.js";
+import { Channel, Witness } from "../channel.js";
 import type {
   ChannelCursor,
   IncomingChannelCursor,
   NotesCursor,
   RecipientsFilter,
-} from "./channel.js";
+} from "../channel.js";
 
 /** Thrown when the indexer reports a block reorg (HTTP 409, BLOCK_REORGED). */
 export class ReorgError extends Error {
@@ -146,7 +146,9 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     let blockRef: string | undefined;
 
     const allNotes = new AddressMap<Note[]>(() => []);
-    const incomingChannels = new AddressMap<IncomingChannelCursor>();
+    const incomingChannels = cursor
+      ? new AddressMap<IncomingChannelCursor>(cursor.incomingChannels.entries())
+      : new AddressMap<IncomingChannelCursor>();
 
     let complete = false;
     do {
@@ -214,6 +216,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     timestamp: BlockIdentifier;
     channels?: AddressMap<ChannelInterface>;
     total?: number;
+    cursor: ChannelCursor;
   }> {
     if (recipients === "total-only") {
       // For total-only, do a minimal outgoing sync to get the total channel count
@@ -224,7 +227,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
         cursor: { channel_discovery_complete: false },
       };
       const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels! };
+      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels!, cursor: { total: resp.cursor.total_n_channels!, blockId: resp.block_ref } };
     }
 
     const cursorMap = params?.cursor?.channels;
@@ -274,6 +277,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       Map<string, { token: bigint; lastIndex: number | null }>
     >();
     const nonCreatedChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
+    const lastKnownBlock = params?.cursor?.blockId as string | undefined;
     let blockRef: string | undefined;
 
     let complete = false;
@@ -286,6 +290,8 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       };
       if (blockRef) {
         body.block_ref = blockRef;
+      } else if (lastKnownBlock) {
+        body.last_known_block = lastKnownBlock;
       }
       if (recipients !== "all") {
         body.recipients = recipients.map((r) => toHex(r));
@@ -321,7 +327,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       }
     }
 
-    return { timestamp: blockRef!, channels };
+    return { timestamp: blockRef!, channels, cursor: { channels, blockId: blockRef! } };
   }
 
   async discoverRequirement(

--- a/sdk/src/internal/indexer/index.ts
+++ b/sdk/src/internal/indexer/index.ts
@@ -1,0 +1,1 @@
+export * from "./discovery.js";

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -138,10 +138,18 @@ export class PoolSimulator {
 
   /**
    * Export tracked state back to the registry.
+   *
+   * TODO: This applies optimistic updates (spent notes removed, new notes/channels added)
+   * before the transaction is confirmed on-chain. If the transaction reverts, the registry
+   * becomes stale — spent notes are gone and phantom notes/channels are present. Callers
+   * must handle this by re-discovering from scratch (e.g. `autoDiscover: "refresh"`) or
+   * by snapshotting the registry before execute and restoring on revert.
    */
   updateRegistry(registry: PrivateRegistry): PrivateRegistry {
     for (const [address, channel] of this.channels.entries()) {
-      registry.channels.set(address, channel);
+      registry.channelCursor ??= {};
+      registry.channelCursor.channels ??= new AddressMap<Channel>();
+      registry.channelCursor.channels.set(address, channel);
     }
     for (const [token, notes] of this.notes.entries()) {
       registry.notes.set(token, Array.from(notes.values()));

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -2,7 +2,6 @@ import {
   SimplePrivateTransfersInterface,
   PrivateTransfersInterface,
   Amount,
-  Channel,
   Note,
   Open,
   PrivateRegistry,
@@ -23,7 +22,6 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
   }
 
   readonly registry: PrivateRegistry = {
-    channels: new AddressMap<Channel>(),
     notes: new AddressMap<Note[]>(),
   };
 

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -33,7 +33,7 @@ export {
   ContractDiscoveryProvider,
   type PoolContractInterface,
 } from "../internal/contract-discovery.js";
-export { IndexerDiscoveryProvider } from "../internal/indexer-discovery.js";
+export { IndexerDiscoveryProvider } from "../internal/indexer/index.js";
 export {
   createConcurrencyProfiler,
   formatReport,

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -8,6 +8,7 @@ import {
   PrivateRegistry,
   PrivateTransfersInterface,
 } from "../../src/interfaces.js";
+import { AddressMap } from "../../src/utils/maps.js";
 
 export const POOL_ADDRESS = 0x1n;
 
@@ -72,15 +73,16 @@ export async function setupSelfChannel(
   executeOutside(await user.build().register().execute());
   executeOutside(await user.build().setup(userAddress).execute());
 
-  let channel = (await user.discoverChannels([userAddress])).channels.get(userAddress)!;
+  let channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
   const registry = createEmptyRegistry();
-  registry.channels.set(userAddress, channel);
+  registry.channelCursor = { channels: new AddressMap() };
+  registry.channelCursor.channels!.set(userAddress, channel);
 
   executeOutside(await user.build({ registry }).with(token).setup(userAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await user.discoverChannels([userAddress])).channels.get(userAddress)!;
-  registry.channels.set(userAddress, channel);
+  channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
+  registry.channelCursor.channels!.set(userAddress, channel);
 
   return registry;
 }
@@ -105,15 +107,18 @@ export async function setupRecipientChannel(
   // Sender sets up channel to recipient
   executeOutside(await sender.build().setup(recipientAddress).execute());
 
-  let channel = (await sender.discoverChannels([recipientAddress])).channels.get(recipientAddress)!;
+  let channel = (await sender.discoverChannels([recipientAddress])).channels!.get(
+    recipientAddress
+  )!;
   const registry = createEmptyRegistry();
-  registry.channels.set(recipientAddress, channel);
+  registry.channelCursor = { channels: new AddressMap() };
+  registry.channelCursor.channels!.set(recipientAddress, channel);
 
   executeOutside(await sender.build({ registry }).with(token).setup(recipientAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await sender.discoverChannels([recipientAddress])).channels.get(recipientAddress)!;
-  registry.channels.set(recipientAddress, channel);
+  channel = (await sender.discoverChannels([recipientAddress])).channels!.get(recipientAddress)!;
+  registry.channelCursor.channels!.set(recipientAddress, channel);
 
   return registry;
 }

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { ActionCompiler } from "../../src/internal/compiler.js";
-import { ReorgError } from "../../src/internal/indexer-discovery.js";
+import { ReorgError } from "../../src/internal/indexer/index.js";
 import { createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
 import type { DiscoveryProviderInterface, Note } from "../../src/interfaces.js";
 import { AddressMap } from "../../src/utils/maps.js";
@@ -24,6 +24,7 @@ function createMockProvider(overrides: Partial<DiscoveryProviderInterface> = {})
         [USER_ADDRESS, new Channel(0xaa1n, 0xcc1n)],
         [RECIPIENT_ADDR, new Channel(0xaa2n, 0xcc2n)],
       ]),
+      cursor: { channels: new AddressMap<Channel>(), blockId: "0xblock" },
     }),
     discoverRequirement: vi.fn().mockResolvedValue(SetupRequirement.Ready),
     ...overrides,
@@ -46,6 +47,7 @@ describe("ActionCompiler reorg handling", () => {
             [USER_ADDRESS, new Channel(0xaa1n, 0xcc1n)],
             [RECIPIENT_ADDR, new Channel(0xaa2n, 0xcc2n)],
           ]),
+          cursor: { channels: new AddressMap<Channel>(), blockId: "0xblock2" },
         }),
     });
 
@@ -60,8 +62,10 @@ describe("ActionCompiler reorg handling", () => {
         sender: 0xaaan,
       },
     ]);
-    registry.channels.set(RECIPIENT_ADDR, new Channel(0xa1dn, 0xa1cn));
-    registry.cursor = { blockId: "0xoldblock", incomingChannels: new AddressMap() };
+    registry.channelCursor = {
+      channels: new AddressMap<Channel>([[RECIPIENT_ADDR, new Channel(0xa1dn, 0xa1cn)]]),
+    };
+    registry.notesCursor = { blockId: "0xoldblock", incomingChannels: new AddressMap() };
 
     const result = await compiler.compile(
       { openChannels: [{ recipient: RECIPIENT_ADDR }] },

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -6,7 +6,7 @@ import {
   apiCursorToNotesCursor,
   convertIncomingNotes,
   buildSubchannelCursors,
-} from "../../src/internal/indexer-discovery.js";
+} from "../../src/internal/indexer/discovery.js";
 import { SetupRequirement } from "../../src/interfaces.js";
 import { AddressMap } from "../../src/utils/maps.js";
 import type { IncomingChannelCursor, NotesCursor } from "../../src/internal/channel.js";
@@ -243,6 +243,50 @@ describe("IndexerDiscoveryProvider", () => {
       mockFetchJson({ body: { error: "BLOCK_REORGED" }, status: 409 });
 
       await expect(provider.discoverNotes(USER_ADDRESS, VIEWING_KEY)).rejects.toThrow(ReorgError);
+    });
+
+    it("incremental call uses channel keys from the input cursor", async () => {
+      const provider = createProvider();
+
+      // The second (incremental) response contains a note from SENDER_ADDR but does NOT
+      // include SENDER_ADDR in the channels array — the server omits it because the
+      // channel was already communicated in the previous sync call.
+      mockFetchJson({
+        body: incomingSyncResponse({
+          channels: [], // no channel info in this response
+          notes: [noteEntry({ index: 1, note_id: "0xde2", amount: "200", salt: "77" })],
+          cursor: completeCursor({
+            [SENDER_ADDR]: {
+              channel_key: CHANNEL_KEY_1,
+              subchannels: {
+                [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 1 },
+              },
+            },
+          }),
+        }),
+      });
+
+      // Build a cursor that carries the channel key from the "previous" discovery call
+      const previousIncomingChannels = new AddressMap<IncomingChannelCursor>();
+      previousIncomingChannels.set(BigInt(SENDER_ADDR), {
+        channelKey: BigInt(CHANNEL_KEY_1),
+        subchannelIdIndex: 0,
+        noteIndexes: new AddressMap<number>([[BigInt(TOKEN_ADDR), 1]]),
+      });
+      const previousCursor: NotesCursor = {
+        blockId: BLOCK_REF,
+        incomingChannels: previousIncomingChannels,
+      };
+
+      // Without the fix this would throw "Missing channel_key for sender 0xaaa1"
+      const result = await provider.discoverNotes(USER_ADDRESS, VIEWING_KEY, {
+        cursor: previousCursor,
+      });
+
+      const tokenNotes = result.notes.get(BigInt(TOKEN_ADDR));
+      expect(tokenNotes).toHaveLength(1);
+      expect(tokenNotes![0].id).toBe("0xde2");
+      expect(tokenNotes![0].witness.channelKey).toBe(BigInt(CHANNEL_KEY_1));
     });
   });
 

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -7,6 +7,7 @@ import {
   POOL_ADDRESS,
 } from "../helpers/test-fixtures.js";
 import { Open } from "../../src/interfaces.js";
+import { AddressMap } from "../../src/utils/maps.js";
 import { debugHint, isDebugEnabled, toBigInt } from "../../src/utils/index.js";
 import { debugLog } from "../../src/utils/logging.js";
 import { toHex } from "../../src/utils/convert.js";
@@ -172,7 +173,8 @@ describe("Private Transfers Integration", () => {
       const channel = (await alice.discoverChannels([env.alice.address])).channels!.get(
         env.alice.address
       )!;
-      channelOnly.channels.set(env.alice.address, channel);
+      channelOnly.channelCursor = { channels: new AddressMap() };
+      channelOnly.channelCursor.channels!.set(env.alice.address, channel);
 
       // Deposit 30n with:
       // - autoSelectNotes: "all" (sweeps ALL notes, not just enough for deficit)


### PR DESCRIPTION
## Refactor PrivateRegistry to use discovery cursors instead of storing channels directly

This change restructures the `PrivateRegistry` to hold discovery cursors (`notesCursor` and `channelCursor`) instead of directly storing channels. The cursors now contain the actual channel data and are used for incremental synchronization with reorg detection.

**Key changes:**
- Replace `registry.channels` and `registry.cursor` with `notesCursor` and `channelCursor` fields
- Move channel storage into `channelCursor.channels` 
- Add `blockId` field to `ChannelCursor` for reorg detection
- Update discovery methods to return cursor information in their responses
- Reorganize indexer discovery code into separate directory structure
- Fix incremental note discovery to properly use channel keys from previous cursor state
- Update documentation to reflect new registry structure and cursor-based discovery flow

The registry now serves as a container for discovery state rather than directly holding user data, enabling better incremental sync and reorg recovery capabilities.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/631)
<!-- Reviewable:end -->