### PR TITLE
feat(sdk): streamline registry management and discovery strategies

### DIFF
--- a/e2e/tests/pagination-discovery.test.ts
+++ b/e2e/tests/pagination-discovery.test.ts
@@ -87,15 +87,11 @@ describe("Discovery pagination with small budget", () => {
       poolContractAddress: de.privacy.address,
     });
 
-    // total-only: exercises total_n_channels
-    const { total } = await aliceTransfers.discoverChannels("total-only");
+    // full discovery: exercises multi-round pagination and returns total
+    const { channels, total } = await aliceTransfers.discoverChannels({
+      recipients: [de.alice.address, de.bob.address],
+    });
     expect(total).toBe(2); // self-channel + Bob
-
-    // full discovery: exercises multi-round pagination
-    const { channels } = await aliceTransfers.discoverChannels([
-      de.alice.address,
-      de.bob.address,
-    ]);
     expect(channels).toBeDefined();
     expect(channels!.size).toBe(2);
     expect(channels!.has(BigInt(de.alice.address))).toBe(true);

--- a/e2e/tests/payment-service-discovery.test.ts
+++ b/e2e/tests/payment-service-discovery.test.ts
@@ -246,7 +246,9 @@ describe("Payment Service Discovery", () => {
     });
 
     const allAddresses = [de.alice.address, ...users.map((u) => u.address)];
-    const { channels } = await aliceDiscover.discoverChannels(allAddresses);
+    const { channels } = await aliceDiscover.discoverChannels({
+      recipients: allAddresses,
+    });
     expect(channels).toBeDefined();
 
     // Self-channel + all 9 users
@@ -294,7 +296,9 @@ describe("Payment Service Discovery", () => {
         poolContractAddress: de.privacy.address,
       });
 
-      const { channels } = await userDiscover.discoverChannels([de.alice.address]);
+      const { channels } = await userDiscover.discoverChannels({
+        recipients: [de.alice.address],
+      });
       expect(channels).toBeDefined();
       expect(channels!.has(BigInt(de.alice.address))).toBe(true);
     }

