### PR TITLE
feat(sdk): add support for history endpoint

### DIFF
--- a/e2e/src/indexer-client.ts
+++ b/e2e/src/indexer-client.ts
@@ -4,6 +4,7 @@ import { createServer } from "net";
 import { createWriteStream, type WriteStream } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { E2E_TIMEOUTS } from "./timeouts.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -108,8 +109,8 @@ export class IndexerClient {
   }
 
   async waitUntilReady(rpcUrl: string): Promise<void> {
-    await this.waitForLog("API server listening", 15_000);
-    await this.waitForLog("Subscribed to new heads", 15_000);
+    await this.waitForLog("API server listening", E2E_TIMEOUTS.indexerLog);
+    await this.waitForLog("Subscribed to new heads", E2E_TIMEOUTS.indexerLog);
 
     // Create a block so the indexer processes at least one
     await fetch(rpcUrl, {
@@ -118,7 +119,7 @@ export class IndexerClient {
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "devnet_createBlock" }),
     });
 
-    await this.waitForLog("New block #", 10_000);
+    await this.waitForLog("New block #", E2E_TIMEOUTS.indexerLog);
   }
 
   async healthCheck(): Promise<Record<string, unknown>> {
@@ -126,8 +127,22 @@ export class IndexerClient {
     return resp.json() as Promise<Record<string, unknown>>;
   }
 
-  shutdown(): void {
+  async shutdown(): Promise<void> {
     this.logStream?.end();
+
+    if (!this.child.pid || this.child.exitCode !== null) return;
+
+    const exitPromise = new Promise<void>((resolve) => {
+      this.child.on("exit", () => resolve());
+    });
+
     this.child.kill("SIGINT");
+
+    const timer = setTimeout(() => {
+      this.child.kill("SIGKILL");
+    }, E2E_TIMEOUTS.processExit);
+
+    await exitPromise;
+    clearTimeout(timer);
   }
 }

--- a/e2e/src/timeouts.ts
+++ b/e2e/src/timeouts.ts
@@ -1,0 +1,11 @@
+/** Shared E2E test timeouts (milliseconds). */
+export const E2E_TIMEOUTS = {
+  /** Vitest hook timeout (beforeAll / afterAll). */
+  hook: 300_000,
+  /** Vitest per-test timeout. */
+  test: 180_000,
+  /** Default timeout for waitForLog / waitForNewLog calls. */
+  indexerLog: 15_000,
+  /** Timeout when waiting for a child process to exit after SIGINT. */
+  processExit: 10_000,
+} as const;

--- a/e2e/tests/devnet/history.test.ts
+++ b/e2e/tests/devnet/history.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  Devnet,
+  IndexerDiscoveryProvider,
+} from "@starkware-libs/starknet-privacy-sdk/testing";
+import { type HistoryTransaction } from "@starkware-libs/starknet-privacy-sdk";
+import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
+
+describe("E2E History", () => {
+  let devnet: Devnet;
+  let env: E2eTestEnv;
+  let indexerDiscovery: IndexerDiscoveryProvider;
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await createE2eTestEnv(devnet);
+    const { env: de, transfers } = env;
+
+    indexerDiscovery = new IndexerDiscoveryProvider(
+      env.indexer.apiUrl,
+      de.privacy.address,
+    );
+
+    // Approve STRK spending
+    await de.alice.execute({
+      contractAddress: de.strk,
+      entrypoint: "approve",
+      calldata: [de.privacy.address, 100n, 0n],
+    });
+
+    // Register bob
+    const { callAndProof: bobReg } = await transfers.bob
+      .build()
+      .register()
+      .execute();
+    await devnet.executeOutside(bobReg);
+
+    // Alice: deposit 100 STRK + transfer 50 to bob
+    const { callAndProof } = await transfers.alice
+      .build({
+        autoRegister: true,
+        autoSetup: true,
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+      })
+      .with(de.strk)
+      .deposit({ amount: 100n })
+      .transfer({ recipient: de.bob.address, amount: 50n })
+      .surplusTo(de.alice.address)
+      .execute();
+
+    await devnet.executeOutside(callAndProof);
+
+    // Create block + wait for indexer
+    await createBlock();
+    await env.indexer.waitForNewLog("New block #", E2E_TIMEOUTS.indexerLog);
+
+    // Bob withdraws 50 STRK
+    const { callAndProof: bobWithdraw } = await transfers.bob
+      .build({
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+        autoSelectNotes: "naive",
+      })
+      .with(de.strk)
+      .withdraw({ amount: 50n, recipient: de.bob.address })
+      .execute();
+
+    await devnet.executeOutside(bobWithdraw);
+
+    // Create block + wait for indexer
+    await createBlock();
+    await env.indexer.waitForNewLog("New block #", E2E_TIMEOUTS.indexerLog);
+  });
+
+  afterAll(async () => {
+    await env?.indexer.shutdown();
+    await devnet?.cleanup();
+  });
+
+  async function createBlock() {
+    await fetch(devnet.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "devnet_createBlock",
+      }),
+    });
+  }
+
+  it("Alice history shows deposit and transfer", async () => {
+    const { env: de } = env;
+    const aliceAddress = BigInt(de.alice.address);
+    const aliceViewingKey = BigInt("0xA11CE");
+
+    const { cursor: notesCursor } = await indexerDiscovery.discoverNotes(
+      aliceAddress,
+      aliceViewingKey,
+    );
+    const { channels } = await indexerDiscovery.discoverChannels(
+      aliceAddress,
+      aliceViewingKey,
+      "all",
+    );
+
+    const historyPage = await indexerDiscovery.fetchHistory(
+      aliceAddress,
+      notesCursor,
+      { channels },
+    );
+
+    expect(historyPage.blockRef).toBeDefined();
+    expect(historyPage.cursor.historyComplete).toBe(true);
+    expect(historyPage.transactions.length).toBeGreaterThan(0);
+
+    const allNotes = historyPage.transactions.flatMap((tx) => tx.notes);
+    const allDeposits = historyPage.transactions.flatMap((tx) => tx.deposits);
+
+    // Alice deposited 100 STRK
+    expect(allDeposits.length).toBeGreaterThanOrEqual(1);
+    const deposit = allDeposits.find(
+      (d) => d.amount === 100n && d.token === BigInt(de.strk),
+    );
+    expect(deposit).toBeDefined();
+
+    // Notes: 50 STRK change to self + 50 STRK transfer to Bob
+    expect(allNotes.length).toBeGreaterThanOrEqual(2);
+    const noteAmounts = allNotes
+      .filter((n) => n.token === BigInt(de.strk))
+      .map((n) => n.amount)
+      .sort();
+    expect(noteAmounts).toContain(50n);
+  });
+
+  it("Alice history paginates correctly with maxTransactions=1", async () => {
+    const { env: de } = env;
+    const aliceAddress = BigInt(de.alice.address);
+    const aliceViewingKey = BigInt("0xA11CE");
+
+    const { cursor: notesCursor } = await indexerDiscovery.discoverNotes(
+      aliceAddress,
+      aliceViewingKey,
+    );
+    const { channels } = await indexerDiscovery.discoverChannels(
+      aliceAddress,
+      aliceViewingKey,
+      "all",
+    );
+    const channelCursor = { channels };
+
+    // Fetch one transaction at a time
+    const allTransactions: HistoryTransaction[] = [];
+    let historyCursor: undefined | typeof firstPage.cursor = undefined;
+    let blockRef: string | undefined;
+
+    const firstPage = await indexerDiscovery.fetchHistory(
+      aliceAddress,
+      notesCursor,
+      channelCursor,
+      { maxTransactions: 1 },
+    );
+    allTransactions.push(...firstPage.transactions);
+    historyCursor = firstPage.cursor;
+    blockRef = firstPage.blockRef;
+
+    // Continue fetching until complete
+    while (!historyCursor.historyComplete) {
+      const page = await indexerDiscovery.fetchHistory(
+        aliceAddress,
+        notesCursor,
+        channelCursor,
+        { maxTransactions: 1, historyCursor, blockRef },
+      );
+      allTransactions.push(...page.transactions);
+      historyCursor = page.cursor;
+      blockRef = page.blockRef;
+    }
+
+    // Should have fetched multiple pages (scenario has at least 1 tx)
+    expect(allTransactions.length).toBeGreaterThan(0);
+
+    // Verify same data as non-paginated: deposit of 100 STRK and note of 50 STRK
+    const allDeposits = allTransactions.flatMap((tx) => tx.deposits);
+    expect(
+      allDeposits.find((d) => d.amount === 100n && d.token === BigInt(de.strk)),
+    ).toBeDefined();
+
+    const allNotes = allTransactions.flatMap((tx) => tx.notes);
+    const noteAmounts = allNotes
+      .filter((n) => n.token === BigInt(de.strk))
+      .map((n) => n.amount);
+    expect(noteAmounts).toContain(50n);
+  });
+
+  it("Bob history shows incoming transfer and withdrawal", async () => {
+    const { env: de } = env;
+    const bobAddress = BigInt(de.bob.address);
+    const bobViewingKey = BigInt("0xB0B");
+
+    const { cursor: notesCursor } = await indexerDiscovery.discoverNotes(
+      bobAddress,
+      bobViewingKey,
+    );
+    const { channels } = await indexerDiscovery.discoverChannels(
+      bobAddress,
+      bobViewingKey,
+      "all",
+    );
+
+    const historyPage = await indexerDiscovery.fetchHistory(
+      bobAddress,
+      notesCursor,
+      { channels },
+    );
+
+    expect(historyPage.blockRef).toBeDefined();
+    expect(historyPage.cursor.historyComplete).toBe(true);
+
+    // Bob received 50 STRK from Alice
+    const allNotes = historyPage.transactions.flatMap((tx) => tx.notes);
+    const incomingNote = allNotes.find(
+      (n) =>
+        n.channelKind === "incoming" &&
+        n.amount === 50n &&
+        n.token === BigInt(de.strk),
+    );
+    expect(incomingNote).toBeDefined();
+
+    // Bob withdrew 50 STRK
+    const allWithdrawals = historyPage.transactions.flatMap(
+      (tx) => tx.withdrawals,
+    );
+    const withdrawal = allWithdrawals.find(
+      (w) => w.amount === 50n && w.token === BigInt(de.strk),
+    );
+    expect(withdrawal).toBeDefined();
+  });
+});

