### PR TITLE
fix(sdk): fail fast on insufficient balance after auto note selection

### DIFF
--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -667,6 +667,19 @@ export class ActionCompiler {
         }
       }
 
+      // Guard against insufficient balance: if still in deficit after auto-selection,
+      // the prover would fail with NEGATIVE_INTERMEDIATE_BALANCE. Fail fast here instead.
+      if (balance < 0n) {
+        const totalAvailable = (registry.notes.get(token) ?? []).reduce(
+          (sum, note) => sum + note.amount,
+          0n
+        );
+        throw new Error(
+          `Insufficient balance for token ${toHex(token)}: ` +
+            `need ${-balance} more (total available: ${totalAvailable})`
+        );
+      }
+
       // If surplus (after adding notes or initially), create change note
       if (balance > 0n) {
         let surplusAction = actions.surpluses?.find((s) => s.token === token);


### PR DESCRIPTION
## Summary

After automatic note selection, if the running balance is still negative, the prover would eventually fail with `NEGATIVE_INTERMEDIATE_BALANCE`. This change throws a clear `Error` earlier with the token, shortfall, and total available amount.

## Verification

- `npm run build` and `npm run lint` in `sdk/` pass locally.
- `npm run test:fast` did not run in this environment (Vitest failed loading `node:inspector/promises` — Node/tooling mismatch). CI should run the full test suite.

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/684)
<!-- Reviewable:end -->
