### PR TITLE
docs: bump sequencer and transaction prover tags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All components in a row are tested together. Use matching revisions when deployi
 | Sequencer | | [`APOLLO-0.14.2-RC.6`](https://github.com/starkware-libs/sequencer/releases/tag/APOLLO-0.14.2-RC.6) |
 | Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover/743671200?tag=PRIVACY-0.14.2-RC.3) |
 | Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service/742029660?tag=PRIVACY-0.14.2-RC.1) |
-| Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.0-beta.3`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.0-beta.3/images/sha256-a71b220d6786ea3685a6755e68cf3d2d715ecb2c740abb8eb30c75f0b84bd5bd) |
+| Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.1`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.1/images/sha256-ff7e7b1b2121c1abc754701f6acd24587da21b26c010061633ebc1f270f08aa7) |
 | SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) |
 
 \* For the transaction prover to work correctly with Pathfinder, set `PATHFINDER_STORAGE_STATE_TRIES=10000`.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Component | Docs | Tag |
 |-----------|------|-------------|
-| Sequencer | | [`APOLLO-0.14.2-RC.1`](https://github.com/starkware-libs/sequencer/releases/tag/APOLLO-0.14.2-RC.1) |
-| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover/743671200?tag=PRIVACY-0.14.2-RC.1) |
+| Sequencer | | [`APOLLO-0.14.2-RC.6`](https://github.com/starkware-libs/sequencer/releases/tag/APOLLO-0.14.2-RC.6) |
+| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover/743671200?tag=PRIVACY-0.14.2-RC.3) |
 | Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service/742029660?tag=PRIVACY-0.14.2-RC.1) |
 | Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.0-beta.3`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.0-beta.3/images/sha256-a71b220d6786ea3685a6755e68cf3d2d715ecb2c740abb8eb30c75f0b84bd5bd) |
 | SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.1`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.1) |


### PR DESCRIPTION
## Summary

Updates the integration components table in the README to match current releases:

- **Sequencer:** `APOLLO-0.14.2-RC.1` → `APOLLO-0.14.2-RC.6`
- **Transaction Prover:** `PRIVACY-0.14.2-RC.1` → `PRIVACY-0.14.2-RC.3`

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/673)
<!-- Reviewable:end -->
