### PR TITLE
refactor(sdk): return registry update data instead of mutated registry

### DIFF
--- a/e2e/tests/reorg-recovery.test.ts
+++ b/e2e/tests/reorg-recovery.test.ts
@@ -69,7 +69,7 @@ describe("E2E Reorg Recovery", () => {
     // Second operation: withdraw triggers a deficit, forcing note discovery.
     // Note discovery sends the fake cursor → indexer returns 409 →
     // ReorgError → compiler clears registry → retries from scratch → succeeds.
-    const { registry: updatedRegistry } = await transfers.alice
+    const { registryUpdate } = await transfers.alice
       .build({
         autoDiscover: { notes: "refresh", channels: "refresh" },
         autoSelectNotes: "naive",
@@ -83,10 +83,11 @@ describe("E2E Reorg Recovery", () => {
     // Verify recovery succeeded:
     // - No error thrown (reorg was handled internally)
     // - Registry notesCursor was cleared and re-populated with a valid blockId
-    expect(updatedRegistry.notesCursor).toBeDefined();
+    // (the compiler clears and re-discovers, so registry.notesCursor is updated)
+    expect(registry.notesCursor).toBeDefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((updatedRegistry.notesCursor as any).blockId).not.toBe("0xdeadbeef");
-    // - Notes were re-discovered (Alice has a 50 STRK change note)
-    expect(updatedRegistry.notes.size).toBeGreaterThanOrEqual(1);
+    expect((registry.notesCursor as any).blockId).not.toBe("0xdeadbeef");
+    // - Notes were re-discovered (registryUpdate has Alice's change note)
+    expect(registryUpdate.notes.size).toBeGreaterThanOrEqual(1);
   });
 });

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,11 +5,18 @@
 ### Breaking
 
 - Rename npm package from `starknet-sdk` to `@starkware-libs/starknet-privacy-sdk`, published to GitHub Packages
+- `PrivateRegistry` is now a class (was a type alias). Object literals `{ notes: new AddressMap(...) }` no longer satisfy the type — use `new PrivateRegistry()`.
+- `ExecuteResult.applyRegistryUpdate` closure replaced with `ExecuteResult.registryUpdate: RegistryUpdate` data object. Migration: `result.applyRegistryUpdate(registry)` -> `registry.applyExecuteResult(result.registryUpdate)`.
+- `ProofInvocationResult.applyRegistryUpdate` — same change as `ExecuteResult`.
+- `discoverNotes` return type now includes `cursor: NotesCursor` (in addition to `timestamp` and `notes`).
 - `PrivateTransfersBuilder.invoke()` now accepts only a `callBuilder(args) => CallDetails` callback (raw/manual invoke input removed).
 - `SimplePrivateTransfersInterface.swap()` now takes executor address directly instead of an object (`swap(fromToken, fromAmount, toToken, executorAddress)`).
 
 ### Changed
 
+- `PrivateRegistry` gains `applyDiscoveredNotes()`, `applyDiscoveredChannels()`, and `applyExecuteResult()` methods, encapsulating all registry mutation logic.
+- `PoolSimulator.createRegistryUpdate()` returns `RegistryUpdate` data object instead of a closure.
+- Cursor/merge logic in compiler.ts and abstract-private-transfers.ts replaced with registry method calls.
 - Switch `starknet` dependency from `m-kus/starknet.js` fork to `starkware-industries/starknet.js`
 - `invoke` call builder now receives structured context: `{ openNotes, withdrawals, poolAddress }`.
 
@@ -20,6 +27,8 @@
 
 ### Added
 
+- `RegistryUpdate` type exported from interfaces.ts.
+- README rewritten with three comprehensive state management flows (discovery, post-tx update, periodic refresh).
 - Invoke action support (#499)
 
 ## 0.1.0-dev.1

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -204,68 +204,130 @@ const result = await transfers.build({
 | `autoRegister` | `boolean` | Automatically register if user has no viewing key on-chain |
 | `autoSetup` | `boolean` | Automatically open channels and token subchannels as needed |
 | `autoSelectNotes` | `"all" \| "naive"` | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum) |
-| `autoDiscover` | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`) |
-| `registry` | `PrivateRegistry` | User's private state (notes, discovery cursors) |
-| `registryConst` | `boolean` | If true, returns a new registry instead of mutating the provided one |
+| `autoDiscover` | `{ notes?, channels? }` | Discovery strategy for notes/channels before executing (`"missing"` or `"refresh"`) |
+| `registry` | `PrivateRegistry` | User's private state (notes, discovery cursors). Discovery updates are applied in-place. |
 | `provingBlockId` | `ProvingBlockId` | Block identifier to use for proving |
 
-## Registry management
+## State management
 
-The `PrivateRegistry` holds the user's private state: unspent notes and discovery cursors. Create one with `new PrivateRegistry()` and pass it through `ExecuteOptions`.
+### Registry
+
+The `PrivateRegistry` holds the user's local private state:
 
 ```typescript
 import { PrivateRegistry } from "starknet-sdk";
 
 const registry = new PrivateRegistry();
+```
 
-// The registry is updated in-place after each execute()
+It contains:
+- **`notes`** — `AddressMap<Note[]>`: unspent notes keyed by token address
+- **`notesCursor`** — pagination cursor for incoming notes discovery
+- **`channelCursor`** — pagination cursor for outgoing channels discovery (includes `blockId` for reorg detection)
+
+### Discovery strategies
+
+Both `autoDiscover` (transaction-scoped) and `discoverNotes`/`discoverChannels` (direct) support two strategies:
+
+| Strategy | Cursor | Notes merge | Use case |
+|----------|--------|-------------|----------|
+| `"missing"` | Sends existing cursor — server skips already-known data | Appends newly discovered notes | Incremental sync, efficient for polling |
+| `"refresh"` | No cursor — full rescan from scratch | Replaces notes per token | Recover from stale state, first load |
+
+### Flow 1: Transaction discovery
+
+The SDK discovers the minimum state needed to build a transaction when `autoDiscover` is set. Discovery is scoped to the tokens and recipients in the current actions:
+
+```typescript
 const result = await transfers.build({
   registry,
-  autoDiscover: { notes: "refresh", channels: "refresh" },
+  autoDiscover: { notes: "missing", channels: "missing" },
   autoSetup: true,
   autoSelectNotes: "naive",
 }).with(STRK, (t) => t
-  .deposit({ amount: 100n }))
-.surplusTo(self)
+  .transfer({ recipient: bob, amount: 50n }))
 .execute();
-
-// result.registry === registry (same object, mutated)
-// Use registryConst: true to get a new object instead
 ```
 
-The registry contains:
-- **`notes`** — `AddressMap<Note[]>`: unspent notes keyed by token address
-- **`notesCursor`** — pagination cursor for incoming notes discovery (incremental sync)
-- **`channelCursor`** — pagination cursor for outgoing channels discovery (incremental sync, includes `blockId` for reorg detection)
+The compiler discovers notes for STRK and channels for Bob, using cursors from the registry for incremental updates. After compilation, the registry's cursors are updated in-place so subsequent calls skip already-known data.
 
-Discovery cursors are internal to the registry flow. When `autoDiscover` is set, the SDK uses them automatically for incremental syncing. You don't need to manage them directly.
+### Flow 2: Post-transaction update
 
-**Optimistic updates:** After `execute()`, the registry is updated optimistically — spent notes are removed and new notes/channels are added before the transaction is confirmed on-chain. If the transaction reverts, the registry becomes stale. Handle this by re-discovering from scratch (`autoDiscover: "refresh"`) or by snapshotting the registry before `execute()` (use `registryConst: true`) and restoring on revert.
+After `execute()`, the SDK returns a `registryUpdate` — the expected state changes from the transaction. The SDK does not apply it automatically because it cannot know whether the on-chain transaction will succeed or revert.
 
-## Discovery
+**Option A: Incremental update** — fast, applies immediately after tx confirmation:
 
-### Check transfer readiness
+```typescript
+const receipt = await sendTransaction(result.callAndProof);
+
+if (receipt.isSuccess) {
+  registry.applyExecuteResult(result.registryUpdate);
+}
+```
+
+**Option B: Re-discover** — slower but reflects actual on-chain state:
+
+```typescript
+const receipt = await sendTransaction(result.callAndProof);
+
+if (receipt.isSuccess) {
+  // Notes must use "refresh" — spent notes need to be removed, not just appended
+  await transfers.discoverNotes({ registry, level: "refresh" });
+  // Channels can use "missing" — channels are never spent, only added
+  await transfers.discoverChannels({ registry, level: "missing" });
+}
+```
+
+On failure, the registry is unchanged.
+
+### Flow 3: Periodic refresh
+
+Use direct discovery to keep the registry up to date — for displaying balances, populating the address book (outgoing channels), and syncing state across devices.
+
+```typescript
+// Incremental balance update — fetch only new notes since last sync
+await transfers.discoverNotes({ registry, level: "missing" });
+
+// Incremental address book update — fetch only new channels since last sync
+await transfers.discoverChannels({ registry, level: "missing" });
+```
+
+For token-scoped or recipient-scoped discovery:
+
+```typescript
+// Only discover STRK notes
+await transfers.discoverNotes({ registry, level: "missing", tokens: [STRK] });
+
+// Only discover channels to specific recipients
+await transfers.discoverChannels({ registry, level: "missing", recipients: [bob, alice] });
+```
+
+For first load or to recover from stale state, use `"refresh"`:
+
+```typescript
+await transfers.discoverNotes({ registry, level: "refresh" });
+await transfers.discoverChannels({ registry, level: "refresh" });
+```
+
+Discovery is cursor-driven and stateless on the server. To sync across devices, persist and restore the registry (including its cursors). Notes must use `"refresh"` because another device may have spent notes that this device still considers unspent — `"missing"` would only append, never remove. Channels can use `"missing"` since channels are append-only and never deleted.
+
+```typescript
+await transfers.discoverNotes({ registry, level: "refresh" });
+await transfers.discoverChannels({ registry, level: "missing" });
+```
+
+> **Future optimisation:** a batch nullifier check method may be added to verify whether existing notes are spent, enabling incremental note sync across devices without a full rescan.
+
+### Setup requirement check
+
+Before transferring to a new recipient, check whether setup is needed:
 
 ```typescript
 const requirement = await transfers.discoverRequirement(recipient, token);
 // Returns: SetupRequirement.Register | SetupChannel | SetupToken | Ready
 ```
 
-### Discover notes
-
-```typescript
-const { notes, timestamp } = await transfers.discoverNotes({
-  tokens: [STRK],
-});
-// notes: AddressMap<Note[]> — unspent notes keyed by token address
-```
-
-### Discover channels
-
-```typescript
-const { timestamp, channels, total } = await transfers.discoverChannels("all");
-// channels: AddressMap<Channel> — channels keyed by recipient address
-```
+With `autoSetup: true` in execute options, the SDK handles this automatically.
 
 ## Execute result
 
@@ -273,13 +335,13 @@ Every `execute()` call returns:
 
 ```typescript
 type ExecuteResult = {
-  callAndProof: CallAndProof;  // Call + proof to send to the contract's execute_actions entry point
-  registry: PrivateRegistry;   // Updated notes and recipient info
-  warnings: Warning[];         // Privacy leakage warnings
+  callAndProof: CallAndProof;    // Call + proof for the contract
+  registryUpdate: RegistryUpdate; // Optimistic state for post-tx update
+  warnings: Warning[];            // Privacy leakage warnings
 };
 ```
 
-The wallet sends `callAndProof` in a transaction to the contract's `execute_actions` entry point. The returned `registry` can be reused in subsequent calls once the transaction is accepted and enough blocks have passed to make the state verifiable.
+The wallet sends `callAndProof` in a transaction to the contract's `apply_actions` entry point. After the transaction is confirmed, call `registry.applyExecuteResult(result.registryUpdate)` to update spent notes and add newly created notes/channels.
 
 ## Key types
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -268,10 +268,8 @@ export type ExecuteOptions = {
   autoSetup?: boolean;
   /** If defined, auto select notes from registry. **/
   autoSelectNotes?: AutoSelectionStrategy;
-  /** Registry for context/notes lookup. Updated during execute unless registryConst is true. */
+  /** Registry for context/notes lookup. Discovery updates are applied in-place. */
   registry?: PrivateRegistry;
-  /** If true, registry is not mutated; a new one is returned instead */
-  registryConst?: boolean;
   /** If defined, use the given block id for proving */
   provingBlockId?: ProvingBlockId;
 };
@@ -285,19 +283,18 @@ export enum WarningCode {
   USER_LINKAGE = "USER_LINKAGE",
 }
 /**
- * Result of execute, including the call/proof and updated registry.
+ * Result of execute.
  */
 export type ExecuteResult = {
   callAndProof: CallAndProof;
-  /** Updated registry (new object if registryConst was true, same object otherwise) */
-  registry: PrivateRegistry;
-
+  /** Post-execution state for optimistic registry update. Apply via `registry.applyExecuteResult()`. */
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 
 export type ProofInvocationResult = {
   invocation: ProofInvocation;
-  registry: PrivateRegistry;
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -73,7 +73,6 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
   };
 }
 
-
 export type ChannelCursor = {
   /** @internal */ blockId?: BlockIdentifier;
   /** @internal */ channels?: AddressMap<Channel>;
@@ -183,6 +182,18 @@ export class PrivateRegistry {
       this.channelCursor = cursor;
     } else {
       mergeChannelCursor(this.channelCursor, cursor);
+    }
+  }
+
+  /** Apply post-execution optimistic update (channels and notes, without touching cursors). */
+  applyExecuteResult(update: RegistryUpdate): void {
+    for (const [address, channel] of update.channels) {
+      this.channelCursor ??= {};
+      this.channelCursor.channels ??= new AddressMap<Channel>();
+      this.channelCursor.channels.set(address, channel);
+    }
+    for (const [token, tokenNotes] of update.notes) {
+      this.notes.set(token, tokenNotes);
     }
   }
 }

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -26,7 +26,7 @@ import type {
   ViewingKey,
   Warning,
 } from "../interfaces.js";
-import { Channel, PrivateRegistry, WarningCode } from "../interfaces.js";
+import { Channel, PrivateRegistry, WarningCode, type RegistryUpdate } from "../interfaces.js";
 import { AddressMap, AdvancedMap, toBigInt } from "../utils/index.js";
 import type { ClientAction } from "./client-actions.js";
 import { PoolSimulator } from "./pool-simulator.js";
@@ -42,7 +42,8 @@ import { ReorgError } from "./indexer/index.js";
 
 export type CompileResult = {
   clientActions: ClientAction[];
-  registry: PrivateRegistry;
+  /** Optimistic state update (new notes and channels). Apply via `registry.applyExecuteResult()` after tx confirmation. */
+  registryUpdate: RegistryUpdate;
   warnings: Warning[];
 };
 
@@ -109,8 +110,7 @@ export class ActionCompiler {
   }
 
   private async compileOnce(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
-    const registry_ = options?.registry ?? new PrivateRegistry();
-    const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
+    const registry = options?.registry ?? new PrivateRegistry();
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
     // Phase 1: Resolve recipient channels
@@ -143,7 +143,7 @@ export class ActionCompiler {
 
     return {
       clientActions,
-      registry: pool.updateRegistry(registry),
+      registryUpdate: pool.createRegistryUpdate(),
       warnings: this.checkWarnings(clientActions),
     };
   }
@@ -689,13 +689,4 @@ export class ActionCompiler {
       }
     }
   }
-
-  private cloneRegistry(registry: PrivateRegistry): PrivateRegistry {
-    const cloned = new PrivateRegistry();
-    cloned.notesCursor = registry.notesCursor;
-    cloned.channelCursor = registry.channelCursor;
-    for (const [addr, notes] of registry.notes.entries()) {
-      cloned.notes.set(addr, [...notes]);
-    }
-    return cloned;
-  }}
+}

--- a/sdk/src/internal/indexer/discovery.ts
+++ b/sdk/src/internal/indexer/discovery.ts
@@ -213,10 +213,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     cursor: ChannelCursor;
   }> {
     const recipients = params?.recipients;
-    let apiCursor = channelMapToApiCursor(
-      params?.cursor?.channels,
-      recipients
-    );
+    let apiCursor = channelMapToApiCursor(params?.cursor?.channels, recipients);
 
     // Accumulate channel/subchannel data across all pagination pages.
     const createdChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();

--- a/sdk/src/internal/pool-simulator.ts
+++ b/sdk/src/internal/pool-simulator.ts
@@ -12,8 +12,8 @@
  * - Just tracks Channel objects with nonces and Note objects
  */
 
-import type { Note, PrivateRegistry, StarknetAddressBigint } from "../interfaces.js";
-import { Channel } from "./channel.js";
+import type { Note, StarknetAddressBigint } from "../interfaces.js";
+import { Channel, type RegistryUpdate } from "./channel.js";
 import { derivePublicKey, toBigInt } from "../utils/crypto.js";
 import { AddressMap } from "../utils/maps.js";
 import type {
@@ -136,25 +136,14 @@ export class PoolSimulator {
     this.notes.get(token)!.set(toBigInt(note.id), note);
   }
 
-  /**
-   * Export tracked state back to the registry.
-   *
-   * TODO: This applies optimistic updates (spent notes removed, new notes/channels added)
-   * before the transaction is confirmed on-chain. If the transaction reverts, the registry
-   * becomes stale — spent notes are gone and phantom notes/channels are present. Callers
-   * must handle this by re-discovering from scratch (e.g. `autoDiscover: "refresh"`) or
-   * by snapshotting the registry before execute and restoring on revert.
-   */
-  updateRegistry(registry: PrivateRegistry): PrivateRegistry {
-    for (const [address, channel] of this.channels.entries()) {
-      registry.channelCursor ??= {};
-      registry.channelCursor.channels ??= new AddressMap<Channel>();
-      registry.channelCursor.channels.set(address, channel);
-    }
-    for (const [token, notes] of this.notes.entries()) {
-      registry.notes.set(token, Array.from(notes.values()));
-    }
-    return registry;
+  /** Returns data for optimistic registry updates after tx inclusion. */
+  createRegistryUpdate(): RegistryUpdate {
+    return {
+      channels: this.channels,
+      notes: new AddressMap<Note[]>(
+        [...this.notes].map(([token, noteMap]): [bigint, Note[]] => [token, [...noteMap.values()]])
+      ),
+    };
   }
 
   private handleSetViewingKey(_input: SetViewingKeyInput): void {

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -61,7 +61,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     );
 
     // Compile actions
-    const { clientActions, registry, warnings } = await compiler.compile(actions, options);
+    const { clientActions, registryUpdate, warnings } = await compiler.compile(actions, options);
 
     // Create invocation for proving
     const details = this.params.provingProvider.getDefaultDetails();
@@ -72,11 +72,14 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       details
     );
 
-    return { invocation, registry, warnings };
+    return { invocation, registryUpdate, warnings };
   }
 
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
-    const { invocation, registry, warnings } = await this.createProofInvocation(actions, options);
+    const { invocation, registryUpdate, warnings } = await this.createProofInvocation(
+      actions,
+      options
+    );
 
     // Get proof from provider (block id only when provided in options)
     const proof = await this.params.provingProvider.prove(invocation, options?.provingBlockId);
@@ -99,7 +102,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
         },
         proof,
       },
-      registry,
+      registryUpdate,
       warnings,
     };
   }

--- a/sdk/src/testing/mocknet.ts
+++ b/sdk/src/testing/mocknet.ts
@@ -146,17 +146,18 @@ export class Mocknet {
   }
 
   /**
-   * Execute the actions from a CallAndProof result.
-   * This applies the state changes to the mock pool.
+   * Execute the actions from a CallAndProof result and apply state updates to the registry.
    *
-   * In real Starknet, this would be done by sending the transaction to the network.
-   * In mocknet, we execute the actions directly on the pool.
+   * In real Starknet, this would be done by sending the transaction to the network
+   * and calling registry.applyExecuteResult only after confirmed success.
+   * In mocknet, execution always succeeds so we apply immediately.
    *
-   * @param result - The ExecuteResult from PrivateTransfers.execute()
-   * @returns The updated registry
+   * If no registry is provided, state updates are discarded (useful for setup-only calls like register).
    */
-  executeOutside(result: ExecuteResult): PrivateRegistry {
+  executeOutside(result: ExecuteResult, registry?: PrivateRegistry): void {
     this.pool.apply_actions(result.callAndProof.call.calldata as string[]);
-    return result.registry;
+    if (registry) {
+      registry.applyExecuteResult(result.registryUpdate);
+    }
   }
 }

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -7,6 +7,7 @@ import {
   POOL_ADDRESS,
 } from "../helpers/test-fixtures.js";
 import { Open } from "../../src/interfaces.js";
+import { cloneChannelCursor } from "../../src/internal/channel.js";
 import { debugHint, isDebugEnabled, toBigInt } from "../../src/utils/index.js";
 import { debugLog } from "../../src/utils/logging.js";
 import { toHex } from "../../src/utils/convert.js";
@@ -41,10 +42,11 @@ describe("Private Transfers Integration", () => {
       mocknet.executeOutside(await bob.build().register().execute());
 
       // Alice: register, setup channels (self + Bob), setup token (self + Bob), deposit
+      const registry = new PrivateRegistry();
       // prettier-ignore
-      const registry = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
-          .build()
+          .build({ registry })
           .register()
           .setup(env.alice.address)
           .setup(env.bob.address)
@@ -52,7 +54,8 @@ describe("Private Transfers Integration", () => {
             .setup(env.alice.address)
             .setup(env.bob.address)
             .deposit({ amount: 100n, recipient: env.alice.address })
-          .execute()
+          .execute(),
+        registry
       );
 
       debugLog("test", "registry", registry);
@@ -71,7 +74,8 @@ describe("Private Transfers Integration", () => {
             .inputs(note)
             .transfer({ recipient: env.bob.address, amount: 50n })
             .withdraw({ amount: 25n })
-          .execute()
+          .execute(),
+        registry
       );
 
       // Alice should have 25n surplus note, Bob should have 50n note
@@ -115,22 +119,21 @@ describe("Private Transfers Integration", () => {
 
       // Alice uses autoRegister, autoSetup and autoSelectNotes: deposits and transfers to Bob
       // prettier-ignore
-      const registry = mocknet.executeOutside(
-        await alice
-          .build(AUTO_ALL)
-          .with(env.ace)
-            .deposit({ amount: 100n })
-            .transfer({ recipient: env.bob.address, amount: 50n })
-            .surplusTo(env.alice.address, true)
-          .with(env.bee)
-            .deposit({ amount: 100n })
-            .transfer({ recipient: env.bob.address, amount: 50n })
-            .transfer({ recipient: env.alice.address, amount: 50n })
-          .execute()
-      );
+      const result = await alice
+        .build(AUTO_ALL)
+        .with(env.ace)
+          .deposit({ amount: 100n })
+          .transfer({ recipient: env.bob.address, amount: 50n })
+          .surplusTo(env.alice.address, true)
+        .with(env.bee)
+          .deposit({ amount: 100n })
+          .transfer({ recipient: env.bob.address, amount: 50n })
+          .transfer({ recipient: env.alice.address, amount: 50n })
+        .execute();
+      mocknet.executeOutside(result);
 
-      expect(registry.notes.get(ace)?.length).toBe(0);
-      expect(registry.notes.get(bee)?.length).toBe(1);
+      expect(result.registryUpdate.notes.get(ace)?.length ?? 0).toBe(0);
+      expect(result.registryUpdate.notes.get(bee)?.length).toBe(1);
 
       const bobNotes = (await bob.discoverNotes()).notes;
       expect(bobNotes.get(ace)?.length).toBe(1);
@@ -139,7 +142,7 @@ describe("Private Transfers Integration", () => {
       expect(bobNotes.get(bee)?.[0].amount).toBe(50n);
     });
 
-    it("covers autoSelectNotes: all, autoDiscover: missing, registryConst, implicit surplus", async () => {
+    it("covers autoSelectNotes: all, autoDiscover: missing, separate working registry, implicit surplus", async () => {
       const { env, transfers } = testEnv;
       const { alice } = transfers;
       const ace = toBigInt(env.ace);
@@ -175,17 +178,20 @@ describe("Private Transfers Integration", () => {
         recipients: [env.alice.address],
       });
 
+      // Create a separate working registry with the same channel cursor.
+      // channelOnly is never passed to build() or executeOutside(), so it stays unchanged.
+      const workingRegistry = new PrivateRegistry();
+      workingRegistry.channelCursor = cloneChannelCursor(channelOnly.channelCursor!);
+
       // Deposit 30n with:
       // - autoSelectNotes: "all" (sweeps ALL notes, not just enough for deficit)
-      // - registryConst: true (don't mutate channelOnly)
       // - autoDiscover: { notes: "missing" } (discover ACE notes since not in registry)
       // - surplusTo triggers the "sweeping" code path for discovery
       debugLog("test", "main");
-      const result = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
           .build({
-            registry: channelOnly,
-            registryConst: true,
+            registry: workingRegistry,
             autoDiscover: { channels: "refresh", notes: "missing" },
             autoSelectNotes: "all",
             autoSetup: true,
@@ -193,15 +199,16 @@ describe("Private Transfers Integration", () => {
           .surplusTo(env.alice.address) // Explicit surplus triggers sweeping discovery
           .with(env.ace)
           .deposit({ amount: 30n })
-          .execute()
+          .execute(),
+        workingRegistry
       );
 
       // Verify autoSelectNotes: "all" swept all notes into one
       // 100n + 50n (discovered & swept) + 30n (deposit) = 180n
-      expect(result.notes.get(ace)?.length).toBe(1);
-      expect(result.notes.get(ace)?.[0].amount).toBe(180n);
+      expect(workingRegistry.notes.get(ace)?.length).toBe(1);
+      expect(workingRegistry.notes.get(ace)?.[0].amount).toBe(180n);
 
-      // Verify registryConst: original registry unchanged
+      // Verify original registry is unchanged (never passed to build/executeOutside)
       expect(channelOnly.notes.has(ace)).toBe(false);
 
       // Verify ERC20 balance
@@ -218,20 +225,19 @@ describe("Private Transfers Integration", () => {
       // Deposit 100n, transfer only 30n to Bob -> 70n surplus with NO explicit surplusTo
       mocknet.executeOutside(await bob.build().register().execute());
 
-      const result = mocknet.executeOutside(
-        await alice
-          .build(AUTO_ALL)
-          .setup(env.alice.address)
-          .setup(env.bob.address)
-          .with(env.ace)
-          .deposit({ amount: 100n }) // No recipient, no surplusTo
-          .transfer({ recipient: env.bob.address, amount: 30n })
-          .execute()
-      );
+      const result = await alice
+        .build(AUTO_ALL)
+        .setup(env.alice.address)
+        .setup(env.bob.address)
+        .with(env.ace)
+        .deposit({ amount: 100n }) // No recipient, no surplusTo
+        .transfer({ recipient: env.bob.address, amount: 30n })
+        .execute();
+      mocknet.executeOutside(result);
 
       // Implicit surplus: 100n - 30n = 70n goes to self
-      expect(result.notes.get(ace)?.length).toBe(1);
-      expect(result.notes.get(ace)?.[0].amount).toBe(70n);
+      expect(result.registryUpdate.notes.get(ace)?.length).toBe(1);
+      expect(result.registryUpdate.notes.get(ace)?.[0].amount).toBe(70n);
 
       // Bob got his 30n
       const bobNotes = (await bob.discoverNotes()).notes.get(ace) ?? [];
@@ -252,14 +258,16 @@ describe("Private Transfers Integration", () => {
       mocknet.executeOutside(await david.build().register().execute());
 
       // Alice deposits and transfers to Bob (creates outgoing channel index 0 to self, index 1 to Bob)
-      const registryAfterBob = mocknet.executeOutside(
+      const registryAfterBob = new PrivateRegistry();
+      mocknet.executeOutside(
         await alice
-          .build(AUTO_ALL)
+          .build({ ...AUTO_ALL, registry: registryAfterBob })
           .with(env.ace)
           .deposit({ amount: 100n })
           .transfer({ recipient: env.bob.address, amount: 30n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        registryAfterBob
       );
 
       // Verify Bob got his transfer
@@ -268,7 +276,7 @@ describe("Private Transfers Integration", () => {
       expect(bobNotes[0].amount).toBe(30n);
 
       // Alice transfers to Carol using the registry from step 1 (creates outgoing channel index 2 to Carol)
-      const registryAfterCarol = mocknet.executeOutside(
+      mocknet.executeOutside(
         await alice
           .build({
             registry: registryAfterBob,
@@ -279,7 +287,8 @@ describe("Private Transfers Integration", () => {
           .with(env.ace)
           .transfer({ recipient: env.carol.address, amount: 20n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        registryAfterBob
       );
 
       // Verify Carol got her transfer
@@ -288,19 +297,21 @@ describe("Private Transfers Integration", () => {
       expect(carolNotes[0].amount).toBe(20n);
 
       // Alice should have 50n remaining (100 - 30 - 20)
-      expect(registryAfterCarol.notes.get(ace)?.length).toBe(1);
-      expect(registryAfterCarol.notes.get(ace)?.[0].amount).toBe(50n);
+      expect(registryAfterBob.notes.get(ace)?.length).toBe(1);
+      expect(registryAfterBob.notes.get(ace)?.[0].amount).toBe(50n);
 
       // Now transfer to David WITHOUT passing a registry (fresh discovery)
       // This tests that the channel index accounting is correct when discovering from scratch
       // and creating a new channel to a completely new recipient
-      const finalRegistry = mocknet.executeOutside(
+      const finalRegistry = new PrivateRegistry();
+      mocknet.executeOutside(
         await alice
-          .build(AUTO_ALL) // Fresh discovery, no registry passed
+          .build({ ...AUTO_ALL, registry: finalRegistry }) // Fresh discovery
           .with(env.ace)
           .transfer({ recipient: env.david.address, amount: 10n })
           .surplusTo(env.alice.address)
-          .execute()
+          .execute(),
+        finalRegistry
       );
 
       // Verify David got his transfer

--- a/sdk/tests/simple-private-transfers.test.ts
+++ b/sdk/tests/simple-private-transfers.test.ts
@@ -26,7 +26,7 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit 100 ACE
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
 
     // Verify: Alice has 100n ACE note
     const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
@@ -46,8 +46,8 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit then withdraw partial
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
-    mocknet.executeOutside(await alice.withdraw(env.ace, env.alice.address, 40n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
+    mocknet.executeOutside(await alice.withdraw(env.ace, env.alice.address, 40n), alice.registry);
 
     // Verify: Alice has 60n surplus note
     const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
@@ -69,8 +69,8 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit then transfer
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
-    mocknet.executeOutside(await alice.transfer(env.ace, env.bob.address, 30n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
+    mocknet.executeOutside(await alice.transfer(env.ace, env.bob.address, 30n), alice.registry);
 
     // Verify: Bob has 30n
     const bobNotes = (await transfers.bob.discoverNotes()).notes.get(ace) ?? [];
@@ -96,11 +96,14 @@ describe("SimplePrivateTransfers", () => {
     const alice = new SimplePrivateTransfersImpl(transfers.alice);
 
     // Deposit 100 ACE first
-    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n), alice.registry);
 
     // Swap 10 ACE for BEE using the swap helper.
     // note_id is auto-injected by the compiler into the invoke calldata.
-    mocknet.executeOutside(await alice.swap(env.ace, 10n, env.bee, toHex(swapHelper.address)));
+    mocknet.executeOutside(
+      await alice.swap(env.ace, 10n, env.bee, toHex(swapHelper.address)),
+      alice.registry
+    );
 
     // Verify: Alice has 90n ACE change note
     const aceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];


### PR DESCRIPTION
## Summary

  - `execute()` and `createProofInvocation()` now return `registryUpdate: RegistryUpdate` — a plain data object —
  instead of the mutated `registry` reference
  - Callers apply optimistic state after tx confirmation via `registry.applyExecuteResult(result.registryUpdate)`
  - `PrivateRegistry.applyExecuteResult()` method added for post-tx updates
  - `registryConst` option removed — no longer needed since execute doesn't mutate
  - `PoolSimulator.updateRegistry(registry)` → `createRegistryUpdate(): RegistryUpdate`
  - Bug fix: `e2e/tests/reorg-recovery.test.ts` was still destructuring `result.registry` which no longer exists

  ## Migration

  ```diff
  - const { registry } = await transfers.execute(actions, { registry: myRegistry });
  + const { registryUpdate } = await transfers.execute(actions, { registry: myRegistry });
  + myRegistry.applyExecuteResult(registryUpdate);
  ```

  Test plan

  - npm run lint passes (0 new type errors)
  - npm test — 162/162 tests pass
  - 23/26 files match reference commit exactly (3 intentional: bug fix + docs)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/657)
<!-- Reviewable:end -->