--- a/e2e/tests/devnet/pagination-discovery.test.ts
+++ b/e2e/tests/devnet/pagination-discovery.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import { createPrivateTransfers } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
 
 describe("Discovery pagination with small budget", () => {
   let devnet: Devnet;
@@ -61,11 +62,11 @@ describe("Discovery pagination with small budget", () => {
         method: "devnet_createBlock",
       }),
     });
-    await env.indexer.waitForNewLog("New block #", 15_000);
+    await env.indexer.waitForNewLog("New block #", E2E_TIMEOUTS.indexerLog);
   });
 
   afterAll(async () => {
-    env?.indexer.shutdown();
+    await env?.indexer.shutdown();
     await devnet?.cleanup();
   });
 

--- a/e2e/tests/devnet/payment-service-discovery.test.ts
+++ b/e2e/tests/devnet/payment-service-discovery.test.ts
@@ -13,6 +13,7 @@ import {
   type PrivateTransfersInterface,
 } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const INDEXER_LOG = path.join(__dirname, "../../indexer-discovery.log");
@@ -216,11 +217,11 @@ describe("Payment Service Discovery", () => {
         method: "devnet_createBlock",
       }),
     });
-    await env.indexer.waitForNewLog("New block #", 60_000);
+    await env.indexer.waitForNewLog("New block #", 4 * E2E_TIMEOUTS.indexerLog);
   });
 
   afterAll(async () => {
-    env?.indexer.shutdown();
+    await env?.indexer.shutdown();
     await devnet?.cleanup();
   });
 

