### PR TITLE
feat(sdk): run channel and note discovery concurrently

### DIFF
--- a/.claude/rules/verification.md
+++ b/.claude/rules/verification.md
@@ -12,6 +12,7 @@
 **SDK verification checklist (from `sdk/`):**
 - `npm run lint` - formatting (prettier), lints (eslint), and type-check (tsc) in one command
 - If lint fails on formatting or auto-fixable eslint issues, run `npm run format` to fix them
+- Update `sdk/CHANGELOG.md` under the `## Unreleased` section (Added/Changed/Fixed/Breaking). Check git tags (`git tag --sort=-v:refname | head -5`) to confirm which versions are already released — never add entries to released versions.
 
 ## E2E integration gate
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Run channel and note discovery concurrently during transaction compilation to reduce latency
 - `ProofInvocationFactory` builds `INVOKE_TXN_V3` manually instead of using `RpcChannel.prototype.buildTransaction()` (removed in v10)
 - `ProvingService.proveTransaction()` parameter type changed from `INVOKE_TXN_V3` to `ProofInvocation` (same underlying type)
 - Remove devnet `getStarknetVersion` monkey-patch and `declareWithoutVersionCheck` workaround (starknet.js#1561 resolved in v10)

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -114,16 +114,11 @@ export class ActionCompiler {
     const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
-    // Phase 1: Resolve recipient channels
-    const { channels, total } = await this.resolveRecipientChannels(
-      actions,
-      options,
-      registry,
-      recipientsNeeded
-    );
-
-    // Phase 2: Resolve notes (discover and/or auto-select)
-    await this.resolveNotes(actions, registry, options);
+    // Resolve channels and notes concurrently (they are independent)
+    const [{ channels, total }] = await Promise.all([
+      this.resolveRecipientChannels(actions, options, registry, recipientsNeeded),
+      this.resolveNotes(actions, registry, options),
+    ]);
 
     debugLog("compiler", "compile", "post resolveNotes", registry?.notes?.size, actions);
 


### PR DESCRIPTION
### TL;DR

Optimized transaction compilation by running channel and note discovery in parallel instead of sequentially.

### What changed?

Modified the ActionCompiler to execute `resolveRecipientChannels` and `resolveNotes` concurrently using `Promise.all()` rather than awaiting them sequentially. Added a changelog entry documenting this performance improvement and updated the verification rules to require changelog updates for SDK changes.

### How to test?

Run the existing SDK test suite with `npm run lint` and verify that transaction compilation still works correctly while observing reduced latency in scenarios with both channel resolution and note discovery.

### Why make this change?

Channel resolution and note discovery are independent operations that don't depend on each other's results, so running them in parallel reduces overall transaction compilation latency and improves user experience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/686)
<!-- Reviewable:end -->
