### PR TITLE
feat(demo): account activity feed

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -24,10 +24,19 @@ jobs:
       # TODO: remove SCARB_IGNORE_CAIRO_VERSION once openzeppelin upgrades to Cairo >=2.17
       - name: Check unused imports and variables
         run: |
-          output=$(SCARB_IGNORE_CAIRO_VERSION=true scarb build -t 2>&1)
+          scarb cache clean
+          echo "::group::scarb build output"
+          output=$(SCARB_IGNORE_CAIRO_VERSION=true scarb build -t 2>&1) || {
+            echo "$output"
+            echo "::endgroup::"
+            echo "::error::scarb build failed"
+            exit 1
+          }
+          echo "$output"
+          echo "::endgroup::"
           matches=$(echo "$output" | grep -E "warn: Unused import|warn\[E0001\]: Unused variable" -A 2 || true)
           if [ -n "$matches" ]; then
-            echo "Unused imports or variables detected:"
+            echo "::error::Unused imports or variables detected"
             echo "$matches"
             exit 1
           fi

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^4.5.2",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "vite": "^6.3.5"
       }
@@ -2005,6 +2006,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/react": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.5.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "vite": "^6.3.5"
   }

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -48,7 +48,7 @@ h3 {
 }
 
 .pool-selector-label {
-  color: #8b949e;
+  color: #c9d1d9;
   white-space: nowrap;
 }
 
@@ -290,12 +290,28 @@ select {
   gap: 12px;
 }
 
