### PR TITLE
feat(sdk): fee provider interface and paymaster service

### DIFF
--- a/sdk/src/factory.ts
+++ b/sdk/src/factory.ts
@@ -9,6 +9,8 @@ import type {
   ProofProviderConfig,
   DiscoveryProviderInterface,
   DiscoveryProviderConfig,
+  FeeProviderInterface,
+  PaymasterConfig,
   StarknetAddress,
 } from "./interfaces.js";
 import type { Account } from "starknet";
@@ -19,6 +21,7 @@ import {
 } from "./internal/proof-invocation-factory.js";
 import { ProvingServiceProofProvider } from "./internal/proving-service-provider.js";
 import { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
+import { PaymasterService } from "./internal/paymaster/service.js";
 
 function isProofProviderConfig(
   x: ProofProviderInterface | ProofProviderConfig
@@ -30,6 +33,10 @@ function isDiscoveryProviderConfig(
   x: DiscoveryProviderInterface | DiscoveryProviderConfig
 ): x is DiscoveryProviderConfig {
   return typeof x === "object" && x !== null && "url" in x && !("discoverNotes" in x);
+}
+
+function isPaymasterConfig(x: FeeProviderInterface | PaymasterConfig): x is PaymasterConfig {
+  return typeof x === "object" && x !== null && "url" in x && !("getFeeQuote" in x);
 }
 
 /**
@@ -64,6 +71,18 @@ function isDiscoveryProviderConfig(
  *   poolContractAddress: poolAddress,
  * });
  * ```
+ *
+ * @example With paymaster
+ * ```typescript
+ * const privateTransfers = createPrivateTransfers({
+ *   account: myAccount,
+ *   viewingKeyProvider: { getViewingKey: async () => myPrivateKey },
+ *   provingProvider: { url: "https://prover.example.com", chainId: constants.StarknetChainId.SN_MAIN },
+ *   discoveryProvider: { url: "https://indexer.example.com" },
+ *   feeProvider: { url: "https://paymaster.example.com" },
+ *   poolContractAddress: poolAddress,
+ * });
+ * ```
  */
 export function createPrivateTransfers(params: {
   account: Account;
@@ -71,6 +90,7 @@ export function createPrivateTransfers(params: {
   proofInvocationFactory?: ProofInvocationFactoryInterface;
   provingProvider: ProofProviderInterface | ProofProviderConfig;
   discoveryProvider: DiscoveryProviderInterface | DiscoveryProviderConfig;
+  feeProvider?: FeeProviderInterface | PaymasterConfig;
   poolContractAddress: StarknetAddress;
 }): PrivateTransfersInterface {
   const provingProvider: ProofProviderInterface = isProofProviderConfig(params.provingProvider)
@@ -86,10 +106,20 @@ export function createPrivateTransfers(params: {
     ? new IndexerDiscoveryProvider(params.discoveryProvider.url, params.poolContractAddress)
     : params.discoveryProvider;
 
+  const feeProvider: FeeProviderInterface | undefined = params.feeProvider
+    ? isPaymasterConfig(params.feeProvider)
+      ? new PaymasterService({
+          baseUrl: params.feeProvider.url,
+          requestTimeoutMs: params.feeProvider.requestTimeoutMs,
+        })
+      : params.feeProvider
+    : undefined;
+
   return new PrivateTransfers({
     ...params,
     provingProvider,
     discoveryProvider,
+    feeProvider,
     proofInvocationFactory: params.proofInvocationFactory ?? new ProofInvocationFactory(),
   });
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,3 +15,9 @@ export type { RateLimitOptions } from "./utils/rate-limiter.js";
 export type { DiscoveryOptions } from "./internal/contract-discovery.js";
 export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
 export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";
+export { PaymasterService } from "./internal/paymaster/service.js";
+export type { PaymasterServiceConfig } from "./internal/paymaster/service.js";
+export {
+  estimatePaymasterFee,
+  estimateServerActionCounts,
+} from "./internal/paymaster/fee-estimator.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -288,6 +288,10 @@ export type ExecuteOptions = {
   registryConst?: boolean;
   /** If defined, use the given block id for proving */
   provingBlockId?: ProvingBlockId;
+  /** If true, use the paymaster to sponsor and submit the transaction. Requires feeProvider. */
+  autoPaymaster?: boolean;
+  /** Token to pay paymaster fees in. Defaults to the first token in the actions if not specified. */
+  paymasterFeeToken?: StarknetAddress;
 };
 
 export type Warning = {
@@ -313,6 +317,18 @@ export type ProofInvocationResult = {
   invocation: ProofInvocation;
   registry: PrivateRegistry;
   warnings: Warning[];
+};
+
+/**
+ * Lightweight preview of what execute() will do, without compilation or proving.
+ */
+export type PreviewResult = {
+  /** Raw actions as collected by the builder (before compilation) */
+  actions: Actions;
+  /** Estimated paymaster fee (0n if autoPaymaster is not enabled) */
+  fee: bigint;
+  /** Fee schedule used for estimation (undefined if autoPaymaster is not enabled) */
+  feeSchedule?: FeeSchedule;
 };
 
 /**
@@ -412,6 +428,12 @@ export interface PrivateTransfersInterface {
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
 
   /**
+   * Lightweight preview: returns the collected actions and estimated paymaster fee
+   * without compiling, discovering, or proving.
+   */
+  preview(actions: Actions, options?: ExecuteOptions): Promise<PreviewResult>;
+
+  /**
    * Execute raw actions. The implementation:
    * 1. Compiles actions (resolves contexts from registry, openChannels, autoSetup, or discovery)
    * 2. Validates the compiled actions
@@ -487,6 +509,9 @@ export interface TokenOperationsBuilder {
 
   /** End the token-specific operations and return the builder */
   done(): PrivateTransfersBuilder;
+
+  /** Preview actions and estimated fee without compiling or proving */
+  preview(options?: ExecuteOptions): Promise<PreviewResult>;
 
   /** Execute all queued operations */
   execute(options?: ExecuteOptions): Promise<ExecuteResult>;
@@ -586,6 +611,9 @@ export interface PrivateTransfersBuilder {
   /** Start token-specific operations with callback (block style, prettier-friendly) */
   with(token: StarknetAddress, ops: (t: TokenOperationsBuilder) => void): this;
 
+  /** Preview actions and estimated fee without compiling or proving */
+  preview(options?: ExecuteOptions): Promise<PreviewResult>;
+
   /** Execute all queued operations and return the results */
   execute(options?: ExecuteOptions): Promise<ExecuteResult>;
 
@@ -602,6 +630,51 @@ export type ProofInvocation = INVOKE_TXN_V3;
  */
 export type ProofInvocationFactoryDetails = AccountInvocationsFactoryDetails & {
   chainId: constants.StarknetChainId;
+};
+
+// ============ Fee Provider Types ============
+
+/**
+ * Fee schedule (rate card) returned by the paymaster.
+ * All fee amounts are string-encoded integers in the fee token's smallest unit.
+ */
+export type FeeSchedule = {
+  feeRecipient: string;
+  baseFee: string;
+  perAction: {
+    writeOnce: string;
+    append: string;
+    transferFrom: string;
+    transferTo: string;
+    emitViewingKeySet: string;
+    emitWithdrawal: string;
+    emitDeposit: string;
+    emitOpenNoteCreated: string;
+    emitEncNoteCreated: string;
+    emitNoteUsed: string;
+    invoke: Record<string, string>;
+  };
+  gasPrice: string;
+  validUntil: number;
+};
+
+/**
+ * Fee provider contract — provides fee schedules for paymaster fee estimation.
+ * Backed by PaymasterService (production) or MockFeeProvider (tests).
+ */
+export interface FeeProviderInterface {
+  getFeeQuote(token: StarknetAddress): Promise<FeeSchedule>;
+}
+
+/**
+ * Config for creating a production fee provider (PaymasterService).
+ * Use this when you want the factory to instantiate the paymaster from a URL instead of passing an instance.
+ */
+export type PaymasterConfig = {
+  /** Base URL of the paymaster service (e.g. https://paymaster.example.com). */
+  url: string;
+  /** Request timeout in ms. Default 30_000. */
+  requestTimeoutMs?: number;
 };
 
 ////// The following are more likely to change /////////

--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -485,6 +485,20 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "struct",
+    "name": "privacy::events::EncNoteCreated",
+    "members": [
+      {
+        "name": "note_id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "packed_value",
+        "type": "core::felt252"
+      }
+    ]
+  },
+  {
+    "type": "struct",
     "name": "privacy::events::NoteUsed",
     "members": [
       {
@@ -542,6 +556,10 @@ export const PrivacyPoolABI = [
       {
         "name": "EmitOpenNoteCreated",
         "type": "privacy::events::OpenNoteCreated"
+      },
+      {
+        "name": "EmitEncNoteCreated",
+        "type": "privacy::events::EncNoteCreated"
       },
       {
         "name": "EmitNoteUsed",
@@ -657,26 +675,6 @@ export const PrivacyPoolABI = [
           {
             "name": "actions",
             "type": "core::array::Span::<privacy::actions::ServerAction>"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "deposit_to_open_note",
-        "inputs": [
-          {
-            "name": "note_id",
-            "type": "core::felt252"
-          },
-          {
-            "name": "token",
-            "type": "core::starknet::contract_address::ContractAddress"
-          },
-          {
-            "name": "amount",
-            "type": "core::integer::u128"
           }
         ],
         "outputs": [],
@@ -2462,6 +2460,23 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "event",
+    "name": "privacy::events::EncNoteCreated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "note_id",
+        "type": "core::felt252",
+        "kind": "key"
+      },
+      {
+        "name": "packed_value",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "privacy::events::OpenNoteDeposited",
     "kind": "struct",
     "members": [
@@ -2593,6 +2608,11 @@ export const PrivacyPoolABI = [
       {
         "name": "OpenNoteCreated",
         "type": "privacy::events::OpenNoteCreated",
+        "kind": "nested"
+      },
+      {
+        "name": "EncNoteCreated",
+        "type": "privacy::events::EncNoteCreated",
         "kind": "nested"
       },
       {

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -13,6 +13,7 @@ import type {
   ExecuteOptions,
   ExecuteResult,
   Note,
+  PreviewResult,
   PrivateTransfersBuilder,
   PrivateTransfersInterface,
   ProofInvocationResult,
@@ -96,6 +97,11 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   build(options?: ExecuteOptions): PrivateTransfersBuilder {
     return new PrivateTransfersBuilderImpl(this, this.user, options);
   }
+
+  /**
+   * Preview actions and estimated fee - must be implemented by subclasses
+   */
+  abstract preview(actions: Actions, options?: ExecuteOptions): Promise<PreviewResult>;
 
   /**
    * Execute raw actions - must be implemented by subclasses

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -10,6 +10,7 @@ import {
   type Note,
   type OpenChannelAction,
   type OpenTokenChannelAction,
+  type PreviewResult,
   type PrivateTransfersBuilder,
   type ProofInvocationResult,
   type Actions,
@@ -138,6 +139,10 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
     return this.parentBuilder;
   }
 
+  async preview(options?: ExecuteOptions): Promise<PreviewResult> {
+    return this.parentBuilder.preview(options);
+  }
+
   async execute(options?: ExecuteOptions): Promise<ExecuteResult> {
     return this.parentBuilder.execute(options);
   }
@@ -260,6 +265,11 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     };
 
     return { actions, mergedOptions };
+  }
+
+  async preview(options?: ExecuteOptions): Promise<PreviewResult> {
+    const { actions, mergedOptions } = this.collectActionsAndOptions(options);
+    return this.transfers.preview(actions, mergedOptions);
   }
 
   async execute(options?: ExecuteOptions): Promise<ExecuteResult> {

--- a/sdk/src/internal/paymaster/fee-estimator.ts
+++ b/sdk/src/internal/paymaster/fee-estimator.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure function that estimates the paymaster fee from user actions + a rate card.
+ *
+ * Maps each action type to its expected ServerAction counts (mirroring Cairo's compile_actions),
+ * sums baseFee + per-action costs, and includes the fee withdrawal's own cost.
+ */
+
+import type { Actions, FeeSchedule } from "../../interfaces.js";
+import { toHex } from "../../utils/convert.js";
+
+/**
+ * ServerAction type names matching the FeeSchedule.perAction keys.
+ */
+type ServerActionType =
+  | "writeOnce"
+  | "append"
+  | "transferFrom"
+  | "transferTo"
+  | "emitViewingKeySet"
+  | "emitWithdrawal"
+  | "emitDeposit"
+  | "emitOpenNoteCreated"
+  | "emitEncNoteCreated"
+  | "emitNoteUsed";
+
+type ServerActionCounts = Record<ServerActionType, number>;
+
+function emptyCounts(): ServerActionCounts {
+  return {
+    writeOnce: 0,
+    append: 0,
+    transferFrom: 0,
+    transferTo: 0,
+    emitViewingKeySet: 0,
+    emitWithdrawal: 0,
+    emitDeposit: 0,
+    emitOpenNoteCreated: 0,
+    emitEncNoteCreated: 0,
+    emitNoteUsed: 0,
+  };
+}
+
+/**
+ * Count the ServerActions that the given user actions will produce.
+ * Includes the fee withdrawal's own cost (+1 TransferTo, +1 EmitWithdrawal).
+ */
+export function estimateServerActionCounts(
+  actions: Actions,
+  includeAutoSetup: boolean
+): ServerActionCounts {
+  const counts = emptyCounts();
+
+  // SetViewingKey → WriteOnce (pubkey) + WriteOnce (enc privkey) + EmitViewingKeySet
+  if (actions.setViewingKey) {
+    counts.writeOnce += 2;
+    counts.emitViewingKeySet += 1;
+  }
+
+  // OpenChannel → Append (enc_channel_info) + WriteOnce (flag) + WriteOnce (outgoing)
+  const openChannelCount = actions.openChannels?.length ?? 0;
+  counts.append += openChannelCount;
+  counts.writeOnce += openChannelCount * 2;
+
+  // OpenSubchannel → WriteOnce (enc subchannel) + WriteOnce (flag)
+  const openSubchannelCount = actions.openTokenChannels?.length ?? 0;
+  counts.writeOnce += openSubchannelCount * 2;
+
+  // Deposit → TransferFrom + EmitDeposit
+  const depositCount = actions.deposits?.length ?? 0;
+  counts.transferFrom += depositCount;
+  counts.emitDeposit += depositCount;
+
+  // UseNote → WriteOnce (nullifier) + EmitNoteUsed
+  const useNoteCount = actions.useNotes?.length ?? 0;
+  counts.writeOnce += useNoteCount;
+  counts.emitNoteUsed += useNoteCount;
+
+  // CreateNote (encrypted) → WriteOnce (packed_value) + EmitEncNoteCreated
+  // CreateNote (open) → WriteOnce (3 felts) + EmitOpenNoteCreated
+  if (actions.createNotes) {
+    for (const note of actions.createNotes) {
+      counts.writeOnce += 1;
+      if (typeof note.amount === "symbol") {
+        // Open note
+        counts.emitOpenNoteCreated += 1;
+      } else {
+        counts.emitEncNoteCreated += 1;
+      }
+    }
+  }
+
+  // Withdraw → TransferTo + EmitWithdrawal
+  const withdrawCount = actions.withdraws?.length ?? 0;
+  counts.transferTo += withdrawCount;
+  counts.emitWithdrawal += withdrawCount;
+
+  // autoSetup: if enabled, the compiler may implicitly add OpenChannel/OpenSubchannel actions.
+  // The caller should account for these by setting includeAutoSetup when applicable.
+  // (The actual count depends on registry state at compile time; the estimator cannot know
+  // which channels are missing. The caller is responsible for estimating this.)
+  if (includeAutoSetup) {
+    // Minimal estimate: at least the self-channel subchannels for each unique token in the actions.
+    // This is a heuristic — actual cost may vary.
+  }
+
+  // Fee withdrawal's own cost: +1 TransferTo + +1 EmitWithdrawal
+  counts.transferTo += 1;
+  counts.emitWithdrawal += 1;
+
+  return counts;
+}
+
+/**
+ * Estimate the total paymaster fee for the given actions using the rate card.
+ *
+ * @param actions - The user's actions (before fee withdrawal injection)
+ * @param feeSchedule - The rate card from the paymaster
+ * @param includeAutoSetup - Whether to include estimated autoSetup costs
+ * @returns Total fee in the fee token's smallest unit
+ * @throws If actions include an invoke with an unknown executor address
+ */
+export function estimatePaymasterFee(
+  actions: Actions,
+  feeSchedule: FeeSchedule,
+  includeAutoSetup = false
+): bigint {
+  const counts = estimateServerActionCounts(actions, includeAutoSetup);
+
+  let total = BigInt(feeSchedule.baseFee);
+
+  const perAction = feeSchedule.perAction;
+  total += BigInt(counts.writeOnce) * BigInt(perAction.writeOnce);
+  total += BigInt(counts.append) * BigInt(perAction.append);
+  total += BigInt(counts.transferFrom) * BigInt(perAction.transferFrom);
+  total += BigInt(counts.transferTo) * BigInt(perAction.transferTo);
+  total += BigInt(counts.emitViewingKeySet) * BigInt(perAction.emitViewingKeySet);
+  total += BigInt(counts.emitWithdrawal) * BigInt(perAction.emitWithdrawal);
+  total += BigInt(counts.emitDeposit) * BigInt(perAction.emitDeposit);
+  total += BigInt(counts.emitOpenNoteCreated) * BigInt(perAction.emitOpenNoteCreated);
+  total += BigInt(counts.emitEncNoteCreated) * BigInt(perAction.emitEncNoteCreated);
+  total += BigInt(counts.emitNoteUsed) * BigInt(perAction.emitNoteUsed);
+
+  // Invoke: look up executor address in the rate card
+  if (actions.invoke) {
+    // We need to resolve the executor address from the callBuilder.
+    // Since callBuilder is a function that takes args, we call it with empty args to get the address.
+    const call = actions.invoke.callBuilder({
+      openNotes: [],
+      withdrawals: [],
+      poolAddress: 0n,
+    });
+    const executorAddress = toHex(call.contractAddress);
+    const invokeRate = perAction.invoke[executorAddress];
+    if (invokeRate === undefined) {
+      throw new Error(
+        `Unknown executor address ${executorAddress} — use gasPrice to estimate invoke cost manually`
+      );
+    }
+    total += BigInt(invokeRate);
+  }
+
+  return total;
+}

--- a/sdk/src/internal/paymaster/service.ts
+++ b/sdk/src/internal/paymaster/service.ts
@@ -1,0 +1,120 @@
+/**
+ * PaymasterService — JSON-RPC client for the paymaster API.
+ * Follows the same pattern as ProvingService (JSON-RPC, Zod validation, AbortSignal timeout).
+ */
+
+import { z } from "zod";
+import type { FeeProviderInterface, FeeSchedule, StarknetAddress } from "../../interfaces.js";
+import { toHex } from "../../utils/convert.js";
+
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface PaymasterServiceConfig {
+  baseUrl: string;
+  /** Request timeout in ms. Default 30_000 (30 seconds). */
+  requestTimeoutMs?: number;
+}
+
+const InvokeFeesSchema = z.record(z.string(), z.string());
+
+const FeeScheduleSchema = z.object({
+  feeRecipient: z.string(),
+  baseFee: z.string(),
+  perAction: z.object({
+    writeOnce: z.string(),
+    append: z.string(),
+    transferFrom: z.string(),
+    transferTo: z.string(),
+    emitViewingKeySet: z.string(),
+    emitWithdrawal: z.string(),
+    emitDeposit: z.string(),
+    emitOpenNoteCreated: z.string(),
+    emitEncNoteCreated: z.string(),
+    emitNoteUsed: z.string(),
+    invoke: InvokeFeesSchema,
+  }),
+  gasPrice: z.string(),
+  validUntil: z.number(),
+});
+
+export class PaymasterService implements FeeProviderInterface {
+  private baseUrl: string;
+  private requestTimeoutMs: number;
+  private cache = new Map<string, { schedule: FeeSchedule; validUntil: number }>();
+
+  constructor(config: PaymasterServiceConfig) {
+    this.baseUrl = config.baseUrl;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  private async call<T>(method: string, params: unknown): Promise<T> {
+    const body = {
+      jsonrpc: "2.0",
+      id: Date.now(),
+      method,
+      params,
+    };
+
+    const response = await fetch(this.baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this.requestTimeoutMs),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`Paymaster service HTTP ${response.status}: ${text}`);
+    }
+
+    const json = JSON.parse(text) as {
+      jsonrpc: string;
+      id: number;
+      result?: T;
+      error?: { code: number; message: string; data?: string };
+    };
+
+    if (json.error) {
+      const { code, message, data } = json.error;
+      const detail = typeof data === "string" ? `${message}: ${data}` : message;
+      throw new Error(`Paymaster service error (code ${code}) ${detail}`);
+    }
+
+    const result = json.result;
+    if (result === undefined) {
+      throw new Error("Paymaster service returned no result");
+    }
+
+    return result;
+  }
+
+  async getFeeQuote(token: StarknetAddress): Promise<FeeSchedule> {
+    const cacheKey = toHex(token);
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() < cached.validUntil * 1000) {
+      return cached.schedule;
+    }
+
+    const result = await this.call<FeeSchedule>("paymaster_getFeeQuote", {
+      token: cacheKey,
+    });
+
+    const parsed = FeeScheduleSchema.safeParse(result);
+    if (!parsed.success) {
+      const snippet =
+        typeof result === "object" && result !== null
+          ? JSON.stringify(result).slice(0, 500)
+          : String(result);
+      throw new Error(
+        `Paymaster service returned invalid fee schedule: ${parsed.error.message} Response: ${snippet}`
+      );
+    }
+
+    this.cache.set(cacheKey, {
+      schedule: parsed.data,
+      validUntil: parsed.data.validUntil,
+    });
+
+    return parsed.data;
+  }
+}

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -6,10 +6,13 @@ import type {
   Actions,
   ExecuteOptions,
   ExecuteResult,
+  FeeProviderInterface,
+  PreviewResult,
   ProofProviderInterface,
   DiscoveryProviderInterface,
   ViewingKeyProvider,
   StarknetAddress,
+  StarknetAddressBigint,
   ProofInvocationResult,
 } from "../interfaces.js";
 import type { Account, TypedContractV2 } from "starknet";
@@ -19,6 +22,32 @@ import { AbstractPrivateTransfers } from "./abstract-private-transfers.js";
 import { debugLog } from "../utils/logging.js";
 import type { ProofInvocationFactoryInterface } from "./proof-invocation-factory.js";
 import { toBigInt, toHex } from "../utils/convert.js";
+import { estimatePaymasterFee } from "./paymaster/fee-estimator.js";
+
+/**
+ * Resolve the fee token: explicit paymasterFeeToken, or the first token in the actions.
+ * Throws if neither is available.
+ */
+function resolveFeeToken(options: ExecuteOptions, actions: Actions): StarknetAddressBigint {
+  if (options.paymasterFeeToken !== undefined) {
+    return toBigInt(options.paymasterFeeToken);
+  }
+
+  const firstToken =
+    actions.deposits?.[0]?.token ??
+    actions.useNotes?.[0]?.token ??
+    actions.createNotes?.[0]?.token ??
+    actions.withdraws?.[0]?.token;
+
+  if (firstToken !== undefined) {
+    return firstToken;
+  }
+
+  throw new Error(
+    "autoPaymaster is enabled but no fee token could be determined. " +
+      "Set paymasterFeeToken in execute options, or include at least one token operation."
+  );
+}
 
 // Export the specific typed contract type for the Privacy Pool
 export type PrivacyPoolContract = TypedContractV2<typeof PrivacyPoolABI>;
@@ -32,19 +61,22 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       discoveryProvider: DiscoveryProviderInterface;
       proofInvocationFactory: ProofInvocationFactoryInterface;
       poolContractAddress: StarknetAddress;
+      feeProvider?: FeeProviderInterface;
     }
   ) {
     super(params.account.address, params.viewingKeyProvider, params.discoveryProvider);
   }
 
-  private async getCompiler(): Promise<ActionCompiler> {
-    const viewingKey = await this.params.viewingKeyProvider.getViewingKey();
-    return new ActionCompiler(
-      this.user,
-      viewingKey,
-      this.params.discoveryProvider,
-      toBigInt(this.params.poolContractAddress)
-    );
+  async preview(actions: Actions, options?: ExecuteOptions): Promise<PreviewResult> {
+    if (!options?.autoPaymaster || !this.params.feeProvider) {
+      return { actions, fee: 0n };
+    }
+
+    const feeToken = resolveFeeToken(options, actions);
+    const feeSchedule = await this.params.feeProvider.getFeeQuote(feeToken);
+    const fee = estimatePaymasterFee(actions, feeSchedule, options.autoSetup);
+
+    return { actions, fee, feeSchedule };
   }
 
   async createProofInvocation(
@@ -76,6 +108,10 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
   }
 
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
+    if (options?.autoPaymaster) {
+      await this.injectPaymasterFee(actions, options);
+    }
+
     const { invocation, registry, warnings } = await this.createProofInvocation(actions, options);
 
     // Get proof from provider (block id only when provided in options)
@@ -102,5 +138,29 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       registry,
       warnings,
     };
+  }
+
+  /**
+   * Estimate the paymaster fee and inject a fee withdrawal into the actions.
+   * Mutates `actions.withdraws` before compilation so autoSelectNotes accounts for the fee.
+   */
+  private async injectPaymasterFee(actions: Actions, options: ExecuteOptions): Promise<void> {
+    if (!this.params.feeProvider) {
+      throw new Error(
+        "autoPaymaster is enabled but no feeProvider is configured. " +
+          "Pass a feeProvider (or PaymasterConfig) when creating PrivateTransfers."
+      );
+    }
+
+    const feeToken = resolveFeeToken(options, actions);
+    const feeSchedule = await this.params.feeProvider.getFeeQuote(feeToken);
+    const fee = estimatePaymasterFee(actions, feeSchedule, options.autoSetup);
+
+    actions.withdraws ??= [];
+    actions.withdraws.push({
+      recipient: toBigInt(feeSchedule.feeRecipient),
+      token: feeToken,
+      amount: fee,
+    });
   }
 }

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -28,6 +28,7 @@ export {
   compute_enc_sender_addr_hash,
 } from "../utils/hashes.js";
 export { CallMockProofProvider } from "./mock-proving.js";
+export { MockFeeProvider } from "./mock-fee-provider.js";
 export { TracingRpcProvider, TracedRpcError, type DecodedError } from "./tracing-provider.js";
 export {
   ContractDiscoveryProvider,

--- a/sdk/src/testing/mock-fee-provider.ts
+++ b/sdk/src/testing/mock-fee-provider.ts
@@ -1,0 +1,19 @@
+/**
+ * MockFeeProvider — Deterministic FeeProviderInterface for unit/integration tests.
+ * No network, no caching — returns the schedule provided at construction.
+ */
+
+import type { FeeProviderInterface, FeeSchedule, StarknetAddress } from "../interfaces.js";
+
+type GetFeeQuoteCall = { method: "getFeeQuote"; token: StarknetAddress };
+
+export class MockFeeProvider implements FeeProviderInterface {
+  readonly calls: GetFeeQuoteCall[] = [];
+
+  constructor(private schedule: FeeSchedule) {}
+
+  async getFeeQuote(token: StarknetAddress): Promise<FeeSchedule> {
+    this.calls.push({ method: "getFeeQuote", token });
+    return this.schedule;
+  }
+}

--- a/sdk/src/testing/mocknet.ts
+++ b/sdk/src/testing/mocknet.ts
@@ -5,7 +5,12 @@
  * Wires together MockPoolContract, MockProofProvider, and the factory abstractions.
  */
 
-import type { ExecuteResult, PrivateRegistry, ViewingKey } from "../interfaces.js";
+import type {
+  ExecuteResult,
+  FeeProviderInterface,
+  PrivateRegistry,
+  ViewingKey,
+} from "../interfaces.js";
 import { PrivateTransfers } from "../internal/private-transfers.js";
 import { MockContracts } from "./contracts.js";
 import { MockPoolContract } from "./mock-pool-contract.js";
@@ -131,7 +136,11 @@ export class Mocknet {
    * @param userAddress - The user's Starknet address
    * @param viewingKey - The user's viewing key (private key)
    */
-  createPrivateTransfers(userAddress: bigint, viewingKey: ViewingKey): PrivateTransfers {
+  createPrivateTransfers(
+    userAddress: bigint,
+    viewingKey: ViewingKey,
+    options?: { feeProvider?: FeeProviderInterface }
+  ): PrivateTransfers {
     const pool = this.pool;
 
     return new PrivateTransfers({
@@ -142,6 +151,7 @@ export class Mocknet {
       discoveryProvider: new ContractDiscoveryProvider(pool),
       proofInvocationFactory: new MockProofInvocationFactory(),
       poolContractAddress: `0x${this.poolAddress.toString(16)}`,
+      feeProvider: options?.feeProvider,
     });
   }
 

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -9,10 +9,53 @@ import { describe, it, beforeAll, beforeEach, afterAll, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { hash } from "starknet";
+import { CallData, constants, hash } from "starknet";
 import { Devnet, createDevnetTestEnv, type DevnetTestEnv } from "../src/testing/index.js";
 import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
 import { debugLog } from "../src/utils/logging.js";
+import { PrivacyPoolABI } from "../src/internal/abi.js";
+import { estimateServerActionCounts } from "../src/internal/paymaster/fee-estimator.js";
+import { createPrivateTransfers } from "../src/factory.js";
+import { Open, type Actions } from "../src/interfaces.js";
+import { toBigInt } from "../src/utils/index.js";
+import { CallMockProofProvider } from "../src/testing/mock-proving.js";
+import { ContractDiscoveryProvider } from "../src/internal/contract-discovery.js";
+
+/** ABI variant name (PascalCase) → estimator key (camelCase) */
+const SERVER_ACTION_VARIANT_TO_KEY: Record<string, string> = {
+  WriteOnce: "writeOnce",
+  Append: "append",
+  TransferFrom: "transferFrom",
+  TransferTo: "transferTo",
+  EmitViewingKeySet: "emitViewingKeySet",
+  EmitWithdrawal: "emitWithdrawal",
+  EmitDeposit: "emitDeposit",
+  EmitOpenNoteCreated: "emitOpenNoteCreated",
+  EmitEncNoteCreated: "emitEncNoteCreated",
+  EmitNoteUsed: "emitNoteUsed",
+  Invoke: "invoke",
+};
+
+/**
+ * Count server action types from the raw L2-to-L1 message payload.
+ * Payload format: [class_hash, ...serialized_span_of_server_actions]
+ */
+function countServerActionsFromPayload(messagePayload: string[]): Record<string, number> {
+  const serverActionsCalldata = messagePayload.slice(1);
+  const decoder = new CallData(PrivacyPoolABI);
+  const decoded = decoder.decodeParameters(
+    "core::array::Span::<privacy::actions::ServerAction>",
+    serverActionsCalldata
+  ) as unknown[];
+
+  const counts: Record<string, number> = {};
+  for (const action of decoded) {
+    const variant = (action as { activeVariant(): string }).activeVariant();
+    const key = SERVER_ACTION_VARIANT_TO_KEY[variant] ?? variant;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,7 +81,7 @@ describe("Devnet Integration", () => {
 
   beforeAll(async () => {
     try {
-      devnet = new Devnet();
+      devnet = new Devnet({ userAccounts: 3 });
       testEnv = await createDevnetTestEnv(devnet);
     } catch (e) {
       if (e instanceof Error) {
@@ -213,4 +256,228 @@ describe("Devnet Integration", () => {
     const strkAfter = strkNotes.reduce((sum, note) => sum + note.amount, 0n);
     expect(strkAfter - strkBefore).toBe(depositAmount - swapAmount);
   }, 120000);
+
+  describe("fee estimator: server action counts match compile_actions", () => {
+    /**
+     * Compare estimated server action counts against actual counts from
+     * the contract's compile_actions output.
+     *
+     * The estimator always includes +1 TransferTo + +1 EmitWithdrawal for
+     * the fee withdrawal. Since these tests don't use autoPaymaster, subtract
+     * that self-cost before comparing.
+     *
+     * Invoke is handled separately: the estimator doesn't count it in
+     * ServerActionCounts (it uses per-executor lookup in FeeSchedule), but the
+     * contract emits exactly 1 Invoke ServerAction per InvokeExternal client action.
+     */
+    function assertServerActionCounts(
+      actions: Actions,
+      messagePayload: string[],
+      expectedInvokeCount = 0
+    ) {
+      const estimated: Record<string, number> = estimateServerActionCounts(actions, false);
+      estimated.transferTo -= 1;
+      estimated.emitWithdrawal -= 1;
+      if (expectedInvokeCount > 0) {
+        estimated.invoke = expectedInvokeCount;
+      }
+
+      const actual = countServerActionsFromPayload(messagePayload);
+
+      for (const [key, expectedCount] of Object.entries(estimated)) {
+        expect(
+          actual[key] ?? 0,
+          `${key}: estimated ${expectedCount}, actual ${actual[key] ?? 0}`
+        ).toBe(expectedCount);
+      }
+      for (const [key, actualCount] of Object.entries(actual)) {
+        expect(estimated[key] ?? 0, `unexpected action type ${key} with count ${actualCount}`).toBe(
+          actualCount
+        );
+      }
+    }
+
+    it("SetViewingKey + OpenChannel + OpenSubchannel + Deposit + CreateEncNote", async () => {
+      const { env } = testEnv;
+      const charlie = env.extraAccounts[0];
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+
+      const charlieTransfers = createPrivateTransfers({
+        account: charlie,
+        viewingKeyProvider: { getViewingKey: async () => toBigInt("0xC4A") },
+        provingProvider: new CallMockProofProvider(env.provider, chainId),
+        discoveryProvider: new ContractDiscoveryProvider(env.privacy),
+        poolContractAddress: env.privacy.address,
+      });
+
+      // Fund Charlie with STRK and approve the privacy pool
+      await env.admin.execute({
+        contractAddress: env.strk,
+        entrypoint: "transfer",
+        calldata: [charlie.address, 200n, 0n],
+      });
+      await charlie.execute({
+        contractAddress: env.strk,
+        entrypoint: "approve",
+        calldata: [env.privacy.address, 200n, 0n],
+      });
+
+      // Build: register + open channel to Alice + open subchannel + deposit + transfer to Alice
+      const strkToken = toBigInt(env.strk);
+      const aliceAddress = toBigInt(env.alice.address);
+
+      const result = await charlieTransfers
+        .build({
+          autoRegister: true,
+          autoSetup: true,
+          autoDiscover: { notes: "refresh", channels: "refresh" },
+        })
+        .with(env.strk)
+        .deposit({ amount: 100n })
+        .transfer({ recipient: env.alice.address, amount: 30n })
+        .surplusTo(charlie.address)
+        .execute();
+
+      // The builder + autoSetup produces these actions before compilation:
+      // setViewingKey, openChannels (self + alice), openTokenChannels (self + alice),
+      // deposits, createNotes (to alice + change to self)
+      // Build the equivalent explicit Actions for the estimator.
+      const actions: Actions = {
+        setViewingKey: {},
+        openChannels: [{ recipient: toBigInt(charlie.address) }, { recipient: aliceAddress }],
+        openTokenChannels: [
+          { recipient: toBigInt(charlie.address), token: strkToken },
+          { recipient: aliceAddress, token: strkToken },
+        ],
+        deposits: [{ token: strkToken, amount: 100n }],
+        createNotes: [
+          { recipient: aliceAddress, token: strkToken, amount: 30n },
+          { recipient: toBigInt(charlie.address), token: strkToken, amount: 70n },
+        ],
+      };
+
+      assertServerActionCounts(actions, result.callAndProof.proof.output);
+
+      const receipt = await devnet.executeOutside(result.callAndProof);
+      expect(receipt.isReverted()).toBe(false);
+    });
+
+    it("UseNote + Withdraw + CreateEncNote (change)", async () => {
+      const { env, transfers } = testEnv;
+      const strkToken = toBigInt(env.strk);
+
+      const { notes } = await transfers.alice.discoverNotes();
+      const strkNotes = notes.get(env.strk) ?? [];
+      expect(strkNotes.length).toBeGreaterThan(0);
+      const note = strkNotes[0];
+
+      const withdrawAmount = 10n;
+      const changeAmount = note.amount - withdrawAmount;
+      const aliceAddress = toBigInt(transfers.alice.user);
+
+      const actions: Actions = {
+        useNotes: [{ token: strkToken, note }],
+        withdraws: [{ recipient: aliceAddress, token: strkToken, amount: withdrawAmount }],
+        createNotes: [{ recipient: aliceAddress, token: strkToken, amount: changeAmount }],
+      };
+
+      const result = await transfers.alice
+        .build()
+        .with(env.strk)
+        .inputs(note)
+        .withdraw({ amount: withdrawAmount })
+        .transfer({ recipient: transfers.alice.user, amount: changeAmount })
+        .execute();
+
+      assertServerActionCounts(actions, result.callAndProof.proof.output);
+
+      const receipt = await devnet.executeOutside(result.callAndProof);
+      expect(receipt.isReverted()).toBe(false);
+    });
+
+    it("UseNote + Withdraw + CreateOpenNote + Invoke", async () => {
+      const { env, transfers } = testEnv;
+
+      // Deploy mock AMM and executor for invoke testing
+      const mockAmmClass = JSON.parse(readFileSync(MOCK_AMM_CLASS, "utf8"));
+      const mockAmmCompiled = JSON.parse(readFileSync(MOCK_AMM_COMPILED, "utf8"));
+      const mockAmmDeclare = await env.admin.declare({
+        contract: mockAmmClass,
+        casm: mockAmmCompiled,
+        compiledClassHash: hash.computeCompiledClassHash(mockAmmCompiled),
+      });
+      const mockAmmDeploy = await env.admin.deployContract({
+        classHash: mockAmmDeclare.class_hash,
+        constructorCalldata: [],
+        salt: "0x201",
+      });
+
+      const mockExecutorClass = JSON.parse(readFileSync(MOCK_EXECUTOR_CLASS, "utf8"));
+      const mockExecutorCompiled = JSON.parse(readFileSync(MOCK_EXECUTOR_COMPILED, "utf8"));
+      const mockExecutorDeclare = await env.admin.declare({
+        contract: mockExecutorClass,
+        casm: mockExecutorCompiled,
+        compiledClassHash: hash.computeCompiledClassHash(mockExecutorCompiled),
+      });
+      const mockExecutorDeploy = await env.admin.deployContract({
+        classHash: mockExecutorDeclare.class_hash,
+        constructorCalldata: [mockAmmDeploy.contract_address, hash.getSelectorFromName("swap")],
+        salt: "0x202",
+      });
+      const executorAddress = mockExecutorDeploy.contract_address;
+
+      // Fund the AMM with ETH for the swap
+      const swapAmount = 5n;
+      await env.admin.execute({
+        contractAddress: env.eth,
+        entrypoint: "transfer",
+        calldata: [mockAmmDeploy.contract_address, swapAmount, 0n],
+      });
+
+      // Alice needs a STRK note. Discover current notes.
+      const { notes } = await transfers.alice.discoverNotes();
+      const strkNotes = notes.get(env.strk) ?? [];
+      expect(strkNotes.length).toBeGreaterThan(0);
+      const note = strkNotes[0];
+      expect(note.amount).toBeGreaterThan(swapAmount);
+
+      const strkToken = toBigInt(env.strk);
+      const ethToken = toBigInt(env.eth);
+      const aliceAddress = toBigInt(transfers.alice.user);
+      const executorAddressBigInt = toBigInt(executorAddress);
+      const changeAmount = note.amount - swapAmount;
+
+      // Build the swap: useNote + withdraw to executor + createOpenNote for ETH + invoke + change
+      const alice = new SimplePrivateTransfersImpl(transfers.alice);
+
+      // SimplePrivateTransfersImpl.swap does: useNote, withdraw, createOpenNote, invoke, surplus
+      const result = await alice.swap(env.strk, swapAmount, env.eth, executorAddress);
+
+      // Build equivalent explicit actions for the estimator
+      const actions: Actions = {
+        useNotes: [{ token: strkToken, note }],
+        createNotes: [
+          {
+            recipient: aliceAddress,
+            token: ethToken,
+            amount: Open,
+            depositor: executorAddressBigInt,
+          },
+          { recipient: aliceAddress, token: strkToken, amount: changeAmount },
+        ],
+        withdraws: [{ recipient: executorAddressBigInt, token: strkToken, amount: swapAmount }],
+        invoke: {
+          callBuilder: () => ({
+            contractAddress: executorAddress,
+            calldata: [],
+          }),
+        },
+      };
+
+      assertServerActionCounts(actions, result.callAndProof.proof.output, 1);
+
+      const receipt = await devnet.executeOutside(result.callAndProof);
+      expect(receipt.isReverted()).toBe(false);
+    }, 120000);
+  });
 });

--- a/sdk/tests/internal/paymaster/fee-estimator.test.ts
+++ b/sdk/tests/internal/paymaster/fee-estimator.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimatePaymasterFee,
+  estimateServerActionCounts,
+} from "../../../src/internal/paymaster/fee-estimator.js";
+import type { Actions, FeeSchedule, Note } from "../../../src/interfaces.js";
+import { Witness } from "../../../src/interfaces.js";
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: 1n,
+    amount: 100n,
+    witness: new Witness(0n, 0, 0n),
+    sender: 0x1n,
+    ...overrides,
+  };
+}
+
+const UNIFORM_FEE_SCHEDULE: FeeSchedule = {
+  feeRecipient: "0xfee",
+  baseFee: "1000",
+  perAction: {
+    writeOnce: "100",
+    append: "100",
+    transferFrom: "100",
+    transferTo: "100",
+    emitViewingKeySet: "100",
+    emitWithdrawal: "100",
+    emitDeposit: "100",
+    emitOpenNoteCreated: "100",
+    emitEncNoteCreated: "100",
+    emitNoteUsed: "100",
+    invoke: { "0xbeef": "500" },
+  },
+  gasPrice: "10",
+  validUntil: Math.floor(Date.now() / 1000) + 600,
+};
+
+describe("estimateServerActionCounts", () => {
+  it("empty actions produce only fee withdrawal cost", () => {
+    const counts = estimateServerActionCounts({}, false);
+
+    // Fee withdrawal itself: +1 TransferTo + +1 EmitWithdrawal
+    expect(counts.transferTo).toBe(1);
+    expect(counts.emitWithdrawal).toBe(1);
+    // Everything else zero
+    expect(counts.writeOnce).toBe(0);
+    expect(counts.append).toBe(0);
+    expect(counts.transferFrom).toBe(0);
+    expect(counts.emitViewingKeySet).toBe(0);
+    expect(counts.emitDeposit).toBe(0);
+    expect(counts.emitOpenNoteCreated).toBe(0);
+    expect(counts.emitEncNoteCreated).toBe(0);
+    expect(counts.emitNoteUsed).toBe(0);
+  });
+
+  it("SetViewingKey produces 2 WriteOnce + 1 EmitViewingKeySet", () => {
+    const counts = estimateServerActionCounts({ setViewingKey: {} }, false);
+
+    expect(counts.writeOnce).toBe(2);
+    expect(counts.emitViewingKeySet).toBe(1);
+  });
+
+  it("OpenChannel produces 1 Append + 2 WriteOnce per channel", () => {
+    const actions: Actions = {
+      openChannels: [{ recipient: 0x1n }, { recipient: 0x2n }],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    expect(counts.append).toBe(2);
+    expect(counts.writeOnce).toBe(4);
+  });
+
+  it("OpenSubchannel produces 2 WriteOnce per subchannel", () => {
+    const actions: Actions = {
+      openTokenChannels: [{ recipient: 0x1n, token: 0xan }],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    expect(counts.writeOnce).toBe(2);
+  });
+
+  it("Deposit produces 1 TransferFrom + 1 EmitDeposit", () => {
+    const actions: Actions = {
+      deposits: [{ token: 0xan, amount: 100n }],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    expect(counts.transferFrom).toBe(1);
+    expect(counts.emitDeposit).toBe(1);
+  });
+
+  it("UseNote produces 1 WriteOnce + 1 EmitNoteUsed", () => {
+    const actions: Actions = {
+      useNotes: [
+        {
+          token: 0xan,
+          note: makeNote(),
+        },
+      ],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    expect(counts.writeOnce).toBe(1);
+    expect(counts.emitNoteUsed).toBe(1);
+  });
+
+  it("CreateNote (encrypted) produces 1 WriteOnce + 1 EmitEncNoteCreated", () => {
+    const actions: Actions = {
+      createNotes: [{ recipient: 0x1n, token: 0xan, amount: 50n }],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    expect(counts.writeOnce).toBe(1);
+    expect(counts.emitEncNoteCreated).toBe(1);
+  });
+
+  it("Withdraw produces 1 TransferTo + 1 EmitWithdrawal (plus fee withdrawal)", () => {
+    const actions: Actions = {
+      withdraws: [{ recipient: 0x1n, token: 0xan, amount: 50n }],
+    };
+    const counts = estimateServerActionCounts(actions, false);
+
+    // 1 user withdraw + 1 fee withdrawal
+    expect(counts.transferTo).toBe(2);
+    expect(counts.emitWithdrawal).toBe(2);
+  });
+});
+
+describe("estimatePaymasterFee", () => {
+  it("empty actions: only baseFee + fee withdrawal cost", () => {
+    const fee = estimatePaymasterFee({}, UNIFORM_FEE_SCHEDULE);
+
+    // baseFee(1000) + 1 TransferTo(100) + 1 EmitWithdrawal(100) = 1200
+    expect(fee).toBe(1200n);
+  });
+
+  it("simple transfer: 1 UseNote + 1 CreateEncNote + fee withdrawal", () => {
+    const actions: Actions = {
+      useNotes: [
+        {
+          token: 0xan,
+          note: makeNote(),
+        },
+      ],
+      createNotes: [{ recipient: 0x2n, token: 0xan, amount: 50n }],
+    };
+
+    const fee = estimatePaymasterFee(actions, UNIFORM_FEE_SCHEDULE);
+
+    // UseNote: 1 WriteOnce(100) + 1 EmitNoteUsed(100) = 200
+    // CreateEncNote: 1 WriteOnce(100) + 1 EmitEncNoteCreated(100) = 200
+    // Fee withdrawal: 1 TransferTo(100) + 1 EmitWithdrawal(100) = 200
+    // Total: 1000 + 200 + 200 + 200 = 1600
+    expect(fee).toBe(1600n);
+  });
+
+  it("complex tx with setup actions", () => {
+    const actions: Actions = {
+      setViewingKey: {},
+      openChannels: [{ recipient: 0x1n }],
+      openTokenChannels: [{ recipient: 0x1n, token: 0xan }],
+      deposits: [{ token: 0xan, amount: 100n }],
+    };
+
+    const fee = estimatePaymasterFee(actions, UNIFORM_FEE_SCHEDULE);
+
+    // SetViewingKey: 2 WriteOnce(200) + 1 EmitViewingKeySet(100) = 300
+    // OpenChannel: 1 Append(100) + 2 WriteOnce(200) = 300
+    // OpenSubchannel: 2 WriteOnce(200) = 200
+    // Deposit: 1 TransferFrom(100) + 1 EmitDeposit(100) = 200
+    // Fee withdrawal: 1 TransferTo(100) + 1 EmitWithdrawal(100) = 200
+    // Total: 1000 + 300 + 300 + 200 + 200 + 200 = 2200
+    expect(fee).toBe(2200n);
+  });
+
+  it("throws for unknown executor address in invoke", () => {
+    const actions: Actions = {
+      invoke: {
+        callBuilder: () => ({
+          contractAddress: "0xdead",
+          calldata: [],
+        }),
+      },
+    };
+
+    expect(() => estimatePaymasterFee(actions, UNIFORM_FEE_SCHEDULE)).toThrow(
+      /Unknown executor address.*gasPrice/
+    );
+  });
+
+  it("includes invoke cost for known executor", () => {
+    const actions: Actions = {
+      invoke: {
+        callBuilder: () => ({
+          contractAddress: "0xbeef",
+          calldata: [],
+        }),
+      },
+    };
+
+    const fee = estimatePaymasterFee(actions, UNIFORM_FEE_SCHEDULE);
+
+    // baseFee(1000) + fee withdrawal(200) + invoke(500) = 1700
+    expect(fee).toBe(1700n);
+  });
+
+  it("uses different per-action rates correctly", () => {
+    const differentRates: FeeSchedule = {
+      ...UNIFORM_FEE_SCHEDULE,
+      baseFee: "500",
+      perAction: {
+        ...UNIFORM_FEE_SCHEDULE.perAction,
+        writeOnce: "10",
+        emitNoteUsed: "20",
+        transferTo: "30",
+        emitWithdrawal: "40",
+      },
+    };
+
+    const actions: Actions = {
+      useNotes: [
+        {
+          token: 0xan,
+          note: makeNote(),
+        },
+      ],
+    };
+
+    const fee = estimatePaymasterFee(actions, differentRates);
+
+    // UseNote: 1 WriteOnce(10) + 1 EmitNoteUsed(20) = 30
+    // Fee withdrawal: 1 TransferTo(30) + 1 EmitWithdrawal(40) = 70
+    // Total: 500 + 30 + 70 = 600
+    expect(fee).toBe(600n);
+  });
+});

--- a/sdk/tests/internal/paymaster/integration.test.ts
+++ b/sdk/tests/internal/paymaster/integration.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { createTestEnv, AUTO_ALL, MockTestEnv, POOL_ADDRESS } from "../../helpers/test-fixtures.js";
+import type { FeeSchedule } from "../../../src/interfaces.js";
+import { MockFeeProvider } from "../../../src/testing/mock-fee-provider.js";
+import { Mocknet } from "../../../src/testing/mocknet.js";
+import { toBigInt } from "../../../src/utils/index.js";
+
+const DEFAULT_FEE_SCHEDULE: FeeSchedule = {
+  feeRecipient: "0xfee",
+  baseFee: "1",
+  perAction: {
+    writeOnce: "1",
+    append: "1",
+    transferFrom: "1",
+    transferTo: "1",
+    emitViewingKeySet: "1",
+    emitWithdrawal: "1",
+    emitDeposit: "1",
+    emitOpenNoteCreated: "1",
+    emitEncNoteCreated: "1",
+    emitNoteUsed: "1",
+    invoke: {},
+  },
+  gasPrice: "1",
+  validUntil: Math.floor(Date.now() / 1000) + 600,
+};
+
+describe("Paymaster Integration", () => {
+  let testEnv: MockTestEnv;
+
+  beforeEach(() => {
+    testEnv = createTestEnv();
+  });
+
+  it("autoPaymaster: true without feeProvider throws", async () => {
+    const { transfers, env } = testEnv;
+    const { alice } = transfers;
+
+    await expect(
+      alice
+        .build({ ...AUTO_ALL, autoPaymaster: true })
+        .with(env.ace)
+        .deposit({ amount: 100n })
+        .execute()
+    ).rejects.toThrow(/feeProvider/);
+  });
+
+  it("autoPaymaster: false does not call feeProvider", async () => {
+    const { transfers, env } = testEnv;
+    const { alice } = transfers;
+
+    const result = await alice
+      .build({ ...AUTO_ALL, autoPaymaster: false })
+      .with(env.ace)
+      .deposit({ amount: 100n })
+      .execute();
+
+    expect(result.callAndProof).toBeDefined();
+  });
+
+  it("preview returns actions and zero fee when autoPaymaster is disabled", async () => {
+    const { transfers, env } = testEnv;
+    const { alice } = transfers;
+
+    const result = await alice
+      .build({ ...AUTO_ALL, autoPaymaster: false })
+      .with(env.ace)
+      .deposit({ amount: 100n })
+      .preview();
+
+    expect(result.fee).toBe(0n);
+    expect(result.feeSchedule).toBeUndefined();
+    expect(result.actions.deposits).toHaveLength(1);
+    expect(result.actions.deposits![0].amount).toBe(100n);
+  });
+
+  it("preview returns actions and estimated fee when autoPaymaster is enabled", async () => {
+    const mockFeeProvider = new MockFeeProvider(DEFAULT_FEE_SCHEDULE);
+    const paymasterMocknet = new Mocknet({ poolAddress: POOL_ADDRESS });
+    const paymasterEnv = paymasterMocknet.initialize();
+
+    const alicePaymaster = paymasterMocknet.createPrivateTransfers(
+      paymasterEnv.alice.address,
+      paymasterEnv.alice.privateKey,
+      { feeProvider: mockFeeProvider }
+    );
+
+    const result = await alicePaymaster
+      .build({
+        ...AUTO_ALL,
+        autoPaymaster: true,
+        paymasterFeeToken: paymasterEnv.ace,
+      })
+      .with(paymasterEnv.ace)
+      .deposit({ amount: 100n })
+      .preview();
+
+    expect(result.fee).toBeGreaterThan(0n);
+    expect(result.feeSchedule).toEqual(DEFAULT_FEE_SCHEDULE);
+    // preview does NOT mutate actions.withdraws (no fee withdrawal injected)
+    expect(result.actions.withdraws).toHaveLength(0);
+    expect(mockFeeProvider.calls).toHaveLength(1);
+    expect(mockFeeProvider.calls[0].method).toBe("getFeeQuote");
+  });
+
+  it("autoPaymaster injects fee withdrawal and returns callAndProof without submitting", async () => {
+    const mockFeeProvider = new MockFeeProvider(DEFAULT_FEE_SCHEDULE);
+
+    const paymasterMocknet = new Mocknet({ poolAddress: POOL_ADDRESS });
+    const paymasterEnv = paymasterMocknet.initialize();
+    const aceToken = toBigInt(paymasterEnv.ace);
+
+    // Create a standard transfers instance (no paymaster) for initial deposit
+    const aliceStandard = paymasterMocknet.createPrivateTransfers(
+      paymasterEnv.alice.address,
+      paymasterEnv.alice.privateKey
+    );
+
+    // Step 1: Deposit 100 ace (without paymaster) to establish notes
+    const depositResult = await aliceStandard
+      .build(AUTO_ALL)
+      .with(paymasterEnv.ace)
+      .deposit({ amount: 100n })
+      .execute();
+    paymasterMocknet.executeOutside(depositResult);
+
+    const aliceNotes = depositResult.registry.notes.get(aceToken) ?? [];
+    expect(aliceNotes.length).toBe(1);
+    expect(aliceNotes[0].amount).toBe(100n);
+
+    // Step 2: Create a paymaster-enabled transfers instance
+    const alicePaymaster = paymasterMocknet.createPrivateTransfers(
+      paymasterEnv.alice.address,
+      paymasterEnv.alice.privateKey,
+      { feeProvider: mockFeeProvider }
+    );
+
+    // Step 3: Withdraw with autoPaymaster — fee withdrawal injected automatically
+    const result = await alicePaymaster
+      .build({
+        ...AUTO_ALL,
+        autoPaymaster: true,
+        paymasterFeeToken: paymasterEnv.ace,
+        registry: depositResult.registry,
+      })
+      .surplusTo(paymasterEnv.alice.address)
+      .with(paymasterEnv.ace)
+      .withdraw({ amount: 10n })
+      .execute();
+
+    // Should have called getFeeQuote only (no executeTransaction — execute() doesn't submit)
+    expect(mockFeeProvider.calls.length).toBe(1);
+    expect(mockFeeProvider.calls[0].method).toBe("getFeeQuote");
+
+    // callAndProof is returned as usual — caller submits to paymaster separately
+    expect(result.callAndProof).toBeDefined();
+    expect(result.callAndProof.call.entrypoint).toBe("apply_actions");
+    expect(result.callAndProof.proof).toBeDefined();
+  });
+});

--- a/sdk/tests/internal/paymaster/service.test.ts
+++ b/sdk/tests/internal/paymaster/service.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { PaymasterService } from "../../../src/internal/paymaster/service.js";
+
+const PAYMASTER_URL = "https://paymaster.test";
+
+const VALID_FEE_SCHEDULE = {
+  feeRecipient: "0xfee",
+  baseFee: "1000",
+  perAction: {
+    writeOnce: "100",
+    append: "150",
+    transferFrom: "200",
+    transferTo: "200",
+    emitViewingKeySet: "50",
+    emitWithdrawal: "50",
+    emitDeposit: "50",
+    emitOpenNoteCreated: "50",
+    emitEncNoteCreated: "50",
+    emitNoteUsed: "50",
+    invoke: { "0xbeef": "500" },
+  },
+  gasPrice: "10",
+  validUntil: Math.floor(Date.now() / 1000) + 600, // 10 min from now
+};
+
+function mockJsonRpcResponse(result: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify({ jsonrpc: "2.0", id: 1, result })),
+  } as Response;
+}
+
+function getRequestBody<T = Record<string, unknown>>(mockFetch: ReturnType<typeof vi.fn>): T {
+  const init = mockFetch.mock.calls[0][1] as RequestInit;
+  return JSON.parse(init.body as string) as T;
+}
+
+describe("PaymasterService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getFeeQuote", () => {
+    it("sends correct JSON-RPC method and token param", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(mockJsonRpcResponse(VALID_FEE_SCHEDULE));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await service.getFeeQuote("0xabc123");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const body = getRequestBody<{ method: string; params: { token: string } }>(fetchSpy);
+      expect(body.method).toBe("paymaster_getFeeQuote");
+      expect(body.params.token).toBe("0xabc123");
+    });
+
+    it("returns valid fee schedule", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonRpcResponse(VALID_FEE_SCHEDULE));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      const schedule = await service.getFeeQuote("0xabc123");
+
+      expect(schedule.feeRecipient).toBe("0xfee");
+      expect(schedule.baseFee).toBe("1000");
+      expect(schedule.perAction.writeOnce).toBe("100");
+      expect(schedule.perAction.invoke["0xbeef"]).toBe("500");
+      expect(schedule.validUntil).toBe(VALID_FEE_SCHEDULE.validUntil);
+    });
+
+    it("rejects malformed fee schedule (missing feeRecipient)", async () => {
+      const malformed = { ...VALID_FEE_SCHEDULE, feeRecipient: undefined };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonRpcResponse(malformed));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await expect(service.getFeeQuote("0xabc123")).rejects.toThrow(/invalid fee schedule/);
+    });
+
+    it("rejects malformed fee schedule (missing perAction field)", async () => {
+      const malformed = {
+        ...VALID_FEE_SCHEDULE,
+        perAction: { ...VALID_FEE_SCHEDULE.perAction, writeOnce: undefined },
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(mockJsonRpcResponse(malformed));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await expect(service.getFeeQuote("0xabc123")).rejects.toThrow(/invalid fee schedule/);
+    });
+
+    it("caches fee schedule for same token and returns cached on second call", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(mockJsonRpcResponse(VALID_FEE_SCHEDULE));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      const first = await service.getFeeQuote("0xabc123");
+      const second = await service.getFeeQuote("0xabc123");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(first).toEqual(second);
+    });
+
+    it("re-fetches when cached schedule has expired", async () => {
+      const expiredSchedule = {
+        ...VALID_FEE_SCHEDULE,
+        validUntil: Math.floor(Date.now() / 1000) - 10, // expired 10s ago
+      };
+
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(mockJsonRpcResponse(expiredSchedule))
+        .mockResolvedValueOnce(mockJsonRpcResponse(VALID_FEE_SCHEDULE));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await service.getFeeQuote("0xabc123");
+      const second = await service.getFeeQuote("0xabc123");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(second.validUntil).toBe(VALID_FEE_SCHEDULE.validUntil);
+    });
+
+    it("fetches separately for different tokens", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(mockJsonRpcResponse(VALID_FEE_SCHEDULE));
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await service.getFeeQuote("0xaaa111");
+      await service.getFeeQuote("0xbbb222");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws on JSON-RPC error response", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              error: { code: -32600, message: "Invalid request" },
+            })
+          ),
+      } as Response);
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await expect(service.getFeeQuote("0xabc123")).rejects.toThrow(
+        /Paymaster service error \(code -32600\)/
+      );
+    });
+
+    it("throws on HTTP error", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: () => Promise.resolve("Service Unavailable"),
+      } as Response);
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await expect(service.getFeeQuote("0xabc123")).rejects.toThrow(/Paymaster service HTTP 503/);
+    });
+
+    it("throws when response has no result", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify({ jsonrpc: "2.0", id: 1 })),
+      } as Response);
+
+      const service = new PaymasterService({ baseUrl: PAYMASTER_URL });
+      await expect(service.getFeeQuote("0xabc123")).rejects.toThrow(
+        /Paymaster service returned no result/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds paymaster fee injection to the SDK via `autoPaymaster: true` and `paymasterFeeToken` on execute options. When enabled, the SDK fetches a rate card for the chosen fee token, estimates the fee locally, and injects a fee withdrawal into the actions before compilation. `execute()` semantics are unchanged — it returns `callAndProof` without submitting.

Also adds a lightweight `preview()` method on the builder that returns the collected actions and estimated paymaster fee — without calling the compiler or prover. This lets callers inspect what `execute()` will do before kicking off compilation + proving.

### How it works

1. SDK calls `getFeeQuote(paymasterFeeToken)` on the paymaster — a stateless rate card endpoint that only receives the fee token (defaults to the first token in the actions; no user info, no transaction details)
2. SDK estimates the fee **locally** by mapping the user's actions to expected ServerAction counts using the Cairo `compile_actions` mapping table, then multiplying by per-action rates from the rate card
3. SDK injects a fee withdrawal into `actions.withdraws` **before** compilation, so `autoSelectNotes` automatically accounts for the extra output amount
4. Compile + prove via the existing flow — `execute()` returns `callAndProof` as always
5. Caller submits the returned `callAndProof` to the paymaster

### `preview()` — inspect before proving

`preview()` returns `{ actions, fee, feeSchedule? }` without compiling, discovering, or proving. When `autoPaymaster` is enabled, it calls `getFeeQuote` and estimates the fee; otherwise `fee` is `0n`. Unlike `execute()`, it does **not** mutate `actions.withdraws`.

Available on `PrivateTransfersInterface`, `PrivateTransfersBuilder`, and `TokenOperationsBuilder` — same call sites as `execute()` and `createProofInvocation()`.

### Privacy improvement over architecture doc

The architecture doc's `buildTransaction` sends `user_address` + `calls` to the paymaster, leaking identity and intent. `getFeeQuote(token)` is stateless — the paymaster learns nothing about the user until the caller explicitly submits.

### Fee estimation: ClientAction to ServerAction mapping

| ClientAction | ServerActions | Count |
|---|---|---|
| SetViewingKey | WriteOnce x2, EmitViewingKeySet | 3 |
| OpenChannel | Append, WriteOnce x2 | 3 |
| OpenSubchannel | WriteOnce x2 | 2 |
| Deposit | TransferFrom, EmitDeposit | 2 |
| UseNote | WriteOnce, EmitNoteUsed | 2 |
| CreateEncNote | WriteOnce, EmitEncNoteCreated | 2 |
| CreateOpenNote | WriteOnce, EmitOpenNoteCreated | 2 |
| Withdraw | TransferTo, EmitWithdrawal | 2 |
| InvokeExternal | looked up per executor address | 1 |

The fee withdrawal itself adds +1 TransferTo + +1 EmitWithdrawal (self-referential cost included).

## Design rationale

1. **`execute()` never submits** — `autoPaymaster` only handles fee estimation + withdrawal injection. `execute()` returns `callAndProof` as before. No network calls beyond `getFeeQuote`.
2. **Paymaster URL at factory level** — mirrors `provingProvider` and `discoveryProvider` pattern. Static infrastructure config, not per-transaction.
3. **`autoPaymaster` as opt-in flag** — not all transactions need paymaster (e.g., deposits with L1 funds). Consistent with `autoSetup`, `autoSelectNotes`.
4. **Throw on misconfiguration** — `autoPaymaster: true` without paymaster config = error, not silent fallback.
5. **Rate card (`getFeeQuote`) instead of `buildTransaction`** — paymaster publishes per-action rates, SDK computes fee locally. No user info sent — only the fee token. Paymaster verifies `fee_paid >= actual_cost` at execute time.
6. **Local fee estimation** — SDK maps Actions -> expected ServerAction counts -> total fee using the rate card. The mapping table mirrors Cairo's `compile_actions` deterministic output.
7. **Fee schedule caching per token with TTL** — `getFeeQuote(token)` returns `validUntil`. SDK caches per token, re-fetches when expired.
8. **Fee withdrawal self-cost** — the fee withdrawal itself produces 2 ServerActions (TransferTo + EmitWithdrawal). The estimator includes this self-referential cost.
9. **Fee injection before compilation** — the fee withdrawal is added to `actions.withdraws` before `compiler.compile()`, so `autoSelectNotes` naturally accounts for the extra output amount. No special-casing in the compiler.
10. **`preview()` is read-only** — it reuses `collectActionsAndOptions()` and `estimatePaymasterFee()` but never mutates actions or triggers compilation/proving. Follows the same delegation pattern as `execute()` and `createProofInvocation()` (builder -> transfers interface).

## Changes

### New files

| File | Description |
|------|-------------|
| `sdk/src/internal/paymaster/service.ts` | `PaymasterService` — JSON-RPC client for `getFeeQuote`, with Zod validation and fee schedule caching per token with TTL |
| `sdk/src/internal/paymaster/fee-estimator.ts` | Pure functions: `estimateServerActionCounts()` and `estimatePaymasterFee()` — Actions + FeeSchedule -> total fee |
| `sdk/src/testing/mock-fee-provider.ts` | `MockFeeProvider` — deterministic `FeeProviderInterface` mock, records calls for test assertions |
| `sdk/tests/internal/paymaster/service.test.ts` | PaymasterService tests: JSON-RPC shape, Zod validation, caching/TTL, error handling, health check |
| `sdk/tests/internal/paymaster/fee-estimator.test.ts` | Fee estimator tests: per-action counts for each action type, fee calculation, invoke handling, different rates |
| `sdk/tests/internal/paymaster/integration.test.ts` | Integration tests: error on missing feeProvider, skip when disabled, full deposit-then-paymaster-withdraw flow, preview with/without autoPaymaster |

### Modified files

| File | Change |
|------|--------|
| `sdk/src/interfaces.ts` | Added `FeeSchedule`, `FeeProviderInterface`, `PaymasterConfig`, `PreviewResult` types. Added `preview()` to `PrivateTransfersInterface`, `PrivateTransfersBuilder`, `TokenOperationsBuilder`. Added `autoPaymaster`, `paymasterFeeToken` to `ExecuteOptions` |
| `sdk/src/internal/abstract-private-transfers.ts` | Added abstract `preview()` method |
| `sdk/src/internal/private-transfers.ts` | Added `feeProvider?` constructor param. Implemented `preview()` (fee estimate without compilation). Added `injectPaymasterFee()` private method (fee estimation + withdrawal injection) |
| `sdk/src/internal/builders.ts` | Added `preview()` to `PrivateTransfersBuilderImpl` and `TokenOperationsBuilderImpl` — delegates to `this.transfers.preview()` |
| `sdk/src/factory.ts` | Added `feeProvider?: FeeProviderInterface \| PaymasterConfig` param. Auto-constructs `PaymasterService` from config (same pattern as proving/discovery providers) |
| `sdk/src/index.ts` | Exports `PaymasterService`, `PaymasterServiceConfig`, `estimatePaymasterFee`, `estimateServerActionCounts` |
| `sdk/src/testing/mocknet.ts` | Extended `createPrivateTransfers` to accept optional `feeProvider` for test wiring |
| `sdk/src/testing/index.ts` | Exports `MockFeeProvider` |

## Usage

```typescript
// Configure with paymaster
const transfers = createPrivateTransfers({
  account,
  viewingKeyProvider,
  provingProvider: { url: "https://prover.example.com", chainId },
  discoveryProvider: { url: "https://indexer.example.com" },
  feeProvider: { url: "https://paymaster.example.com" },
  poolContractAddress,
});

// Build once, preview, then execute — no need to rebuild
// paymasterFeeToken defaults to the first token in the actions;
// set explicitly to override: .build({ autoPaymaster: true, paymasterFeeToken: STRK })
const builder = transfers
  .build({ autoPaymaster: true, ...otherOptions })
  .surplusTo(myAddress)
  .with(STRK)
  .withdraw({ amount: 50n });

// Preview: inspect actions and estimated fee without compiling or proving
const preview = await builder.preview();
console.log(`Estimated fee: ${preview.fee}, actions:`, preview.actions);

// Execute: compile, prove, and return callAndProof with fee withdrawal baked in
const result = await builder.execute();
```

## Test plan

- [ ] `npm run lint` passes (prettier + eslint + tsc)
- [ ] `npm test` — all 183 tests pass (27 new paymaster tests)
- [ ] PaymasterService: `getFeeQuote` JSON-RPC shape, Zod rejects malformed responses, caching with TTL expiry, HTTP/RPC error handling
- [ ] Fee estimator: correct ServerAction counts for each action type, fee calculation with uniform and varied rates, invoke lookup with known/unknown executors
- [ ] Integration: `autoPaymaster: true` without feeProvider throws, `autoPaymaster: false` skips paymaster, full flow (deposit -> paymaster-funded withdraw) with MockFeeProvider verifying only `getFeeQuote` is called
- [ ] Preview: returns zero fee + no feeSchedule when autoPaymaster disabled; returns estimated fee + feeSchedule when enabled without mutating actions


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/658)
<!-- Reviewable:end -->
