### PR TITLE
fix(discovery-service): return 400 instead of 404 for contract not found

### DIFF
--- a/crates/discovery-service/specs/08-error-handling.md
+++ b/crates/discovery-service/specs/08-error-handling.md
@@ -17,7 +17,6 @@ All error responses follow a consistent structure:
 **HTTP status codes:**
 
 - `400` - Client errors (invalid input, validation failures)
-- `404` - Resource not found
 - `409` - Conflict (reorg detected)
 - `429` - Rate limited
 - `500` - Internal server error
@@ -30,6 +29,7 @@ All error responses follow a consistent structure:
 | `INVALID_REQUEST` | 400 | No | Malformed request body or missing required fields |
 | `MAX_READS_EXCEEDED` | 400 | No | Requested `max_reads` exceeds allowed maximum |
 | `DECRYPTION_FAILED` | 400 | No | Provided key could not decrypt channel/note data. Generic message only — channel index and internal error details are logged server-side, not exposed to the client |
+| `CONTRACT_NOT_FOUND` | 400 | No | Contract not found at the provided address |
 | `BLOCK_REORGED` | 409 | Yes | `last_known_block` was reorged out; client should re-sync |
 | `RATE_LIMITED` | 429 | Yes | Too many requests. `Retry-After` header is set by the reverse proxy, not the service itself |
 | `SERVICE_UNAVAILABLE` | 503 | Yes | Service is starting up or no chain head available. `Retry-After` header, if present, is set by the reverse proxy |

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -76,7 +76,7 @@ pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErr
             if matches!(storage_err, StorageError::ContractNotFound) {
                 warn!("Contract not found during discovery");
                 (
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     ApiErrorResponse::new(
                         error_codes::CONTRACT_NOT_FOUND,
                         "Contract not found at the configured address",

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -195,7 +195,7 @@ pub async fn validate_viewing_key<S: StorageSnapshot>(
             .await
             .map_err(|storage_error| match storage_error {
                 StorageError::ContractNotFound => (
-                    StatusCode::NOT_FOUND,
+                    StatusCode::BAD_REQUEST,
                     ApiErrorResponse::new(
                         error_codes::CONTRACT_NOT_FOUND,
                         "Contract not found at the configured address",

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -219,7 +219,7 @@ async fn test_incoming_sync_contract_not_found() {
 
     let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
 
-    assert_eq!(status, 404);
+    assert_eq!(status, 400);
     assert_eq!(error.error.code, "CONTRACT_NOT_FOUND");
 
     indexer.signal_shutdown().unwrap();


### PR DESCRIPTION
### TL;DR

Changed HTTP status code for contract not found errors from 404 to 400

### What changed?

The `CONTRACT_NOT_FOUND` error now returns HTTP status code 400 (Bad Request) instead of 404 (Not Found). This affects both the discovery error handling and viewing key validation flows. The error specification documentation has been updated to reflect this change and remove the generic 404 status code from the list of supported HTTP codes.

### How to test?

Run the existing test `test_incoming_sync_contract_not_found()` which has been updated to expect a 400 status code instead of 404. The test should pass and verify that contract not found scenarios return the correct status code.

### Why make this change?

This aligns the error handling with the principle that 404 should be reserved for endpoint-level "not found" errors, while 400 is more appropriate for client input validation failures like providing an invalid contract address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/669)
<!-- Reviewable:end -->
