### PR TITLE
refactor(sdk): replace private registry type alias with class

### DIFF
--- a/e2e/tests/reorg-recovery.test.ts
+++ b/e2e/tests/reorg-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
-import { createEmptyRegistry, AddressMap } from "@starkware-libs/starknet-privacy-sdk";
+import { PrivateRegistry, AddressMap } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../src/harness.js";
 
 describe("E2E Reorg Recovery", () => {
@@ -62,7 +62,7 @@ describe("E2E Reorg Recovery", () => {
     // The fake blockId will be sent as last_known_block to the indexer,
     // which will respond with HTTP 409 (BLOCK_REORGED).
     // NotesCursor fields are @internal (stripped from .d.ts), so we cast through `any`.
-    const registry = createEmptyRegistry();
+    const registry = new PrivateRegistry();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registry.notesCursor = { blockId: "0xdeadbeef", incomingChannels: new AddressMap() } as any;
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -211,12 +211,12 @@ const result = await transfers.build({
 
 ## Registry management
 
-The `PrivateRegistry` holds the user's private state: unspent notes and discovery cursors. Create one with `createEmptyRegistry()` and pass it through `ExecuteOptions`.
+The `PrivateRegistry` holds the user's private state: unspent notes and discovery cursors. Create one with `new PrivateRegistry()` and pass it through `ExecuteOptions`.
 
 ```typescript
-import { createEmptyRegistry } from "starknet-sdk";
+import { PrivateRegistry } from "starknet-sdk";
 
-const registry = createEmptyRegistry();
+const registry = new PrivateRegistry();
 
 // The registry is updated in-place after each execute()
 const result = await transfers.build({
@@ -287,7 +287,7 @@ The wallet sends `callAndProof` in a transaction to the contract's `execute_acti
 
 **`Channel`** — A communication channel to a recipient, holding a shared key and per-token nonces.
 
-**`PrivateRegistry`** — The user's local state: unspent notes and discovery cursors for incremental sync. Create with `createEmptyRegistry()`.
+**`PrivateRegistry`** — The user's local state: unspent notes and discovery cursors for incremental sync. Create with `new PrivateRegistry()`.
 
 **`AddressMap<V>`** — A `Map` that normalizes Starknet addresses for consistent key lookup.
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -52,12 +52,12 @@ export enum SetupRequirement {
 export type StarknetAddressBigint = bigint;
 
 // Import and re-export from internal channel
-import { Witness, Channel } from "./internal/channel.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./internal/channel.js";
+import { Witness, Channel, PrivateRegistry } from "./internal/channel.js";
+import type { ChannelCursor, NotesCursor, RecipientsFilter, RegistryUpdate } from "./internal/channel.js";
 import type { INVOKE_TXN_V3 } from "@starknet-io/starknet-types-010";
-export { Witness, Channel };
+export { Witness, Channel, PrivateRegistry };
 export type { NotesCursor as DiscoveryCursor };
-export type { NotesCursor, ChannelCursor };
+export type { NotesCursor, ChannelCursor, RegistryUpdate };
 
 export type Note = {
   readonly id: NoteId;
@@ -242,26 +242,6 @@ export type AutoDiscoveryOptions = {
  * - 'naive': Select first notes until balance is non negative (may create surplus)
  */
 export type AutoSelectionStrategy = "all" | "naive" /*| "exact"*/; //
-
-/**
- * Registry holding the user's private state: cursors and notes.
- * Passed to execute() for context resolution and updated with new state.
- */
-export type PrivateRegistry = {
-  /** Cursor for incoming notes discovery */
-  notesCursor?: NotesCursor;
-  /** Cursor for outgoing channels discovery */
-  channelCursor?: ChannelCursor;
-  /** Notes by token address */
-  notes: AddressMap<Note[]>;
-};
-
-/** Create an empty private registry */
-export function createEmptyRegistry(): PrivateRegistry {
-  return {
-    notes: new AddressMap<Note[]>(() => []),
-  };
-}
 
 /**
  * Block reference for proving. Passed as block_id to the proving service.

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -4,6 +4,8 @@ import {
   StarknetAddressBigint,
   type Blob,
   type ChannelSerde,
+  type DiscoveryLevel,
+  type Note,
   type StarknetAddress,
   type WitnessSerde,
 } from "../interfaces.js";
@@ -99,6 +101,98 @@ export function cloneChannelCursor(cursor?: ChannelCursor): ChannelCursor {
     total: cursor.total,
   };
 }
+
+/**
+ * Merge a discovered channel cursor into `target` in-place. Overwrites channels
+ * present in `update`, preserves channels only in `target`.
+ */
+export function mergeChannelCursor(target: ChannelCursor, update: ChannelCursor): void {
+  target.blockId = update.blockId;
+  target.total = update.total;
+  if (update.channels) {
+    target.channels ??= new AddressMap<Channel>();
+    for (const [addr, channel] of update.channels) {
+      target.channels.set(addr, channel);
+    }
+  }
+}
+
+/**
+ * Merge a discovered notes cursor into `target` in-place. For each incoming channel,
+ * merges per-token subchannel cursors (noteIndexes, totalNoteCounts) so that tokens
+ * not in the discovery filter are preserved.
+ */
+export function mergeNotesCursor(target: NotesCursor, update: NotesCursor): void {
+  target.blockId = update.blockId;
+  for (const [sender, incomingCursor] of update.incomingChannels) {
+    const existing = target.incomingChannels.get(sender);
+    if (!existing) {
+      target.incomingChannels.set(sender, incomingCursor);
+    } else {
+      existing.subchannelIdIndex = incomingCursor.subchannelIdIndex;
+      for (const [token, noteIndex] of incomingCursor.noteIndexes) {
+        existing.noteIndexes.set(token, noteIndex);
+      }
+      for (const [token, count] of incomingCursor.totalNoteCounts) {
+        existing.totalNoteCounts.set(token, count);
+      }
+    }
+  }
+}
+
+/**
+ * Registry holding the user's private state: cursors and notes.
+ * Passed to execute() for context resolution and updated with new state.
+ */
+export class PrivateRegistry {
+  notesCursor?: NotesCursor;
+  channelCursor?: ChannelCursor;
+  notes: AddressMap<Note[]>;
+
+  constructor() {
+    this.notes = new AddressMap<Note[]>(() => []);
+  }
+
+  /** Apply discovered notes using missing/refresh semantics and merge the cursor. */
+  applyDiscoveredNotes(
+    level: DiscoveryLevel | undefined,
+    notes: AddressMap<Note[]>,
+    cursor: NotesCursor
+  ): void {
+    for (const [token, discoveredNotes] of notes.entries()) {
+      if (level === "missing") {
+        const existing = this.notes.get(token);
+        if (existing) {
+          existing.push(...discoveredNotes);
+        } else {
+          this.notes.set(token, discoveredNotes);
+        }
+      } else {
+        this.notes.set(token, discoveredNotes);
+      }
+    }
+    if (!this.notesCursor) {
+      this.notesCursor = cursor;
+    } else {
+      mergeNotesCursor(this.notesCursor, cursor);
+    }
+  }
+
+  /** Apply a discovered channel cursor (merge in-place). */
+  applyDiscoveredChannels(cursor: ChannelCursor): void {
+    if (!this.channelCursor) {
+      this.channelCursor = cursor;
+    } else {
+      mergeChannelCursor(this.channelCursor, cursor);
+    }
+  }
+}
+
+/** Data produced by compilation for optimistic registry updates after tx inclusion. */
+export type RegistryUpdate = {
+  channels: AddressMap<Channel>;
+  notes: AddressMap<Note[]>;
+};
 
 type ChannelKey = bigint;
 

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -22,12 +22,11 @@ import type {
   DiscoveryProviderInterface,
   ExecuteOptions,
   Note,
-  PrivateRegistry,
   StarknetAddressBigint,
   ViewingKey,
   Warning,
 } from "../interfaces.js";
-import { Channel, createEmptyRegistry, WarningCode } from "../interfaces.js";
+import { Channel, PrivateRegistry, WarningCode } from "../interfaces.js";
 import { AddressMap, AdvancedMap, toBigInt } from "../utils/index.js";
 import type { ClientAction } from "./client-actions.js";
 import { PoolSimulator } from "./pool-simulator.js";
@@ -110,7 +109,7 @@ export class ActionCompiler {
   }
 
   private async compileOnce(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
-    const registry_ = options?.registry ?? createEmptyRegistry();
+    const registry_ = options?.registry ?? new PrivateRegistry();
     const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
@@ -709,17 +708,13 @@ export class ActionCompiler {
   }
 
   private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {
-    // Clone notes
-    const clonedNotes = new AddressMap<Note[]>(() => []);
+    const cloned = new PrivateRegistry();
+    cloned.notesCursor = registry.notesCursor;
+    cloned.channelCursor = registry.channelCursor;
     for (const [addr, notes] of registry.notes.entries()) {
-      clonedNotes.set(addr, [...notes]);
+      cloned.notes.set(addr, [...notes]);
     }
-
-    return {
-      notesCursor: registry.notesCursor,
-      channelCursor: registry.channelCursor,
-      notes: clonedNotes,
-    };
+    return cloned;
   }
 
   private allOpen(

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -2,16 +2,14 @@ import {
   SimplePrivateTransfersInterface,
   PrivateTransfersInterface,
   Amount,
-  Note,
   Open,
   PrivateRegistry,
   StarknetAddress,
   All,
   ExecuteResult,
-} from "./interfaces.js"; // Assuming you moved interfaces
+} from "./interfaces.js";
 import { toBigInt } from "./utils/convert.js";
 import { toHex } from "./utils/convert.js";
-import { AddressMap } from "./utils/maps.js";
 import { isAll } from "./utils/validation.js";
 
 export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterface {
@@ -21,9 +19,7 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     return this.inner.user;
   }
 
-  readonly registry: PrivateRegistry = {
-    notes: new AddressMap<Note[]>(),
-  };
+  readonly registry: PrivateRegistry = new PrivateRegistry();
 
   deposit(token: StarknetAddress, amount: Amount): Promise<ExecuteResult> {
     return this.build(token).deposit({ amount }).execute();

--- a/sdk/tests/factory.test.ts
+++ b/sdk/tests/factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { constants, type Account } from "starknet";
 import { createPrivateTransfers } from "../src/factory.js";
-import type { ProofProviderConfig, DiscoveryProviderConfig } from "../src/interfaces.js";
+import { type ProofProviderConfig, type DiscoveryProviderConfig } from "../src/interfaces.js";
 import { Mocknet } from "../src/testing/mocknet.js";
 import { MockProofProvider } from "../src/testing/mock-proof-provider.js";
 import { MockProofInvocationFactory } from "../src/testing/mock-proof-invocation-factory.js";

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -2,7 +2,6 @@
 import { Mocknet, type MocknetEnvironment } from "../../src/testing/mocknet.js";
 import { MockPoolContract } from "../../src/testing/mock-pool-contract.js";
 import {
-  createEmptyRegistry,
   ExecuteOptions,
   ExecuteResult,
   PrivateRegistry,
@@ -74,7 +73,7 @@ export async function setupSelfChannel(
   executeOutside(await user.build().setup(userAddress).execute());
 
   let channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
-  const registry = createEmptyRegistry();
+  const registry = new PrivateRegistry();
   registry.channelCursor = { channels: new AddressMap() };
   registry.channelCursor.channels!.set(userAddress, channel);
 
@@ -110,7 +109,7 @@ export async function setupRecipientChannel(
   let channel = (await sender.discoverChannels([recipientAddress])).channels!.get(
     recipientAddress
   )!;
-  const registry = createEmptyRegistry();
+  const registry = new PrivateRegistry();
   registry.channelCursor = { channels: new AddressMap() };
   registry.channelCursor.channels!.set(recipientAddress, channel);
 
@@ -124,4 +123,4 @@ export async function setupRecipientChannel(
 }
 
 // Re-export commonly used utilities
-export { createEmptyRegistry };
+export { PrivateRegistry };

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { ActionCompiler } from "../../src/internal/compiler.js";
 import { ReorgError } from "../../src/internal/indexer/index.js";
-import { createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
+import { PrivateRegistry, SetupRequirement } from "../../src/interfaces.js";
 import type { DiscoveryProviderInterface, Note } from "../../src/interfaces.js";
 import { AddressMap } from "../../src/utils/maps.js";
 import { Channel } from "../../src/internal/channel.js";
@@ -53,7 +53,7 @@ describe("ActionCompiler reorg handling", () => {
 
     const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, mockProvider);
 
-    const registry = createEmptyRegistry();
+    const registry = new PrivateRegistry();
     registry.notes.set(TOKEN_ADDR, [
       {
         id: "0xstale",
@@ -88,7 +88,7 @@ describe("ActionCompiler reorg handling", () => {
     await expect(
       compiler.compile(
         { openChannels: [{ recipient: RECIPIENT_ADDR }] },
-        { registry: createEmptyRegistry(), autoDiscover: { channels: "refresh" } }
+        { registry: new PrivateRegistry(), autoDiscover: { channels: "refresh" } }
       )
     ).rejects.toThrow("network failure");
 

--- a/sdk/tests/internal/cursor-merge.test.ts
+++ b/sdk/tests/internal/cursor-merge.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { Channel, mergeChannelCursor, mergeNotesCursor } from "../../src/internal/channel.js";
+import type {
+  ChannelCursor,
+  NotesCursor,
+  IncomingChannelCursor,
+} from "../../src/internal/channel.js";
+import { AddressMap } from "../../src/utils/maps.js";
+
+const ALICE = 0xa11cen;
+const BOB = 0xb0bn;
+const CAROL = 0xca201n;
+
+const TOKEN_A = 0xace1n;
+const TOKEN_B = 0xbee1n;
+const TOKEN_C = 0xcee1n;
+
+function makeChannel(publicKey: bigint, key: bigint): Channel {
+  return new Channel(publicKey, key);
+}
+
+function makeIncomingChannelCursor(
+  channelKey: bigint,
+  subchannelIdIndex: number,
+  noteIndexes: [bigint, number][],
+  totalNoteCounts: [bigint, number][]
+): IncomingChannelCursor {
+  return {
+    channelKey,
+    subchannelIdIndex,
+    noteIndexes: new AddressMap<number>(noteIndexes),
+    totalNoteCounts: new AddressMap<number>(totalNoteCounts),
+  };
+}
+
+describe("mergeChannelCursor", () => {
+  it("preserves channels not in update (recipient-filtered discovery)", () => {
+    const target: ChannelCursor = {
+      blockId: "0xblock1",
+      total: 2,
+      channels: new AddressMap<Channel>([
+        [ALICE, makeChannel(0x1n, 0x10n)],
+        [BOB, makeChannel(0x2n, 0x20n)],
+      ]),
+    };
+
+    // Discovery only returned Carol (new) — Alice and Bob should be preserved
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 3,
+      channels: new AddressMap<Channel>([[CAROL, makeChannel(0x3n, 0x30n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+
+    expect(target.blockId).toBe("0xblock2");
+    expect(target.total).toBe(3);
+    expect(target.channels!.get(ALICE)!.key).toBe(0x10n);
+    expect(target.channels!.get(BOB)!.key).toBe(0x20n);
+    expect(target.channels!.get(CAROL)!.key).toBe(0x30n);
+  });
+
+  it("overwrites channels present in both target and update", () => {
+    const target: ChannelCursor = {
+      blockId: "0xblock1",
+      total: 2,
+      channels: new AddressMap<Channel>([
+        [ALICE, makeChannel(0x1n, 0x10n)],
+        [BOB, makeChannel(0x2n, 0x20n)],
+      ]),
+    };
+
+    // Discovery refreshed Alice with updated key
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 2,
+      channels: new AddressMap<Channel>([[ALICE, makeChannel(0x1n, 0x99n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+
+    expect(target.channels!.get(ALICE)!.key).toBe(0x99n);
+    expect(target.channels!.get(BOB)!.key).toBe(0x20n);
+  });
+
+  it("initializes channels map when target has no channels", () => {
+    const target: ChannelCursor = { blockId: "0xblock1" };
+
+    const update: ChannelCursor = {
+      blockId: "0xblock2",
+      total: 1,
+      channels: new AddressMap<Channel>([[ALICE, makeChannel(0x1n, 0x10n)]]),
+    };
+
+    mergeChannelCursor(target, update);
+    expect(target.channels!.has(ALICE)).toBe(true);
+  });
+});
+
+describe("mergeNotesCursor", () => {
+  it("adds new senders from update", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 2, [[TOKEN_A, 5]], [[TOKEN_A, 10]])],
+      ]),
+    };
+
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [BOB, makeIncomingChannelCursor(0x2n, 1, [[TOKEN_A, 3]], [[TOKEN_A, 8]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    expect(target.blockId).toBe("0xblock2");
+    expect(target.incomingChannels.has(ALICE)).toBe(true);
+    expect(target.incomingChannels.has(BOB)).toBe(true);
+  });
+
+  it("preserves token cursors not in update (token-filtered discovery)", () => {
+    // Existing cursor has data for TOKEN_A and TOKEN_B from Alice
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [
+          ALICE,
+          makeIncomingChannelCursor(
+            0x1n,
+            3,
+            [
+              [TOKEN_A, 5],
+              [TOKEN_B, 8],
+            ],
+            [
+              [TOKEN_A, 10],
+              [TOKEN_B, 16],
+            ]
+          ),
+        ],
+      ]),
+    };
+
+    // Discovery was filtered to TOKEN_C only — TOKEN_A and TOKEN_B should be preserved
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 4, [[TOKEN_C, 2]], [[TOKEN_C, 6]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    // Preserved from target
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(5);
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(8);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_A)).toBe(10);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_B)).toBe(16);
+    // Added from update
+    expect(aliceCursor.noteIndexes.get(TOKEN_C)).toBe(2);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_C)).toBe(6);
+    // subchannelIdIndex updated
+    expect(aliceCursor.subchannelIdIndex).toBe(4);
+  });
+
+  it("overwrites token cursors present in both target and update", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [
+          ALICE,
+          makeIncomingChannelCursor(
+            0x1n,
+            2,
+            [
+              [TOKEN_A, 5],
+              [TOKEN_B, 8],
+            ],
+            [
+              [TOKEN_A, 10],
+              [TOKEN_B, 16],
+            ]
+          ),
+        ],
+      ]),
+    };
+
+    // Discovery refreshed TOKEN_A with new values
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 3, [[TOKEN_A, 12]], [[TOKEN_A, 20]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    // TOKEN_A overwritten
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(12);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_A)).toBe(20);
+    // TOKEN_B preserved
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(8);
+    expect(aliceCursor.totalNoteCounts.get(TOKEN_B)).toBe(16);
+  });
+
+  it("handles mixed: new sender + existing sender with token filter", () => {
+    const target: NotesCursor = {
+      blockId: "0xblock1",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        [ALICE, makeIncomingChannelCursor(0x1n, 2, [[TOKEN_A, 5]], [[TOKEN_A, 10]])],
+      ]),
+    };
+
+    const update: NotesCursor = {
+      blockId: "0xblock2",
+      incomingChannels: new AddressMap<IncomingChannelCursor>([
+        // Alice: add TOKEN_B subchannel
+        [ALICE, makeIncomingChannelCursor(0x1n, 3, [[TOKEN_B, 1]], [[TOKEN_B, 4]])],
+        // Bob: entirely new sender
+        [BOB, makeIncomingChannelCursor(0x2n, 1, [[TOKEN_A, 3]], [[TOKEN_A, 7]])],
+      ]),
+    };
+
+    mergeNotesCursor(target, update);
+
+    // Alice: TOKEN_A preserved, TOKEN_B added
+    const aliceCursor = target.incomingChannels.get(ALICE)!;
+    expect(aliceCursor.noteIndexes.get(TOKEN_A)).toBe(5);
+    expect(aliceCursor.noteIndexes.get(TOKEN_B)).toBe(1);
+    expect(aliceCursor.subchannelIdIndex).toBe(3);
+
+    // Bob: new entry
+    const bobCursor = target.incomingChannels.get(BOB)!;
+    expect(bobCursor.noteIndexes.get(TOKEN_A)).toBe(3);
+    expect(bobCursor.totalNoteCounts.get(TOKEN_A)).toBe(7);
+  });
+});

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -272,6 +272,7 @@ describe("IndexerDiscoveryProvider", () => {
         channelKey: BigInt(CHANNEL_KEY_1),
         subchannelIdIndex: 0,
         noteIndexes: new AddressMap<number>([[BigInt(TOKEN_ADDR), 1]]),
+        totalNoteCounts: new AddressMap<number>([[BigInt(TOKEN_ADDR), 1]]),
       });
       const previousCursor: NotesCursor = {
         blockId: BLOCK_REF,

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
 import {
   createTestEnv,
-  createEmptyRegistry,
+  PrivateRegistry,
   AUTO_ALL,
   MockTestEnv,
   POOL_ADDRESS,
@@ -169,7 +169,7 @@ describe("Private Transfers Integration", () => {
 
       // Phase 2: Use registry with channels but WITHOUT notes
       // This tests autoDiscover: "missing" (discovers notes not in registry)
-      const channelOnly = createEmptyRegistry();
+      const channelOnly = new PrivateRegistry();
       const channel = (await alice.discoverChannels([env.alice.address])).channels!.get(
         env.alice.address
       )!;


### PR DESCRIPTION
## Summary

  - `PrivateRegistry` is now a class with `applyDiscoveredNotes()` and `applyDiscoveredChannels()` methods,
  encapsulating cursor merge logic that was previously scattered across callers
  - Add `mergeNotesCursor()` and `mergeChannelCursor()` utilities for in-place cursor merging
  - Add `RegistryUpdate` data type (used by later PRs)
  - Remove `createEmptyRegistry()` — use `new PrivateRegistry()` instead

  No public API signature changes. All existing callers continue to work because the class fields (`notesCursor`,
  `channelCursor`, `notes`) are public and writable.

  ## Test plan

  - [x] New `cursor-merge.test.ts` covering `mergeNotesCursor` and `mergeChannelCursor` edge cases
  - [x] `npm run lint` passes (0 new type errors)
  - [x] `npm test` — 162/162 tests pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/653)
<!-- Reviewable:end -->