--- a/e2e/tests/devnet/reorg-recovery.test.ts
+++ b/e2e/tests/devnet/reorg-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   AddressMap,
 } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
 
 describe("E2E Reorg Recovery", () => {
   let devnet: Devnet;
@@ -16,7 +17,7 @@ describe("E2E Reorg Recovery", () => {
   });
 
   afterAll(async () => {
-    env?.indexer.shutdown();
+    await env?.indexer.shutdown();
     await devnet?.cleanup();
   });
 
@@ -66,7 +67,7 @@ describe("E2E Reorg Recovery", () => {
 
     // Sync indexer with the new block
     await createBlock();
-    await env.indexer.waitForNewLog("New block #", 15_000);
+    await env.indexer.waitForNewLog("New block #", E2E_TIMEOUTS.indexerLog);
 
     // Prepare a registry with a fake cursor to simulate a reorged block.
     // The fake blockId will be sent as last_known_block to the indexer,

--- a/e2e/tests/devnet/smoke.test.ts
+++ b/e2e/tests/devnet/smoke.test.ts
@@ -10,6 +10,7 @@ import {
   SetupRequirement,
 } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
 
 describe("E2E Smoke", () => {
   let devnet: Devnet;
@@ -21,7 +22,7 @@ describe("E2E Smoke", () => {
   });
 
   afterAll(async () => {
-    env?.indexer.shutdown();
+    await env?.indexer.shutdown();
     await devnet?.cleanup();
   });
 
@@ -67,7 +68,7 @@ describe("E2E Smoke", () => {
         method: "devnet_createBlock",
       }),
     });
-    await env.indexer.waitForNewLog("New block #", 15_000);
+    await env.indexer.waitForNewLog("New block #", E2E_TIMEOUTS.indexerLog);
 
     // Verify discovery via IndexerDiscoveryProvider (exercises SDK → indexer end-to-end)
     const indexerDiscovery = new IndexerDiscoveryProvider(

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -1,12 +1,13 @@
 import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";
+import { E2E_TIMEOUTS } from "./src/timeouts.js";
 
 export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     fileParallelism: false,
-    hookTimeout: 180_000,
-    testTimeout: 120_000,
+    hookTimeout: E2E_TIMEOUTS.hook,
+    testTimeout: E2E_TIMEOUTS.test,
     env: loadEnv("", process.cwd(), ""),
   },
 });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,3 +15,15 @@ export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
 export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
 export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";
+export { buildHistoryCursor } from "./internal/history.js";
+export type {
+  ChannelKind,
+  HistorySubchannel,
+  HistoryCursor,
+  HistoryNote,
+  HistoryDeposit,
+  HistoryWithdrawal,
+  HistoryOpenNoteDeposit,
+  HistoryTransaction,
+  HistoryPage,
+} from "./internal/history.js";

--- a/sdk/src/internal/history.ts
+++ b/sdk/src/internal/history.ts
@@ -1,0 +1,231 @@
+import type { StarknetAddressBigint } from "../interfaces.js";
+import { toHex } from "../utils/convert.js";
+import type { NotesCursor, ChannelCursor } from "./channel.js";
+
+// SDK public types
+
+export type ChannelKind = "incoming" | "outgoing" | "self_channel";
+
+export type HistorySubchannel = {
+  channelKey: bigint;
+  token: bigint;
+  channelKind: ChannelKind;
+  counterparty: bigint;
+  nextIndex: number | undefined;
+};
+
+export type HistoryCursor = {
+  subchannels: HistorySubchannel[];
+  beginBlockNumber: number;
+  historyComplete: boolean;
+};
+
+export type HistoryNote = {
+  channelKind: ChannelKind;
+  token: bigint;
+  noteIndex: number;
+  noteId: bigint;
+  counterparty: bigint;
+  amount: bigint;
+  salt: bigint;
+};
+
+export type HistoryDeposit = {
+  userAddress: bigint;
+  token: bigint;
+  amount: bigint;
+};
+
+export type HistoryWithdrawal = {
+  toAddress: bigint;
+  token: bigint;
+  amount: bigint;
+};
+
+export type HistoryOpenNoteDeposit = {
+  depositor: bigint;
+  token: bigint;
+  noteId: bigint;
+  amount: bigint;
+};
+
+export type HistoryTransaction = {
+  blockNumber: number;
+  transactionHash: bigint;
+  notes: HistoryNote[];
+  deposits: HistoryDeposit[];
+  withdrawals: HistoryWithdrawal[];
+  openNoteDeposits: HistoryOpenNoteDeposit[];
+};
+
+export type HistoryPage = {
+  blockRef: string;
+  transactions: HistoryTransaction[];
+  cursor: HistoryCursor;
+};
+
+// API wire types (private)
+
+type ApiHistorySubchannel = {
+  channel_key: string;
+  token: string;
+  channel_kind: string;
+  counterparty: string;
+  next_index: number | null;
+};
+
+type ApiHistoryCursor = {
+  subchannels: ApiHistorySubchannel[];
+  begin_block_number: number;
+  history_complete: boolean;
+};
+
+type ApiHistoryNote = {
+  channel_kind: string;
+  token: string;
+  note_index: number;
+  note_id: string;
+  counterparty: string;
+  amount: string;
+  salt: string;
+};
+
+type ApiHistoryDeposit = {
+  user_address: string;
+  token: string;
+  amount: string;
+};
+
+type ApiHistoryWithdrawal = {
+  to_address: string;
+  token: string;
+  amount: string;
+};
+
+type ApiHistoryOpenNoteDeposit = {
+  depositor: string;
+  token: string;
+  note_id: string;
+  amount: string;
+};
+
+type ApiHistoryTransaction = {
+  block_number: number;
+  transaction_hash: string;
+  notes: ApiHistoryNote[];
+  deposits: ApiHistoryDeposit[];
+  withdrawals: ApiHistoryWithdrawal[];
+  open_note_deposits: ApiHistoryOpenNoteDeposit[];
+};
+
+export type ApiHistoryResponse = {
+  block_ref: string;
+  transactions: ApiHistoryTransaction[];
+  cursor: ApiHistoryCursor;
+};
+
+// Conversion helpers
+
+/** Builds a HistoryCursor from sync cursors (notes + channels). */
+export function buildHistoryCursor(
+  userAddress: StarknetAddressBigint,
+  notesCursor: NotesCursor,
+  channelCursor: ChannelCursor
+): HistoryCursor {
+  const subchannels: HistorySubchannel[] = [];
+
+  // Incoming subchannels from notesCursor
+  for (const [sender, incomingChannel] of notesCursor.incomingChannels) {
+    for (const [token, noteIndex] of incomingChannel.noteIndexes) {
+      subchannels.push({
+        channelKey: incomingChannel.channelKey,
+        token,
+        channelKind: sender === userAddress ? "self_channel" : "incoming",
+        counterparty: sender,
+        nextIndex: noteIndex > 0 ? noteIndex - 1 : undefined,
+      });
+    }
+  }
+
+  // Outgoing subchannels from channelCursor
+  if (channelCursor.channels) {
+    for (const [recipient, channel] of channelCursor.channels) {
+      if (!channel.key) continue;
+      if (recipient === userAddress) continue;
+      const channelKind: ChannelKind = "outgoing";
+      for (const [token, tokenChannel] of channel.tokens) {
+        subchannels.push({
+          channelKey: channel.key,
+          token,
+          channelKind,
+          counterparty: recipient,
+          nextIndex: tokenChannel.noteNonce > 0 ? tokenChannel.noteNonce - 1 : undefined,
+        });
+      }
+    }
+  }
+
+  return { subchannels, beginBlockNumber: 0, historyComplete: false };
+}
+
+/** Converts SDK HistoryCursor → API wire format. */
+export function historyCursorToApi(cursor: HistoryCursor): ApiHistoryCursor {
+  return {
+    subchannels: cursor.subchannels.map((sc) => ({
+      channel_key: toHex(sc.channelKey),
+      token: toHex(sc.token),
+      channel_kind: sc.channelKind,
+      counterparty: toHex(sc.counterparty),
+      next_index: sc.nextIndex ?? null,
+    })),
+    begin_block_number: cursor.beginBlockNumber,
+    history_complete: cursor.historyComplete,
+  };
+}
+
+/** Converts API history response → SDK HistoryPage. */
+export function apiResponseToHistoryPage(resp: ApiHistoryResponse): HistoryPage {
+  return {
+    blockRef: resp.block_ref,
+    transactions: resp.transactions.map((tx) => ({
+      blockNumber: tx.block_number,
+      transactionHash: BigInt(tx.transaction_hash),
+      notes: tx.notes.map((note) => ({
+        channelKind: note.channel_kind as ChannelKind,
+        token: BigInt(note.token),
+        noteIndex: note.note_index,
+        noteId: BigInt(note.note_id),
+        counterparty: BigInt(note.counterparty),
+        amount: BigInt(note.amount),
+        salt: BigInt(note.salt),
+      })),
+      deposits: tx.deposits.map((deposit) => ({
+        userAddress: BigInt(deposit.user_address),
+        token: BigInt(deposit.token),
+        amount: BigInt(deposit.amount),
+      })),
+      withdrawals: tx.withdrawals.map((withdrawal) => ({
+        toAddress: BigInt(withdrawal.to_address),
+        token: BigInt(withdrawal.token),
+        amount: BigInt(withdrawal.amount),
+      })),
+      openNoteDeposits: tx.open_note_deposits.map((deposit) => ({
+        depositor: BigInt(deposit.depositor),
+        token: BigInt(deposit.token),
+        noteId: BigInt(deposit.note_id),
+        amount: BigInt(deposit.amount),
+      })),
+    })),
+    cursor: {
+      subchannels: resp.cursor.subchannels.map((sc) => ({
+        channelKey: BigInt(sc.channel_key),
+        token: BigInt(sc.token),
+        channelKind: sc.channel_kind as ChannelKind,
+        counterparty: BigInt(sc.counterparty),
+        nextIndex: sc.next_index ?? undefined,
+      })),
+      beginBlockNumber: resp.cursor.begin_block_number,
+      historyComplete: resp.cursor.history_complete,
+    },
+  };
+}

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -18,6 +18,8 @@ import type {
   NotesCursor,
   RecipientsFilter,
 } from "./channel.js";
+import type { ApiHistoryResponse, HistoryCursor, HistoryPage } from "./history.js";
+import { buildHistoryCursor, historyCursorToApi, apiResponseToHistoryPage } from "./history.js";
 
 /** Thrown when the indexer reports a block reorg (HTTP 409, BLOCK_REORGED). */
 export class ReorgError extends Error {
@@ -346,6 +348,35 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     if (!resp.channel_exists) return SetupRequirement.SetupChannel;
     if (!resp.subchannel_exists) return SetupRequirement.SetupToken;
     return SetupRequirement.Ready;
+  }
+
+  async fetchHistory(
+    userAddress: StarknetAddressBigint,
+    notesCursor: NotesCursor,
+    channelCursor: ChannelCursor,
+    options?: {
+      maxTransactions?: number;
+      lastKnownBlock?: string;
+      blockRef?: string;
+      /** Pass the cursor from a previous HistoryPage to continue pagination. */
+      historyCursor?: HistoryCursor;
+    }
+  ): Promise<HistoryPage> {
+    const cursor =
+      options?.historyCursor ?? buildHistoryCursor(userAddress, notesCursor, channelCursor);
+    const body: Record<string, unknown> = {
+      contract_address: toHex(this.contractAddress),
+      user_address: toHex(userAddress),
+      max_transactions: options?.maxTransactions ?? 50,
+      cursor: historyCursorToApi(cursor),
+    };
+    if (options?.blockRef) {
+      body.block_ref = options.blockRef;
+    } else if (options?.lastKnownBlock) {
+      body.last_known_block = options.lastKnownBlock;
+    }
+    const resp = await this.post<ApiHistoryResponse>("/v1/history", body);
+    return apiResponseToHistoryPage(resp);
   }
 
   private async post<T>(path: string, body: unknown): Promise<T> {

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -426,12 +426,31 @@ export class Devnet {
   }
 
   /**
-   * Terminate the devnet process.
+   * Terminate the devnet process and wait for it to exit.
+   * Sends SIGINT first; escalates to SIGKILL after {@link timeoutMs}.
    */
-  async cleanup(): Promise<void> {
-    if (this.devnet) {
-      this.devnet.kill("SIGINT");
-    }
+  async cleanup(timeoutMs = 10_000): Promise<void> {
+    if (!this.devnet) return;
+
+    // StarknetDevnet.process is typed as private but exists at runtime.
+    const childProcess = (
+      this.devnet as unknown as { process: import("child_process").ChildProcess }
+    ).process;
+
+    if (!childProcess.pid || childProcess.exitCode !== null) return;
+
+    const exitPromise = new Promise<void>((resolve) => {
+      childProcess.on("exit", () => resolve());
+    });
+
+    this.devnet.kill("SIGINT");
+
+    const timer = setTimeout(() => {
+      childProcess.kill("SIGKILL");
+    }, timeoutMs);
+
+    await exitPromise;
+    clearTimeout(timer);
   }
 }
 

--- a/sdk/tests/internal/history-cursor.test.ts
+++ b/sdk/tests/internal/history-cursor.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { buildHistoryCursor, type HistorySubchannel } from "../../src/internal/history.js";
+import type {
+  NotesCursor,
+  ChannelCursor,
+  IncomingChannelCursor,
+} from "../../src/internal/channel.js";
+import { Channel } from "../../src/internal/channel.js";
+import { AddressMap } from "../../src/utils/maps.js";
+
+const ALICE = 0x1n;
+const BOB = 0x2n;
+const CHARLIE = 0x3n;
+const TOKEN_A = 0xaa1n;
+const TOKEN_B = 0xaa2n;
+const CHANNEL_KEY_SELF = 100n;
+const CHANNEL_KEY_BOB = 200n;
+const CHANNEL_KEY_CHARLIE = 300n;
+
+function makeNotesCursor(entries: [bigint, IncomingChannelCursor][]): NotesCursor {
+  return {
+    blockId: 0,
+    incomingChannels: new AddressMap<IncomingChannelCursor>(entries),
+  };
+}
+
+function makeChannelCursor(entries: [bigint, Channel][]): ChannelCursor {
+  return {
+    blockId: 0,
+    channels: new AddressMap<Channel>(entries),
+  };
+}
+
+function findSubchannels(
+  subchannels: HistorySubchannel[],
+  filter: Partial<HistorySubchannel>
+): HistorySubchannel[] {
+  return subchannels.filter((subchannel) =>
+    Object.entries(filter).every(
+      ([key, value]) => subchannel[key as keyof HistorySubchannel] === value
+    )
+  );
+}
+
+describe("buildHistoryCursor", () => {
+  it("self-channel appears once with channelKind 'self_channel', not duplicated", () => {
+    // Alice has a self-channel: appears in both incoming (sender=Alice) and outgoing (recipient=Alice)
+    const notesCursor = makeNotesCursor([
+      [
+        ALICE,
+        {
+          channelKey: CHANNEL_KEY_SELF,
+          subchannelIdIndex: 0,
+          noteIndexes: new AddressMap<number>([[TOKEN_A, 3]]),
+        },
+      ],
+    ]);
+
+    const selfChannel = new Channel(0n, CHANNEL_KEY_SELF);
+    selfChannel.tokens.set(TOKEN_A, { tokenIndex: 0, noteNonce: 3 });
+
+    const channelCursor = makeChannelCursor([[ALICE, selfChannel]]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    const selfSubchannels = findSubchannels(cursor.subchannels, {
+      channelKey: CHANNEL_KEY_SELF,
+      token: TOKEN_A,
+    });
+    expect(selfSubchannels).toHaveLength(1);
+    expect(selfSubchannels[0].channelKind).toBe("self_channel");
+    expect(selfSubchannels[0].counterparty).toBe(ALICE);
+  });
+
+  it("regular incoming channels are tagged 'incoming'", () => {
+    const notesCursor = makeNotesCursor([
+      [
+        BOB,
+        {
+          channelKey: CHANNEL_KEY_BOB,
+          subchannelIdIndex: 0,
+          noteIndexes: new AddressMap<number>([[TOKEN_A, 5]]),
+        },
+      ],
+    ]);
+
+    const channelCursor = makeChannelCursor([]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    expect(cursor.subchannels).toHaveLength(1);
+    expect(cursor.subchannels[0].channelKind).toBe("incoming");
+    expect(cursor.subchannels[0].counterparty).toBe(BOB);
+    expect(cursor.subchannels[0].nextIndex).toBe(4);
+  });
+
+  it("regular outgoing channels are tagged 'outgoing'", () => {
+    const notesCursor = makeNotesCursor([]);
+
+    const outgoingChannel = new Channel(0n, CHANNEL_KEY_BOB);
+    outgoingChannel.tokens.set(TOKEN_A, { tokenIndex: 0, noteNonce: 2 });
+
+    const channelCursor = makeChannelCursor([[BOB, outgoingChannel]]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    expect(cursor.subchannels).toHaveLength(1);
+    expect(cursor.subchannels[0].channelKind).toBe("outgoing");
+    expect(cursor.subchannels[0].counterparty).toBe(BOB);
+    expect(cursor.subchannels[0].nextIndex).toBe(1);
+  });
+
+  it("mixed scenario: self-channel + incoming from Bob + outgoing to Charlie", () => {
+    const notesCursor = makeNotesCursor([
+      [
+        ALICE,
+        {
+          channelKey: CHANNEL_KEY_SELF,
+          subchannelIdIndex: 0,
+          noteIndexes: new AddressMap<number>([[TOKEN_A, 1]]),
+        },
+      ],
+      [
+        BOB,
+        {
+          channelKey: CHANNEL_KEY_BOB,
+          subchannelIdIndex: 0,
+          noteIndexes: new AddressMap<number>([[TOKEN_A, 2]]),
+        },
+      ],
+    ]);
+
+    const selfChannel = new Channel(0n, CHANNEL_KEY_SELF);
+    selfChannel.tokens.set(TOKEN_A, { tokenIndex: 0, noteNonce: 1 });
+
+    const outgoingChannel = new Channel(0n, CHANNEL_KEY_CHARLIE);
+    outgoingChannel.tokens.set(TOKEN_B, { tokenIndex: 0, noteNonce: 4 });
+
+    const channelCursor = makeChannelCursor([
+      [ALICE, selfChannel],
+      [CHARLIE, outgoingChannel],
+    ]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    // 3 total: self_channel, incoming from Bob, outgoing to Charlie
+    expect(cursor.subchannels).toHaveLength(3);
+
+    const selfSubchannels = findSubchannels(cursor.subchannels, { channelKind: "self_channel" });
+    expect(selfSubchannels).toHaveLength(1);
+    expect(selfSubchannels[0].counterparty).toBe(ALICE);
+    expect(selfSubchannels[0].token).toBe(TOKEN_A);
+
+    const incomingSubchannels = findSubchannels(cursor.subchannels, { channelKind: "incoming" });
+    expect(incomingSubchannels).toHaveLength(1);
+    expect(incomingSubchannels[0].counterparty).toBe(BOB);
+
+    const outgoingSubchannels = findSubchannels(cursor.subchannels, { channelKind: "outgoing" });
+    expect(outgoingSubchannels).toHaveLength(1);
+    expect(outgoingSubchannels[0].counterparty).toBe(CHARLIE);
+    expect(outgoingSubchannels[0].token).toBe(TOKEN_B);
+  });
+
+  it("nextIndex is undefined when noteIndex or noteNonce is 0", () => {
+    const notesCursor = makeNotesCursor([
+      [
+        BOB,
+        {
+          channelKey: CHANNEL_KEY_BOB,
+          subchannelIdIndex: 0,
+          noteIndexes: new AddressMap<number>([[TOKEN_A, 0]]),
+        },
+      ],
+    ]);
+
+    const outgoingChannel = new Channel(0n, CHANNEL_KEY_CHARLIE);
+    outgoingChannel.tokens.set(TOKEN_A, { tokenIndex: 0, noteNonce: 0 });
+
+    const channelCursor = makeChannelCursor([[CHARLIE, outgoingChannel]]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    expect(cursor.subchannels).toHaveLength(2);
+    for (const subchannel of cursor.subchannels) {
+      expect(subchannel.nextIndex).toBeUndefined();
+    }
+  });
+
+  it("outgoing channel without key is skipped", () => {
+    const notesCursor = makeNotesCursor([]);
+
+    // Channel with no key set
+    const channelWithoutKey = new Channel(0n);
+    channelWithoutKey.tokens.set(TOKEN_A, { tokenIndex: 0, noteNonce: 1 });
+
+    const channelCursor = makeChannelCursor([[BOB, channelWithoutKey]]);
+
+    const cursor = buildHistoryCursor(ALICE, notesCursor, channelCursor);
+
+    expect(cursor.subchannels).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### TL;DR

Added transaction history functionality to the SDK with support for fetching paginated transaction history including deposits, withdrawals, and private transfers.

### What changed?

- Added `fetchHistory` method to `IndexerDiscoveryProvider` that retrieves transaction history for a user
- Implemented history cursor system with `buildHistoryCursor` function to track pagination state across incoming, outgoing, and self-channels
- Created comprehensive type definitions for history data including `HistoryTransaction`, `HistoryNote`, `HistoryDeposit`, `HistoryWithdrawal`, and `HistoryPage`
- Added conversion utilities between SDK types and API wire format for history responses
- Exported new history-related types and functions from the main SDK index

### How to test?

Run the new E2E test suite:
```bash
npm test e2e/tests/history.test.ts
```

The test covers:
- Alice depositing 100 STRK and transferring 50 to Bob
- Bob withdrawing 50 STRK  
- Fetching complete transaction history for both users
- Testing pagination with `maxTransactions=1` parameter
- Verifying history shows correct deposits, transfers, and withdrawals

### Why make this change?

This enables applications to display comprehensive transaction history to users, showing their complete activity including deposits, withdrawals, incoming transfers, and outgoing transfers. The pagination support ensures the API can handle users with extensive transaction history efficiently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/641)
<!-- Reviewable:end -->
