### PR TITLE
refactor(sdk): replace recipients filter with optional recipients param

### DIFF
--- a/e2e/tests/pagination-discovery.test.ts
+++ b/e2e/tests/pagination-discovery.test.ts
@@ -88,10 +88,9 @@ describe("Discovery pagination with small budget", () => {
     });
 
     // full discovery: exercises multi-round pagination and returns total
-    const { channels, total } = await aliceTransfers.discoverChannels([
-      de.alice.address,
-      de.bob.address,
-    ]);
+    const { channels, total } = await aliceTransfers.discoverChannels({
+      recipients: [de.alice.address, de.bob.address],
+    });
     expect(total).toBe(2); // self-channel + Bob
     expect(channels).toBeDefined();
     expect(channels!.size).toBe(2);

--- a/e2e/tests/payment-service-discovery.test.ts
+++ b/e2e/tests/payment-service-discovery.test.ts
@@ -246,7 +246,9 @@ describe("Payment Service Discovery", () => {
     });
 
     const allAddresses = [de.alice.address, ...users.map((u) => u.address)];
-    const { channels } = await aliceDiscover.discoverChannels(allAddresses);
+    const { channels } = await aliceDiscover.discoverChannels({
+      recipients: allAddresses,
+    });
     expect(channels).toBeDefined();
 
     // Self-channel + all 9 users
@@ -294,7 +296,9 @@ describe("Payment Service Discovery", () => {
         poolContractAddress: de.privacy.address,
       });
 
-      const { channels } = await userDiscover.discoverChannels([de.alice.address]);
+      const { channels } = await userDiscover.discoverChannels({
+        recipients: [de.alice.address],
+      });
       expect(channels).toBeDefined();
       expect(channels!.has(BigInt(de.alice.address))).toBe(true);
     }