-.info-panel,
+.island,
 .action-panel {
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
   padding: 12px;
+}
+
+.island-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.island-header h2 {
+  margin: 0;
+}
+
+.island-header button {
+  font-size: 11px;
+  padding: 2px 8px;
 }
 
 table {
@@ -566,10 +582,43 @@ input[type="number"] {
   min-width: auto;
 }
 
-.balances,
+.balances {
+  margin-top: 16px;
+}
+
+.tab-section {
+  margin-top: 16px;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 24px;
+  border-bottom: 1px solid #30363d;
+  margin-bottom: 12px;
+}
+
+.tab {
+  padding: 4px 0 8px;
+  margin: 0 0 -1px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #8b949e;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tab:hover {
+  color: #c9d1d9;
+}
+
+.tab-active {
+  color: #58a6ff;
+  border-bottom-color: #58a6ff;
+}
+
 .notes-section,
 .channels-section {
-  margin-top: 16px;
+  margin-top: 8px;
 }
 
 .notes-section h3 {
@@ -607,6 +656,69 @@ input[type="number"] {
 .channel-card-sep {
   color: #30363d;
   margin: 0 6px;
+}
+
+.channel-card table {
+  table-layout: fixed;
+}
+
+.channel-card table col.col-note-id {
+  width: 50%;
+}
+
+.channel-card table col.col-amount {
+  width: 30%;
+}
+
+.channel-card table col.col-index {
+  width: 20%;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+.cards-grid .channel-card {
+  margin-bottom: 0;
+}
+
+.token-subgroup {
+  margin-top: 16px;
+}
+
+.token-subgroup:first-child {
+  margin-top: 0;
+}
+
+.token-subgroup-header {
+  font-size: 12px;
+  margin-bottom: 4px;
+  line-height: 1.6;
+}
+
+.self-label {
+  color: #58a6ff;
+}
+
+.inline-copy-button {
+  background: none;
+  border: none;
+  color: #484f58;
+  cursor: pointer;
+  padding: 0 2px;
+  margin-left: 4px;
+  font-size: 12px;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.inline-copy-button:hover,
+.inline-copy-button:hover:not(:disabled) {
+  color: #c9d1d9;
+  background: none;
+  transform: scale(1.3);
 }
 
 .pagination {
@@ -654,6 +766,134 @@ input[type="number"] {
 .health-detail {
   color: #8b949e;
   font-size: 11px;
+}
+
+.history-section {
+  margin-top: 8px;
+}
+
+.history-row {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.history-row:last-of-type {
+  margin-bottom: 0;
+}
+
+.history-row-expanded {
+  border-color: #58a6ff44;
+}
+
+.history-row-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #c9d1d9;
+}
+
+.history-row-summary:hover {
+  background: #1c2128;
+}
+
+.history-expand-icon {
+  color: #8b949e;
+  font-size: 10px;
+  flex-shrink: 0;
+  width: 12px;
+}
+
+.history-field {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.history-label {
+  color: #8b949e;
+}
+
+.history-value {
+  color: #c9d1d9;
+}
+
+.history-timestamp {
+  color: #c9d1d9;
+}
+
+.history-balance-field {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.balance-positive {
+  color: #3fb950;
+  font-weight: 600;
+}
+
+.balance-negative {
+  color: #f85149;
+  font-weight: 600;
+}
+
+.history-chips-field {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.history-row-details {
+  margin: 0;
+  padding: 8px 14px 12px 52px;
+  border-top: 1px solid #21262d;
+  list-style: disc;
+}
+
+.history-action {
+  font-size: 12px;
+  padding: 2px 0;
+  color: #c9d1d9;
+}
+
+.history-action::marker {
+  color: #8b949e;
+}
+
+.explorer-link {
+  color: #58a6ff;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.explorer-link:hover {
+  text-decoration: underline;
+}
+
+.note-count {
+  color: #8b949e;
+  font-size: 11px;
+}
+
+.load-more {
+  width: 100%;
+  margin-top: 8px;
+  background: #21262d;
+  border-color: #30363d;
+  color: #c9d1d9;
+}
+
+.load-more:hover:not(:disabled) {
+  background: #30363d;
 }
 
 .app-footer {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createEmptyRegistry } from "starknet-sdk";
 import { formatChainId } from "./format.ts";
 import { loadConfig } from "./config.ts";
 import { createProvider, createAccount, createTransfers } from "./starknet.ts";
@@ -6,6 +7,7 @@ import { useAccounts } from "./hooks/useAccounts.ts";
 import { usePoolSelector } from "./hooks/usePoolSelector.ts";
 import { useDeployPool } from "./hooks/useDeployPool.ts";
 import { usePrivateState } from "./hooks/usePrivateState.ts";
+import { useHistory } from "./hooks/useHistory.ts";
 import { useTransactions } from "./hooks/useTransactions.ts";
 import { AccountSelector } from "./components/AccountSelector.tsx";
 import { PoolSelector } from "./components/PoolSelector.tsx";
@@ -16,6 +18,7 @@ import { StatusBar } from "./components/StatusBar.tsx";
 import { ServiceHealthBar } from "./components/ServiceHealthBar.tsx";
 import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
 import { useServiceHealth } from "./hooks/useServiceHealth.ts";
+import { useTokenMetadata } from "./hooks/useTokenMetadata.ts";
 import "./App.css";
 
 const config = loadConfig();
@@ -57,18 +60,58 @@ export function App() {
     return createTransfers(provider, account, activeAccount, poolAddress, config);
   }, [provider, account, activeAccount, poolAddress]);
 
-  const { state, loading, error, refresh } = usePrivateState(
+  const registry = useRef(createEmptyRegistry());
+
+  // Reset registry in-place when account or pool changes so discovery starts
+  // fresh. Mutating the existing object (rather than replacing it) ensures that
+  // callbacks captured during this render cycle see the cleared state.
+  useEffect(() => {
+    const reg = registry.current;
+    reg.cursor = undefined;
+    reg.channels = createEmptyRegistry().channels;
+    reg.notes = createEmptyRegistry().notes;
+  }, [activeAccount, poolAddress]);
+
+  const tokenAddresses = useMemo(() => [config.tokenAddress], []);
+  const tokenMetadata = useTokenMetadata(provider, tokenAddresses);
+
+  const { state, loading, error, refresh, refreshBalances } = usePrivateState(
     provider,
     transfers,
     activeAccount,
     accounts,
     poolAddress,
     config,
+    registry.current,
+    tokenMetadata,
   );
 
+  const {
+    transactions: historyTransactions,
+    loading: historyLoading,
+    error: historyError,
+    historyComplete,
+    fetchMore: fetchHistory,
+    refreshLatest: refreshHistoryLatest,
+  } = useHistory(provider, poolAddress, config, activeAccount, accounts, registry.current, tokenMetadata);
+
+  const refreshAll = useCallback(async () => {
+    // Reset cursors so refresh does a full re-sync — incremental discovery
+    // only returns new notes, so stale cursors would yield empty results
+    // after a transaction that consumed/created notes.
+    const reg = registry.current;
+    reg.cursor = undefined;
+    reg.channels = createEmptyRegistry().channels;
+    reg.notes = createEmptyRegistry().notes;
+    await refresh();
+    refreshHistoryLatest();
+  }, [refresh, refreshHistoryLatest]);
+
+  const metadataReady = tokenMetadata.size > 0;
+
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    if (metadataReady) refresh();
+  }, [refresh, metadataReady]);
 
   const { status, register, mint, deposit, withdraw, transfer } = useTransactions(
     provider,
@@ -77,8 +120,11 @@ export function App() {
     poolAddress,
     config,
     accounts,
-    refresh,
+    refreshAll,
+    refreshBalances,
   );
+
+  const tokenDecimals = tokenMetadata.get(config.tokenAddress)?.decimals ?? 0;
 
   const { status: builderStatus, executeBatch } = useTransactionBuilder(
     provider,
@@ -87,7 +133,8 @@ export function App() {
     poolAddress,
     config,
     accounts,
-    refresh,
+    refreshAll,
+    tokenDecimals,
   );
 
   const serviceHealth = useServiceHealth(provider, config);
@@ -128,7 +175,13 @@ export function App() {
               state={state}
               loading={loading}
               error={error}
-              onRefresh={refresh}
+              onRefresh={refreshAll}
+              historyTransactions={historyTransactions}
+              explorerUrl={config.explorerUrl}
+              historyLoading={historyLoading}
+              historyError={historyError}
+              historyComplete={historyComplete}
+              onFetchHistory={fetchHistory}
             />
             <div className="action-panel">
               <div className="view-toggle">
@@ -150,6 +203,7 @@ export function App() {
                   pending={status.pending}
                   activeAddress={activeAccount.address}
                   otherAccounts={accounts.filter((_, index) => index !== activeIndex)}
+                  tokenDecimals={tokenDecimals}
                   onRegister={register}
                   onMint={mint}
                   onDeposit={deposit}

--- a/demo/src/components/ActionPanel.tsx
+++ b/demo/src/components/ActionPanel.tsx
@@ -1,10 +1,12 @@
 import { useState, type FormEvent } from "react";
 import type { AccountConfig } from "../config.ts";
+import { toRawAmount } from "../format.ts";
 
 type Props = {
   pending: boolean;
   activeAddress: string;
   otherAccounts: AccountConfig[];
+  tokenDecimals: number;
   onRegister: () => void;
   onMint: (amount: bigint) => void;
   onDeposit: (amount: bigint) => void;
@@ -16,6 +18,7 @@ export function ActionPanel({
   pending,
   activeAddress,
   otherAccounts,
+  tokenDecimals,
   onRegister,
   onMint,
   onDeposit,
@@ -28,25 +31,27 @@ export function ActionPanel({
   const [transferAmount, setTransferAmount] = useState("50");
   const [transferRecipient, setTransferRecipient] = useState("");
 
+  const parseAmount = (value: string) => toRawAmount(value, tokenDecimals);
+
   function handleMint(event: FormEvent) {
     event.preventDefault();
-    onMint(BigInt(mintAmount));
+    onMint(parseAmount(mintAmount));
   }
 
   function handleDeposit(event: FormEvent) {
     event.preventDefault();
-    onDeposit(BigInt(depositAmount));
+    onDeposit(parseAmount(depositAmount));
   }
 
   function handleWithdraw(event: FormEvent) {
     event.preventDefault();
-    onWithdraw(BigInt(withdrawAmount));
+    onWithdraw(parseAmount(withdrawAmount));
   }
 
   function handleTransfer(event: FormEvent) {
     event.preventDefault();
     if (!transferRecipient) return;
-    onTransfer(transferRecipient, BigInt(transferAmount));
+    onTransfer(transferRecipient, parseAmount(transferAmount));
   }
 
   return (
@@ -56,11 +61,11 @@ export function ActionPanel({
       <form onSubmit={handleMint} className="action-form">
         <h3>Mint tokens (transparent)</h3>
         <input
-          type="number"
+          type="text"
+          inputMode="decimal"
           value={mintAmount}
           onChange={(event) => setMintAmount(event.target.value)}
           placeholder="Amount"
-          min="1"
         />
         <button type="submit" disabled={pending}>
           Mint
@@ -77,11 +82,11 @@ export function ActionPanel({
       <form onSubmit={handleDeposit} className="action-form">
         <h3>Deposit to self (auto setup)</h3>
         <input
-          type="number"
+          type="text"
+          inputMode="decimal"
           value={depositAmount}
           onChange={(event) => setDepositAmount(event.target.value)}
           placeholder="Amount"
-          min="1"
         />
         <button type="submit" disabled={pending}>
           Deposit
@@ -91,11 +96,11 @@ export function ActionPanel({
       <form onSubmit={handleWithdraw} className="action-form">
         <h3>Withdraw to self</h3>
         <input
-          type="number"
+          type="text"
+          inputMode="decimal"
           value={withdrawAmount}
           onChange={(event) => setWithdrawAmount(event.target.value)}
           placeholder="Amount"
-          min="1"
         />
         <button type="submit" disabled={pending}>
           Withdraw
@@ -128,11 +133,11 @@ export function ActionPanel({
           />
         )}
         <input
-          type="number"
+          type="text"
+          inputMode="decimal"
           value={transferAmount}
           onChange={(event) => setTransferAmount(event.target.value)}
           placeholder="Amount"
-          min="1"
         />
         <button
           type="submit"

--- a/demo/src/components/HistoryPanel.tsx
+++ b/demo/src/components/HistoryPanel.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import type { TransactionDisplay, ActionDisplay } from "../hooks/useHistory.ts";
+import { formatTokenAmount, formatRelativeTime } from "../format.ts";
+
+const chipLabel: Record<string, string> = {
+  transferReceived: "transfer in",
+  transferSelf: "reorganize",
+  transferSent: "transfer out",
+};
+
+function actionChipLabel(action: ActionDisplay): string {
+  return chipLabel[action.type] ?? action.type;
+}
+
+type Props = {
+  transactions: TransactionDisplay[];
+  explorerUrl?: string;
+  loading: boolean;
+  error: string | null;
+  historyComplete: boolean;
+  onFetchMore: () => void;
+};
+
+export function HistoryPanel({
+  transactions,
+  explorerUrl,
+  loading,
+  error,
+  historyComplete,
+  onFetchMore,
+}: Props) {
+  const [expandedIndexes, setExpandedIndexes] = useState<Set<number>>(
+    new Set(),
+  );
+
+  function toggleExpanded(index: number) {
+    setExpandedIndexes((previous) => {
+      const next = new Set(previous);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="history-section">
+      {error && <div className="error">Error: {error}</div>}
+
+      {transactions.length === 0 && !loading && !error && (
+        <p className="empty">No history yet</p>
+      )}
+
+      {transactions.map((transaction, transactionIndex) => {
+        const expanded = expandedIndexes.has(transactionIndex);
+        return (
+          <div
+            key={transactionIndex}
+            className={`history-row ${expanded ? "history-row-expanded" : ""}`}
+          >
+            <div
+              className="history-row-summary"
+              onClick={() => toggleExpanded(transactionIndex)}
+            >
+              <span className="history-expand-icon">
+                {expanded ? "\u25BC" : "\u25B6"}
+              </span>
+              {transaction.timestamp != null && (
+                <span className="history-field">
+                  <span className="history-value history-timestamp">
+                    {formatRelativeTime(transaction.timestamp)}
+                  </span>
+                </span>
+              )}
+              <span className="history-field">
+                <span className="history-label">Block</span>
+                <span className="history-value">
+                  #{transaction.blockNumber}
+                </span>
+              </span>
+              <span className="history-field">
+                <span className="history-label">Tx</span>
+                <span className="history-value">
+                  {transaction.transactionHash}
+                </span>
+              </span>
+              <span className="history-field history-balance-field">
+                {transaction.balanceUpdates.map((update, updateIndex) => (
+                  <span
+                    key={updateIndex}
+                    className={
+                      update.amount >= 0n
+                        ? "balance-positive"
+                        : "balance-negative"
+                    }
+                  >
+                    {update.amount >= 0n ? "+" : "\u2212"}
+                    {formatTokenAmount(update.amount < 0n ? -update.amount : update.amount, update.decimals)} {update.tokenName}
+                  </span>
+                ))}
+              </span>
+              <span className="history-field history-chips-field">
+                {[
+                  ...new Set(transaction.actions.map((action) => action.type)),
+                ].map((type) => {
+                  const action = transaction.actions.find(
+                    (a) => a.type === type,
+                  )!;
+                  return (
+                    <span key={type} className={`chip ${action.chipClass}`}>
+                      {actionChipLabel(action)}
+                    </span>
+                  );
+                })}
+              </span>
+            </div>
+
+            {expanded && (
+              <ul className="history-row-details">
+                {transaction.actions.map((action, actionIndex) => (
+                  <li key={actionIndex} className="history-action">
+                    {action.label}
+                    {action.noteCount !== undefined && (
+                      <span className="note-count">
+                        {" "}
+                        ({action.noteCount}{" "}
+                        {action.noteCount === 1 ? "note" : "notes"})
+                      </span>
+                    )}
+                  </li>
+                ))}
+                {explorerUrl && (
+                  <li className="history-action">
+                    <a
+                      className="explorer-link"
+                      href={`${explorerUrl.replace(/\/$/, "")}/tx/${transaction.fullTransactionHash}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      View on explorer ↗
+                    </a>
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+
+      {loading && <p className="empty">Loading...</p>}
+
+      {!historyComplete && !loading && transactions.length > 0 && (
+        <button className="load-more" onClick={onFetchMore}>
+          Load More
+        </button>
+      )}
+    </div>
+  );
+}

--- a/demo/src/components/InfoPanel.tsx
+++ b/demo/src/components/InfoPanel.tsx
@@ -1,21 +1,36 @@
 import { useState } from "react";
-import type { ChannelGroup, NoteDisplay } from "../hooks/usePrivateState.ts";
-import type { PrivateState } from "../hooks/usePrivateState.ts";
+import type {
+  IncomingChannelCard,
+  OutgoingChannelCard,
+  TokenNoteGroup,
+  NoteDisplay,
+  PrivateState,
+} from "../hooks/usePrivateState.ts";
+import type { TransactionDisplay } from "../hooks/useHistory.ts";
+import { HistoryPanel } from "./HistoryPanel.tsx";
+import { formatTokenAmount, truncateAddress } from "../format.ts";
 
-const NOTES_PER_PAGE = 10;
+const NOTES_PER_PAGE = 5;
 
-type Props = {
-  state: PrivateState;
-  loading: boolean;
-  error: string | null;
-  onRefresh: () => void;
-};
-
-function formatAmount(value: bigint): string {
-  return value.toLocaleString("en-US");
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="inline-copy-button"
+      title={copied ? "Copied!" : "Copy full value"}
+      onClick={() => {
+        void navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? "\u2713" : "\u29C9"}
+    </button>
+  );
 }
 
-function ChannelCard({ group }: { group: ChannelGroup }) {
+function TokenSubgroup({ group }: { group: TokenNoteGroup }) {
   const [page, setPage] = useState(0);
 
   const totalPages = Math.max(1, Math.ceil(group.notes.length / NOTES_PER_PAGE));
@@ -26,22 +41,19 @@ function ChannelCard({ group }: { group: ChannelGroup }) {
   );
 
   return (
-    <div className="channel-card">
-      <div className="channel-card-header">
-        <span className="channel-card-label">Sender</span>{" "}
-        <span className="channel-card-value">{group.sender}</span>
-        {group.senderName && <span className="chip">{group.senderName}</span>}
+    <div className="token-subgroup">
+      <div className="token-subgroup-header">
+        <span className="channel-card-label">{group.tokenName}</span>
         <span className="channel-card-sep">|</span>
-        <span className="channel-card-label">Token</span>{" "}
-        <span className="channel-card-value">{group.token}</span>
-        <span className="channel-card-sep">|</span>
-        <span className="channel-card-label">Channel Key</span>{" "}
-        <span className="channel-card-value">{group.channelKey}</span>
-        <span className="channel-card-sep">|</span>
-        <span className="channel-card-label">Unspent Notes</span>{" "}
+        <span className="channel-card-label">Notes</span>{" "}
         <span className="channel-card-value">{group.notes.length}</span>
       </div>
       <table>
+        <colgroup>
+          <col className="col-note-id" />
+          <col className="col-amount" />
+          <col className="col-index" />
+        </colgroup>
         <thead>
           <tr>
             <th>Note ID</th>
@@ -52,12 +64,15 @@ function ChannelCard({ group }: { group: ChannelGroup }) {
         <tbody>
           {visibleNotes.map((note: NoteDisplay) => (
             <tr key={note.id}>
-              <td>{note.id}</td>
-              <td>{formatAmount(note.amount)}</td>
               <td>
-                {note.nonce}
+                {note.id}
+                <CopyButton value={`0x${note.rawId.toString(16)}`} />
+              </td>
+              <td>
+                {formatTokenAmount(note.amount, note.decimals)}
                 {note.open && <span className="chip">open</span>}
               </td>
+              <td>{note.nonce}</td>
             </tr>
           ))}
         </tbody>
@@ -85,15 +100,102 @@ function ChannelCard({ group }: { group: ChannelGroup }) {
   );
 }
 
-export function InfoPanel({ state, loading, error, onRefresh }: Props) {
+function IncomingCard({ card }: { card: IncomingChannelCard }) {
   return (
-    <div className="info-panel">
-      <h2>
-        State{" "}
+    <div className="channel-card">
+      <div className="channel-card-header">
+        <span className="channel-card-label">Sender</span>{" "}
+        {card.senderName === "Self" ? (
+          <span className="self-label">Self</span>
+        ) : (
+          <span className="channel-card-value">{card.senderName ?? card.sender}</span>
+        )}
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Channel Key</span>{" "}
+        <span className="channel-card-value">
+          {card.channelKey}
+          <CopyButton value={card.rawChannelKey} />
+        </span>
+      </div>
+      {card.tokenGroups.map((tokenGroup) => (
+        <TokenSubgroup key={tokenGroup.tokenAddress} group={tokenGroup} />
+      ))}
+    </div>
+  );
+}
+
+function OutgoingCard({ card }: { card: OutgoingChannelCard }) {
+  return (
+    <div className="channel-card">
+      <div className="channel-card-header">
+        <span className="channel-card-label">Recipient</span>{" "}
+        {card.recipientName === "Self" ? (
+          <span className="self-label">Self</span>
+        ) : (
+          <span className="channel-card-value">{card.recipientName ?? card.recipient}</span>
+        )}
+        <span className="channel-card-sep">|</span>
+        <span className="channel-card-label">Channel Key</span>{" "}
+        <span className="channel-card-value">
+          {card.channelKey}
+          <CopyButton value={card.rawChannelKey} />
+        </span>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Token</th>
+            <th>Next Note Index</th>
+          </tr>
+        </thead>
+        <tbody>
+          {card.tokens.map((token) => (
+            <tr key={token.tokenAddress}>
+              <td>{token.tokenName}</td>
+              <td>{token.noteNonce}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type Props = {
+  state: PrivateState;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+  historyTransactions: TransactionDisplay[];
+  explorerUrl?: string;
+  historyLoading: boolean;
+  historyError: string | null;
+  historyComplete: boolean;
+  onFetchHistory: () => void;
+};
+
+export function InfoPanel({
+  state,
+  loading,
+  error,
+  onRefresh,
+  historyTransactions,
+  explorerUrl,
+  historyLoading,
+  historyError,
+  historyComplete,
+  onFetchHistory,
+}: Props) {
+  const [view, setView] = useState<"notes" | "channels" | "activity">("activity");
+
+  return (
+    <div className="island">
+      <div className="island-header">
+        <h2>State</h2>
         <button type="button" onClick={onRefresh} disabled={loading}>
           {loading ? "Loading..." : "Refresh"}
         </button>
-      </h2>
+      </div>
       {error && <div className="error">Error: {error}</div>}
 
       <div>
@@ -110,68 +212,101 @@ export function InfoPanel({ state, loading, error, onRefresh }: Props) {
       <div className="balances">
         <h3>Balances</h3>
         <table>
+          <thead>
+            <tr>
+              <th>Token</th>
+              <th>Private</th>
+              <th>Notes</th>
+              <th>Transparent</th>
+              <th>Token Address</th>
+            </tr>
+          </thead>
           <tbody>
+            {state.tokenBalances.map((tb) => (
+              <tr key={tb.address}>
+                <td>{tb.name}</td>
+                <td>{formatTokenAmount(tb.private, tb.decimals)}</td>
+                <td>{tb.noteCount}</td>
+                <td>{formatTokenAmount(tb.transparent, tb.decimals)}</td>
+                <td>
+                  {truncateAddress(tb.address)}
+                  <CopyButton value={tb.address} />
+                </td>
+              </tr>
+            ))}
             <tr>
-              <td>Fee Token</td>
-              <td>{formatAmount(state.feeTokenBalance)}</td>
-            </tr>
-            <tr>
-              <td>Token (transparent)</td>
-              <td>{formatAmount(state.tokenBalance)}</td>
-            </tr>
-            <tr>
-              <td>Token (private)</td>
-              <td>{formatAmount(state.privateBalance)}</td>
+              <td>STRK <span className="chip">fee</span></td>
+              <td>&mdash;</td>
+              <td>&mdash;</td>
+              <td>{formatTokenAmount(state.feeTokenBalance, 18)}</td>
+              <td>
+                {truncateAddress(state.feeTokenAddress)}
+                <CopyButton value={state.feeTokenAddress} />
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
 
-      <div className="notes-section">
-        <h3>Unspent Notes ({state.notes.length})</h3>
-        {state.channelGroups.length === 0 ? (
-          <p className="empty">No notes discovered</p>
-        ) : (
-          state.channelGroups.map((group) => (
-            <ChannelCard key={group.channelKey} group={group} />
-          ))
-        )}
-      </div>
+      <div className="tab-section">
+        <div className="tab-bar">
+          <h3
+            className={`tab ${view === "activity" ? "tab-active" : ""}`}
+            onClick={() => setView("activity")}
+          >
+            Activity
+          </h3>
+          <h3
+            className={`tab ${view === "notes" ? "tab-active" : ""}`}
+            onClick={() => setView("notes")}
+          >
+            Unspent Notes
+          </h3>
+          <h3
+            className={`tab ${view === "channels" ? "tab-active" : ""}`}
+            onClick={() => setView("channels")}
+          >
+            Outgoing Channels
+          </h3>
+        </div>
 
-      <div className="channels-section">
-        <h3>Outgoing Channels ({state.channels.length})</h3>
-        {state.channels.length === 0 ? (
-          <p className="empty">No channels discovered</p>
-        ) : (
-          <table>
-            <thead>
-              <tr>
-                <th>Recipient</th>
-                <th>Token</th>
-                <th>Channel Key</th>
-                <th>Next Note Index</th>
-              </tr>
-            </thead>
-            <tbody>
-              {state.channels.map((channel, index) => (
-                <tr key={index}>
-                  <td>
-                    {channel.recipient}
-                    {channel.recipientName && <span className="chip">{channel.recipientName}</span>}
-                  </td>
-                  <td>
-                    {channel.tokens.map((tokenEntry, tokenIndex) => (
-                      <div key={tokenIndex}>
-                        {tokenEntry.tokenAddress}
-                      </div>
-                    ))}
-                  </td>
-                  <td>{channel.channelKey}</td>
-                  <td>{channel.noteNonce}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        {view === "notes" && (
+          <div className="notes-section">
+            {state.incomingCards.length === 0 ? (
+              <p className="empty">No notes discovered</p>
+            ) : (
+              <div className="cards-grid">
+                {state.incomingCards.map((card) => (
+                  <IncomingCard key={card.cardKey} card={card} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {view === "channels" && (
+          <div className="channels-section">
+            {state.outgoingCards.length === 0 ? (
+              <p className="empty">No channels discovered</p>
+            ) : (
+              <div className="cards-grid">
+                {state.outgoingCards.map((card) => (
+                  <OutgoingCard key={card.cardKey} card={card} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {view === "activity" && (
+          <HistoryPanel
+            transactions={historyTransactions}
+            explorerUrl={explorerUrl}
+            loading={historyLoading}
+            error={historyError}
+            historyComplete={historyComplete}
+            onFetchMore={onFetchHistory}
+          />
         )}
       </div>
     </div>

--- a/demo/src/components/TransactionBuilder.tsx
+++ b/demo/src/components/TransactionBuilder.tsx
@@ -41,12 +41,9 @@ export function TransactionBuilder({ pending, activeAddress, otherAccounts, onEx
   const [selectedType, setSelectedType] = useState<OperationType>("deposit");
   const [amount, setAmount] = useState("100");
   const [recipient, setRecipient] = useState("");
-  const [contractAddress, setContractAddress] = useState("");
-  const [calldata, setCalldata] = useState("");
   const [withdrawSurplus, setWithdrawSurplus] = useState(false);
   const nextOperationId = useRef(0);
 
-  const hasInvoke = operations.some((op) => op.operationType === "invoke");
   const hasSurplus = operations.some((op) => op.operationType === "surplus");
 
   function handleAdd(event: FormEvent) {
@@ -61,9 +58,6 @@ export function TransactionBuilder({ pending, activeAddress, otherAccounts, onEx
       amount,
       ...(needsRecipient ? { recipient } : {}),
       ...(selectedType === "surplus" ? { withdrawSurplus } : {}),
-      ...(selectedType === "invoke"
-        ? { contractAddress, calldata }
-        : {}),
     };
 
     setOperations((previous) => {
@@ -84,9 +78,6 @@ export function TransactionBuilder({ pending, activeAddress, otherAccounts, onEx
   }
 
   function formatOperationDetails(operation: BuilderOperation): string {
-    if (operation.operationType === "invoke") {
-      return `${operation.contractAddress?.slice(0, 10)}...`;
-    }
     if (operation.operationType === "surplus") {
       const target = operation.recipient
         ? `${operation.recipient.slice(0, 10)}...`
@@ -113,16 +104,15 @@ export function TransactionBuilder({ pending, activeAddress, otherAccounts, onEx
           <option value="transfer">Transfer</option>
           <option value="withdraw">Withdraw</option>
           <option value="surplus" disabled={hasSurplus}>Surplus To</option>
-          <option value="invoke" disabled={hasInvoke}>Invoke</option>
         </select>
 
-        {selectedType !== "invoke" && selectedType !== "surplus" && (
+        {selectedType !== "surplus" && (
           <input
-            type="number"
+            type="text"
+            inputMode="decimal"
             value={amount}
             onChange={(event) => setAmount(event.target.value)}
             placeholder="Amount"
-            min="1"
           />
         )}
 
@@ -159,28 +149,10 @@ export function TransactionBuilder({ pending, activeAddress, otherAccounts, onEx
           </label>
         )}
 
-        {selectedType === "invoke" && (
-          <>
-            <input
-              type="text"
-              value={contractAddress}
-              onChange={(event) => setContractAddress(event.target.value)}
-              placeholder="Contract address (0x...)"
-            />
-            <input
-              type="text"
-              value={calldata}
-              onChange={(event) => setCalldata(event.target.value)}
-              placeholder="Calldata (comma-separated)"
-            />
-          </>
-        )}
-
         <button
           type="submit"
           disabled={
             pending ||
-            (selectedType === "invoke" && hasInvoke) ||
             (selectedType === "surplus" && hasSurplus) ||
             ((selectedType === "transfer" || selectedType === "surplus") && !recipient)
           }

--- a/demo/src/config.ts
+++ b/demo/src/config.ts
@@ -22,6 +22,7 @@ export type AppConfig = {
   provingServiceUrl?: string;
   gatewayUrl?: string;
   feederGatewayUrl?: string;
+  explorerUrl?: string;
 };
 
 function requireEnv(key: string): string {
@@ -46,5 +47,6 @@ export function loadConfig(): AppConfig {
       | undefined,
     gatewayUrl: import.meta.env.VITE_GATEWAY_URL as string | undefined,
     feederGatewayUrl: import.meta.env.VITE_FEEDER_GATEWAY_URL as string | undefined,
+    explorerUrl: import.meta.env.VITE_EXPLORER_URL as string | undefined,
   };
 }

--- a/demo/src/format.ts
+++ b/demo/src/format.ts
@@ -8,6 +8,87 @@ export function formatChainId(hex: string): string {
   return name;
 }
 
+/** Format a bigint token amount for display, optionally with decimal places. */
+export function formatAmount(value: bigint, decimals?: number): string {
+  if (decimals == null || decimals === 0) {
+    return value.toLocaleString("en-US");
+  }
+  const divisor = 10n ** BigInt(decimals);
+  const whole = value / divisor;
+  const remainder = value % divisor;
+  const fractionStr = remainder.toString().padStart(decimals, "0").replace(/0+$/, "");
+  const wholeFormatted = whole.toLocaleString("en-US");
+  return fractionStr ? `${wholeFormatted}.${fractionStr}` : wholeFormatted;
+}
+
+const SUPERSCRIPT_DIGITS = "\u2070\u00b9\u00b2\u00b3\u2074\u2075\u2076\u2077\u2078\u2079";
+
+function toSuperscript(value: number): string {
+  return value.toString().split("").map((digit) => SUPERSCRIPT_DIGITS[Number(digit)]).join("");
+}
+
+/** Format a bigint token amount with capped fractional digits.
+ *  Falls back to multiplication notation (e.g. 1×10⁻⁵) for values too small to show within maxFraction. */
+export function formatTokenAmount(rawAmount: bigint, decimals: number, maxFraction = 4): string {
+  if (rawAmount === 0n) return "0";
+  if (decimals === 0) return rawAmount.toLocaleString("en-US");
+
+  const divisor = 10n ** BigInt(decimals);
+  const wholePart = rawAmount / divisor;
+  const remainder = rawAmount % divisor;
+
+  if (remainder === 0n) return wholePart.toLocaleString("en-US");
+
+  const fractionFull = remainder.toString().padStart(decimals, "0");
+  const fractionTrimmed = fractionFull.slice(0, maxFraction).replace(/0+$/, "");
+
+  if (fractionTrimmed) {
+    return `${wholePart.toLocaleString("en-US")}.${fractionTrimmed}`;
+  }
+
+  // Significant digits are beyond maxFraction — use multiplication notation
+  if (wholePart === 0n) {
+    const leadingZeros = fractionFull.match(/^0*/)![0].length;
+    const significant = fractionFull.slice(leadingZeros).replace(/0+$/, "");
+    const exponent = leadingZeros + 1;
+    const mantissa = significant.length > 1
+      ? `${significant[0]}.${significant.slice(1, 4).replace(/0+$/, "")}`
+      : significant;
+    return `${mantissa}\u00b710\u207b${toSuperscript(exponent)}`;
+  }
+
+  return wholePart.toLocaleString("en-US");
+}
+
+/** Convert a human-readable amount string (e.g. "100", "0.5") to raw bigint units. */
+export function toRawAmount(humanAmount: string, decimals: number): bigint {
+  const [wholePart, fractionPart = ""] = humanAmount.trim().split(".");
+  if (fractionPart.length > decimals) {
+    throw new Error(`Too many decimal places: ${fractionPart.length} > ${decimals}`);
+  }
+  const paddedFraction = fractionPart.padEnd(decimals, "0");
+  return BigInt((wholePart || "0") + paddedFraction);
+}
+
+/** Format a unix timestamp as a relative or absolute time string. */
+export function formatRelativeTime(timestampSecs: number): string {
+  const nowSecs = Math.floor(Date.now() / 1000);
+  const diffSecs = nowSecs - timestampSecs;
+
+  if (diffSecs < 60) return `${Math.max(0, diffSecs)}s ago`;
+  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}m ago`;
+  if (diffSecs < 86400) {
+    const date = new Date(timestampSecs * 1000);
+    const today = new Date();
+    if (date.toDateString() === today.toDateString()) {
+      return date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    }
+  }
+  const date = new Date(timestampSecs * 1000);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+    + " " + date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+}
+
 /** Truncate a hex address for display: 0x1234abcd...ef01 */
 export function truncateAddress(hex: string): string {
   const padded = hex.startsWith("0x") ? hex : `0x${hex}`;

--- a/demo/src/hooks/useDeployPool.ts
+++ b/demo/src/hooks/useDeployPool.ts
@@ -2,7 +2,6 @@ import { useState, useCallback, useMemo } from "react";
 import { Account, type RpcProvider } from "starknet";
 import type { AccountConfig, AppConfig } from "../config.ts";
 
-
 export function useDeployPool(
   provider: RpcProvider | undefined,
   config: AppConfig,
@@ -46,7 +45,9 @@ export function useDeployPool(
         { tip: 0n, resourceBounds: deployFee.resourceBounds },
       );
 
-      const receipt = await provider.waitForTransaction(deployResult.transaction_hash);
+      const receipt = await provider.waitForTransaction(
+        deployResult.transaction_hash,
+      );
       if (!receipt.isSuccess()) {
         throw new Error(`Deploy reverted: ${JSON.stringify(receipt)}`);
       }

--- a/demo/src/hooks/useHistory.ts
+++ b/demo/src/hooks/useHistory.ts
@@ -1,0 +1,426 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  classifyTransaction,
+  type PrivateRegistry,
+  type HistoryCursor,
+  type HistoryAction,
+  type HistoryTransaction,
+} from "starknet-sdk";
+// @ts-expect-error — deep import into dist, not part of the declared exports
+import { IndexerDiscoveryProvider } from "starknet-sdk/dist/internal/indexer-discovery.js";
+import type { RpcProvider } from "starknet";
+import type { AppConfig, AccountConfig } from "../config.ts";
+import { formatTokenAmount, truncateAddress } from "../format.ts";
+import type { TokenMetadataMap } from "./useTokenMetadata.ts";
+
+export type ActionDisplay = {
+  type: HistoryAction["type"];
+  label: string;
+  chipClass: string;
+  noteCount?: number;
+};
+
+export type BalanceUpdate = {
+  tokenName: string;
+  amount: bigint; // positive = incoming, negative = outgoing
+  decimals: number;
+};
+
+export type TransactionDisplay = {
+  blockNumber: number;
+  timestamp: number | null;
+  transactionHash: string;
+  fullTransactionHash: string;
+  actions: ActionDisplay[];
+  balanceUpdates: BalanceUpdate[];
+};
+
+function formatActionLabel(
+  action: HistoryAction,
+  nameByAddress: Map<bigint, string>,
+  tokenNameByAddress: Map<bigint, string>,
+  tokenDecimalsByAddress: Map<bigint, number>,
+): { label: string; chipClass: string } {
+  const tokenName = (token: bigint) =>
+    tokenNameByAddress.get(token) ?? truncateAddress(token.toString(16));
+  const resolveName = (address: bigint) =>
+    nameByAddress.get(address) ?? truncateAddress(address.toString(16));
+  const fmtAmount = (amount: bigint, token: bigint) =>
+    formatTokenAmount(amount, tokenDecimalsByAddress.get(token) ?? 0);
+
+  switch (action.type) {
+    case "deposit":
+      return {
+        label: `Deposited ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)}`,
+        chipClass: "chip-ok",
+      };
+    case "withdrawal": {
+      const toName = resolveName(action.toAddress);
+      return {
+        label: `Withdrew ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)} to ${toName}`,
+        chipClass: "chip-no",
+      };
+    }
+    case "transferSent": {
+      const name =
+        nameByAddress.get(action.toAddress) ??
+        truncateAddress(action.toAddress.toString(16));
+      return {
+        label: `Sent ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)} to ${name}`,
+        chipClass: "chip-no",
+      };
+    }
+    case "transferReceived": {
+      const name =
+        nameByAddress.get(action.fromAddress) ??
+        truncateAddress(action.fromAddress.toString(16));
+      return {
+        label: `Received ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)} from ${name}`,
+        chipClass: "chip-ok",
+      };
+    }
+    case "swap": {
+      const executor = truncateAddress(action.executor.toString(16));
+      const sentParts = action.sent.map(
+        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`,
+      );
+      const receivedParts = action.received.map(
+        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`,
+      );
+      return {
+        label: `Swapped ${sentParts.join(", ")} for ${receivedParts.join(", ")} via ${executor}`,
+        chipClass: "chip",
+      };
+    }
+    case "transferSelf":
+      return {
+        label: `Reorganized ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)}`,
+        chipClass: "chip",
+      };
+  }
+}
+
+function computeBalanceUpdates(
+  actions: HistoryAction[],
+  viewerAddress: bigint,
+  tokenNameByAddress: Map<bigint, string>,
+  tokenDecimalsByAddress: Map<bigint, number>,
+): BalanceUpdate[] {
+  const netByToken = new Map<bigint, bigint>();
+
+  for (const action of actions) {
+    switch (action.type) {
+      case "deposit":
+        break;
+      case "withdrawal":
+        if (action.toAddress !== viewerAddress) {
+          netByToken.set(
+            action.token,
+            (netByToken.get(action.token) ?? 0n) - action.amount,
+          );
+        }
+        break;
+      case "transferSent":
+        netByToken.set(
+          action.token,
+          (netByToken.get(action.token) ?? 0n) - action.amount,
+        );
+        break;
+      case "transferReceived":
+        netByToken.set(
+          action.token,
+          (netByToken.get(action.token) ?? 0n) + action.amount,
+        );
+        break;
+      case "swap":
+        for (const leg of action.sent) {
+          netByToken.set(
+            leg.token,
+            (netByToken.get(leg.token) ?? 0n) - leg.amount,
+          );
+        }
+        for (const leg of action.received) {
+          netByToken.set(
+            leg.token,
+            (netByToken.get(leg.token) ?? 0n) + leg.amount,
+          );
+        }
+        break;
+      case "transferSelf":
+        break;
+    }
+  }
+
+  const resolveTokenName = (token: bigint): string =>
+    tokenNameByAddress.get(token) ?? truncateAddress(token.toString(16));
+
+  return Array.from(netByToken.entries()).map(([token, amount]) => ({
+    tokenName: resolveTokenName(token),
+    amount,
+    decimals: tokenDecimalsByAddress.get(token) ?? 0,
+  }));
+}
+
+function buildDisplayMaps(
+  account: AccountConfig,
+  allAccounts: AccountConfig[],
+  config: AppConfig,
+  tokenMetadata: TokenMetadataMap,
+): {
+  nameByAddress: Map<bigint, string>;
+  tokenNameByAddress: Map<bigint, string>;
+  tokenDecimalsByAddress: Map<bigint, number>;
+} {
+  const nameByAddress = new Map<bigint, string>();
+  for (const acc of allAccounts) {
+    const accAddress = BigInt(acc.address);
+    nameByAddress.set(
+      accAddress,
+      accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase(),
+    );
+  }
+  const tokenMeta = tokenMetadata.get(config.tokenAddress);
+  const tokenNameByAddress = new Map<bigint, string>();
+  tokenNameByAddress.set(BigInt(config.tokenAddress), tokenMeta?.symbol ?? "Token");
+  tokenNameByAddress.set(BigInt(config.feeTokenAddress), "STRK");
+  const tokenDecimalsByAddress = new Map<bigint, number>();
+  tokenDecimalsByAddress.set(BigInt(config.tokenAddress), tokenMeta?.decimals ?? 0);
+  tokenDecimalsByAddress.set(BigInt(config.feeTokenAddress), 18);
+  return { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress };
+}
+
+const ACTION_ORDER: Record<string, number> = {
+  deposit: 0,
+  transferReceived: 1,
+  transferSelf: 2,
+  transferSent: 3,
+  swap: 4,
+  withdrawal: 5,
+};
+
+function toDisplayTransactions(
+  rawTransactions: HistoryTransaction[],
+  viewerAddress: bigint,
+  nameByAddress: Map<bigint, string>,
+  tokenNameByAddress: Map<bigint, string>,
+  tokenDecimalsByAddress: Map<bigint, number>,
+): TransactionDisplay[] {
+  return rawTransactions.map((transaction) => {
+    const classified = classifyTransaction(transaction);
+    const actions: ActionDisplay[] = classified.actions
+      .map((action) => {
+        const { label, chipClass } = formatActionLabel(
+          action,
+          nameByAddress,
+          tokenNameByAddress,
+          tokenDecimalsByAddress,
+        );
+        const noteCount = "noteCount" in action ? action.noteCount : undefined;
+        return { type: action.type, label, chipClass, noteCount };
+      })
+      .sort(
+        (a, b) => (ACTION_ORDER[a.type] ?? 99) - (ACTION_ORDER[b.type] ?? 99),
+      );
+    const balanceUpdates = computeBalanceUpdates(
+      classified.actions,
+      viewerAddress,
+      tokenNameByAddress,
+      tokenDecimalsByAddress,
+    );
+    return {
+      blockNumber: classified.blockNumber,
+      timestamp: null,
+      transactionHash: truncateAddress(classified.transactionHash.toString(16)),
+      fullTransactionHash: `0x${classified.transactionHash.toString(16)}`,
+      actions,
+      balanceUpdates,
+    };
+  });
+}
+
+async function resolveTimestamps(
+  provider: RpcProvider,
+  transactions: TransactionDisplay[],
+): Promise<TransactionDisplay[]> {
+  const blockNumbers = [...new Set(transactions.map((tx) => tx.blockNumber))];
+  const entries = await Promise.all(
+    blockNumbers.map(async (blockNumber) => {
+      const block = await provider.getBlock(blockNumber);
+      return [blockNumber, block.timestamp] as const;
+    }),
+  );
+  const timestampByBlock = new Map(entries);
+  return transactions.map((tx) => ({
+    ...tx,
+    timestamp: timestampByBlock.get(tx.blockNumber) ?? null,
+  }));
+}
+
+export function useHistory(
+  provider: RpcProvider | undefined,
+  poolAddress: string,
+  config: AppConfig,
+  account: AccountConfig | undefined,
+  allAccounts: AccountConfig[],
+  registry: PrivateRegistry,
+  tokenMetadata: TokenMetadataMap,
+) {
+  const [transactions, setTransactions] = useState<TransactionDisplay[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [historyComplete, setHistoryComplete] = useState(false);
+
+  const tokenMetadataRef = useRef(tokenMetadata);
+  tokenMetadataRef.current = tokenMetadata;
+
+  const historyCursorRef = useRef<HistoryCursor | undefined>(undefined);
+  const blockRefValue = useRef<string | undefined>(undefined);
+  const loadingRef = useRef(false);
+
+  const autoFetchedRef = useRef(false);
+
+  // Reset on account/pool change
+  useEffect(() => {
+    setTransactions([]);
+    setError(null);
+    setHistoryComplete(false);
+    historyCursorRef.current = undefined;
+    blockRefValue.current = undefined;
+    autoFetchedRef.current = false;
+  }, [account, poolAddress]);
+
+  const fetchMore = useCallback(async () => {
+    if (!account || loadingRef.current) return;
+
+    if (!registry.cursor || !registry.channels) {
+      setError("Refresh state first to populate discovery cursors");
+      return;
+    }
+
+    loadingRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const indexer = new IndexerDiscoveryProvider(
+        config.indexerUrl,
+        poolAddress,
+      );
+      const page = await indexer.fetchHistory(
+        BigInt(account.address),
+        registry.cursor,
+        { channels: registry.channels },
+        {
+          maxTransactions: 5,
+          historyCursor: historyCursorRef.current,
+          blockRef: blockRefValue.current,
+        },
+      );
+
+      historyCursorRef.current = page.cursor;
+      blockRefValue.current = page.blockRef;
+      setHistoryComplete(page.cursor.historyComplete);
+
+      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress } = buildDisplayMaps(
+        account,
+        allAccounts,
+        config,
+        tokenMetadataRef.current,
+      );
+      let newTransactions = toDisplayTransactions(
+        page.transactions,
+        BigInt(account.address),
+        nameByAddress,
+        tokenNameByAddress,
+        tokenDecimalsByAddress,
+      );
+      if (provider) {
+        newTransactions = await resolveTimestamps(provider, newTransactions);
+      }
+
+      setTransactions((previous) => [...previous, ...newTransactions]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      loadingRef.current = false;
+      setLoading(false);
+    }
+  }, [account, registry, config, poolAddress, allAccounts]);
+
+  // Fetch the latest transaction (no pagination cursor) and prepend if new.
+  // Intended to be called after state refresh so cursors are up to date.
+  // Retries once after a delay if the indexer hasn't caught up yet.
+  const refreshLatest = useCallback(async () => {
+    if (!account || loadingRef.current) return;
+    if (!registry.cursor || !registry.channels) return;
+
+    loadingRef.current = true;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const indexer = new IndexerDiscoveryProvider(
+        config.indexerUrl,
+        poolAddress,
+      );
+      const page = await indexer.fetchHistory(
+        BigInt(account.address),
+        registry.cursor,
+        { channels: registry.channels },
+        { maxTransactions: 1 },
+      );
+
+      if (page.transactions.length === 0) return;
+
+      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress } = buildDisplayMaps(
+        account,
+        allAccounts,
+        config,
+        tokenMetadataRef.current,
+      );
+      let freshTransactions = toDisplayTransactions(
+        page.transactions,
+        BigInt(account.address),
+        nameByAddress,
+        tokenNameByAddress,
+        tokenDecimalsByAddress,
+      );
+      if (provider) {
+        freshTransactions = await resolveTimestamps(provider, freshTransactions);
+      }
+
+      setTransactions((previous) => {
+        const existingHashes = new Set(
+          previous.map((tx) => tx.transactionHash),
+        );
+        const newOnly = freshTransactions.filter(
+          (tx) => !existingHashes.has(tx.transactionHash),
+        );
+        if (newOnly.length === 0) return previous;
+        return [...newOnly, ...previous];
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      loadingRef.current = false;
+      setLoading(false);
+    }
+  }, [account, registry, config, poolAddress, allAccounts]);
+
+  // Auto-fetch first page when cursors become available
+  useEffect(() => {
+    if (autoFetchedRef.current) return;
+    if (!registry.cursor || !registry.channels) return;
+    autoFetchedRef.current = true;
+    fetchMore();
+  }, [registry.cursor, registry.channels, fetchMore]);
+
+  return {
+    transactions,
+    loading,
+    error,
+    historyComplete,
+    fetchMore,
+    refreshLatest,
+  };
+}

--- a/demo/src/hooks/usePrivateState.ts
+++ b/demo/src/hooks/usePrivateState.ts
@@ -1,59 +1,87 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { RpcProvider } from "starknet";
-import { SetupRequirement, type Note, type Channel, type PrivateTransfersInterface } from "starknet-sdk";
+import {
+  SetupRequirement,
+  createEmptyRegistry,
+  type Note,
+  type Channel,
+  type PrivateTransfersInterface,
+  type PrivateRegistry,
+} from "starknet-sdk";
 // Direct import avoids pulling in Node-only modules from the testing barrel
 // @ts-expect-error — deep import into dist, not part of the declared exports
 import { IndexerDiscoveryProvider } from "starknet-sdk/dist/internal/indexer-discovery.js";
 import type { AppConfig, AccountConfig } from "../config.ts";
 import { getErc20Balance } from "../starknet.ts";
+import type { TokenMetadataMap } from "./useTokenMetadata.ts";
 
 export type NoteDisplay = {
   id: string;
   rawId: bigint;
   amount: bigint;
+  decimals: number;
   token: string;
+  tokenName: string;
   sender: string;
   senderName: string | null;
   channelKey: string;
+  rawChannelKey: string;
   nonce: number;
   open: boolean;
 };
 
-export type ChannelDisplay = {
-  recipient: string;
-  recipientName: string | null;
-  publicKey: string;
-  channelKey: string;
-  noteNonce: number;
-  tokens: Array<{ tokenAddress: string }>;
+export type TokenNoteGroup = {
+  tokenAddress: string;
+  tokenName: string;
+  decimals: number;
+  notes: NoteDisplay[];
 };
 
-export type ChannelGroup = {
-  channelKey: string;
+export type IncomingChannelCard = {
+  cardKey: string;
   sender: string;
   senderName: string | null;
-  token: string;
-  notes: NoteDisplay[];
+  channelKey: string;
+  rawChannelKey: string;
+  tokenGroups: TokenNoteGroup[];
+};
+
+export type OutgoingChannelCard = {
+  cardKey: string;
+  recipient: string;
+  recipientName: string | null;
+  channelKey: string;
+  rawChannelKey: string;
+  tokens: { tokenAddress: string; tokenName: string; noteNonce: number }[];
+};
+
+export type TokenBalance = {
+  name: string;
+  address: string;
+  decimals: number;
+  transparent: bigint;
+  private: bigint;
+  noteCount: number;
 };
 
 export type PrivateState = {
   isRegistered: boolean | null;
-  tokenBalance: bigint;
+  tokenBalances: TokenBalance[];
   feeTokenBalance: bigint;
-  privateBalance: bigint;
+  feeTokenAddress: string;
   notes: NoteDisplay[];
-  channelGroups: ChannelGroup[];
-  channels: ChannelDisplay[];
+  incomingCards: IncomingChannelCard[];
+  outgoingCards: OutgoingChannelCard[];
 };
 
 const EMPTY_STATE: PrivateState = {
   isRegistered: null,
-  tokenBalance: 0n,
+  tokenBalances: [],
   feeTokenBalance: 0n,
-  privateBalance: 0n,
+  feeTokenAddress: "",
   notes: [],
-  channelGroups: [],
-  channels: [],
+  incomingCards: [],
+  outgoingCards: [],
 };
 
 // SDK fields are marked @internal, access via runtime shape
@@ -79,13 +107,17 @@ export function usePrivateState(
   allAccounts: AccountConfig[],
   poolAddress: string,
   config: AppConfig,
+  registry: PrivateRegistry,
+  tokenMetadata: TokenMetadataMap,
 ) {
   const [state, setState] = useState<PrivateState>(EMPTY_STATE);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset displayed state when the active account or pool changes so stale
-  // data from the previous selection is never shown.
+  // Use ref so refresh callback doesn't re-trigger when metadata loads
+  const tokenMetadataRef = useRef(tokenMetadata);
+  tokenMetadataRef.current = tokenMetadata;
+
   useEffect(() => {
     setState(EMPTY_STATE);
   }, [account, poolAddress]);
@@ -97,15 +129,20 @@ export function usePrivateState(
 
     try {
       const indexer = new IndexerDiscoveryProvider(config.indexerUrl, poolAddress);
-      const [tokenBalance, feeTokenBalance, { notes: notesMap }, channelsResult, requirement] =
+      const [tokenBalance, feeTokenBalance, notesResult, channelsResult, requirement] =
         await Promise.all([
-          getErc20Balance(provider, config.tokenAddress, account.address),
-          getErc20Balance(provider, config.feeTokenAddress, account.address),
-          transfers.discoverNotes({ tokens: [BigInt(config.tokenAddress)] }),
+          getErc20Balance(provider, config.tokenAddress, account.address, "pre_confirmed"),
+          getErc20Balance(provider, config.feeTokenAddress, account.address, "pre_confirmed"),
+          indexer.discoverNotes(
+            BigInt(account.address),
+            BigInt(account.viewingKey),
+            { cursor: registry.cursor, tokens: [BigInt(config.tokenAddress)] },
+          ),
           indexer.discoverChannels(
             BigInt(account.address),
             BigInt(account.viewingKey),
             "all",
+            { cursor: { channels: registry.channels } },
           ),
           indexer.discoverRequirement(
             BigInt(account.address),
@@ -116,16 +153,36 @@ export function usePrivateState(
         ]);
       const isRegistered = requirement !== SetupRequirement.Register;
 
-      const tokenNotes = notesMap.get(BigInt(config.tokenAddress)) ?? [];
+      registry.cursor = notesResult.cursor;
+      if (channelsResult.channels) registry.channels = channelsResult.channels;
+
+      const meta = tokenMetadataRef.current.get(config.tokenAddress);
+      const tokenName = meta?.symbol ?? "Token";
+      const tokenDecimals = meta?.decimals ?? 0;
+
+      const tokenNotes = notesResult.notes.get(BigInt(config.tokenAddress)) ?? [];
+      registry.notes = notesResult.notes;
       const privateBalance = tokenNotes.reduce(
         (sum: bigint, note: Note) => sum + note.amount,
         0n,
       );
 
+      // Note amounts in the privacy pool are already in human-readable units
+      // (e.g. 50 for 50 STRK), NOT raw ERC20 units (50 * 10^18).
+      // Only transparent ERC20 balances need decimal scaling.
+      const tokenBalances: TokenBalance[] = [{
+        name: tokenName,
+        address: config.tokenAddress,
+        decimals: tokenDecimals,
+        transparent: tokenBalance,
+        private: privateBalance,
+        noteCount: tokenNotes.length,
+      }];
+
       const nameByAddress = new Map<bigint, string>();
       for (const acc of allAccounts) {
         const accAddress = BigInt(acc.address);
-        nameByAddress.set(accAddress, accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase());
+        nameByAddress.set(accAddress, accAddress === BigInt(account.address) ? "Self" : acc.name);
       }
 
       const tokenAddressBigInt = BigInt(config.tokenAddress);
@@ -137,68 +194,145 @@ export function usePrivateState(
           id: formatBigInt(noteIdBigInt),
           rawId: noteIdBigInt,
           amount: note.amount,
+          decimals: tokenDecimals,
           token: truncateAddress(tokenAddressBigInt.toString(16)),
+          tokenName,
           sender: truncateAddress(senderBigInt.toString(16)),
           senderName: nameByAddress.get(senderBigInt) ?? null,
           channelKey: formatBigInt(witness.channelKey),
+          rawChannelKey: `0x${witness.channelKey.toString(16)}`,
           nonce: witness.nonce,
           open: note.open ?? false,
         };
       });
-      const channels: ChannelDisplay[] = [];
-      for (const [recipient, channel] of channelsResult.channels) {
-        const internal = readChannel(channel);
-        const tokens: ChannelDisplay["tokens"] = [];
-        let noteNonce = 0;
-        for (const [tokenAddress, tokenChannel] of internal.tokens) {
-          tokens.push({
-            tokenAddress: truncateAddress(tokenAddress.toString(16)),
-          });
-          noteNonce = Math.max(noteNonce, tokenChannel.noteNonce);
-        }
-        channels.push({
-          recipient: truncateAddress(recipient.toString(16)),
-          recipientName: nameByAddress.get(recipient) ?? null,
-          publicKey: formatBigInt(internal.publicKey),
-          channelKey: internal.key ? formatBigInt(internal.key) : "N/A",
-          noteNonce,
-          tokens,
-        });
-      }
 
-      const groupsByKey = new Map<string, NoteDisplay[]>();
+      // Build incoming cards: group notes by sender, then by token
+      const bySender = new Map<string, NoteDisplay[]>();
       for (const note of notes) {
-        const existing = groupsByKey.get(note.channelKey);
+        const key = note.sender;
+        const existing = bySender.get(key);
         if (existing) {
           existing.push(note);
         } else {
-          groupsByKey.set(note.channelKey, [note]);
+          bySender.set(key, [note]);
         }
       }
 
-      const channelGroups: ChannelGroup[] = [];
-      for (const [channelKey, groupNotes] of groupsByKey) {
-        groupNotes.sort((a, b) => b.nonce - a.nonce);
-        const firstNote = groupNotes[0];
-        channelGroups.push({
-          channelKey,
-          sender: firstNote.sender,
+      const incomingCards: IncomingChannelCard[] = [];
+      for (const [sender, senderNotes] of bySender) {
+        senderNotes.sort((a, b) => b.nonce - a.nonce);
+        const firstNote = senderNotes[0];
+
+        // Sub-group by token (single token for now, but structure is ready)
+        const byToken = new Map<string, NoteDisplay[]>();
+        for (const note of senderNotes) {
+          const existing = byToken.get(note.token);
+          if (existing) {
+            existing.push(note);
+          } else {
+            byToken.set(note.token, [note]);
+          }
+        }
+
+        const tokenGroups: TokenNoteGroup[] = [];
+        for (const [tokenAddr, tokenNotesList] of byToken) {
+          const first = tokenNotesList[0];
+          tokenGroups.push({
+            tokenAddress: tokenAddr,
+            tokenName: first.tokenName,
+            decimals: first.decimals,
+            notes: tokenNotesList,
+          });
+        }
+
+        incomingCards.push({
+          cardKey: sender,
+          sender,
           senderName: firstNote.senderName,
-          token: firstNote.token,
-          notes: groupNotes,
+          channelKey: firstNote.channelKey,
+          rawChannelKey: firstNote.rawChannelKey,
+          tokenGroups,
         });
       }
-      channelGroups.sort((a, b) => b.notes[0].nonce - a.notes[0].nonce);
+      // Sort: Self first, then alphabetical
+      incomingCards.sort((a, b) => {
+        if (a.senderName === "Self") return -1;
+        if (b.senderName === "Self") return 1;
+        return (a.senderName ?? a.sender).localeCompare(b.senderName ?? b.sender);
+      });
 
-      setState({ isRegistered, tokenBalance, feeTokenBalance, privateBalance, notes, channelGroups, channels });
+      // Build outgoing cards
+      const outgoingCards: OutgoingChannelCard[] = [];
+      for (const [recipient, channel] of channelsResult.channels) {
+        const internal = readChannel(channel);
+        const tokens: OutgoingChannelCard["tokens"] = [];
+        for (const [tokenAddr, tokenChannel] of internal.tokens) {
+          const tokenMeta = tokenMetadataRef.current.get(
+            `0x${tokenAddr.toString(16)}`,
+          );
+          tokens.push({
+            tokenAddress: truncateAddress(tokenAddr.toString(16)),
+            tokenName: tokenMeta?.symbol ?? truncateAddress(tokenAddr.toString(16)),
+            noteNonce: tokenChannel.noteNonce,
+          });
+        }
+        const recipientName = nameByAddress.get(recipient) ?? null;
+        outgoingCards.push({
+          cardKey: recipient.toString(16),
+          recipient: truncateAddress(recipient.toString(16)),
+          recipientName,
+          channelKey: internal.key ? formatBigInt(internal.key) : "N/A",
+          rawChannelKey: internal.key ? `0x${internal.key.toString(16)}` : "",
+          tokens,
+        });
+      }
+      // Sort: Self first, then alphabetical
+      outgoingCards.sort((a, b) => {
+        if (a.recipientName === "Self") return -1;
+        if (b.recipientName === "Self") return 1;
+        return (a.recipientName ?? a.recipient).localeCompare(b.recipientName ?? b.recipient);
+      });
+
+      setState({
+        isRegistered,
+        tokenBalances,
+        feeTokenBalance,
+        feeTokenAddress: config.feeTokenAddress,
+        notes,
+        incomingCards,
+        outgoingCards,
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      Object.assign(registry, createEmptyRegistry());
     } finally {
       setLoading(false);
     }
-  }, [provider, transfers, account, allAccounts, poolAddress, config]);
+  }, [provider, transfers, account, allAccounts, poolAddress, config, registry]);
 
-  return { state, loading, error, refresh };
+  const refreshBalances = useCallback(async () => {
+    if (!provider || !account) return;
+    const meta = tokenMetadataRef.current.get(config.tokenAddress);
+    const tokenDecimals = meta?.decimals ?? 0;
+    const tokenName = meta?.symbol ?? "Token";
+    const [tokenBalance, feeTokenBalance] = await Promise.all([
+      getErc20Balance(provider, config.tokenAddress, account.address, "pre_confirmed"),
+      getErc20Balance(provider, config.feeTokenAddress, account.address, "pre_confirmed"),
+    ]);
+    setState((previous) => ({
+      ...previous,
+      feeTokenBalance,
+      tokenBalances: previous.tokenBalances.length > 0
+        ? previous.tokenBalances.map((tb) =>
+            tb.address === config.tokenAddress
+              ? { ...tb, transparent: tokenBalance }
+              : tb,
+          )
+        : [{ name: tokenName, address: config.tokenAddress, decimals: tokenDecimals, transparent: tokenBalance, private: 0n, noteCount: 0 }],
+    }));
+  }, [provider, account, config.tokenAddress, config.feeTokenAddress]);
+
+  return { state, loading, error, refresh, refreshBalances };
 }
 
 function truncateAddress(hex: string): string {
@@ -213,7 +347,6 @@ function formatBigInt(value: bigint): string {
   return `0x${hex.slice(0, 6)}...${hex.slice(-4)}`;
 }
 
-/** Convert BigNumberish (string | number | bigint) to bigint. Handles hex and decimal strings. */
 function toBigInt(value: string | number | bigint): bigint {
   if (typeof value === "bigint") return value;
   return BigInt(value);

--- a/demo/src/hooks/useServiceHealth.ts
+++ b/demo/src/hooks/useServiceHealth.ts
@@ -22,6 +22,7 @@ export type ServiceHealthState = {
 
 const POLL_INTERVAL_MS = 30_000;
 const RPC_STALENESS_THRESHOLD_SECS = 120;
+const RPC_BLOCK_DIVERGENCE_THRESHOLD = 0;
 const FETCH_TIMEOUT_MS = 8_000;
 
 function pending(): SubsystemHealth {
@@ -42,16 +43,36 @@ async function checkDiscovery(indexerUrl: string): Promise<SubsystemHealth> {
   }
 }
 
-async function checkRpc(provider: RpcProvider): Promise<SubsystemHealth> {
+async function checkRpc(provider: RpcProvider, feederGatewayUrl?: string): Promise<SubsystemHealth> {
   try {
     const block = await provider.getBlock("latest");
-    const blockTimestamp = block.timestamp;
+    const rpcBlockNumber = block.block_number;
     const nowSecs = Math.floor(Date.now() / 1000);
-    const lagSecs = nowSecs - blockTimestamp;
-    if (lagSecs <= RPC_STALENESS_THRESHOLD_SECS) {
-      return { status: "healthy", detail: `lag: ${lagSecs}s` };
+    const lagSecs = nowSecs - block.timestamp;
+    if (lagSecs > RPC_STALENESS_THRESHOLD_SECS) {
+      return { status: "unhealthy", detail: `stale: ${lagSecs}s behind` };
     }
-    return { status: "unhealthy", detail: `stale: ${lagSecs}s behind` };
+
+    if (feederGatewayUrl) {
+      try {
+        const response = await fetch(
+          `${feederGatewayUrl}/feeder_gateway/get_block?blockNumber=latest`,
+          { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+        );
+        if (response.ok) {
+          const feederBlock = await response.json();
+          const feederBlockNumber = feederBlock.block_number as number;
+          const divergence = Math.abs(rpcBlockNumber - feederBlockNumber);
+          if (divergence > RPC_BLOCK_DIVERGENCE_THRESHOLD) {
+            return { status: "unhealthy", detail: `block ${rpcBlockNumber} vs feeder ${feederBlockNumber} (${divergence} behind)` };
+          }
+        }
+      } catch {
+        // Feeder gateway unavailable — skip divergence check
+      }
+    }
+
+    return { status: "healthy", detail: `block ${rpcBlockNumber}, lag: ${lagSecs}s` };
   } catch (error) {
     return { status: "unhealthy", detail: error instanceof Error ? error.message : "unreachable" };
   }
@@ -102,7 +123,7 @@ export function useServiceHealth(
     };
 
     checkDiscovery(config.indexerUrl).then(update("discovery"));
-    checkRpc(provider).then(update("rpc"));
+    checkRpc(provider, config.feederGatewayUrl).then(update("rpc"));
 
     if (config.provingServiceUrl) {
       checkProving(config.provingServiceUrl).then(update("proving"));

--- a/demo/src/hooks/useTokenMetadata.ts
+++ b/demo/src/hooks/useTokenMetadata.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from "react";
+import type { RpcProvider } from "starknet";
+import { getErc20Metadata, type TokenMetadata } from "../starknet.ts";
+
+export type TokenMetadataMap = Map<string, TokenMetadata>;
+
+export function useTokenMetadata(
+  provider: RpcProvider | undefined,
+  tokenAddresses: string[],
+): TokenMetadataMap {
+  const [metadata, setMetadata] = useState<TokenMetadataMap>(new Map());
+  const fetchedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!provider) return;
+    const missing = tokenAddresses.filter(
+      (address) => !fetchedRef.current.has(address),
+    );
+    if (missing.length === 0) return;
+
+    for (const address of missing) {
+      fetchedRef.current.add(address);
+    }
+
+    Promise.all(
+      missing.map(async (address) => {
+        const meta = await getErc20Metadata(provider, address);
+        return [address, meta] as const;
+      }),
+    ).then((entries) => {
+      setMetadata((previous) => {
+        const next = new Map(previous);
+        for (const [address, meta] of entries) {
+          next.set(address, meta);
+        }
+        return next;
+      });
+    });
+  }, [provider, tokenAddresses]);
+
+  return metadata;
+}

--- a/demo/src/hooks/useTransactionBuilder.ts
+++ b/demo/src/hooks/useTransactionBuilder.ts
@@ -1,10 +1,12 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { Account, TransactionFinalityStatus, type RpcProvider } from "starknet";
 import type { PrivateTransfersInterface } from "starknet-sdk";
 import type { AccountConfig, AppConfig } from "../config.ts";
 import type { TransactionStatus } from "./useTransactions.ts";
 import type { BuilderOperation } from "../components/TransactionBuilder.tsx";
 import { Timeline } from "../timeline.ts";
+
+import { toRawAmount } from "../format.ts";
 
 const WAIT_OPTIONS = {
   successStates: [TransactionFinalityStatus.PRE_CONFIRMED],
@@ -23,7 +25,8 @@ export function useTransactionBuilder(
   poolAddress: string,
   config: AppConfig,
   accounts: AccountConfig[],
-  onSuccess: () => void,
+  onSettled: () => void,
+  tokenDecimals: number,
 ) {
   const [status, setStatus] = useState<TransactionStatus>({
     pending: false,
@@ -32,6 +35,9 @@ export function useTransactionBuilder(
     proofSizeBytes: null,
     timeline: null,
   });
+
+  const onSettledRef = useRef(onSettled);
+  onSettledRef.current = onSettled;
 
   const userAccount = useMemo(() => {
     if (!provider || !activeAddress) return undefined;
@@ -61,7 +67,7 @@ export function useTransactionBuilder(
           await timeline.step(action, async () => {
             const totalDepositAmount = operations
               .filter((op) => op.operationType === "deposit")
-              .reduce((sum, op) => sum + BigInt(op.amount), 0n);
+              .reduce((sum, op) => sum + toRawAmount(op.amount, tokenDecimals), 0n);
 
             if (totalDepositAmount > 0n) {
               await timeline.step("Approve", async () => {
@@ -114,11 +120,11 @@ export function useTransactionBuilder(
                 .with(config.tokenAddress, (tokenBuilder) => {
                   for (const op of operations) {
                     if (op.operationType === "deposit")
-                      tokenBuilder.deposit({ amount: BigInt(op.amount), recipient: op.recipient || undefined });
+                      tokenBuilder.deposit({ amount: toRawAmount(op.amount, tokenDecimals), recipient: op.recipient || undefined });
                     if (op.operationType === "transfer")
-                      tokenBuilder.transfer({ recipient: op.recipient!, amount: BigInt(op.amount) });
+                      tokenBuilder.transfer({ recipient: op.recipient!, amount: toRawAmount(op.amount, tokenDecimals) });
                     if (op.operationType === "withdraw")
-                      tokenBuilder.withdraw({ amount: BigInt(op.amount), recipient: op.recipient || activeAddress });
+                      tokenBuilder.withdraw({ amount: toRawAmount(op.amount, tokenDecimals), recipient: op.recipient || activeAddress });
                   }
                 })
                 .execute({ provingBlockId }),
@@ -146,16 +152,26 @@ export function useTransactionBuilder(
               ? base64ByteLength(callAndProof.proof.data)
               : null;
             setStatus({ pending: false, lastTxHash: executeTx.transaction_hash, lastError: null, proofSizeBytes, timeline });
-            onSuccess();
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           console.error(`[${action}] failed:`, err);
           setStatus({ pending: false, lastTxHash: null, lastError: `${action}: ${message}`, proofSizeBytes: null, timeline });
+        } finally {
+          onSettledRef.current();
         }
       })();
     },
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, onSuccess],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      accounts,
+      tokenDecimals,
+    ],
   );
 
   return { status, executeBatch };

--- a/demo/src/hooks/useTransactions.ts
+++ b/demo/src/hooks/useTransactions.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { Account, TransactionFinalityStatus, type RpcProvider } from "starknet";
 import type { PrivateTransfersInterface } from "starknet-sdk";
 import type { AccountConfig, AppConfig } from "../config.ts";
@@ -29,7 +29,8 @@ export function useTransactions(
   poolAddress: string,
   config: AppConfig,
   accounts: AccountConfig[],
-  onSuccess: () => void,
+  onSettled: () => void,
+  onBalancesChanged?: () => Promise<void>,
 ) {
   const [status, setStatus] = useState<TransactionStatus>({
     pending: false,
@@ -38,6 +39,11 @@ export function useTransactions(
     proofSizeBytes: null,
     timeline: null,
   });
+
+  const onSettledRef = useRef(onSettled);
+  onSettledRef.current = onSettled;
+  const onBalancesChangedRef = useRef(onBalancesChanged);
+  onBalancesChangedRef.current = onBalancesChanged;
 
   const adminAccount = useMemo(() => {
     if (!provider) return undefined;
@@ -78,14 +84,15 @@ export function useTransactions(
           proofSizeBytes: result.proofSizeBytes ?? null,
           timeline,
         });
-        onSuccess();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error(`[${action}] failed:`, err);
         setStatus({ pending: false, lastTxHash: null, lastError: `${action}: ${message}`, proofSizeBytes: null, timeline });
+      } finally {
+        onSettledRef.current();
       }
     },
-    [onSuccess],
+    [],
   );
 
   const register = useCallback(
@@ -148,6 +155,7 @@ export function useTransactions(
           provider.waitForTransaction(tx.transaction_hash, WAIT_OPTIONS),
         );
 
+        if (onBalancesChangedRef.current) await onBalancesChangedRef.current();
         return { txHash: tx.transaction_hash };
       }),
     [adminAccount, activeAddress, provider, config.tokenAddress, execute],

--- a/demo/src/starknet.ts
+++ b/demo/src/starknet.ts
@@ -11,7 +11,7 @@ import type { AppConfig, AccountConfig } from "./config.ts";
 import { NoValidateProofProvider } from "./proof-provider.ts";
 
 export function createProvider(rpcUrl: string): RpcProvider {
-  return new RpcProvider({ nodeUrl: rpcUrl });
+  return new RpcProvider({ nodeUrl: rpcUrl, batch: 50 });
 }
 
 export function createAccount(
@@ -19,7 +19,12 @@ export function createAccount(
   address: string,
   privateKey: string,
 ): Account {
-  return new Account({ provider, address, signer: privateKey, cairoVersion: "1" });
+  return new Account({
+    provider,
+    address,
+    signer: privateKey,
+    cairoVersion: "1",
+  });
 }
 
 export function createTransfers(
@@ -29,16 +34,18 @@ export function createTransfers(
   poolAddress: string,
   config: AppConfig,
 ): PrivateTransfersInterface {
-  const discovery = new IndexerDiscoveryProvider(config.indexerUrl, poolAddress);
+  const discovery = new IndexerDiscoveryProvider(
+    config.indexerUrl,
+    poolAddress,
+  );
   const provingProvider = config.provingServiceUrl
-    ? new ProvingServiceProofProvider(
-        config.provingServiceUrl,
-        config.chainId,
-      )
+    ? new ProvingServiceProofProvider(config.provingServiceUrl, config.chainId)
     : new NoValidateProofProvider(provider, config.chainId);
   return createPrivateTransfers({
     account,
-    viewingKeyProvider: { getViewingKey: async () => BigInt(accountConfig.viewingKey) },
+    viewingKeyProvider: {
+      getViewingKey: async () => BigInt(accountConfig.viewingKey),
+    },
     provingProvider,
     discoveryProvider: discovery,
     poolContractAddress: poolAddress,
@@ -49,11 +56,48 @@ export async function getErc20Balance(
   provider: RpcProvider,
   tokenAddress: string,
   ownerAddress: string,
+  blockIdentifier?: string,
 ): Promise<bigint> {
-  const result = await provider.callContract({
-    contractAddress: tokenAddress,
-    entrypoint: "balance_of",
-    calldata: [ownerAddress],
-  });
+  const result = await provider.callContract(
+    {
+      contractAddress: tokenAddress,
+      entrypoint: "balance_of",
+      calldata: [ownerAddress],
+    },
+    blockIdentifier,
+  );
   return BigInt(result[0]);
+}
+
+export type TokenMetadata = {
+  name: string;
+  symbol: string;
+  decimals: number;
+};
+
+function decodeFeltString(hex: string): string {
+  const raw = hex.startsWith("0x") ? hex.slice(2) : hex;
+  let result = "";
+  for (let offset = 0; offset < raw.length; offset += 2) {
+    const code = parseInt(raw.slice(offset, offset + 2), 16);
+    if (code === 0) break;
+    result += String.fromCharCode(code);
+  }
+  return result;
+}
+
+export async function getErc20Metadata(
+  provider: RpcProvider,
+  tokenAddress: string,
+): Promise<TokenMetadata> {
+  const [nameResult, symbolResult, decimalsResult] = await Promise.all([
+    provider.callContract({ contractAddress: tokenAddress, entrypoint: "name", calldata: [] }),
+    provider.callContract({ contractAddress: tokenAddress, entrypoint: "symbol", calldata: [] }),
+    provider.callContract({ contractAddress: tokenAddress, entrypoint: "decimals", calldata: [] }),
+  ]);
+  return {
+    name: decodeFeltString(nameResult[0]),
+    symbol: decodeFeltString(symbolResult[0]),
+    decimals: Number(decimalsResult[0]),
+  };
 }

--- a/e2e/scripts/batch-operations.ts
+++ b/e2e/scripts/batch-operations.ts
@@ -38,6 +38,7 @@ import { IndexerDiscoveryProvider } from "@starkware-libs/starknet-privacy-sdk/t
 import {
   createPrivateTransfers,
   ProvingServiceProofProvider,
+  type CallAndProof,
   type TokenOperationsBuilder,
 } from "@starkware-libs/starknet-privacy-sdk";
 interface AccountEntry {
@@ -154,10 +155,7 @@ async function submitOutsideExecution(
   provider: RpcProvider,
   aliceAccount: Account,
   adminAccount: Account,
-  callAndProof: {
-    call: unknown;
-    proof: { proofFacts?: unknown; data?: unknown };
-  },
+  callAndProof: CallAndProof,
 ): Promise<{ transactionHash: string; blockNumber: number | undefined }> {
   const nowSeconds = Math.floor(Date.now() / 1000);
   const callOptions: OutsideExecutionOptions = {


### PR DESCRIPTION
### TL;DR

Added a transaction history feature to the demo application that displays past deposits, withdrawals, transfers, and swaps with pagination support.

### What changed?

- Added a new `HistoryPanel` component that displays transaction history in cards showing block numbers, transaction hashes, and formatted actions
- Created a `useHistory` hook that fetches transaction data from the indexer with pagination and formats it for display
- Modified the `InfoPanel` to include a tab switcher between "State" and "History" views
- Updated the private state hook to use a persistent registry for incremental syncing and to populate discovery cursors needed for history fetching
- Added CSS styles for history cards, headers, actions, and a "Load More" button
- Moved the `formatAmount` function to a shared format utility

### How to test?

1. Navigate to the demo application
2. Ensure you have an account with some transaction history
3. Click on the "History" tab in the info panel
4. Verify that transactions are displayed with proper formatting showing deposits, withdrawals, transfers, and swaps
5. Test the "Load More" button to fetch additional historical transactions
6. Switch between "State" and "History" tabs to ensure both views work correctly

### Why make this change?

This change provides users with visibility into their transaction history, making it easier to track past activity and understand account behavior. The pagination feature ensures good performance even with extensive transaction histories, while the formatted display makes the information easily readable and actionable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/638)
<!-- Reviewable:end -->
