### PR TITLE
refactor(sdk): separate discovery and note selection phases in compiler

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -220,9 +220,9 @@ export type Actions = {
 
 /**
  * Discovery level controls when/whether to call the discovery service.
- * - 'none': Never call discovery. Missing data → error.
- * - 'missing': Only discover when data is missing from registry. Trust existing registry contents.
- * - 'refresh': Always discover. Use registry as optimization hint.
+ * - undefined: No discovery.
+ * - 'missing': Discover with existing cursor (skip already-known data).
+ * - 'refresh': Discover from scratch (empty cursor, full rescan).
  */
 export type DiscoveryLevel = "missing" | "refresh";
 
@@ -230,8 +230,14 @@ export type DiscoveryLevel = "missing" | "refresh";
  * Options for automatic discovery during execute.
  */
 export type AutoDiscoveryOptions = {
-  /** Discovery level for notes. 'all' means discover all tokens regardless if used in the actions */
-  notes?: DiscoveryLevel | "all";
+  /**
+   * Discovery level for notes.
+   * - 'missing': Discover with existing cursor (skip already-scanned data).
+   * - 'refresh': Discover from scratch (empty cursor, full rescan).
+   *
+   * Token filter defaults to tokens referenced in the current actions.
+   */
+  notes?: DiscoveryLevel;
   /** Discovery level for recipient channels (includes self) */
   channels?: DiscoveryLevel;
 };
@@ -375,22 +381,39 @@ export interface PrivateTransfersInterface {
   ): Promise<SetupRequirement>;
 
   /**
-   * Discover unspent notes per token
+   * Discover unspent notes per token.
    *
+   * When `registry` is provided, uses `registry.notesCursor` to seed the
+   * discovery cursor and updates the registry in-place after discovery:
+   * - `"missing"`: incremental — sends existing cursor, appends newly
+   *   discovered notes to existing ones.
+   * - `"refresh"`: full rescan — ignores cursor, replaces notes per token.
+   *
+   * When `registry` is omitted, returns raw results without side effects.
    */
-  discoverNotes(params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }): Promise<{
+  discoverNotes(params?: {
+    registry?: PrivateRegistry;
+    level?: DiscoveryLevel;
+    tokens?: StarknetAddressBigint[];
+  }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
+    cursor: NotesCursor;
   }>;
 
   /**
    * Discover channels for one or more recipients.
    * Omit `recipients` to discover all outgoing channels.
    * Pass an array for specific recipients (server also precomputes channels for them).
+   *
+   * When `registry` is provided, uses `registry.channelCursor` to seed
+   * the discovery cursor and merges the result back in-place.
+   * When `registry` is omitted, returns raw results without side effects.
    */
   discoverChannels(params?: {
+    registry?: PrivateRegistry;
+    level?: DiscoveryLevel;
     recipients?: StarknetAddress[];
-    cursor?: ChannelCursor;
   }): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -9,10 +9,13 @@ import type { BlockIdentifier } from "starknet";
 import type {
   Actions,
   Channel,
+  DiscoveryLevel,
   DiscoveryProviderInterface,
   ExecuteOptions,
   ExecuteResult,
   Note,
+  NotesCursor,
+  PrivateRegistry,
   PrivateTransfersBuilder,
   PrivateTransfersInterface,
   ProofInvocationResult,
@@ -25,7 +28,6 @@ import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { toBigInt } from "../utils/crypto.js";
 import { PrivateTransfersBuilderImpl } from "./builders.js";
-import type { ChannelCursor, NotesCursor } from "./channel.js";
 
 /**
  * Abstract base class that implements the common functionality for PrivateTransfers.
@@ -50,35 +52,70 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   }
 
   /**
-   * Discover unspent notes per token
+   * Discover unspent notes per token.
+   * When `registry` and `level` are provided, updates the registry in-place.
    */
-  async discoverNotes(params: { since?: BlockIdentifier; cursor?: NotesCursor } = {}): Promise<{
+  async discoverNotes(
+    params: {
+      registry?: PrivateRegistry;
+      level?: DiscoveryLevel;
+      tokens?: StarknetAddressBigint[];
+    } = {}
+  ): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
+    cursor: NotesCursor;
   }> {
-    return this.discoveryProvider.discoverNotes(this.user, await this.getViewingKey(), params);
+    const { registry, level, tokens } = params;
+
+    const result = await this.discoveryProvider.discoverNotes(
+      this.user,
+      await this.getViewingKey(),
+      { cursor: level === "missing" ? registry?.notesCursor : undefined, tokens }
+    );
+
+    if (registry) {
+      registry.applyDiscoveredNotes(level, result.notes, result.cursor);
+    }
+
+    return { timestamp: result.timestamp, notes: result.notes, cursor: result.cursor };
   }
 
   /**
    * Discover channels for one or more recipients.
-   * Omit `recipients` to discover all outgoing channels.
+   * When `registry` is provided, updates `channelCursor` in-place.
    */
   async discoverChannels(
     params: {
+      registry?: PrivateRegistry;
+      level?: DiscoveryLevel;
       recipients?: StarknetAddress[];
-      cursor?: ChannelCursor;
     } = {}
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<Channel>;
     total?: number;
   }> {
-    const { recipients, ...rest } = params;
-    return this.discoveryProvider.discoverChannels(
+    const { registry, level, recipients } = params;
+
+    const result = await this.discoveryProvider.discoverChannels(
       this.user,
       await this.getViewingKey(),
-      { recipients: recipients?.map(toBigInt), ...rest }
+      {
+        recipients: recipients?.map(toBigInt),
+        cursor: level === "missing" ? registry?.channelCursor : undefined,
+      }
     );
+
+    if (registry) {
+      registry.applyDiscoveredChannels(result.cursor);
+    }
+
+    return {
+      timestamp: result.timestamp,
+      channels: result.channels,
+      total: result.total,
+    };
   }
 
   /**

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -19,9 +19,9 @@
 import type {
   Actions,
   Amount,
+  DiscoveryLevel,
   DiscoveryProviderInterface,
   ExecuteOptions,
-  Note,
   StarknetAddressBigint,
   ViewingKey,
   Warning,
@@ -121,8 +121,15 @@ export class ActionCompiler {
       recipientsNeeded
     );
 
-    // Phase 2: Resolve notes (discover and/or auto-select)
-    await this.resolveNotes(actions, registry, options);
+    // Phase 2a: Discover notes (update registry)
+    const notesDiscoveryLevel = options?.autoDiscover?.notes;
+    if (notesDiscoveryLevel) {
+      const actionTokens = this.getActionTokens(actions);
+      await this.discoverNotes(registry, notesDiscoveryLevel, actionTokens);
+    }
+
+    // Phase 2b: Resolve notes (select from registry, handle surpluses)
+    this.resolveNotes(actions, registry, options);
 
     debugLog("compiler", "compile", "post resolveNotes", registry?.notes?.size, actions);
 
@@ -182,6 +189,16 @@ export class ActionCompiler {
       }
     }
     return recipientsNeeded;
+  }
+
+  private getActionTokens(actions: Actions): StarknetAddressBigint[] {
+    const tokens = new Set<bigint>();
+    for (const d of actions.deposits ?? []) tokens.add(d.token);
+    for (const u of actions.useNotes ?? []) tokens.add(u.token);
+    for (const w of actions.withdraws ?? []) tokens.add(w.token);
+    for (const c of actions.createNotes ?? []) tokens.add(c.token);
+    for (const s of actions.surpluses ?? []) tokens.add(s.token);
+    return [...tokens];
   }
 
   private createPool(
@@ -523,13 +540,40 @@ export class ActionCompiler {
   }
 
   /**
-   * Resolve notes by discovering and/or auto-selecting from registry.
+   * Discover notes and update registry. Token filter controls which tokens to fetch;
+   * undefined means all tokens.
    */
-  private async resolveNotes(
+  private async discoverNotes(
+    registry: PrivateRegistry,
+    notesDiscoveryLevel: DiscoveryLevel,
+    tokenFilter?: StarknetAddressBigint[]
+  ): Promise<void> {
+    const tokensToDiscover = tokenFilter ?? undefined;
+
+    debugLog("compiler", "discovering notes", tokensToDiscover);
+
+    if (!tokensToDiscover || tokensToDiscover.length > 0) {
+      const { notes, cursor } = await this.discoveryProvider.discoverNotes(
+        this.userAddress,
+        this.userViewingKey,
+        {
+          cursor: notesDiscoveryLevel === "missing" ? registry.notesCursor : undefined,
+          tokens: tokensToDiscover,
+        }
+      );
+      registry.applyDiscoveredNotes(notesDiscoveryLevel, notes, cursor);
+    }
+  }
+
+  /**
+   * Resolve note selection: compute balances, auto-select notes from registry,
+   * and create surplus/change actions.
+   */
+  private resolveNotes(
     actions: Actions,
     registry: PrivateRegistry,
     options?: ExecuteOptions
-  ): Promise<void> {
+  ): void {
     if (!actions.surpluses && !options?.autoSelectNotes) return;
 
     // Calculate token balances (inputs - outputs)
@@ -584,47 +628,6 @@ export class ActionCompiler {
         if (!isOpen(c.amount)) {
           update(c.token, -c.amount);
         }
-      }
-    }
-
-    const notesDiscoveryLevel = options?.autoDiscover?.notes;
-    // discover notes if requested
-    if (notesDiscoveryLevel !== undefined) {
-      const tokensToDiscover = (() => {
-        if (notesDiscoveryLevel === "all") return undefined;
-        return [...balances.entries()]
-          .filter(([token, balance]) => {
-            // Case 1: We have a deficit (negative balance), so we need inputs.
-            const hasDeficit = balance < 0n;
-
-            // Case 2: We want to sweep all funds (autoSelectNotes="all") into a surplus recipient.
-            // Even if balance is 0, we check if we should fetch notes to dump them.
-            const isSweeping =
-              options?.autoSelectNotes === "all" && // assume 'all' means the user wants to always "compress" their notes even if balance is 0
-              actions.surpluses?.some((s) => s.token === token);
-
-            if (!hasDeficit && !isSweeping) return false;
-
-            // Finally, check if discovery is actually needed (forced refresh or missing from registry)
-            return notesDiscoveryLevel === "refresh" || !registry.notes.has(token);
-          })
-          .map(([token]) => token);
-      })();
-
-      debugLog("compiler", "discovering notes", tokensToDiscover);
-
-      if (!tokensToDiscover || tokensToDiscover.length > 0) {
-        const { notes, cursor } = await this.discoveryProvider.discoverNotes(
-          this.userAddress,
-          this.userViewingKey,
-          { cursor: registry.notesCursor, tokens: tokensToDiscover }
-        );
-
-        // Replace registry notes (don't merge - some may have been spent)
-        for (const [token, discoveredNotes] of notes.entries()) {
-          registry.notes.set(token, discoveredNotes);
-        }
-        registry.notesCursor = cursor;
       }
     }
 

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -7,7 +7,6 @@ import {
   PrivateRegistry,
   PrivateTransfersInterface,
 } from "../../src/interfaces.js";
-import { AddressMap } from "../../src/utils/maps.js";
 
 export const POOL_ADDRESS = 0x1n;
 
@@ -66,22 +65,18 @@ export async function setupSelfChannel(
 ): Promise<PrivateRegistry> {
   const executeOutside = (result: ExecuteResult) => {
     pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
   };
 
   executeOutside(await user.build().register().execute());
   executeOutside(await user.build().setup(userAddress).execute());
 
-  let channel = (await user.discoverChannels({ recipients: [userAddress] })).channels!.get(userAddress)!;
   const registry = new PrivateRegistry();
-  registry.channelCursor = { channels: new AddressMap() };
-  registry.channelCursor.channels!.set(userAddress, channel);
+  await user.discoverChannels({ registry, level: "refresh", recipients: [userAddress] });
 
   executeOutside(await user.build({ registry }).with(token).setup(userAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await user.discoverChannels({ recipients: [userAddress] })).channels!.get(userAddress)!;
-  registry.channelCursor.channels!.set(userAddress, channel);
+  await user.discoverChannels({ registry, level: "refresh", recipients: [userAddress] });
 
   return registry;
 }
@@ -97,7 +92,6 @@ export async function setupRecipientChannel(
 ): Promise<PrivateRegistry> {
   const executeOutside = (result: ExecuteResult) => {
     pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
   };
 
   // Recipient must be registered first
@@ -106,20 +100,20 @@ export async function setupRecipientChannel(
   // Sender sets up channel to recipient
   executeOutside(await sender.build().setup(recipientAddress).execute());
 
-  let channel = (await sender.discoverChannels({ recipients: [recipientAddress] })).channels!.get(
-    recipientAddress
-  )!;
   const registry = new PrivateRegistry();
-  registry.channelCursor = { channels: new AddressMap() };
-  registry.channelCursor.channels!.set(recipientAddress, channel);
+  await sender.discoverChannels({ registry, level: "refresh", recipients: [recipientAddress] });
 
   executeOutside(await sender.build({ registry }).with(token).setup(recipientAddress).execute());
 
   // Refresh channel to include token info
-  channel = (await sender.discoverChannels({ recipients: [recipientAddress] })).channels!.get(recipientAddress)!;
-  registry.channelCursor.channels!.set(recipientAddress, channel);
+  await sender.discoverChannels({ registry, level: "refresh", recipients: [recipientAddress] });
 
   return registry;
+}
+
+/** Shorthand for verification-only discovery: fresh registry, full rescan. */
+export function freshDiscover() {
+  return { registry: new PrivateRegistry(), level: "refresh" as const };
 }
 
 // Re-export commonly used utilities

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -7,7 +7,6 @@ import {
   POOL_ADDRESS,
 } from "../helpers/test-fixtures.js";
 import { Open } from "../../src/interfaces.js";
-import { AddressMap } from "../../src/utils/maps.js";
 import { debugHint, isDebugEnabled, toBigInt } from "../../src/utils/index.js";
 import { debugLog } from "../../src/utils/logging.js";
 import { toHex } from "../../src/utils/convert.js";
@@ -168,13 +167,13 @@ describe("Private Transfers Integration", () => {
       );
 
       // Phase 2: Use registry with channels but WITHOUT notes
-      // This tests autoDiscover: "missing" (discovers notes not in registry)
+      // This tests autoDiscover: "missing" for notes (discovers notes not in registry)
       const channelOnly = new PrivateRegistry();
-      const channel = (await alice.discoverChannels({ recipients: [env.alice.address] })).channels!.get(
-        env.alice.address
-      )!;
-      channelOnly.channelCursor = { channels: new AddressMap() };
-      channelOnly.channelCursor.channels!.set(env.alice.address, channel);
+      await alice.discoverChannels({
+        registry: channelOnly,
+        level: "refresh",
+        recipients: [env.alice.address],
+      });
 
       // Deposit 30n with:
       // - autoSelectNotes: "all" (sweeps ALL notes, not just enough for deficit)


### PR DESCRIPTION
## Summary

  - Discovery and note selection are now separate phases in the compiler:
    - Phase 2a: `discoverNotes()` — async, fetches from provider, updates registry
    - Phase 2b: `resolveNotes()` — sync, selects from registry, handles surpluses
  - `AutoDiscoveryOptions.notes` no longer accepts `"all"` — token filter is derived from actions automatically
  via `getActionTokens()`
  - `PrivateTransfersInterface.discoverNotes/discoverChannels` accept `{ registry, level }` and apply results via
  registry methods
  - Test fixtures simplified: `discoverChannels({ registry, level: "refresh" })` replaces manual cursor
  construction

  ## Test plan

  - [x] `npm run lint` passes (0 new type errors)
  - [x] `npm test` — 162/162 tests pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/656)
<!-- Reviewable:end -->
