### PR TITLE
refactor(sdk): remove total-only discovery and use single outgoing sync

### DIFF
--- a/e2e/tests/pagination-discovery.test.ts
+++ b/e2e/tests/pagination-discovery.test.ts
@@ -87,15 +87,12 @@ describe("Discovery pagination with small budget", () => {
       poolContractAddress: de.privacy.address,
     });
 
-    // total-only: exercises total_n_channels
-    const { total } = await aliceTransfers.discoverChannels("total-only");
-    expect(total).toBe(2); // self-channel + Bob
-
-    // full discovery: exercises multi-round pagination
-    const { channels } = await aliceTransfers.discoverChannels([
+    // full discovery: exercises multi-round pagination and returns total
+    const { channels, total } = await aliceTransfers.discoverChannels([
       de.alice.address,
       de.bob.address,
     ]);
+    expect(total).toBe(2); // self-channel + Bob
     expect(channels).toBeDefined();
     expect(channels!.size).toBe(2);
     expect(channels!.has(BigInt(de.alice.address))).toBe(true);

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -73,7 +73,7 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
   };
 }
 
-export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all" | "total-only";
+export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all";
 
 export type ChannelCursor = {
   /** @internal */ blockId?: BlockIdentifier;

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -496,48 +496,28 @@ export class ActionCompiler {
     const recipientDiscoveryLevel = options?.autoDiscover?.channels;
 
     if (!recipientDiscoveryLevel) {
-      // Allow discovery for OpenChannel actions as they require fetching the recipient's public key
+      // OpenChannel actions require fetching the recipient's public key even
+      // without an explicit autoDiscover policy.
       const hasOpenChannels = actions.openChannels && actions.openChannels.length > 0;
       if (!hasOpenChannels && !options?.autoSetup) {
         return { channels: undefined, total: undefined };
       }
     }
 
-    // Determine which recipients to discover based on discovery level
-    let recipientsToDiscover: StarknetAddressBigint[];
-
-    if (recipientDiscoveryLevel === "refresh") {
-      // Refresh: discover ALL recipients to get latest nonces
-      recipientsToDiscover = [...recipientsNeeded.keys()];
-    } else {
-      // None or 'missing': only discover recipients not in registry
-      recipientsToDiscover = [...recipientsNeeded.keys()].filter(
-        (r) => !registry.channelCursor?.channels?.has(r)
-      );
-    }
-
+    const recipientsToDiscover = [...recipientsNeeded.keys()];
     if (recipientsToDiscover.length === 0) {
       return { channels: undefined, total: undefined };
     }
 
-    // Discover channels for all recipients that need discovery in a single call
-    // discoverChannels computes channel keys and returns current nonce state
-    const { channels } = await this.discoveryProvider.discoverChannels(
+    const { channels, total, cursor } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      recipientsToDiscover
+      recipientsToDiscover,
+      {
+        cursor: recipientDiscoveryLevel === "missing" ? registry.channelCursor : undefined,
+      }
     );
-
-    // see if all recipients were discoveredall
-    if (this.allOpen(channels, recipientsToDiscover)) {
-      return { channels, total: undefined };
-    }
-
-    const { total } = await this.discoveryProvider.discoverChannels(
-      this.userAddress,
-      this.userViewingKey,
-      "total-only"
-    );
+    registry.applyDiscoveredChannels(cursor);
 
     return { channels, total };
   }
@@ -715,12 +695,4 @@ export class ActionCompiler {
       cloned.notes.set(addr, [...notes]);
     }
     return cloned;
-  }
-
-  private allOpen(
-    channels: AddressMap<Channel> | undefined,
-    recipients: StarknetAddressBigint[]
-  ): boolean {
-    return recipients.every((recipient) => channels?.get(recipient)?.key !== undefined);
-  }
-}
+  }}

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -255,28 +255,25 @@ class ChannelsDiscovery {
     total?: number;
     cursor: ChannelCursor;
   }> {
-    if (this.recipients == "all" || this.recipients == "total-only") {
+    if (this.recipients === "all") {
       void scan(
         async (s) => {
           const encOutgoingChannelInfo = await this.pool.get_outgoing_channel_info(
             compute_outgoing_channel_id(this.address, toBigInt(this.viewingKey), s)
           );
           if (toBigInt(encOutgoingChannelInfo.salt) === 0n) return false;
-          if (this.recipients !== "total-only") {
-            const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
-              encOutgoingChannelInfo,
-              this.address,
-              this.viewingKey,
-              s
-            );
-            void this.tracker.add(this.discoverChannel(recipientAddr));
-          }
+          const { recipientAddr } = encryptions.decryptOutgoingChannelInfo(
+            encOutgoingChannelInfo,
+            this.address,
+            this.viewingKey,
+            s
+          );
+          void this.tracker.add(this.discoverChannel(recipientAddr));
           this.total = Math.max(this.total ?? 0, s + 1);
           return true;
         },
         this.total ?? 0,
-        this.tracker,
-        this.recipients === "total-only"
+        this.tracker
       );
     } else {
       for (const recipient of this.recipients) {

--- a/sdk/src/internal/indexer/discovery.ts
+++ b/sdk/src/internal/indexer/discovery.ts
@@ -218,57 +218,11 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     total?: number;
     cursor: ChannelCursor;
   }> {
-    if (recipients === "total-only") {
-      // For total-only, do a minimal outgoing sync to get the total channel count
-      const body: Record<string, unknown> = {
-        contract_address: toHex(this.contractAddress),
-        sender_address: toHex(address),
-        viewing_key: toHex(viewingKey),
-        cursor: { channel_discovery_complete: false },
-      };
-      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels!, cursor: { total: resp.cursor.total_n_channels!, blockId: resp.block_ref } };
-    }
-
     const cursorMap = params?.cursor?.channels;
-    let apiCursor: ApiDiscoveryCursor;
-
-    if (recipients === "all") {
-      apiCursor = channelMapToApiCursor(cursorMap, false);
-    } else {
-      let allResolved = true;
-      const resolved = new Map<bigint, { key: bigint; publicKey: bigint }>();
-      for (const r of recipients) {
-        const rb = toBigInt(r);
-        const existing = cursorMap?.get(rb);
-        if (existing?.key) {
-          resolved.set(rb, { key: existing.key, publicKey: toBigInt(existing.publicKey) });
-        } else {
-          allResolved = false;
-        }
-      }
-
-      if (allResolved) {
-        // Targeted scan: skip channel discovery, only refresh subchannels
-        apiCursor = { channel_discovery_complete: true, channels: {} };
-        for (const [rb, info] of resolved) {
-          const existing = cursorMap?.get(rb);
-          const subchannels = existing
-            ? buildSubchannelCursors(
-                [...existing.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
-                null
-              )
-            : {};
-          apiCursor.channels![toHex(rb)] = {
-            channel_key: toHex(info.key),
-            subchannel_discovery_complete: false,
-            subchannels,
-          };
-        }
-      } else {
-        apiCursor = { channel_discovery_complete: false, channels: {} };
-      }
-    }
+    let apiCursor = channelMapToApiCursor(
+      cursorMap,
+      Array.isArray(recipients) ? recipients : undefined
+    );
 
     // Accumulate channel/subchannel data across all pagination pages.
     const createdChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
@@ -279,6 +233,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     const nonCreatedChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
     const lastKnownBlock = params?.cursor?.blockId as string | undefined;
     let blockRef: string | undefined;
+    let totalChannels: number | undefined;
 
     let complete = false;
     do {
@@ -300,6 +255,10 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
 
       blockRef = resp.block_ref;
+      // total_n_channels is only populated once channel discovery completes (final page)
+      if (resp.cursor.total_n_channels != null) {
+        totalChannels = resp.cursor.total_n_channels;
+      }
 
       accumulateOutgoingResponse(
         resp,
@@ -327,7 +286,12 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       }
     }
 
-    return { timestamp: blockRef!, channels, cursor: { channels, blockId: blockRef! } };
+    return {
+      timestamp: blockRef!,
+      channels,
+      total: totalChannels,
+      cursor: { channels, total: totalChannels, blockId: blockRef! },
+    };
   }
 
   async discoverRequirement(
@@ -416,10 +380,13 @@ export function notesCursorToApiCursor(
   };
   for (const [sender, icc] of cursor.incomingChannels) {
     const subchannels = buildSubchannelCursors(icc.noteIndexes, tokenFilter, icc.totalNoteCounts);
+    // Only mark complete when every filtered token already has a known subchannel —
+    // otherwise the server must scan for subchannels matching the desired tokens.
+    const subchannelDiscoveryComplete =
+      tokenFilter != null && [...tokenFilter].every((token) => icc.noteIndexes.has(token));
     apiCursor.channels![toHex(sender)] = {
       channel_key: toHex(icc.channelKey),
-      subchannel_discovery_complete:
-        tokenFilter != null && tokenFilter.size === Object.keys(subchannels).length,
+      subchannel_discovery_complete: subchannelDiscoveryComplete,
       last_subchannel_index: icc.subchannelIdIndex > 0 ? icc.subchannelIdIndex - 1 : undefined,
       subchannels,
     };
@@ -460,15 +427,19 @@ export function apiCursorToNotesCursor(
 /** Converts SDK `AddressMap<Channel>` → API cursor for an outgoing sync request. */
 export function channelMapToApiCursor(
   channels: AddressMap<ChannelInterface> | undefined,
-  channelDiscoveryComplete: boolean
+  recipientFilter?: StarknetAddressBigint[]
 ): ApiDiscoveryCursor {
   const apiCursor: ApiDiscoveryCursor = {
-    channel_discovery_complete: channelDiscoveryComplete,
+    channel_discovery_complete: false,
     channels: {},
   };
   if (channels) {
+    const allowedRecipients = recipientFilter
+      ? new Set(recipientFilter.map((r) => toBigInt(r)))
+      : null;
     for (const [recipient, channel] of channels) {
       if (!channel.key) continue;
+      if (allowedRecipients && !allowedRecipients.has(recipient)) continue;
       const subchannels = buildSubchannelCursors(
         [...channel.tokens].map(([token, nonces]) => [token, nonces.noteNonce]),
         null

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -402,22 +402,30 @@ describe("IndexerDiscoveryProvider", () => {
       expect(requestBody.recipients).toBeUndefined();
     });
 
-    it("returns total from total_n_channels for 'total-only' recipients filter", async () => {
+    it("returns total from total_n_channels in outgoing sync response for all recipients", async () => {
       const provider = createProvider();
       mockFetchJson({
         body: outgoingSyncResponse({
+          channels: [channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1)],
+          subchannels: [{ recipient_addr: RECIPIENT_ADDR, token: TOKEN_ADDR, last_note_index: 0 }],
           cursor: {
-            channel_discovery_complete: true,
-            last_channel_index: 4,
+            ...completeCursor({
+              [RECIPIENT_ADDR]: {
+                channel_key: CHANNEL_KEY_1,
+                subchannels: {
+                  [TOKEN_ADDR]: { note_discovery_complete: true, last_note_index: 0 },
+                },
+              },
+            }),
             total_n_channels: 5,
           },
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
 
       expect(result.total).toBe(5);
-      expect(result.channels).toBeUndefined();
+      expect(result.channels).toBeDefined();
     });
 
     it("prefers real channels over precomputed channels for the same recipient", async () => {


### PR DESCRIPTION
## Summary

  - Remove `"total-only"` from `RecipientsFilter` — the compiler no longer makes a second `discoverChannels` call
  just to fetch the total channel count
  - `discoverChannels` now returns `total` and `cursor` from the outgoing sync response, so the total is available
   from the first (and only) call
  - `channelMapToApiCursor` accepts an optional recipient filter instead of a boolean, enabling cursor scoping by
  recipient
  - Compiler calls `registry.applyDiscoveredChannels(cursor)` to persist discovered state

  ## Test plan

  - [x] Rewrote "total-only" test → verifies `total` from full outgoing sync
  - [x] `npm run lint` passes (0 new type errors)
  - [x] `npm test` — 162/162 tests pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/654)
<!-- Reviewable:end -->