--- a/e2e/tests/reorg-recovery.test.ts
+++ b/e2e/tests/reorg-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
-import { createEmptyRegistry, AddressMap } from "@starkware-libs/starknet-privacy-sdk";
+import { PrivateRegistry, AddressMap } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../src/harness.js";
 
 describe("E2E Reorg Recovery", () => {
@@ -62,7 +62,7 @@ describe("E2E Reorg Recovery", () => {
     // The fake blockId will be sent as last_known_block to the indexer,
     // which will respond with HTTP 409 (BLOCK_REORGED).
     // NotesCursor fields are @internal (stripped from .d.ts), so we cast through `any`.
-    const registry = createEmptyRegistry();
+    const registry = new PrivateRegistry();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registry.notesCursor = { blockId: "0xdeadbeef", incomingChannels: new AddressMap() } as any;
 

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -72,7 +72,9 @@ describe("E2E Smoke", () => {
     expect(strkNotes!.length).toBeGreaterThanOrEqual(1);
     expect(strkNotes![0].amount).toBe(50n); // Alice's change note
 
-    const { channels } = await aliceIndexer.discoverChannels([de.alice.address, de.bob.address]);
+    const { channels } = await aliceIndexer.discoverChannels({
+      recipients: [de.alice.address, de.bob.address],
+    });
     expect(channels).toBeDefined();
     expect(channels!.size).toBeGreaterThanOrEqual(2); // self-channel + Bob
     expect(channels!.has(BigInt(de.alice.address))).toBe(true);

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,11 +5,18 @@
 ### Breaking
 
 - Rename npm package from `starknet-sdk` to `@starkware-libs/starknet-privacy-sdk`, published to GitHub Packages
+- `PrivateRegistry` is now a class (was a type alias). Object literals `{ notes: new AddressMap(...) }` no longer satisfy the type — use `new PrivateRegistry()`.
+- `ExecuteResult.applyRegistryUpdate` closure replaced with `ExecuteResult.registryUpdate: RegistryUpdate` data object. Migration: `result.applyRegistryUpdate(registry)` -> `registry.applyExecuteResult(result.registryUpdate)`.
+- `ProofInvocationResult.applyRegistryUpdate` — same change as `ExecuteResult`.
+- `discoverNotes` return type now includes `cursor: NotesCursor` (in addition to `timestamp` and `notes`).
 - `PrivateTransfersBuilder.invoke()` now accepts only a `callBuilder(args) => CallDetails` callback (raw/manual invoke input removed).
 - `SimplePrivateTransfersInterface.swap()` now takes executor address directly instead of an object (`swap(fromToken, fromAmount, toToken, executorAddress)`).
 
 ### Changed
 
+- `PrivateRegistry` gains `applyDiscoveredNotes()`, `applyDiscoveredChannels()`, and `applyExecuteResult()` methods, encapsulating all registry mutation logic.
+- `PoolSimulator.createRegistryUpdate()` returns `RegistryUpdate` data object instead of a closure.
+- Cursor/merge logic in compiler.ts and abstract-private-transfers.ts replaced with registry method calls.
 - Switch `starknet` dependency from `m-kus/starknet.js` fork to `starkware-industries/starknet.js`
 - `invoke` call builder now receives structured context: `{ openNotes, withdrawals, poolAddress }`.
 
@@ -20,6 +27,8 @@
 
 ### Added
 
+- `RegistryUpdate` type exported from interfaces.ts.
+- README rewritten with three comprehensive state management flows (discovery, post-tx update, periodic refresh).
 - Invoke action support (#499)
 
 ## 0.1.0-dev.1

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -204,68 +204,130 @@ const result = await transfers.build({
 | `autoRegister` | `boolean` | Automatically register if user has no viewing key on-chain |
 | `autoSetup` | `boolean` | Automatically open channels and token subchannels as needed |
 | `autoSelectNotes` | `"all" \| "naive"` | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum) |
-| `autoDiscover` | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`) |
-| `registry` | `PrivateRegistry` | User's private state (notes, discovery cursors) |
-| `registryConst` | `boolean` | If true, returns a new registry instead of mutating the provided one |
+| `autoDiscover` | `{ notes?, channels? }` | Discovery strategy for notes/channels before executing (`"missing"` or `"refresh"`) |
+| `registry` | `PrivateRegistry` | User's private state (notes, discovery cursors). Discovery updates are applied in-place. |
 | `provingBlockId` | `ProvingBlockId` | Block identifier to use for proving |
 
-## Registry management
+## State management
 
-The `PrivateRegistry` holds the user's private state: unspent notes and discovery cursors. Create one with `createEmptyRegistry()` and pass it through `ExecuteOptions`.
+### Registry
+
+The `PrivateRegistry` holds the user's local private state:
 
 ```typescript
-import { createEmptyRegistry } from "starknet-sdk";
+import { PrivateRegistry } from "starknet-sdk";
 
-const registry = createEmptyRegistry();
+const registry = new PrivateRegistry();
+```
 
-// The registry is updated in-place after each execute()
+It contains:
+- **`notes`** — `AddressMap<Note[]>`: unspent notes keyed by token address
+- **`notesCursor`** — pagination cursor for incoming notes discovery
+- **`channelCursor`** — pagination cursor for outgoing channels discovery (includes `blockId` for reorg detection)
+
+### Discovery strategies
+
+Both `autoDiscover` (transaction-scoped) and `discoverNotes`/`discoverChannels` (direct) support two strategies:
+
+| Strategy | Cursor | Notes merge | Use case |
+|----------|--------|-------------|----------|
+| `"missing"` | Sends existing cursor — server skips already-known data | Appends newly discovered notes | Incremental sync, efficient for polling |
+| `"refresh"` | No cursor — full rescan from scratch | Replaces notes per token | Recover from stale state, first load |
+
+### Flow 1: Transaction discovery
+
+The SDK discovers the minimum state needed to build a transaction when `autoDiscover` is set. Discovery is scoped to the tokens and recipients in the current actions:
+
+```typescript
 const result = await transfers.build({
   registry,
-  autoDiscover: { notes: "refresh", channels: "refresh" },
+  autoDiscover: { notes: "missing", channels: "missing" },
   autoSetup: true,
   autoSelectNotes: "naive",
 }).with(STRK, (t) => t
-  .deposit({ amount: 100n }))
-.surplusTo(self)
+  .transfer({ recipient: bob, amount: 50n }))
 .execute();
-
-// result.registry === registry (same object, mutated)
-// Use registryConst: true to get a new object instead
 ```
 
-The registry contains:
-- **`notes`** — `AddressMap<Note[]>`: unspent notes keyed by token address
-- **`notesCursor`** — pagination cursor for incoming notes discovery (incremental sync)
-- **`channelCursor`** — pagination cursor for outgoing channels discovery (incremental sync, includes `blockId` for reorg detection)
+The compiler discovers notes for STRK and channels for Bob, using cursors from the registry for incremental updates. After compilation, the registry's cursors are updated in-place so subsequent calls skip already-known data.
 
-Discovery cursors are internal to the registry flow. When `autoDiscover` is set, the SDK uses them automatically for incremental syncing. You don't need to manage them directly.
+### Flow 2: Post-transaction update
 
-**Optimistic updates:** After `execute()`, the registry is updated optimistically — spent notes are removed and new notes/channels are added before the transaction is confirmed on-chain. If the transaction reverts, the registry becomes stale. Handle this by re-discovering from scratch (`autoDiscover: "refresh"`) or by snapshotting the registry before `execute()` (use `registryConst: true`) and restoring on revert.
+After `execute()`, the SDK returns a `registryUpdate` — the expected state changes from the transaction. The SDK does not apply it automatically because it cannot know whether the on-chain transaction will succeed or revert.
 
-## Discovery
+**Option A: Optimistic update** — fast, applies immediately after tx confirmation:
 
-### Check transfer readiness
+```typescript
+const receipt = await sendTransaction(result.callAndProof);
+
+if (receipt.isSuccess) {
+  registry.applyExecuteResult(result.registryUpdate);
+}
+```
+
+**Option B: Re-discover** — slower but reflects actual on-chain state (recommended over optimistic):
+
+```typescript
+const receipt = await sendTransaction(result.callAndProof);
+
+if (receipt.isSuccess) {
+  // Notes must use "refresh" — spent notes need to be removed, not just appended
+  await transfers.discoverNotes({ registry, level: "refresh" });
+  // Channels can use "missing" — channels are never spent, only added
+  await transfers.discoverChannels({ registry, level: "missing" });
+}
+```
+
+On failure, the registry is unchanged.
+
+### Flow 3: Periodic refresh
+
+Use direct discovery to keep the registry up to date — for displaying balances, populating the address book (outgoing channels), and syncing state across devices.
+
+```typescript
+// Incremental balance update — fetch only new notes since last sync
+await transfers.discoverNotes({ registry, level: "missing" });
+
+// Incremental address book update — fetch only new channels since last sync
+await transfers.discoverChannels({ registry, level: "missing" });
+```
+
+For token-scoped or recipient-scoped discovery:
+
+```typescript
+// Only discover STRK notes
+await transfers.discoverNotes({ registry, level: "missing", tokens: [STRK] });
+
+// Only discover channels to specific recipients
+await transfers.discoverChannels({ registry, level: "missing", recipients: [bob, alice] });
+```
+
+For first load or to recover from stale state, use `"refresh"`:
+
+```typescript
+await transfers.discoverNotes({ registry, level: "refresh" });
+await transfers.discoverChannels({ registry, level: "refresh" });
+```
+
+Discovery is cursor-driven and stateless on the server. To sync across devices, persist and restore the registry (including its cursors). Notes must use `"refresh"` because another device may have spent notes that this device still considers unspent — `"missing"` would only append, never remove. Channels can use `"missing"` since channels are append-only and never deleted.
+
+```typescript
+await transfers.discoverNotes({ registry, level: "refresh" });
+await transfers.discoverChannels({ registry, level: "missing" });
+```
+
+> **Future optimisation:** a batch nullifier check method may be added to verify whether existing notes are spent, enabling incremental note sync across devices without a full rescan.
+
+### Setup requirement check
+
+Before transferring to a new recipient, check whether setup is needed:
 
 ```typescript
 const requirement = await transfers.discoverRequirement(recipient, token);
 // Returns: SetupRequirement.Register | SetupChannel | SetupToken | Ready
 ```
 
-### Discover notes
-
-```typescript
-const { notes, timestamp } = await transfers.discoverNotes({
-  tokens: [STRK],
-});
-// notes: AddressMap<Note[]> — unspent notes keyed by token address
-```
-
-### Discover channels
-
-```typescript
-const { timestamp, channels, total } = await transfers.discoverChannels("all");
-// channels: AddressMap<Channel> — channels keyed by recipient address
-```
+With `autoSetup: true` in execute options, the SDK handles this automatically.
 
 ## Execute result
 
@@ -273,13 +335,13 @@ Every `execute()` call returns:
 
 ```typescript
 type ExecuteResult = {
-  callAndProof: CallAndProof;  // Call + proof to send to the contract's execute_actions entry point
-  registry: PrivateRegistry;   // Updated notes and recipient info
-  warnings: Warning[];         // Privacy leakage warnings
+  callAndProof: CallAndProof;    // Call + proof for the contract
+  registryUpdate: RegistryUpdate; // Optimistic state for post-tx update
+  warnings: Warning[];            // Privacy leakage warnings
 };
 ```
 
-The wallet sends `callAndProof` in a transaction to the contract's `execute_actions` entry point. The returned `registry` can be reused in subsequent calls once the transaction is accepted and enough blocks have passed to make the state verifiable.
+The wallet sends `callAndProof` in a transaction to the contract's `apply_actions` entry point. After the transaction is confirmed, call `registry.applyExecuteResult(result.registryUpdate)` to update spent notes and add newly created notes/channels.
 
 ## Key types
 
@@ -287,7 +349,7 @@ The wallet sends `callAndProof` in a transaction to the contract's `execute_acti
 
 **`Channel`** — A communication channel to a recipient, holding a shared key and per-token nonces.
 
-**`PrivateRegistry`** — The user's local state: unspent notes and discovery cursors for incremental sync. Create with `createEmptyRegistry()`.
+**`PrivateRegistry`** — The user's local state: unspent notes and discovery cursors for incremental sync. Create with `new PrivateRegistry()`.
 
 **`AddressMap<V>`** — A `Map` that normalizes Starknet addresses for consistent key lookup.
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -52,12 +52,12 @@ export enum SetupRequirement {
 export type StarknetAddressBigint = bigint;
 
 // Import and re-export from internal channel
-import { Witness, Channel } from "./internal/channel.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./internal/channel.js";
+import { Witness, Channel, PrivateRegistry } from "./internal/channel.js";
+import type { ChannelCursor, NotesCursor, RegistryUpdate } from "./internal/channel.js";
 import type { INVOKE_TXN_V3 } from "@starknet-io/starknet-types-010";
-export { Witness, Channel };
+export { Witness, Channel, PrivateRegistry };
 export type { NotesCursor as DiscoveryCursor };
-export type { NotesCursor, ChannelCursor };
+export type { NotesCursor, ChannelCursor, RegistryUpdate };
 
 export type Note = {
   readonly id: NoteId;
@@ -220,9 +220,9 @@ export type Actions = {
 
 /**
  * Discovery level controls when/whether to call the discovery service.
- * - 'none': Never call discovery. Missing data → error.
- * - 'missing': Only discover when data is missing from registry. Trust existing registry contents.
- * - 'refresh': Always discover. Use registry as optimization hint.
+ * - undefined: No discovery.
+ * - 'missing': Discover with existing cursor (skip already-known data).
+ * - 'refresh': Discover from scratch (empty cursor, full rescan).
  */
 export type DiscoveryLevel = "missing" | "refresh";
 
@@ -230,8 +230,14 @@ export type DiscoveryLevel = "missing" | "refresh";
  * Options for automatic discovery during execute.
  */
 export type AutoDiscoveryOptions = {
-  /** Discovery level for notes. 'all' means discover all tokens regardless if used in the actions */
-  notes?: DiscoveryLevel | "all";
+  /**
+   * Discovery level for notes.
+   * - 'missing': Discover with existing cursor (skip already-scanned data).
+   * - 'refresh': Discover from scratch (empty cursor, full rescan).
+   *
+   * Token filter defaults to tokens referenced in the current actions.
+   */
+  notes?: DiscoveryLevel;
   /** Discovery level for recipient channels (includes self) */
   channels?: DiscoveryLevel;
 };
@@ -242,26 +248,6 @@ export type AutoDiscoveryOptions = {
  * - 'naive': Select first notes until balance is non negative (may create surplus)
  */
 export type AutoSelectionStrategy = "all" | "naive" /*| "exact"*/; //
-
-/**
- * Registry holding the user's private state: cursors and notes.
- * Passed to execute() for context resolution and updated with new state.
- */
-export type PrivateRegistry = {
-  /** Cursor for incoming notes discovery */
-  notesCursor?: NotesCursor;
-  /** Cursor for outgoing channels discovery */
-  channelCursor?: ChannelCursor;
-  /** Notes by token address */
-  notes: AddressMap<Note[]>;
-};
-
-/** Create an empty private registry */
-export function createEmptyRegistry(): PrivateRegistry {
-  return {
-    notes: new AddressMap<Note[]>(() => []),
-  };
-}
 
 /**
  * Block reference for proving. Passed as block_id to the proving service.
@@ -282,10 +268,8 @@ export type ExecuteOptions = {
   autoSetup?: boolean;
   /** If defined, auto select notes from registry. **/
   autoSelectNotes?: AutoSelectionStrategy;
-  /** Registry for context/notes lookup. Updated during execute unless registryConst is true. */
+  /** Registry for context/notes lookup. Discovery updates are applied in-place. */
   registry?: PrivateRegistry;
-  /** If true, registry is not mutated; a new one is returned instead */
-  registryConst?: boolean;
   /** If defined, use the given block id for proving */
   provingBlockId?: ProvingBlockId;
 };
@@ -299,19 +283,18 @@ export enum WarningCode {
   USER_LINKAGE = "USER_LINKAGE",
 }
 /**
- * Result of execute, including the call/proof and updated registry.
+ * Result of execute.
  */
 export type ExecuteResult = {
   callAndProof: CallAndProof;
-  /** Updated registry (new object if registryConst was true, same object otherwise) */
-  registry: PrivateRegistry;
-
+  /** Post-execution state for optimistic registry update. Apply via `registry.applyExecuteResult()`. */
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 
 export type ProofInvocationResult = {
   invocation: ProofInvocation;
-  registry: PrivateRegistry;
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 
@@ -395,21 +378,40 @@ export interface PrivateTransfersInterface {
   ): Promise<SetupRequirement>;
 
   /**
-   * Discover unspent notes per token
+   * Discover unspent notes per token.
    *
+   * When `registry` is provided, uses `registry.notesCursor` to seed the
+   * discovery cursor and updates the registry in-place after discovery:
+   * - `"missing"`: incremental — sends existing cursor, appends newly
+   *   discovered notes to existing ones.
+   * - `"refresh"`: full rescan — ignores cursor, replaces notes per token.
+   *
+   * When `registry` is omitted, returns raw results without side effects.
    */
-  discoverNotes(params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }): Promise<{
+  discoverNotes(params?: {
+    registry?: PrivateRegistry;
+    level?: DiscoveryLevel;
+    tokens?: StarknetAddressBigint[];
+  }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
+    cursor: NotesCursor;
   }>;
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * Omit `recipients` to discover all outgoing channels.
+   * Pass an array for specific recipients (server also precomputes channels for them).
+   *
+   * When `registry` is provided, uses `registry.channelCursor` to seed
+   * the discovery cursor and merges the result back in-place.
+   * When `registry` is omitted, returns raw results without side effects.
    */
-  discoverChannels(
-    recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
-  ): Promise<{
+  discoverChannels(params?: {
+    registry?: PrivateRegistry;
+    level?: DiscoveryLevel;
+    recipients?: StarknetAddress[];
+  }): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
@@ -647,13 +649,13 @@ export interface DiscoveryProviderInterface {
 
   /**
    * Discover channels for one or more recipients.
-   * Pass "all" to discover all outgoing channels by iterating through the outgoing channel map.
+   * Omit `recipients` to discover all outgoing channels.
+   * Pass an array for specific recipients (server also precomputes channels for them).
    */
   discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -8,7 +8,7 @@ import type {
 } from "../interfaces.js";
 import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
+import type { ChannelCursor, NotesCursor } from "./channel.js";
 
 export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInterface {
   // Abstract methods that subclasses must implement
@@ -29,8 +29,7 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
   abstract discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
@@ -45,7 +44,9 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
     recipient: StarknetAddressBigint,
     token: StarknetAddressBigint
   ): Promise<SetupRequirement> {
-    const { channels } = await this.discoverChannels(address, viewingKey, [recipient]);
+    const { channels } = await this.discoverChannels(address, viewingKey, {
+      recipients: [recipient],
+    });
     const channel = channels?.get(recipient);
     return channel?.toSetupRequirement(token) ?? SetupRequirement.Register;
   }

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -9,10 +9,13 @@ import type { BlockIdentifier } from "starknet";
 import type {
   Actions,
   Channel,
+  DiscoveryLevel,
   DiscoveryProviderInterface,
   ExecuteOptions,
   ExecuteResult,
   Note,
+  NotesCursor,
+  PrivateRegistry,
   PrivateTransfersBuilder,
   PrivateTransfersInterface,
   ProofInvocationResult,
@@ -26,7 +29,6 @@ import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { toBigInt } from "../utils/crypto.js";
 import { PrivateTransfersBuilderImpl } from "./builders.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
 
 /**
  * Abstract base class that implements the common functionality for PrivateTransfers.
@@ -51,33 +53,70 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   }
 
   /**
-   * Discover unspent notes per token
+   * Discover unspent notes per token.
+   * When `registry` and `level` are provided, updates the registry in-place.
    */
-  async discoverNotes(params: { since?: BlockIdentifier; cursor?: NotesCursor } = {}): Promise<{
+  async discoverNotes(
+    params: {
+      registry?: PrivateRegistry;
+      level?: DiscoveryLevel;
+      tokens?: StarknetAddressBigint[];
+    } = {}
+  ): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
+    cursor: NotesCursor;
   }> {
-    return this.discoveryProvider.discoverNotes(this.user, await this.getViewingKey(), params);
+    const { registry, level, tokens } = params;
+
+    const result = await this.discoveryProvider.discoverNotes(
+      this.user,
+      await this.getViewingKey(),
+      { cursor: level === "missing" ? registry?.notesCursor : undefined, tokens }
+    );
+
+    if (registry) {
+      registry.applyDiscoveredNotes(level, result.notes, result.cursor);
+    }
+
+    return { timestamp: result.timestamp, notes: result.notes, cursor: result.cursor };
   }
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * When `registry` is provided, updates `channelCursor` in-place.
    */
-
   async discoverChannels(
-    recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
+    params: {
+      registry?: PrivateRegistry;
+      level?: DiscoveryLevel;
+      recipients?: StarknetAddress[];
+    } = {}
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
   }> {
-    return this.discoveryProvider.discoverChannels(
+    const { registry, level, recipients } = params;
+
+    const result = await this.discoveryProvider.discoverChannels(
       this.user,
       await this.getViewingKey(),
-      Array.isArray(recipients) ? recipients.map(toBigInt) : recipients,
-      params
+      {
+        recipients: recipients?.map(toBigInt),
+        cursor: level === "missing" ? registry?.channelCursor : undefined,
+      }
     );
+
+    if (registry) {
+      registry.applyDiscoveredChannels(result.cursor);
+    }
+
+    return {
+      timestamp: result.timestamp,
+      channels: result.channels,
+      total: result.total,
+    };
   }
 
   /**

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -4,6 +4,8 @@ import {
   StarknetAddressBigint,
   type Blob,
   type ChannelSerde,
+  type DiscoveryLevel,
+  type Note,
   type StarknetAddress,
   type WitnessSerde,
 } from "../interfaces.js";
@@ -71,8 +73,6 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
   };
 }
 
-export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all" | "total-only";
-
 export type ChannelCursor = {
   /** @internal */ blockId?: BlockIdentifier;
   /** @internal */ channels?: AddressMap<Channel>;
@@ -99,6 +99,110 @@ export function cloneChannelCursor(cursor?: ChannelCursor): ChannelCursor {
     total: cursor.total,
   };
 }
+
+/**
+ * Merge a discovered channel cursor into `target` in-place. Overwrites channels
+ * present in `update`, preserves channels only in `target`.
+ */
+export function mergeChannelCursor(target: ChannelCursor, update: ChannelCursor): void {
+  target.blockId = update.blockId;
+  target.total = update.total;
+  if (update.channels) {
+    target.channels ??= new AddressMap<Channel>();
+    for (const [addr, channel] of update.channels) {
+      target.channels.set(addr, channel);
+    }
+  }
+}
+
+/**
+ * Merge a discovered notes cursor into `target` in-place. For each incoming channel,
+ * merges per-token subchannel cursors (noteIndexes, totalNoteCounts) so that tokens
+ * not in the discovery filter are preserved.
+ */
+export function mergeNotesCursor(target: NotesCursor, update: NotesCursor): void {
+  target.blockId = update.blockId;
+  for (const [sender, incomingCursor] of update.incomingChannels) {
+    const existing = target.incomingChannels.get(sender);
+    if (!existing) {
+      target.incomingChannels.set(sender, incomingCursor);
+    } else {
+      existing.subchannelIdIndex = incomingCursor.subchannelIdIndex;
+      for (const [token, noteIndex] of incomingCursor.noteIndexes) {
+        existing.noteIndexes.set(token, noteIndex);
+      }
+      for (const [token, count] of incomingCursor.totalNoteCounts) {
+        existing.totalNoteCounts.set(token, count);
+      }
+    }
+  }
+}
+
+/**
+ * Registry holding the user's private state: cursors and notes.
+ * Passed to execute() for context resolution and updated with new state.
+ */
+export class PrivateRegistry {
+  notesCursor?: NotesCursor;
+  channelCursor?: ChannelCursor;
+  notes: AddressMap<Note[]>;
+
+  constructor() {
+    this.notes = new AddressMap<Note[]>(() => []);
+  }
+
+  /** Apply discovered notes using missing/refresh semantics and merge the cursor. */
+  applyDiscoveredNotes(
+    level: DiscoveryLevel | undefined,
+    notes: AddressMap<Note[]>,
+    cursor: NotesCursor
+  ): void {
+    for (const [token, discoveredNotes] of notes.entries()) {
+      if (level === "missing") {
+        const existing = this.notes.get(token);
+        if (existing) {
+          existing.push(...discoveredNotes);
+        } else {
+          this.notes.set(token, discoveredNotes);
+        }
+      } else {
+        this.notes.set(token, discoveredNotes);
+      }
+    }
+    if (!this.notesCursor) {
+      this.notesCursor = cursor;
+    } else {
+      mergeNotesCursor(this.notesCursor, cursor);
+    }
+  }
+
+  /** Apply a discovered channel cursor (merge in-place). */
+  applyDiscoveredChannels(cursor: ChannelCursor): void {
+    if (!this.channelCursor) {
+      this.channelCursor = cursor;
+    } else {
+      mergeChannelCursor(this.channelCursor, cursor);
+    }
+  }
+
+  /** Apply post-execution optimistic update (channels and notes, without touching cursors). */
+  applyExecuteResult(update: RegistryUpdate): void {
+    for (const [address, channel] of update.channels) {
+      this.channelCursor ??= {};
+      this.channelCursor.channels ??= new AddressMap<Channel>();
+      this.channelCursor.channels.set(address, channel);
+    }
+    for (const [token, tokenNotes] of update.notes) {
+      this.notes.set(token, tokenNotes);
+    }
+  }
+}
+
+/** Data produced by compilation for optimistic registry updates after tx inclusion. */
+export type RegistryUpdate = {
+  channels: AddressMap<Channel>;
+  notes: AddressMap<Note[]>;
+};
 
 type ChannelKey = bigint;
 

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -19,15 +19,14 @@
 import type {
   Actions,
   Amount,
+  DiscoveryLevel,
   DiscoveryProviderInterface,
   ExecuteOptions,
-  Note,
-  PrivateRegistry,
   StarknetAddressBigint,
   ViewingKey,
   Warning,
 } from "../interfaces.js";
-import { Channel, createEmptyRegistry, WarningCode } from "../interfaces.js";
+import { Channel, PrivateRegistry, WarningCode, type RegistryUpdate } from "../interfaces.js";
 import { AddressMap, AdvancedMap, toBigInt } from "../utils/index.js";
 import type { ClientAction } from "./client-actions.js";
 import { PoolSimulator } from "./pool-simulator.js";
@@ -43,7 +42,8 @@ import { ReorgError } from "./indexer/index.js";
 
 export type CompileResult = {
   clientActions: ClientAction[];
-  registry: PrivateRegistry;
+  /** Optimistic state update (new notes and channels). Apply via `registry.applyExecuteResult()` after tx confirmation. */
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 
@@ -110,8 +110,7 @@ export class ActionCompiler {
   }
 
   private async compileOnce(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
-    const registry_ = options?.registry ?? createEmptyRegistry();
-    const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
+    const registry = options?.registry ?? new PrivateRegistry();
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
     // Phase 1: Resolve recipient channels
@@ -122,8 +121,15 @@ export class ActionCompiler {
       recipientsNeeded
     );
 
-    // Phase 2: Resolve notes (discover and/or auto-select)
-    await this.resolveNotes(actions, registry, options);
+    // Phase 2a: Discover notes (update registry)
+    const notesDiscoveryLevel = options?.autoDiscover?.notes;
+    if (notesDiscoveryLevel) {
+      const actionTokens = this.getActionTokens(actions);
+      await this.discoverNotes(registry, notesDiscoveryLevel, actionTokens);
+    }
+
+    // Phase 2b: Resolve notes (select from registry, handle surpluses)
+    this.resolveNotes(actions, registry, options);
 
     debugLog("compiler", "compile", "post resolveNotes", registry?.notes?.size, actions);
 
@@ -137,7 +143,7 @@ export class ActionCompiler {
 
     return {
       clientActions,
-      registry: pool.updateRegistry(registry),
+      registryUpdate: pool.createRegistryUpdate(),
       warnings: this.checkWarnings(clientActions),
     };
   }
@@ -183,6 +189,16 @@ export class ActionCompiler {
       }
     }
     return recipientsNeeded;
+  }
+
+  private getActionTokens(actions: Actions): StarknetAddressBigint[] {
+    const tokens = new Set<bigint>();
+    for (const d of actions.deposits ?? []) tokens.add(d.token);
+    for (const u of actions.useNotes ?? []) tokens.add(u.token);
+    for (const w of actions.withdraws ?? []) tokens.add(w.token);
+    for (const c of actions.createNotes ?? []) tokens.add(c.token);
+    for (const s of actions.surpluses ?? []) tokens.add(s.token);
+    return [...tokens];
   }
 
   private createPool(
@@ -497,60 +513,67 @@ export class ActionCompiler {
     const recipientDiscoveryLevel = options?.autoDiscover?.channels;
 
     if (!recipientDiscoveryLevel) {
-      // Allow discovery for OpenChannel actions as they require fetching the recipient's public key
+      // OpenChannel actions require fetching the recipient's public key even
+      // without an explicit autoDiscover policy.
       const hasOpenChannels = actions.openChannels && actions.openChannels.length > 0;
       if (!hasOpenChannels && !options?.autoSetup) {
         return { channels: undefined, total: undefined };
       }
     }
 
-    // Determine which recipients to discover based on discovery level
-    let recipientsToDiscover: StarknetAddressBigint[];
-
-    if (recipientDiscoveryLevel === "refresh") {
-      // Refresh: discover ALL recipients to get latest nonces
-      recipientsToDiscover = [...recipientsNeeded.keys()];
-    } else {
-      // None or 'missing': only discover recipients not in registry
-      recipientsToDiscover = [...recipientsNeeded.keys()].filter(
-        (r) => !registry.channelCursor?.channels?.has(r)
-      );
-    }
-
+    const recipientsToDiscover = [...recipientsNeeded.keys()];
     if (recipientsToDiscover.length === 0) {
       return { channels: undefined, total: undefined };
     }
 
-    // Discover channels for all recipients that need discovery in a single call
-    // discoverChannels computes channel keys and returns current nonce state
-    const { channels } = await this.discoveryProvider.discoverChannels(
+    const { channels, total, cursor } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      recipientsToDiscover
+      {
+        recipients: recipientsToDiscover,
+        cursor: recipientDiscoveryLevel === "missing" ? registry.channelCursor : undefined,
+      }
     );
-
-    // see if all recipients were discoveredall
-    if (this.allOpen(channels, recipientsToDiscover)) {
-      return { channels, total: undefined };
-    }
-
-    const { total } = await this.discoveryProvider.discoverChannels(
-      this.userAddress,
-      this.userViewingKey,
-      "total-only"
-    );
+    registry.applyDiscoveredChannels(cursor);
 
     return { channels, total };
   }
 
   /**
-   * Resolve notes by discovering and/or auto-selecting from registry.
+   * Discover notes and update registry. Token filter controls which tokens to fetch;
+   * undefined means all tokens.
    */
-  private async resolveNotes(
+  private async discoverNotes(
+    registry: PrivateRegistry,
+    notesDiscoveryLevel: DiscoveryLevel,
+    tokenFilter?: StarknetAddressBigint[]
+  ): Promise<void> {
+    const tokensToDiscover = tokenFilter ?? undefined;
+
+    debugLog("compiler", "discovering notes", tokensToDiscover);
+
+    if (!tokensToDiscover || tokensToDiscover.length > 0) {
+      const { notes, cursor } = await this.discoveryProvider.discoverNotes(
+        this.userAddress,
+        this.userViewingKey,
+        {
+          cursor: notesDiscoveryLevel === "missing" ? registry.notesCursor : undefined,
+          tokens: tokensToDiscover,
+        }
+      );
+      registry.applyDiscoveredNotes(notesDiscoveryLevel, notes, cursor);
+    }
+  }
+
+  /**
+   * Resolve note selection: compute balances, auto-select notes from registry,
+   * and create surplus/change actions.
+   */
+  private resolveNotes(
     actions: Actions,
     registry: PrivateRegistry,
     options?: ExecuteOptions
-  ): Promise<void> {
+  ): void {
     if (!actions.surpluses && !options?.autoSelectNotes) return;
 
     // Calculate token balances (inputs - outputs)
@@ -605,47 +628,6 @@ export class ActionCompiler {
         if (!isOpen(c.amount)) {
           update(c.token, -c.amount);
         }
-      }
-    }
-
-    const notesDiscoveryLevel = options?.autoDiscover?.notes;
-    // discover notes if requested
-    if (notesDiscoveryLevel !== undefined) {
-      const tokensToDiscover = (() => {
-        if (notesDiscoveryLevel === "all") return undefined;
-        return [...balances.entries()]
-          .filter(([token, balance]) => {
-            // Case 1: We have a deficit (negative balance), so we need inputs.
-            const hasDeficit = balance < 0n;
-
-            // Case 2: We want to sweep all funds (autoSelectNotes="all") into a surplus recipient.
-            // Even if balance is 0, we check if we should fetch notes to dump them.
-            const isSweeping =
-              options?.autoSelectNotes === "all" && // assume 'all' means the user wants to always "compress" their notes even if balance is 0
-              actions.surpluses?.some((s) => s.token === token);
-
-            if (!hasDeficit && !isSweeping) return false;
-
-            // Finally, check if discovery is actually needed (forced refresh or missing from registry)
-            return notesDiscoveryLevel === "refresh" || !registry.notes.has(token);
-          })
-          .map(([token]) => token);
-      })();
-
-      debugLog("compiler", "discovering notes", tokensToDiscover);
-
-      if (!tokensToDiscover || tokensToDiscover.length > 0) {
-        const { notes, cursor } = await this.discoveryProvider.discoverNotes(
-          this.userAddress,
-          this.userViewingKey,
-          { cursor: registry.notesCursor, tokens: tokensToDiscover }
-        );
-
-        // Replace registry notes (don't merge - some may have been spent)
-        for (const [token, discoveredNotes] of notes.entries()) {
-          registry.notes.set(token, discoveredNotes);
-        }
-        registry.notesCursor = cursor;
       }
     }
 
@@ -706,26 +688,5 @@ export class ActionCompiler {
         }
       }
     }
-  }
-
-  private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {
-    // Clone notes
-    const clonedNotes = new AddressMap<Note[]>(() => []);
-    for (const [addr, notes] of registry.notes.entries()) {
-      clonedNotes.set(addr, [...notes]);
-    }
-
-    return {
-      notesCursor: registry.notesCursor,
-      channelCursor: registry.channelCursor,
-      notes: clonedNotes,
-    };
-  }
-
-  private allOpen(
-    channels: AddressMap<Channel> | undefined,
-    recipients: StarknetAddressBigint[]
-  ): boolean {
-    return recipients.every((recipient) => channels?.get(recipient)?.key !== undefined);
   }
 }

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -15,7 +15,7 @@ import {
 } from "../utils/hashes.js";
 import { encryptions } from "../utils/encryptions.js";
 import { cloneNotesCursor, cloneChannelCursor } from "./channel.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
+import type { ChannelCursor, NotesCursor } from "./channel.js";
 import { bisect, scan, Tracker } from "../utils/scan.js";
 import { createRateLimitedObject, type RateLimitOptions } from "../utils/rate-limiter.js";
 import type { PoolContractInterface, NoteData } from "./pool-contract-interface.js";
@@ -240,7 +240,7 @@ class ChannelsDiscovery {
   constructor(
     private readonly address: StarknetAddressBigint,
     private readonly viewingKey: bigint,
-    private readonly recipients: RecipientsFilter,
+    private readonly recipients: StarknetAddressBigint[] | undefined,
     private readonly cursor: ChannelCursor | undefined,
     private readonly pool: PoolContractInterface
   ) {
@@ -255,28 +255,25 @@ class ChannelsDiscovery {
     total?: number;
     cursor: ChannelCursor;
   }> {
-    if (this.recipients == "all" || this.recipients == "total-only") {
+    if (this.recipients === undefined) {
       void scan(
         async (s) => {
           const encOutgoingChannelInfo = await this.pool.get_outgoing_channel_info(
             compute_outgoing_channel_id(this.address, toBigInt(this.viewingKey), s)
           );
           if (toBigInt(encOutgoingChannelInfo.salt) === 0n) return false;
-          if (this.recipients !== "total-only") {
-            const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
-              encOutgoingChannelInfo,
-              this.address,
-              this.viewingKey,
-              s
-            );
-            void this.tracker.add(this.discoverChannel(recipientAddr));
-          }
+          const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
+            encOutgoingChannelInfo,
+            this.address,
+            this.viewingKey,
+            s
+          );
+          void this.tracker.add(this.discoverChannel(recipientAddr));
           this.total = Math.max(this.total ?? 0, s + 1);
           return true;
         },
         this.total ?? 0,
-        this.tracker,
-        this.recipients === "total-only"
+        this.tracker
       );
     } else {
       for (const recipient of this.recipients) {
@@ -416,8 +413,7 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
@@ -427,7 +423,7 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
     const discovery = new ChannelsDiscovery(
       address,
       toBigInt(viewingKey),
-      recipients,
+      params?.recipients,
       params?.cursor,
       this.pool
     );

--- a/sdk/src/internal/indexer/discovery.ts
+++ b/sdk/src/internal/indexer/discovery.ts
@@ -12,12 +12,7 @@ import { toHex } from "../../utils/convert.js";
 import { AddressMap } from "../../utils/maps.js";
 import { AbstractDiscoveryProvider } from "../abstract-discovery.js";
 import { Channel, Witness } from "../channel.js";
-import type {
-  ChannelCursor,
-  IncomingChannelCursor,
-  NotesCursor,
-  RecipientsFilter,
-} from "../channel.js";
+import type { ChannelCursor, IncomingChannelCursor, NotesCursor } from "../channel.js";
 
 /** Thrown when the indexer reports a block reorg (HTTP 409, BLOCK_REORGED). */
 export class ReorgError extends Error {
@@ -210,65 +205,15 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<ChannelInterface>;
     total?: number;
     cursor: ChannelCursor;
   }> {
-    if (recipients === "total-only") {
-      // For total-only, do a minimal outgoing sync to get the total channel count
-      const body: Record<string, unknown> = {
-        contract_address: toHex(this.contractAddress),
-        sender_address: toHex(address),
-        viewing_key: toHex(viewingKey),
-        cursor: { channel_discovery_complete: false },
-      };
-      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels!, cursor: { total: resp.cursor.total_n_channels!, blockId: resp.block_ref } };
-    }
-
-    const cursorMap = params?.cursor?.channels;
-    let apiCursor: ApiDiscoveryCursor;
-
-    if (recipients === "all") {
-      apiCursor = channelMapToApiCursor(cursorMap, false);
-    } else {
-      let allResolved = true;
-      const resolved = new Map<bigint, { key: bigint; publicKey: bigint }>();
-      for (const r of recipients) {
-        const rb = toBigInt(r);
-        const existing = cursorMap?.get(rb);
-        if (existing?.key) {
-          resolved.set(rb, { key: existing.key, publicKey: toBigInt(existing.publicKey) });
-        } else {
-          allResolved = false;
-        }
-      }
-
-      if (allResolved) {
-        // Targeted scan: skip channel discovery, only refresh subchannels
-        apiCursor = { channel_discovery_complete: true, channels: {} };
-        for (const [rb, info] of resolved) {
-          const existing = cursorMap?.get(rb);
-          const subchannels = existing
-            ? buildSubchannelCursors(
-                [...existing.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
-                null
-              )
-            : {};
-          apiCursor.channels![toHex(rb)] = {
-            channel_key: toHex(info.key),
-            subchannel_discovery_complete: false,
-            subchannels,
-          };
-        }
-      } else {
-        apiCursor = { channel_discovery_complete: false, channels: {} };
-      }
-    }
+    const recipients = params?.recipients;
+    let apiCursor = channelMapToApiCursor(params?.cursor?.channels, recipients);
 
     // Accumulate channel/subchannel data across all pagination pages.
     const createdChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
@@ -279,6 +224,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     const nonCreatedChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
     const lastKnownBlock = params?.cursor?.blockId as string | undefined;
     let blockRef: string | undefined;
+    let totalChannels: number | undefined;
 
     let complete = false;
     do {
@@ -293,13 +239,17 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       } else if (lastKnownBlock) {
         body.last_known_block = lastKnownBlock;
       }
-      if (recipients !== "all") {
+      if (recipients !== undefined) {
         body.recipients = recipients.map((r) => toHex(r));
       }
 
       const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
 
       blockRef = resp.block_ref;
+      // total_n_channels is only populated once channel discovery completes (final page)
+      if (resp.cursor.total_n_channels != null) {
+        totalChannels = resp.cursor.total_n_channels;
+      }
 
       accumulateOutgoingResponse(
         resp,
@@ -320,14 +270,19 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       nonCreatedChannelMap
     );
 
-    if (recipients !== "all") {
+    if (recipients !== undefined) {
       const requested = new Set(recipients.map((r) => toBigInt(r)));
       for (const key of [...channels.keys()]) {
         if (!requested.has(key)) channels.delete(key);
       }
     }
 
-    return { timestamp: blockRef!, channels, cursor: { channels, blockId: blockRef! } };
+    return {
+      timestamp: blockRef!,
+      channels,
+      total: totalChannels,
+      cursor: { channels, total: totalChannels, blockId: blockRef! },
+    };
   }
 
   async discoverRequirement(
@@ -416,10 +371,13 @@ export function notesCursorToApiCursor(
   };
   for (const [sender, icc] of cursor.incomingChannels) {
     const subchannels = buildSubchannelCursors(icc.noteIndexes, tokenFilter, icc.totalNoteCounts);
+    // Only mark complete when every filtered token already has a known subchannel —
+    // otherwise the server must scan for subchannels matching the desired tokens.
+    const subchannelDiscoveryComplete =
+      tokenFilter != null && [...tokenFilter].every((token) => icc.noteIndexes.has(token));
     apiCursor.channels![toHex(sender)] = {
       channel_key: toHex(icc.channelKey),
-      subchannel_discovery_complete:
-        tokenFilter != null && tokenFilter.size === Object.keys(subchannels).length,
+      subchannel_discovery_complete: subchannelDiscoveryComplete,
       last_subchannel_index: icc.subchannelIdIndex > 0 ? icc.subchannelIdIndex - 1 : undefined,
       subchannels,
     };
@@ -460,15 +418,19 @@ export function apiCursorToNotesCursor(
 /** Converts SDK `AddressMap<Channel>` → API cursor for an outgoing sync request. */
 export function channelMapToApiCursor(
   channels: AddressMap<ChannelInterface> | undefined,
-  channelDiscoveryComplete: boolean
+  recipientFilter?: StarknetAddressBigint[]
 ): ApiDiscoveryCursor {
   const apiCursor: ApiDiscoveryCursor = {
-    channel_discovery_complete: channelDiscoveryComplete,
+    channel_discovery_complete: false,
     channels: {},
   };
   if (channels) {
+    const allowedRecipients = recipientFilter
+      ? new Set(recipientFilter.map((r) => toBigInt(r)))
+      : null;
     for (const [recipient, channel] of channels) {
       if (!channel.key) continue;
+      if (allowedRecipients && !allowedRecipients.has(recipient)) continue;
       const subchannels = buildSubchannelCursors(
         [...channel.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
         null

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -12,8 +12,8 @@
  * - Just tracks Channel objects with nonces and Note objects
  */
 
-import type { Note, PrivateRegistry, StarknetAddressBigint } from "../interfaces.js";
-import { Channel } from "./channel.js";
+import type { Note, StarknetAddressBigint } from "../interfaces.js";
+import { Channel, type RegistryUpdate } from "./channel.js";
 import { derivePublicKey, toBigInt } from "../utils/crypto.js";
 import { AddressMap } from "../utils/maps.js";
 import type {
@@ -136,25 +136,14 @@ export class PoolSimulator {
     this.notes.get(token)!.set(toBigInt(note.id), note);
   }
 
-  /**
-   * Export tracked state back to the registry.
-   *
-   * TODO: This applies optimistic updates (spent notes removed, new notes/channels added)
-   * before the transaction is confirmed on-chain. If the transaction reverts, the registry
-   * becomes stale — spent notes are gone and phantom notes/channels are present. Callers
-   * must handle this by re-discovering from scratch (e.g. `autoDiscover: "refresh"`) or
-   * by snapshotting the registry before execute and restoring on revert.
-   */
-  updateRegistry(registry: PrivateRegistry): PrivateRegistry {
-    for (const [address, channel] of this.channels.entries()) {
-      registry.channelCursor ??= {};
-      registry.channelCursor.channels ??= new AddressMap<Channel>();
-      registry.channelCursor.channels.set(address, channel);
-    }
-    for (const [token, notes] of this.notes.entries()) {
-      registry.notes.set(token, Array.from(notes.values()));
-    }
-    return registry;
+  /** Returns data for optimistic registry updates after tx inclusion. */
+  createRegistryUpdate(): RegistryUpdate {
+    return {
+      channels: this.channels,
+      notes: new AddressMap<Note[]>(
+        [...this.notes].map(([token, noteMap]): [bigint, Note[]] => [token, [...noteMap.values()]])
+      ),
+    };
   }
 
   private handleSetViewingKey(_input: SetViewingKeyInput): void {

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -62,7 +62,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     );
 
     // Compile actions
-    const { clientActions, registry, warnings } = await compiler.compile(actions, options);
+    const { clientActions, registryUpdate, warnings } = await compiler.compile(actions, options);
 
     // Create invocation for proving
     const details = this.params.provingProvider.getDefaultDetails();
@@ -73,14 +73,25 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       details
     );
 
-    return { invocation, registry, warnings };
+    return { invocation, registryUpdate, warnings };
   }
 
+<<<<<<< HEAD
   async executeWithInvocation(
     { invocation, registry, warnings }: ProofInvocationResult,
     provingBlockId?: ProvingBlockId
   ): Promise<ExecuteResult> {
     const proof = await this.params.provingProvider.prove(invocation, provingBlockId);
+=======
+  async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
+    const { invocation, registryUpdate, warnings } = await this.createProofInvocation(
+      actions,
+      options
+    );
+
+    // Get proof from provider (block id only when provided in options)
+    const proof = await this.params.provingProvider.prove(invocation, options?.provingBlockId);
+>>>>>>> feec196d (refactor(sdk): do a single outgoing sync)
 
     // proof.output is the L2-to-L1 message payload: [class_hash, ...serialized_actions].
     // Strip the class_hash prefix — apply_actions expects only Span<ServerAction>.
@@ -100,7 +111,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
         },
         proof,
       },
-      registry,
+      registryUpdate,
       warnings,
     };
   }

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -2,16 +2,14 @@ import {
   SimplePrivateTransfersInterface,
   PrivateTransfersInterface,
   Amount,
-  Note,
   Open,
   PrivateRegistry,
   StarknetAddress,
   All,
   ExecuteResult,
-} from "./interfaces.js"; // Assuming you moved interfaces
+} from "./interfaces.js";
 import { toBigInt } from "./utils/convert.js";
 import { toHex } from "./utils/convert.js";
-import { AddressMap } from "./utils/maps.js";
 import { isAll } from "./utils/validation.js";
 
 export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterface {
@@ -21,9 +19,7 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     return this.inner.user;
   }
 
-  readonly registry: PrivateRegistry = {
-    notes: new AddressMap<Note[]>(),
-  };
+  readonly registry: PrivateRegistry = new PrivateRegistry();
 
   deposit(token: StarknetAddress, amount: Amount): Promise<ExecuteResult> {
     return this.build(token).deposit({ amount }).execute();

--- a/sdk/src/testing/mocknet.ts
+++ b/sdk/src/testing/mocknet.ts
@@ -146,17 +146,18 @@ export class Mocknet {
   }
 
   /**
-   * Execute the actions from a CallAndProof result.
-   * This applies the state changes to the mock pool.
+   * Execute the actions from a CallAndProof result and apply state updates to the registry.
    *
-   * In real Starknet, this would be done by sending the transaction to the network.
-   * In mocknet, we execute the actions directly on the pool.
+   * In real Starknet, this would be done by sending the transaction to the network
+   * and calling registry.applyExecuteResult only after confirmed success.
+   * In mocknet, execution always succeeds so we apply immediately.
    *
-   * @param result - The ExecuteResult from PrivateTransfers.execute()
-   * @returns The updated registry
+   * If no registry is provided, state updates are discarded (useful for setup-only calls like register).
    */
-  executeOutside(result: ExecuteResult): PrivateRegistry {
+  executeOutside(result: ExecuteResult, registry?: PrivateRegistry): void {
     this.pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
+    if (registry) {
+      registry.applyExecuteResult(result.registryUpdate);
+    }
   }
 }

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -133,7 +133,9 @@ describe("Devnet Integration", () => {
     expect(notes.notes.get(env.strk)?.length).toBe(1);
     expect(notes.notes.get(env.strk)?.[0].amount).toBe(50n);
 
-    const { channels } = await transfers.alice.discoverChannels([env.bob.address]);
+    const { channels } = await transfers.alice.discoverChannels({
+      recipients: [env.bob.address],
+    });
     debugLog("test", "should deposit", "channels", channels);
 
     expect(channels!.get(env.bob.address)?.tokens.get(env.strk)?.noteNonce).toBe(1);

--- a/sdk/tests/factory.test.ts
+++ b/sdk/tests/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { constants, type Account } from "starknet";
 import { createPrivateTransfers } from "../src/factory.js";
-import type { ProofProviderConfig, DiscoveryProviderConfig } from "../src/interfaces.js";
+import { type ProofProviderConfig, type DiscoveryProviderConfig } from "../src/interfaces.js";
 import { Mocknet } from "../src/testing/mocknet.js";
 import { MockProofProvider } from "../src/testing/mock-proof-provider.js";
 import { MockProofInvocationFactory } from "../src/testing/mock-proof-invocation-factory.js";

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -2,13 +2,11 @@
 import { Mocknet, type MocknetEnvironment } from "../../src/testing/mocknet.js";
 import { MockPoolContract } from "../../src/testing/mock-pool-contract.js";
 import {
-  createEmptyRegistry,
   ExecuteOptions,
   ExecuteResult,
   PrivateRegistry,
   PrivateTransfersInterface,
 } from "../../src/interfaces.js";
-import { AddressMap } from "../../src/utils/maps.js";
 
 export const POOL_ADDRESS = 0x1n;
 
@@ -67,22 +65,18 @@ export async function setupSelfChannel(
 ): Promise<PrivateRegistry> {
   const executeOutside = (result: ExecuteResult) => {
     pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
   };
 
   executeOutside(await user.build().register().execute());
   executeOutside(await user.build().setup(userAddress).execute());
 
-  let channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
-  const registry = createEmptyRegistry();
-  registry.channelCursor = { channels: new AddressMap() };
-  registry.channelCursor.channels!.set(userAddress, channel);
+  const registry = new PrivateRegistry();
+  await user.discoverChannels({ registry, level: "refresh", recipients: [userAddress] });
 
   executeOutside(await user.build({ registry }).with(token).setup(userAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
-  registry.channelCursor.channels!.set(userAddress, channel);
+  await user.discoverChannels({ registry, level: "refresh", recipients: [userAddress] });
 
   return registry;
 }
@@ -98,7 +92,6 @@ export async function setupRecipientChannel(
 ): Promise<PrivateRegistry> {
   const executeOutside = (result: ExecuteResult) => {
     pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
   };
 
   // Recipient must be registered first
@@ -107,21 +100,21 @@ export async function setupRecipientChannel(
   // Sender sets up channel to recipient
   executeOutside(await sender.build().setup(recipientAddress).execute());
 
-  let channel = (await sender.discoverChannels([recipientAddress])).channels!.get(
-    recipientAddress
-  )!;
-  const registry = createEmptyRegistry();
-  registry.channelCursor = { channels: new AddressMap() };
-  registry.channelCursor.channels!.set(recipientAddress, channel);
+  const registry = new PrivateRegistry();
+  await sender.discoverChannels({ registry, level: "refresh", recipients: [recipientAddress] });
 
   executeOutside(await sender.build({ registry }).with(token).setup(recipientAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await sender.discoverChannels([recipientAddress])).channels!.get(recipientAddress)!;
-  registry.channelCursor.channels!.set(recipientAddress, channel);
+  await sender.discoverChannels({ registry, level: "refresh", recipients: [recipientAddress] });
 
   return registry;
 }
 
+/** Shorthand for verification-only discovery: fresh registry, full rescan. */
+export function freshDiscover() {
+  return { registry: new PrivateRegistry(), level: "refresh" as const };
+}
+
 // Re-export commonly used utilities
-export { createEmptyRegistry };
+export { PrivateRegistry };

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { ActionCompiler } from "../../src/internal/compiler.js";
 import { ReorgError } from "../../src/internal/indexer/index.js";
-import { createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
+import { PrivateRegistry, SetupRequirement } from "../../src/interfaces.js";
 import type { DiscoveryProviderInterface, Note } from "../../src/interfaces.js";
 import { AddressMap } from "../../src/utils/maps.js";
 import { Channel } from "../../src/internal/channel.js";
@@ -53,7 +53,7 @@ describe("ActionCompiler reorg handling", () => {
 
     const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, mockProvider);
 
-    const registry = createEmptyRegistry();
+    const registry = new PrivateRegistry();
     registry.notes.set(TOKEN_ADDR, [
       {
         id: "0xstale",
@@ -88,7 +88,7 @@ describe("ActionCompiler reorg handling", () => {
     await expect(
       compiler.compile(
         { openChannels: [{ recipient: RECIPIENT_ADDR }] },
-        { registry: createEmptyRegistry(), autoDiscover: { channels: "refresh" } }
+        { registry: new PrivateRegistry(), autoDiscover: { channels: "refresh" } }
       )
     ).rejects.toThrow("network failure");
 

--- a/sdk/tests/internal/cursor-merge.test.ts
+++ b/sdk/tests/internal/cursor-merge.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { Channel, mergeChannelCursor, mergeNotesCursor } from "../../src/internal/channel.js";
+import type {
+  ChannelCursor,
+  NotesCursor,
+  IncomingChannelCursor,
+} from "../../src/internal/channel.js";
+import { AddressMap } from "../../src/utils/maps.js";
+
+const ALICE = 0xa11cen;
+const BOB = 0xb0bn;
+const CAROL = 0xca201n;
+
+const TOKEN_A = 0xace1n;
+const TOKEN_B = 0xbee1n;
+const TOKEN_C = 0xcee1n;
+
+function makeChannel(publicKey: bigint, key: bigint): Channel {
+  return new Channel(publicKey, key);
+}
+
+function makeIncomingChannelCursor(
+  channelKey: bigint,
+  subchannelIdIndex: number,
+  noteIndexes: [bigint, number][],
+  totalNoteCounts: [bigint, number][]
+): IncomingChannelCursor {
+  return {
+    channelKey,
+    subchannelIdIndex,
+    noteIndexes: new AddressMap<number>(noteIndexes),
+    totalNoteCounts: new AddressMap<number>(totalNoteCounts),
+  };
+}
+
+describe("mergeChannelCursor", () => {
+  it("preserves channels not in update (recipient-filtered discovery)", () => {
+    const target: ChannelCursor = {
+      blockId: "0xblock1",
+      total: 2,
+      channels: new AddressMap<Channel>([
+        [ALICE, makeChannel(0x1n, 0x10n)],
+        [BOB, makeChannel(0x2n, 0x20n)],
+      ]),
+    };
+
+    // Discovery only returned Carol (new) — Alice and Bob should be preserved
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 3,
+      channels: new AddressMap<Channel>([[CAROL, makeChannel(0x3n, 0x30n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+
+    expect(target.blockId).toBe("0xblock2");
+    expect(target.total).toBe(3);
+    expect(target.channels!.get(ALICE)!.key).toBe(0x10n);
+    expect(target.channels!.get(BOB)!.key).toBe(0x20n);
+    expect(target.channels!.get(CAROL)!.key).toBe(0x30n);
+  });
+
+  it("overwrites channels present in both target and update", () => {
+    const target: ChannelCursor = {
+      blockId: "0xblock1",
+      total: 2,
+      channels: new AddressMap<Channel>([
+        [ALICE, makeChannel(0x1n, 0x10n)],
+        [BOB, makeChannel(0x2n, 0x20n)],
+      ]),
+    };
+
+    // Discovery refreshed Alice with updated key
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 2,
+      channels: new AddressMap<Channel>([[ALICE, makeChannel(0x1n, 0x99n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+
+    expect(target.channels!.get(ALICE)!.key).toBe(0x99n);
+    expect(target.channels!.get(BOB)!.key).toBe(0x20n);
+  });
+
+  it("initializes channels map when target has no channels", () => {
+    const target: ChannelCursor = { blockId: "0xblock1" };
+
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 1,
+      channels: new AddressMap<Channel>([[ALICE, makeChannel(0x1n, 0x10n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+    expect(target.channels!.has(ALICE)).toBe(true);
+  });
+});
+
+describe("mergeNotesCursor", () => {
+  it("adds new senders from update", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 2, [[TOKEN_A, 5]], [[TOKEN_A, 10]])],
+      ]),
+    };
+
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [BOB, makeIncomingChannelCursor(0x2n, 1, [[TOKEN_A, 3]], [[TOKEN_A, 8]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    expect(target.blockId).toBe("0xblock2");
+    expect(target.incomingChannels.has(ALICE)).toBe(true);
+    expect(target.incomingChannels.has(BOB)).toBe(true);
+  });
+
+  it("preserves token cursors not in update (token-filtered discovery)", () => {
+    // Existing cursor has data for TOKEN_A and TOKEN_B from Alice
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [
+          ALICE,
+          makeIncomingChannelCursor(
+            0x1n,
+            3,
+            [
+              [TOKEN_A, 5],
+              [TOKEN_B, 8],
+            ],
+            [
+              [TOKEN_A, 10],
+              [TOKEN_B, 16],
+            ]
+          ),
+        ],
+      ]),
+    };
+
+    // Discovery was filtered to TOKEN_C only — TOKEN_A and TOKEN_B should be preserved
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 4, [[TOKEN_C, 2]], [[TOKEN_C, 6]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    // Preserved from target
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(5);
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(8);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_A)).toBe(10);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_B)).toBe(16);
+    // Added from update
+    expect(aliceCursor.noteIndexes.get(TOKEN_C)).toBe(2);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_C)).toBe(6);
+    // subchannelIdIndex updated
+    expect(aliceCursor.subchannelIdIndex).toBe(4);
+  });
+
+  it("overwrites token cursors present in both target and update", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [
+          ALICE,
+          makeIncomingChannelCursor(
+            0x1n,
+            2,
+            [
+              [TOKEN_A, 5],
+              [TOKEN_B, 8],
+            ],
+            [
+              [TOKEN_A, 10],
+              [TOKEN_B, 16],
+            ]
+          ),
+        ],
+      ]),
+    };
+
+    // Discovery refreshed TOKEN_A with new values
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 3, [[TOKEN_A, 12]], [[TOKEN_A, 20]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    // TOKEN_A overwritten
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(12);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_A)).toBe(20);
+    // TOKEN_B preserved
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(8);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_B)).toBe(16);
+  });
+
+  it("handles mixed: new sender + existing sender with token filter", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 2, [[TOKEN_A, 5]], [[TOKEN_A, 10]])],
+      ]),
+    };
+
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        // Alice: add TOKEN_B subchannel
+        [ALICE, makeIncomingChannelCursor(0x1n, 3, [[TOKEN_B, 1]], [[TOKEN_B, 4]])],
+        // Bob: entirely new sender
+        [BOB, makeIncomingChannelCursor(0x2n, 1, [[TOKEN_A, 3]], [[TOKEN_A, 7]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    // Alice: TOKEN_A preserved, TOKEN_B added
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(5);
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(1);
+    expect(aliceCursor.subchannelIdIndex).toBe(3);
+
+    // Bob: new entry
+    const bobCursor = target.incomingChannels.get(BOB)!;
+    expect(bobCursor.noteIndexes.get(TOKEN_A)).toBe(3);
+    expect(bobCursor.totalNoteCounts.get(TOKEN_A)).toBe(7);
+  });
+});

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -272,6 +272,7 @@ describe("IndexerDiscoveryProvider", () => {
         channelKey: BigInt(CHANNEL_KEY_1),
         subchannelIdIndex: 0,
         noteIndexes: new AddressMap<number>([[BigInt(TOKEN_ADDR), 1]]),
+        totalNoteCounts: new AddressMap<number>([[BigInt(TOKEN_ADDR), 1]]),
       });
       const previousCursor: NotesCursor = {
         blockId: BLOCK_REF,
@@ -291,7 +292,7 @@ describe("IndexerDiscoveryProvider", () => {
   });
 
   describe("discoverChannels", () => {
-    it("returns channels for 'all' recipients on a single page", async () => {
+    it("returns channels for all recipients on a single page", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({
         body: outgoingSyncResponse({
@@ -308,7 +309,7 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(fetchMock).toHaveBeenCalledOnce();
       expect(result.timestamp).toBe(BLOCK_REF);
@@ -323,7 +324,7 @@ describe("IndexerDiscoveryProvider", () => {
       expect(tokenNonces!.noteNonce).toBe(3); // last_note_index 2 + 1
     });
 
-    it("paginates 'all' recipients across 2 pages and merges", async () => {
+    it("paginates all recipients across 2 pages and merges", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson(
         {
@@ -353,7 +354,7 @@ describe("IndexerDiscoveryProvider", () => {
         }
       );
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
@@ -376,10 +377,9 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, [
-        BigInt(RECIPIENT_ADDR),
-        BigInt(RECIPIENT_ADDR_2),
-      ]);
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, {
+        recipients: [BigInt(RECIPIENT_ADDR), BigInt(RECIPIENT_ADDR_2)],
+      });
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.recipients).toBeDefined();
@@ -389,34 +389,42 @@ describe("IndexerDiscoveryProvider", () => {
       expect(result.channels!.has(BigInt(RECIPIENT_ADDR_2))).toBe(true);
     });
 
-    it("does not send recipients field for 'all' filter", async () => {
+    it("does not send recipients field when recipients is undefined", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({
         body: outgoingSyncResponse(),
       });
 
-      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.recipients).toBeUndefined();
     });
 
-    it("returns total from total_n_channels for 'total-only' recipients filter", async () => {
+    it("returns total from total_n_channels in outgoing sync response for all recipients", async () => {
       const provider = createProvider();
       mockFetchJson({
         body: outgoingSyncResponse({
+          channels: [channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1)],
+          subchannels: [{ recipient_addr: RECIPIENT_ADDR, token: TOKEN_ADDR, last_note_index: 0 }],
           cursor: {
-            channel_discovery_complete: true,
-            last_channel_index: 4,
+            ...completeCursor({
+              [RECIPIENT_ADDR]: {
+                channel_key: CHANNEL_KEY_1,
+                subchannels: {
+                  [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 0 },
+                },
+              },
+            }),
             total_n_channels: 5,
           },
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(result.total).toBe(5);
-      expect(result.channels).toBeUndefined();
+      expect(result.channels).toBeDefined();
     });
 
     it("prefers real channels over precomputed channels for the same recipient", async () => {
@@ -437,7 +445,7 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const channel = result.channels!.get(BigInt(RECIPIENT_ADDR));
       expect(channel).toBeDefined();
@@ -502,7 +510,7 @@ describe("IndexerDiscoveryProvider", () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({ body: outgoingSyncResponse() });
 
-      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.contract_address).toBe("0x123");

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
 import {
   createTestEnv,
-  createEmptyRegistry,
+  PrivateRegistry,
   AUTO_ALL,
   MockTestEnv,
   POOL_ADDRESS,
 } from "../helpers/test-fixtures.js";
 import { Open } from "../../src/interfaces.js";
-import { AddressMap } from "../../src/utils/maps.js";
+import { cloneChannelCursor } from "../../src/internal/channel.js";
 import { debugHint, isDebugEnabled, toBigInt } from "../../src/utils/index.js";
 import { debugLog } from "../../src/utils/logging.js";
 import { toHex } from "../../src/utils/convert.js";
@@ -42,10 +42,11 @@ describe("Private Transfers Integration", () => {
       mocknet.executeOutside(await bob.build().register().execute());
 
       // Alice: register, setup channels (self + Bob), setup token (self + Bob), deposit
+      const registry = new PrivateRegistry();
       // prettier-ignore
-      const registry = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
-          .build()
+          .build({ registry })
           .register()
           .setup(env.alice.address)
           .setup(env.bob.address)
@@ -53,7 +54,8 @@ describe("Private Transfers Integration", () => {
             .setup(env.alice.address)
             .setup(env.bob.address)
             .deposit({ amount: 100n, recipient: env.alice.address })
-          .execute()
+          .execute(),
+        registry
       );
 
       debugLog("test", "registry", registry);
@@ -72,7 +74,8 @@ describe("Private Transfers Integration", () => {
             .inputs(note)
             .transfer({ recipient: env.bob.address, amount: 50n })
             .withdraw({ amount: 25n })
-          .execute()
+          .execute(),
+        registry
       );
 
       // Alice should have 25n surplus note, Bob should have 50n note
@@ -116,22 +119,21 @@ describe("Private Transfers Integration", () => {
 
       // Alice uses autoRegister, autoSetup and autoSelectNotes: deposits and transfers to Bob
       // prettier-ignore
-      const registry = mocknet.executeOutside(
-        await alice
-          .build(AUTO_ALL)
-          .with(env.ace)
-            .deposit({ amount: 100n })
-            .transfer({ recipient: env.bob.address, amount: 50n })
-            .surplusTo(env.alice.address, true)
-          .with(env.bee)
-            .deposit({ amount: 100n })
-            .transfer({ recipient: env.bob.address, amount: 50n })
-            .transfer({ recipient: env.alice.address, amount: 50n })
-          .execute()
-      );
+      const result = await alice
+        .build(AUTO_ALL)
+        .with(env.ace)
+          .deposit({ amount: 100n })
+          .transfer({ recipient: env.bob.address, amount: 50n })
+          .surplusTo(env.alice.address, true)
+        .with(env.bee)
+          .deposit({ amount: 100n })
+          .transfer({ recipient: env.bob.address, amount: 50n })
+          .transfer({ recipient: env.alice.address, amount: 50n })
+        .execute();
+      mocknet.executeOutside(result);
 
-      expect(registry.notes.get(ace)?.length).toBe(0);
-      expect(registry.notes.get(bee)?.length).toBe(1);
+      expect(result.registryUpdate.notes.get(ace)?.length ?? 0).toBe(0);
+      expect(result.registryUpdate.notes.get(bee)?.length).toBe(1);
 
       const bobNotes = (await bob.discoverNotes()).notes;
       expect(bobNotes.get(ace)?.length).toBe(1);
@@ -140,7 +142,7 @@ describe("Private Transfers Integration", () => {
       expect(bobNotes.get(bee)?.[0].amount).toBe(50n);
     });
 
-    it("covers autoSelectNotes: all, autoDiscover: missing, registryConst, implicit surplus", async () => {
+    it("covers autoSelectNotes: all, autoDiscover: missing, separate working registry, implicit surplus", async () => {
       const { env, transfers } = testEnv;
       const { alice } = transfers;
       const ace = toBigInt(env.ace);
@@ -168,25 +170,28 @@ describe("Private Transfers Integration", () => {
       );
 
       // Phase 2: Use registry with channels but WITHOUT notes
-      // This tests autoDiscover: "missing" (discovers notes not in registry)
-      const channelOnly = createEmptyRegistry();
-      const channel = (await alice.discoverChannels([env.alice.address])).channels!.get(
-        env.alice.address
-      )!;
-      channelOnly.channelCursor = { channels: new AddressMap() };
-      channelOnly.channelCursor.channels!.set(env.alice.address, channel);
+      // This tests autoDiscover: "missing" for notes (discovers notes not in registry)
+      const channelOnly = new PrivateRegistry();
+      await alice.discoverChannels({
+        registry: channelOnly,
+        level: "refresh",
+        recipients: [env.alice.address],
+      });
+
+      // Create a separate working registry with the same channel cursor.
+      // channelOnly is never passed to build() or executeOutside(), so it stays unchanged.
+      const workingRegistry = new PrivateRegistry();
+      workingRegistry.channelCursor = cloneChannelCursor(channelOnly.channelCursor!);
 
       // Deposit 30n with:
       // - autoSelectNotes: "all" (sweeps ALL notes, not just enough for deficit)
-      // - registryConst: true (don't mutate channelOnly)
       // - autoDiscover: { notes: "missing" } (discover ACE notes since not in registry)
       // - surplusTo triggers the "sweeping" code path for discovery
       debugLog("test", "main");
-      const result = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
           .build({
-            registry: channelOnly,
-            registryConst: true,
+            registry: workingRegistry,
             autoDiscover: { channels: "refresh", notes: "missing" },
             autoSelectNotes: "all",
             autoSetup: true,
@@ -194,15 +199,16 @@ describe("Private Transfers Integration", () => {
           .surplusTo(env.alice.address) // Explicit surplus triggers sweeping discovery
           .with(env.ace)
           .deposit({ amount: 30n })
-          .execute()
+          .execute(),
+        workingRegistry
       );
 
       // Verify autoSelectNotes: "all" swept all notes into one
       // 100n + 50n (discovered & swept) + 30n (deposit) = 180n
-      expect(result.notes.get(ace)?.length).toBe(1);
-      expect(result.notes.get(ace)?.[0].amount).toBe(180n);
+      expect(workingRegistry.notes.get(ace)?.length).toBe(1);
+      expect(workingRegistry.notes.get(ace)?.[0].amount).toBe(180n);
 
-      // Verify registryConst: original registry unchanged
+      // Verify original registry is unchanged (never passed to build/executeOutside)
       expect(channelOnly.notes.has(ace)).toBe(false);
 
       // Verify ERC20 balance
@@ -219,20 +225,19 @@ describe("Private Transfers Integration", () => {
       // Deposit 100n, transfer only 30n to Bob -> 70n surplus with NO explicit surplusTo
       mocknet.executeOutside(await bob.build().register().execute());
 
-      const result = mocknet.executeOutside(
-        await alice
-          .build(AUTO_ALL)
-          .setup(env.alice.address)
-          .setup(env.bob.address)
-          .with(env.ace)
-          .deposit({ amount: 100n }) // No recipient, no surplusTo
-          .transfer({ recipient: env.bob.address, amount: 30n })
-          .execute()
-      );
+      const result = await alice
+        .build(AUTO_ALL)
+        .setup(env.alice.address)
+        .setup(env.bob.address)
+        .with(env.ace)
+        .deposit({ amount: 100n }) // No recipient, no surplusTo
+        .transfer({ recipient: env.bob.address, amount: 30n })
+        .execute();
+      mocknet.executeOutside(result);
 
       // Implicit surplus: 100n - 30n = 70n goes to self
-      expect(result.notes.get(ace)?.length).toBe(1);
-      expect(result.notes.get(ace)?.[0].amount).toBe(70n);
+      expect(result.registryUpdate.notes.get(ace)?.length).toBe(1);
+      expect(result.registryUpdate.notes.get(ace)?.[0].amount).toBe(70n);
 
       // Bob got his 30n
       const bobNotes = (await bob.discoverNotes()).notes.get(ace) ?? [];
@@ -253,14 +258,16 @@ describe("Private Transfers Integration", () => {
       mocknet.executeOutside(await david.build().register().execute());
 
       // Alice deposits and transfers to Bob (creates outgoing channel index 0 to self, index 1 to Bob)
-      const registryAfterBob = mocknet.executeOutside(
+      const registryAfterBob = new PrivateRegistry();
+      mocknet.executeOutside(
         await alice
-          .build(AUTO_ALL)
+          .build({ ...AUTO_ALL, registry: registryAfterBob })
           .with(env.ace)
           .deposit({ amount: 100n })
           .transfer({ recipient: env.bob.address, amount: 30n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        registryAfterBob
       );
 
       // Verify Bob got his transfer
@@ -269,7 +276,7 @@ describe("Private Transfers Integration", () => {
       expect(bobNotes[0].amount).toBe(30n);
 
       // Alice transfers to Carol using the registry from step 1 (creates outgoing channel index 2 to Carol)
-      const registryAfterCarol = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
           .build({
             registry: registryAfterBob,
@@ -280,7 +287,8 @@ describe("Private Transfers Integration", () => {
           .with(env.ace)
           .transfer({ recipient: env.carol.address, amount: 20n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        registryAfterBob
       );
 
       // Verify Carol got her transfer
@@ -289,19 +297,21 @@ describe("Private Transfers Integration", () => {
       expect(carolNotes[0].amount).toBe(20n);
 
       // Alice should have 50n remaining (100 - 30 - 20)
-      expect(registryAfterCarol.notes.get(ace)?.length).toBe(1);
-      expect(registryAfterCarol.notes.get(ace)?.[0].amount).toBe(50n);
+      expect(registryAfterBob.notes.get(ace)?.length).toBe(1);
+      expect(registryAfterBob.notes.get(ace)?.[0].amount).toBe(50n);
 
       // Now transfer to David WITHOUT passing a registry (fresh discovery)
       // This tests that the channel index accounting is correct when discovering from scratch
       // and creating a new channel to a completely new recipient
-      const finalRegistry = mocknet.executeOutside(
+      const finalRegistry = new PrivateRegistry();
+      mocknet.executeOutside(
         await alice
-          .build(AUTO_ALL) // Fresh discovery, no registry passed
+          .build({ ...AUTO_ALL, registry: finalRegistry }) // Fresh discovery
           .with(env.ace)
           .transfer({ recipient: env.david.address, amount: 10n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        finalRegistry
       );
 
       // Verify David got his transfer

--- a/sdk/tests/internal/parallel-discovery.test.ts
+++ b/sdk/tests/internal/parallel-discovery.test.ts
@@ -196,7 +196,7 @@ describe("Parallel Discovery", () => {
 
     // Discover channels for Alice (outgoing channels to all recipients)
     const recipientAddresses = recipients.map((r) => r.address);
-    await discovery.discoverChannels(aliceAddress, aliceKey, recipientAddresses);
+    await discovery.discoverChannels(aliceAddress, aliceKey, { recipients: recipientAddresses });
 
     const report = profiler.getReport();
     console.log("\n" + formatReport(report));

--- a/sdk/tests/simple-private-transfers.test.ts
+++ b/sdk/tests/simple-private-transfers.test.ts
@@ -26,7 +26,7 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit 100 ACE
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
 
     // Verify: Alice has 100n ACE note
     const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
@@ -46,8 +46,8 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit then withdraw partial
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
-    mocknet.executeOutside(await alice.withdraw(env.ace, env.alice.address, 40n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
+    mocknet.executeOutside(await alice.withdraw(env.ace, env.alice.address, 40n), alice.registry);
 
     // Verify: Alice has 60n surplus note
     const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
@@ -69,8 +69,8 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit then transfer
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
-    mocknet.executeOutside(await alice.transfer(env.ace, env.bob.address, 30n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
+    mocknet.executeOutside(await alice.transfer(env.ace, env.bob.address, 30n), alice.registry);
 
     // Verify: Bob has 30n
     const bobNotes = (await transfers.bob.discoverNotes()).notes.get(ace) ?? [];
@@ -96,11 +96,14 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit 100 ACE first
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
 
     // Swap 10 ACE for BEE using the swap helper.
     // note_id is auto-injected by the compiler into the invoke calldata.
-    mocknet.executeOutside(await alice.swap(env.ace, 10n, env.bee, toHex(swapHelper.address)));
+    mocknet.executeOutside(
+      await alice.swap(env.ace, 10n, env.bee, toHex(swapHelper.address)),
+      alice.registry
+    );
 
     // Verify: Alice has 90n ACE change note
     const aceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];


### PR DESCRIPTION
## Summary

### 1. Registry owns its mutation logic

`PrivateRegistry` is now a class with three methods — `applyDiscoveredNotes`, `applyDiscoveredChannels`, `applyExecuteResult` — instead of a plain type alias that every caller mutated ad-hoc. Merge semantics (missing vs refresh, cursor merging) live in one place.

### 2. Compilation produces data, not side effects

`ExecuteResult` no longer returns the same registry reference pre-mutated during compilation. Instead it returns a `RegistryUpdate` data object that the caller applies explicitly — typically after on-chain tx confirmation. This eliminates `registryConst` (a workaround for eager mutation) and gives the caller control over when optimistic state is committed.

### 3. Discovery and note selection are separate phases

The compiler's `resolveNotes` was a single async function that discovered notes, updated the registry, selected notes, and created surplus actions. Discovery is now a dedicated phase before note resolution. `resolveNotes` is synchronous — it only selects from what's already in the registry.

### 4. Token/recipient filters are separated from discovery strategies

The old API conflated filtering with discovery levels: `"all"` meant "discover all tokens regardless of balance", `"total-only"` meant "don't return channels, just count them", and `RecipientsFilter` was a union of `T[] | "all" | "total-only"`. Now discovery level (`"missing"` | `"refresh"`) controls only the cursor strategy, and token/recipient arrays control filtering orthogonally. The compiler extracts action tokens as a filter; callers pass explicit arrays or omit for all.

## What was wrong

**Scattered registry mutations.** The compiler, AbstractPrivateTransfers, and PoolSimulator each had their own copy of registry update logic. Adding a field to the registry required updating every caller. Cursor merge logic was duplicated with no single source of truth for consistency.

**Eager mutation during compilation.** `PoolSimulator.updateRegistry()` unconditionally wrote new channels and notes into the registry during `compile()`, before the tx was submitted. If the tx failed, the registry was corrupted. `registryConst: true` existed as a workaround (clone before mutation), adding API surface for what should have been a non-issue. The returned `registry` on `ExecuteResult` was the same reference passed in — confusing and impossible to diff.

**Entangled discovery and selection.** `resolveNotes` was a 100-line async function mixing balance calculation, token filtering, discovery calls, registry mutation, note selection, and surplus creation. The `"all"` discovery level added another branch to decide "discover all tokens regardless of balance" vs "only tokens with deficits".

**Double outgoing sync call.** When not all recipients had open channels, the compiler made a second `discoverChannels("total-only")` call just to fetch the total count — an extra round-trip now unnecessary because the cursor already contains the total.

**Incremental sync was broken.** Outgoing channel discovery never seeded the cursor from the registry, so every call did a full rescan. Notes had a similar problem — discovery results were written to the registry but the cursor wasn't properly merged, so incremental updates re-fetched already-known data. Neither `discoverNotes` nor `discoverChannels` applied their results back to the registry — callers had to do it manually, and the compiler didn't.

**Cursor not forwarded.** `discoverNotes` consumed the cursor internally and didn't return it, so callers couldn't access `totalNoteCounts` for UI display.

## Changes

### `PrivateRegistry` class (`channel.ts`)

```typescript
export class PrivateRegistry {
  notesCursor?: NotesCursor;
  channelCursor?: ChannelCursor;
  notes: AddressMap<Note[]>;

  applyDiscoveredNotes(level, notes, cursor): void;  // missing=append, refresh=replace + cursor merge
  applyDiscoveredChannels(cursor): void;              // merge channel cursor in-place
  applyExecuteResult(update: RegistryUpdate): void;   // optimistic post-tx state (no cursor changes)
}
```

### `RegistryUpdate` data type

```typescript
export type RegistryUpdate = { channels: AddressMap<Channel>; notes: AddressMap<Note[]> };
```

Returned by `PoolSimulator.createRegistryUpdate()` and surfaced on `ExecuteResult.registryUpdate`. Plain data — inspectable, deferrable, applied only when the caller decides to.

### Compiler

- Discovery split into dedicated `discoverNotes` phase; `resolveNotes` is now sync (select + surplus only)
- Single `discoverChannels` call (total from cursor, no `"total-only"` second call)
- Returns `registryUpdate: RegistryUpdate` instead of mutated registry
- Removed `cloneRegistry`, `allOpen`, `registryConst`
- Token filter extracted from actions via `getActionTokens()`

### `AbstractPrivateTransfers`

- `discoverNotes`/`discoverChannels` accept `{ registry, level, tokens/recipients }` and update registry via its methods
- `discoverNotes` returns `cursor: NotesCursor`
- Removed `RecipientsFilter` union — recipients is `StarknetAddress[] | undefined`

### Other files

| File | Change |
|------|--------|
| `interfaces.ts` | Re-export `PrivateRegistry` class and `RegistryUpdate` from `channel.ts`. Remove old type alias, `createEmptyRegistry`, `registryConst`, `RecipientsFilter`. |
| `pool-simulator.ts` | `updateRegistry(registry)` -> `createRegistryUpdate(): RegistryUpdate` (data, no mutation) |
| `private-transfers.ts` | Destructure `registryUpdate` instead of `registry` |
| `simple-private-transfers.ts` | Object literal -> `new PrivateRegistry()` |
| `mocknet.ts` | `executeOutside(result): PrivateRegistry` -> `executeOutside(result, registry?): void` |
| `README.md` | State management section rewritten: transaction discovery, post-tx update, periodic refresh |

## Migration guide

### Registry creation

```diff
- import { createEmptyRegistry } from "starknet-sdk";
- const registry = createEmptyRegistry();
+ import { PrivateRegistry } from "starknet-sdk";
+ const registry = new PrivateRegistry();
```

Object literals no longer satisfy the type:
```diff
- const registry: PrivateRegistry = { channels: new AddressMap(), notes: new AddressMap() };
+ const registry = new PrivateRegistry();
```

### Post-execution update

```diff
- const { registry } = await transfers.execute(actions, { registry: myRegistry });
- // registry === myRegistry, already mutated
+ const { registryUpdate } = await transfers.execute(actions, { registry: myRegistry });
+ // myRegistry is NOT mutated — apply only after tx confirmation:
+ myRegistry.applyExecuteResult(registryUpdate);
```

Same for `createProofInvocation`:
```diff
- const { invocation, registry } = await transfers.createProofInvocation(actions, options);
+ const { invocation, registryUpdate } = await transfers.createProofInvocation(actions, options);
```

### Remove `registryConst`

No longer needed — execution doesn't mutate the registry.
```diff
  await transfers.execute(actions, {
    registry,
-   registryConst: true,
  });
```

### Mocknet

```diff
- const updatedRegistry = mocknet.executeOutside(result);
+ mocknet.executeOutside(result, registry);
```

### Discovery (direct calls)

`discoverNotes` — new params shape, returns cursor:
```diff
- const { notes } = await transfers.discoverNotes({ cursor: registry.cursor, tokens: [STRK] });
+ const { notes, cursor } = await transfers.discoverNotes({ registry, level: "missing", tokens: [STRK] });
```

`discoverChannels` — positional `recipients` arg replaced with params object:
```diff
- const { channels, total } = await transfers.discoverChannels("all", { cursor });
+ const { channels, total } = await transfers.discoverChannels({ registry, level: "missing" });

- const { channels } = await transfers.discoverChannels([bob, alice], { cursor });
+ const { channels } = await transfers.discoverChannels({ registry, level: "missing", recipients: [bob, alice] });
```

### `AutoDiscoveryOptions.notes`

`"all"` is removed — token filter is now derived from the actions automatically:
```diff
  autoDiscover: {
-   notes: "all",
+   notes: "refresh",
    channels: "missing",
  }
```

### `DiscoveryProviderInterface` (custom discovery providers)

`discoverChannels` signature changed:
```diff
  discoverChannels(
    address: StarknetAddressBigint,
    viewingKey: ViewingKey,
-   recipients: RecipientsFilter,
+   recipients: StarknetAddressBigint[] | undefined,
    params?: { cursor?: ChannelCursor }
- ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
+ ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number; cursor: ChannelCursor }>;
```

Return type now includes `cursor: ChannelCursor`.

### Removed exports

| Export | Replacement |
|--------|-------------|
| `createEmptyRegistry()` | `new PrivateRegistry()` |
| `RecipientsFilter` | `StarknetAddress[]` or `undefined` |
| `ExecuteResult.registry` | `ExecuteResult.registryUpdate: RegistryUpdate` |
| `ExecuteOptions.registryConst` | removed (no-op) |
| `AutoDiscoveryOptions.notes: "all"` | `"refresh"` (tokens derived from actions) |

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/644)
<!-- Reviewable:end -->
