### PR TITLE
ci: publish Cairo docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,31 @@
+name: Publish Cairo Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: software-mansion/setup-scarb@v1
+      - run: scarb doc --build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Contract | Docs | Tag | Class Hash |
 |----------|------|-----|------------|
-| Privacy Pool | [README](packages/privacy/README.md) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) | `0x21a53b2cde0fbec5761793c09626fe6e53357d7856389711a8391d8468102e3` |
+| Privacy Pool | [README](packages/privacy/README.md) · [API docs](https://starkware-libs.github.io/starknet-privacy/privacy/) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) | `0x21a53b2cde0fbec5761793c09626fe6e53357d7856389711a8391d8468102e3` |
 | Ekubo Helper | | | |
-| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) | `0x1973a0ccabe1e1fc995bcac13c52300fc9953342293d3c15e878bdca84751a1` |
+| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) · [API docs](https://starkware-libs.github.io/starknet-privacy/vesu_lending_helper/) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) | `0x1973a0ccabe1e1fc995bcac13c52300fc9953342293d3c15e878bdca84751a1` |
 
 ## Repository map
 
 | Directory | Description |
 |-----------|-------------|
-| [`packages/privacy/`](packages/privacy/) | Cairo smart contract ([README](packages/privacy/README.md)) |
+| [`packages/privacy/`](packages/privacy/) | Cairo smart contract ([README](packages/privacy/README.md), [API docs](https://starkware-libs.github.io/starknet-privacy/privacy/)) |
 | [`crates/discovery-core/`](crates/discovery-core/) | Core discovery logic & cryptography ([README](crates/discovery-core/README.md)) |
 | [`crates/discovery-service/`](crates/discovery-service/) | HTTP discovery service (RPC-backed) ([README](crates/discovery-service/README.md)) |
 | [`sdk/`](sdk/) | TypeScript SDK for private transfers ([README](sdk/README.md)) |


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `scarb doc --build` on every merge to `main` and deploys the generated HTML to GitHub Pages
- Links to the generated docs from the README for both the Privacy Pool and Vesu Helper contracts

Published URLs after merge:
- `https://starkware-libs.github.io/starknet-privacy/privacy/`
- `https://starkware-libs.github.io/starknet-privacy/vesu_lending_helper/`

## Setup required
GitHub Pages must be configured to use **GitHub Actions** as the source: Settings → Pages → Source → GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/664)
<!-- Reviewable:end -->