--- a/e2e/tests/smoke.test.ts
+++ b/e2e/tests/smoke.test.ts
@@ -72,7 +72,9 @@ describe("E2E Smoke", () => {
     expect(strkNotes!.length).toBeGreaterThanOrEqual(1);
     expect(strkNotes![0].amount).toBe(50n); // Alice's change note
 
-    const { channels } = await aliceIndexer.discoverChannels([de.alice.address, de.bob.address]);
+    const { channels } = await aliceIndexer.discoverChannels({
+      recipients: [de.alice.address, de.bob.address],
+    });
     expect(channels).toBeDefined();
     expect(channels!.size).toBeGreaterThanOrEqual(2); // self-channel + Bob
     expect(channels!.has(BigInt(de.alice.address))).toBe(true);

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -53,7 +53,7 @@ export type StarknetAddressBigint = bigint;
 
 // Import and re-export from internal channel
 import { Witness, Channel, PrivateRegistry } from "./internal/channel.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter, RegistryUpdate } from "./internal/channel.js";
+import type { ChannelCursor, NotesCursor, RegistryUpdate } from "./internal/channel.js";
 import type { INVOKE_TXN_V3 } from "@starknet-io/starknet-types-010";
 export { Witness, Channel, PrivateRegistry };
 export type { NotesCursor as DiscoveryCursor };
@@ -384,12 +384,14 @@ export interface PrivateTransfersInterface {
   }>;
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * Omit `recipients` to discover all outgoing channels.
+   * Pass an array for specific recipients (server also precomputes channels for them).
    */
-  discoverChannels(
-    recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
-  ): Promise<{
+  discoverChannels(params?: {
+    recipients?: StarknetAddress[];
+    cursor?: ChannelCursor;
+  }): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
@@ -616,13 +618,13 @@ export interface DiscoveryProviderInterface {
 
   /**
    * Discover channels for one or more recipients.
-   * Pass "all" to discover all outgoing channels by iterating through the outgoing channel map.
+   * Omit `recipients` to discover all outgoing channels.
+   * Pass an array for specific recipients (server also precomputes channels for them).
    */
   discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -8,7 +8,7 @@ import type {
 } from "../interfaces.js";
 import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
+import type { ChannelCursor, NotesCursor } from "./channel.js";
 
 export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInterface {
   // Abstract methods that subclasses must implement
@@ -29,8 +29,7 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
   abstract discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
@@ -45,7 +44,9 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
     recipient: StarknetAddressBigint,
     token: StarknetAddressBigint
   ): Promise<SetupRequirement> {
-    const { channels } = await this.discoverChannels(address, viewingKey, [recipient]);
+    const { channels } = await this.discoverChannels(address, viewingKey, {
+      recipients: [recipient],
+    });
     const channel = channels?.get(recipient);
     return channel?.toSetupRequirement(token) ?? SetupRequirement.Register;
   }

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -25,7 +25,7 @@ import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { toBigInt } from "../utils/crypto.js";
 import { PrivateTransfersBuilderImpl } from "./builders.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
+import type { ChannelCursor, NotesCursor } from "./channel.js";
 
 /**
  * Abstract base class that implements the common functionality for PrivateTransfers.
@@ -60,22 +60,24 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   }
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * Omit `recipients` to discover all outgoing channels.
    */
-
   async discoverChannels(
-    recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
+    params: {
+      recipients?: StarknetAddress[];
+      cursor?: ChannelCursor;
+    } = {}
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
   }> {
+    const { recipients, ...rest } = params;
     return this.discoveryProvider.discoverChannels(
       this.user,
       await this.getViewingKey(),
-      Array.isArray(recipients) ? recipients.map(toBigInt) : recipients,
-      params
+      { recipients: recipients?.map(toBigInt), ...rest }
     );
   }
 

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -73,7 +73,6 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
   };
 }
 
-export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all";
 
 export type ChannelCursor = {
   /** @internal */ blockId?: BlockIdentifier;

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -512,8 +512,8 @@ export class ActionCompiler {
     const { channels, total, cursor } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      recipientsToDiscover,
       {
+        recipients: recipientsToDiscover,
         cursor: recipientDiscoveryLevel === "missing" ? registry.channelCursor : undefined,
       }
     );

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -15,7 +15,7 @@ import {
 } from "../utils/hashes.js";
 import { encryptions } from "../utils/encryptions.js";
 import { cloneNotesCursor, cloneChannelCursor } from "./channel.js";
-import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
+import type { ChannelCursor, NotesCursor } from "./channel.js";
 import { bisect, scan, Tracker } from "../utils/scan.js";
 import { createRateLimitedObject, type RateLimitOptions } from "../utils/rate-limiter.js";
 import type { PoolContractInterface, NoteData } from "./pool-contract-interface.js";
@@ -240,7 +240,7 @@ class ChannelsDiscovery {
   constructor(
     private readonly address: StarknetAddressBigint,
     private readonly viewingKey: bigint,
-    private readonly recipients: RecipientsFilter,
+    private readonly recipients: StarknetAddressBigint[] | undefined,
     private readonly cursor: ChannelCursor | undefined,
     private readonly pool: PoolContractInterface
   ) {
@@ -255,7 +255,7 @@ class ChannelsDiscovery {
     total?: number;
     cursor: ChannelCursor;
   }> {
-    if (this.recipients === "all") {
+    if (this.recipients === undefined) {
       void scan(
         async (s) => {
           const encOutgoingChannelInfo = await this.pool.get_outgoing_channel_info(
@@ -413,8 +413,7 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
@@ -424,7 +423,7 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
     const discovery = new ChannelsDiscovery(
       address,
       toBigInt(viewingKey),
-      recipients,
+      params?.recipients,
       params?.cursor,
       this.pool
     );

--- a/sdk/src/internal/indexer/discovery.ts
+++ b/sdk/src/internal/indexer/discovery.ts
@@ -12,12 +12,7 @@ import { toHex } from "../../utils/convert.js";
 import { AddressMap } from "../../utils/maps.js";
 import { AbstractDiscoveryProvider } from "../abstract-discovery.js";
 import { Channel, Witness } from "../channel.js";
-import type {
-  ChannelCursor,
-  IncomingChannelCursor,
-  NotesCursor,
-  RecipientsFilter,
-} from "../channel.js";
+import type { ChannelCursor, IncomingChannelCursor, NotesCursor } from "../channel.js";
 
 /** Thrown when the indexer reports a block reorg (HTTP 409, BLOCK_REORGED). */
 export class ReorgError extends Error {
@@ -210,18 +205,17 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverChannels(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { recipients?: StarknetAddressBigint[]; cursor?: ChannelCursor }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<ChannelInterface>;
     total?: number;
     cursor: ChannelCursor;
   }> {
-    const cursorMap = params?.cursor?.channels;
+    const recipients = params?.recipients;
     let apiCursor = channelMapToApiCursor(
-      cursorMap,
-      Array.isArray(recipients) ? recipients : undefined
+      params?.cursor?.channels,
+      recipients
     );
 
     // Accumulate channel/subchannel data across all pagination pages.
@@ -248,7 +242,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       } else if (lastKnownBlock) {
         body.last_known_block = lastKnownBlock;
       }
-      if (recipients !== "all") {
+      if (recipients !== undefined) {
         body.recipients = recipients.map((r) => toHex(r));
       }
 
@@ -279,7 +273,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       nonCreatedChannelMap
     );
 
-    if (recipients !== "all") {
+    if (recipients !== undefined) {
       const requested = new Set(recipients.map((r) => toBigInt(r)));
       for (const key of [...channels.keys()]) {
         if (!requested.has(key)) channels.delete(key);

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -133,7 +133,9 @@ describe("Devnet Integration", () => {
     expect(notes.notes.get(env.strk)?.length).toBe(1);
     expect(notes.notes.get(env.strk)?.[0].amount).toBe(50n);
 
-    const { channels } = await transfers.alice.discoverChannels([env.bob.address]);
+    const { channels } = await transfers.alice.discoverChannels({
+      recipients: [env.bob.address],
+    });
     debugLog("test", "should deposit", "channels", channels);
 
     expect(channels!.get(env.bob.address)?.tokens.get(env.strk)?.noteNonce).toBe(1);

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -72,7 +72,7 @@ export async function setupSelfChannel(
   executeOutside(await user.build().register().execute());
   executeOutside(await user.build().setup(userAddress).execute());
 
-  let channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
+  let channel = (await user.discoverChannels({ recipients: [userAddress] })).channels!.get(userAddress)!;
   const registry = new PrivateRegistry();
   registry.channelCursor = { channels: new AddressMap() };
   registry.channelCursor.channels!.set(userAddress, channel);
@@ -80,7 +80,7 @@ export async function setupSelfChannel(
   executeOutside(await user.build({ registry }).with(token).setup(userAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await user.discoverChannels([userAddress])).channels!.get(userAddress)!;
+  channel = (await user.discoverChannels({ recipients: [userAddress] })).channels!.get(userAddress)!;
   registry.channelCursor.channels!.set(userAddress, channel);
 
   return registry;
@@ -106,7 +106,7 @@ export async function setupRecipientChannel(
   // Sender sets up channel to recipient
   executeOutside(await sender.build().setup(recipientAddress).execute());
 
-  let channel = (await sender.discoverChannels([recipientAddress])).channels!.get(
+  let channel = (await sender.discoverChannels({ recipients: [recipientAddress] })).channels!.get(
     recipientAddress
   )!;
   const registry = new PrivateRegistry();
@@ -116,7 +116,7 @@ export async function setupRecipientChannel(
   executeOutside(await sender.build({ registry }).with(token).setup(recipientAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await sender.discoverChannels([recipientAddress])).channels!.get(recipientAddress)!;
+  channel = (await sender.discoverChannels({ recipients: [recipientAddress] })).channels!.get(recipientAddress)!;
   registry.channelCursor.channels!.set(recipientAddress, channel);
 
   return registry;

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -292,7 +292,7 @@ describe("IndexerDiscoveryProvider", () => {
   });
 
   describe("discoverChannels", () => {
-    it("returns channels for 'all' recipients on a single page", async () => {
+    it("returns channels for all recipients on a single page", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({
         body: outgoingSyncResponse({
@@ -309,7 +309,7 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(fetchMock).toHaveBeenCalledOnce();
       expect(result.timestamp).toBe(BLOCK_REF);
@@ -324,7 +324,7 @@ describe("IndexerDiscoveryProvider", () => {
       expect(tokenNonces!.noteNonce).toBe(3); // last_note_index 2 + 1
     });
 
-    it("paginates 'all' recipients across 2 pages and merges", async () => {
+    it("paginates all recipients across 2 pages and merges", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson(
         {
@@ -354,7 +354,7 @@ describe("IndexerDiscoveryProvider", () => {
         }
       );
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
@@ -377,10 +377,9 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, [
-        BigInt(RECIPIENT_ADDR),
-        BigInt(RECIPIENT_ADDR_2),
-      ]);
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, {
+        recipients: [BigInt(RECIPIENT_ADDR), BigInt(RECIPIENT_ADDR_2)],
+      });
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.recipients).toBeDefined();
@@ -390,13 +389,13 @@ describe("IndexerDiscoveryProvider", () => {
       expect(result.channels!.has(BigInt(RECIPIENT_ADDR_2))).toBe(true);
     });
 
-    it("does not send recipients field for 'all' filter", async () => {
+    it("does not send recipients field when recipients is undefined", async () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({
         body: outgoingSyncResponse(),
       });
 
-      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.recipients).toBeUndefined();
@@ -422,7 +421,7 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       expect(result.total).toBe(5);
       expect(result.channels).toBeDefined();
@@ -446,7 +445,7 @@ describe("IndexerDiscoveryProvider", () => {
         }),
       });
 
-      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const channel = result.channels!.get(BigInt(RECIPIENT_ADDR));
       expect(channel).toBeDefined();
@@ -511,7 +510,7 @@ describe("IndexerDiscoveryProvider", () => {
       const provider = createProvider();
       const fetchMock = mockFetchJson({ body: outgoingSyncResponse() });
 
-      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "all");
+      await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY);
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody.contract_address).toBe("0x123");

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -170,7 +170,7 @@ describe("Private Transfers Integration", () => {
       // Phase 2: Use registry with channels but WITHOUT notes
       // This tests autoDiscover: "missing" (discovers notes not in registry)
       const channelOnly = new PrivateRegistry();
-      const channel = (await alice.discoverChannels([env.alice.address])).channels!.get(
+      const channel = (await alice.discoverChannels({ recipients: [env.alice.address] })).channels!.get(
         env.alice.address
       )!;
       channelOnly.channelCursor = { channels: new AddressMap() };

--- a/sdk/tests/internal/parallel-discovery.test.ts
+++ b/sdk/tests/internal/parallel-discovery.test.ts
@@ -196,7 +196,7 @@ describe("Parallel Discovery", () => {
 
     // Discover channels for Alice (outgoing channels to all recipients)
     const recipientAddresses = recipients.map((r) => r.address);
-    await discovery.discoverChannels(aliceAddress, aliceKey, recipientAddresses);
+    await discovery.discoverChannels(aliceAddress, aliceKey, { recipients: recipientAddresses });
 
     const report = profiler.getReport();
     console.log("\n" + formatReport(report));


### PR DESCRIPTION
## Summary

  - Remove `RecipientsFilter` type (`T[] | "all"`) — callers now omit `recipients` for "all" instead of passing a
  string literal
  - `DiscoveryProviderInterface.discoverChannels`: positional `recipients` arg merged into `params` object
  - `PrivateTransfersInterface.discoverChannels`: `(recipients, params?)` → `(params?)`
  - Addresses reviewer feedback that `undefined` is confusing — by making `recipients` an optional named param, no
   one writes `undefined` explicitly

  ## Test plan

  - [x] All `"all"` → omit, `[recipients]` → `{ recipients: [...] }` across SDK tests and e2e
  - [x] `npm run lint` passes (0 new type errors)
  - [x] `npm test` — 162/162 tests pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/655)
<!-- Reviewable:end -->
