### PR TITLE
feat(prover-proxy): Prometheus metrics with /metrics endpoint

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -41,17 +41,17 @@ The secret value must be a JSON string with this structure:
 }
 ```
 
-| Field | Description |
-|-------|-------------|
-| `elliptic.url` | Elliptic API base URL |
-| `elliptic.key` | Real Elliptic API key |
-| `elliptic.secret` | Real Elliptic HMAC secret (base64-encoded) |
-| `elliptic.timeoutMs` | Timeout for upstream Elliptic requests (ms) |
-| `rateLimitPerMinute` | Per-partner rate limit (requests per minute) |
-| `maxBodyBytes` | Max request body size |
-| `configCacheTtlSeconds` | How long to cache the config before re-reading from Secret Manager (seconds) |
-| `blockedCacheTtlSeconds` | How long to cache blocked address verdicts (seconds) |
-| `partners.<name>` | Partner HMAC secret (base64-encoded). The key is the partner name, sent in `x-access-key` |
+| Field                    | Description                                                                               |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `elliptic.url`           | Elliptic API base URL                                                                     |
+| `elliptic.key`           | Real Elliptic API key                                                                     |
+| `elliptic.secret`        | Real Elliptic HMAC secret (base64-encoded)                                                |
+| `elliptic.timeoutMs`     | Timeout for upstream Elliptic requests (ms)                                               |
+| `rateLimitPerMinute`     | Per-partner rate limit (requests per minute)                                              |
+| `maxBodyBytes`           | Max request body size                                                                     |
+| `configCacheTtlSeconds`  | How long to cache the config before re-reading from Secret Manager (seconds)              |
+| `blockedCacheTtlSeconds` | How long to cache blocked address verdicts (seconds)                                      |
+| `partners.<name>`        | Partner HMAC secret (base64-encoded). The key is the partner name, sent in `x-access-key` |
 
 ### Generating partner secrets
 
@@ -74,11 +74,11 @@ Note: the request path is lowercased before signing, matching the Elliptic API c
 
 Required headers on every request:
 
-| Header | Value |
-|--------|-------|
-| `x-access-key` | Partner name (matches a key in `config.partners`) |
-| `x-access-sign` | Base64-encoded HMAC-SHA256 signature |
-| `x-access-timestamp` | Unix timestamp in milliseconds |
+| Header               | Value                                             |
+| -------------------- | ------------------------------------------------- |
+| `x-access-key`       | Partner name (matches a key in `config.partners`) |
+| `x-access-sign`      | Base64-encoded HMAC-SHA256 signature              |
+| `x-access-timestamp` | Unix timestamp in milliseconds                    |
 
 ## Deployment
 
@@ -142,14 +142,14 @@ npm run test:watch   # watch mode
 
 All requests are logged as structured JSON to stdout (picked up by Cloud Logging automatically). Each log line includes:
 
-| Field | Description |
-|-------|-------------|
-| `method` | HTTP method |
-| `path` | Request path |
-| `status` | Response status code |
-| `latencyMs` | Total request duration |
-| `partner` | Partner name (if identified) |
-| `reason` | Rejection reason (`missing_headers`, `timestamp_expired`, `unknown_partner`, `invalid_signature`, `rate_limited`, `upstream_request_failed`, `upstream_non_2xx`) |
-| `ellipticStatus` | Upstream Elliptic response status (on success) |
+| Field            | Description                                                                                                                                                      |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `method`         | HTTP method                                                                                                                                                      |
+| `path`           | Request path                                                                                                                                                     |
+| `status`         | Response status code                                                                                                                                             |
+| `latencyMs`      | Total request duration                                                                                                                                           |
+| `partner`        | Partner name (if identified)                                                                                                                                     |
+| `reason`         | Rejection reason (`missing_headers`, `timestamp_expired`, `unknown_partner`, `invalid_signature`, `rate_limited`, `upstream_request_failed`, `upstream_non_2xx`) |
+| `ellipticStatus` | Upstream Elliptic response status (on success)                                                                                                                   |
 
 Config load failures are logged to stderr with `error: "config_load_failed"`.

--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -49,17 +49,17 @@ re-reads it according to `configCacheTtlSeconds`.
 
 ### Configuration fields
 
-| Field | Description |
-|-------|-------------|
-| `elliptic.url` | Elliptic API base URL |
-| `elliptic.key` | Real Elliptic API key |
-| `elliptic.secret` | Real Elliptic HMAC secret (base64) |
-| `elliptic.timeoutMs` | Timeout for upstream Elliptic requests (ms) |
-| `rateLimitPerMinute` | Global per-partner rate limit |
-| `maxBodyBytes` | Max request body size |
-| `configCacheTtlSeconds` | How often the proxy re-reads config from Secret Manager (seconds) |
-| `blockedCacheTtlSeconds` | How long to cache blocked address verdicts (seconds) |
-| `partners.<name>` | Partner HMAC secret (base64). The key is the partner name, sent in `x-access-key` |
+| Field                    | Description                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `elliptic.url`           | Elliptic API base URL                                                             |
+| `elliptic.key`           | Real Elliptic API key                                                             |
+| `elliptic.secret`        | Real Elliptic HMAC secret (base64)                                                |
+| `elliptic.timeoutMs`     | Timeout for upstream Elliptic requests (ms)                                       |
+| `rateLimitPerMinute`     | Global per-partner rate limit                                                     |
+| `maxBodyBytes`           | Max request body size                                                             |
+| `configCacheTtlSeconds`  | How often the proxy re-reads config from Secret Manager (seconds)                 |
+| `blockedCacheTtlSeconds` | How long to cache blocked address verdicts (seconds)                              |
+| `partners.<name>`        | Partner HMAC secret (base64). The key is the partner name, sent in `x-access-key` |
 
 ## Authentication
 
@@ -79,6 +79,7 @@ signature = HMAC-SHA256(
 ```
 
 The proxy:
+
 1. Looks up the partner's HMAC secret by name (`x-access-key` header value)
 2. Recomputes the HMAC using the partner's secret and verifies it matches
    `x-access-sign`
@@ -96,15 +97,15 @@ The proxy:
 
 ## Error Handling
 
-| Condition | Response |
-|-----------|----------|
-| Missing/invalid `x-access-key` | `401 Unauthorized` |
-| Bad HMAC signature | `401 Unauthorized` |
-| Rate limit exceeded | `429 Too Many Requests` |
-| Body exceeds `maxBodyBytes` | `413 Payload Too Large` |
+| Condition                              | Response                  |
+| -------------------------------------- | ------------------------- |
+| Missing/invalid `x-access-key`         | `401 Unauthorized`        |
+| Bad HMAC signature                     | `401 Unauthorized`        |
+| Rate limit exceeded                    | `429 Too Many Requests`   |
+| Body exceeds `maxBodyBytes`            | `413 Payload Too Large`   |
 | Config unavailable from Secret Manager | `503 Service Unavailable` |
-| Elliptic network error | `503 Service Unavailable` |
-| Elliptic non-2xx response | `502 Upstream Error` |
+| Elliptic network error                 | `503 Service Unavailable` |
+| Elliptic non-2xx response              | `502 Upstream Error`      |
 
 ## Project Structure
 

--- a/elliptic-proxy/elliptic-proxy-config.json
+++ b/elliptic-proxy/elliptic-proxy-config.json
@@ -1,0 +1,15 @@
+{
+  "elliptic": {
+    "url": "https://aml-api.elliptic.co",
+    "key": "e2825978e0bc475b358ac232f16f2468",
+    "secret": "2586b6295906e305ba2a37db56b03aaa",
+    "timeoutMs": 10000
+  },
+  "rateLimitPerMinute": 100,
+  "maxBodyBytes": 10240,
+  "configCacheTtlSeconds": 300,
+  "blockedCacheTtlSeconds": 3600,
+  "partners": {
+    "starkware": "L2Fl3rlEVsEHOGaZt95NjmnY5ZKpQ1t5BD1nCV19TUQ="
+  }
+}

--- a/elliptic-proxy/scripts/local-screen.mjs
+++ b/elliptic-proxy/scripts/local-screen.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Run the proxy pipeline locally against a config file and a single address.
+// Loads the config through the proxy's own ConfigLoader (same validation the
+// deployed function uses), then calls forwardToElliptic + scoreResponse and
+// prints the verdict the proxy would return.
+//
+// Usage:
+//   node scripts/local-screen.mjs <config.json> <address>
+//
+// Build first: `npm run build` (imports from dist/).
+
+import { readFile } from "node:fs/promises";
+import { ConfigLoader } from "../dist/config.js";
+import { forwardToElliptic } from "../dist/elliptic.js";
+import { scoreResponse } from "../dist/scoring.js";
+
+const [, , configPath, addressArg] = process.argv;
+if (!configPath || !addressArg) {
+  console.error("usage: local-screen.mjs <config.json> <address>");
+  process.exit(2);
+}
+
+const loader = new ConfigLoader(() => readFile(configPath, "utf8"));
+const config = await loader.get();
+
+const address = addressArg.toLowerCase();
+const upstream = await forwardToElliptic({
+  ellipticUrl: config.elliptic.url,
+  ellipticKey: config.elliptic.key,
+  ellipticSecret: config.elliptic.secret,
+  ellipticTimeoutMs: config.elliptic.timeoutMs,
+  address,
+});
+
+console.error(`elliptic HTTP ${upstream.status}  (${upstream.durationMs} ms)`);
+
+if (upstream.status < 200 || upstream.status >= 300) {
+  console.error("upstream error — body:");
+  console.error(upstream.body);
+  process.exit(1);
+}
+
+const verdict = scoreResponse(upstream.body);
+// Match the proxy's on-the-wire response shape (handler.ts sends { blocked }).
+// Full verdict details are printed to stderr for inspection.
+console.error("verdict detail:", JSON.stringify(verdict));
+console.log(JSON.stringify({ blocked: verdict.blocked }));
+process.exit(0);

--- a/elliptic-proxy/scripts/proxy-screen.mjs
+++ b/elliptic-proxy/scripts/proxy-screen.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Call the deployed elliptic-proxy Cloud Function for a single address.
+// Signs the request as a partner using the same HMAC scheme the proxy verifies.
+//
+// Usage:
+//   PARTNER_NAME=acme PARTNER_SECRET=<base64> \
+//     node scripts/proxy-screen.mjs <proxy-url> <address>
+//   PARTNER_NAME=acme PARTNER_SECRET_HEX=<hex> \
+//     node scripts/proxy-screen.mjs <proxy-url> <address>
+//
+// Build first: `npm run build` (imports computeHmacSignature from dist/).
+
+import { computeHmacSignature } from "../dist/auth.js";
+
+const [, , proxyUrlArg, address] = process.argv;
+if (!proxyUrlArg || !address) {
+  console.error("usage: proxy-screen.mjs <proxy-url> <address>");
+  process.exit(2);
+}
+
+const partnerName = process.env.PARTNER_NAME;
+const secretHex = process.env.PARTNER_SECRET_HEX;
+const partnerSecret = secretHex
+  ? Buffer.from(secretHex.replace(/^0x/, ""), "hex").toString("base64")
+  : process.env.PARTNER_SECRET;
+if (!partnerName || !partnerSecret) {
+  console.error(
+    "PARTNER_NAME and PARTNER_SECRET (base64) or PARTNER_SECRET_HEX must be set"
+  );
+  process.exit(2);
+}
+
+const proxyUrl = new URL(proxyUrlArg);
+// Cloud Functions (cloudfunctions.net/<name>) strips the function-name segment
+// before dispatching to the container, so the server always sees req.path="/".
+// Override with PROXY_SIGN_PATH if you deploy behind a path-preserving gateway.
+const path = process.env.PROXY_SIGN_PATH ?? "/";
+const body = JSON.stringify({ address });
+const timestamp = Date.now().toString();
+const signature = computeHmacSignature(
+  partnerSecret,
+  timestamp,
+  "POST",
+  path,
+  body
+);
+
+const started = Date.now();
+const response = await fetch(proxyUrl, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-access-key": partnerName,
+    "x-access-sign": signature,
+    "x-access-timestamp": timestamp,
+  },
+  body,
+});
+const text = await response.text();
+console.error(`HTTP ${response.status}  (${Date.now() - started} ms)`);
+try {
+  console.log(JSON.stringify(JSON.parse(text), null, 2));
+} catch {
+  console.log(text);
+}
+process.exit(response.ok ? 0 : 1);

--- a/elliptic-proxy/scripts/wallet-exposure.mjs
+++ b/elliptic-proxy/scripts/wallet-exposure.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Run a wallet_exposure analysis against Elliptic for a single address.
+// Reuses forwardToElliptic from the proxy so signing/body shape stay in sync.
+//
+// Usage:
+//   ELLIPTIC_KEY=... ELLIPTIC_SECRET=<base64>       node scripts/wallet-exposure.mjs <address>
+//   ELLIPTIC_KEY=... ELLIPTIC_SECRET_HEX=<hex>      node scripts/wallet-exposure.mjs <address>
+//
+// Optional env:
+//   ELLIPTIC_URL       default https://aml-api.elliptic.co
+//   ELLIPTIC_TIMEOUT   default 30000 (ms)
+//
+// Build first: `npm run build` (script imports from dist/).
+
+import { forwardToElliptic } from "../dist/elliptic.js";
+
+const address = process.argv[2];
+if (!address) {
+  console.error("usage: wallet-exposure.mjs <address>");
+  process.exit(2);
+}
+
+const ellipticKey = process.env.ELLIPTIC_KEY;
+const secretHex = process.env.ELLIPTIC_SECRET_HEX;
+const ellipticSecret = secretHex
+  ? Buffer.from(secretHex.replace(/^0x/, ""), "hex").toString("base64")
+  : process.env.ELLIPTIC_SECRET;
+if (!ellipticKey || !ellipticSecret) {
+  console.error(
+    "ELLIPTIC_KEY and ELLIPTIC_SECRET (base64) or ELLIPTIC_SECRET_HEX must be set"
+  );
+  process.exit(2);
+}
+
+const { status, body, durationMs } = await forwardToElliptic({
+  ellipticUrl: process.env.ELLIPTIC_URL ?? "https://aml-api.elliptic.co",
+  ellipticKey,
+  ellipticSecret,
+  ellipticTimeoutMs: Number(process.env.ELLIPTIC_TIMEOUT ?? 30000),
+  address,
+});
+
+console.error(`HTTP ${status}  (${durationMs} ms)`);
+try {
+  console.log(JSON.stringify(JSON.parse(body), null, 2));
+} catch {
+  console.log(body);
+}
+process.exit(status >= 200 && status < 300 ? 0 : 1);

--- a/elliptic-proxy/src/cache.ts
+++ b/elliptic-proxy/src/cache.ts
@@ -12,10 +12,15 @@ const DEFAULT_MAX_ENTRIES = 10_000;
 export class BlockedAddressCache {
   private readonly cache: LRUCache<string, true>;
 
-  constructor(ttlMs: number, maxEntries: number = DEFAULT_MAX_ENTRIES) {
+  constructor(
+    ttlMs: number,
+    maxEntries: number = DEFAULT_MAX_ENTRIES,
+    clock: { now(): number } = performance
+  ) {
     this.cache = new LRUCache<string, true>({
       max: maxEntries,
       ttl: ttlMs,
+      perf: clock,
     });
   }
 

--- a/elliptic-proxy/src/config.ts
+++ b/elliptic-proxy/src/config.ts
@@ -110,7 +110,10 @@ function validateConfig(raw: unknown): Config {
     rateLimitPerMinute: requirePositiveNumber(root, "rateLimitPerMinute"),
     maxBodyBytes: requirePositiveNumber(root, "maxBodyBytes"),
     configCacheTtlSeconds: requirePositiveNumber(root, "configCacheTtlSeconds"),
-    blockedCacheTtlSeconds: requirePositiveNumber(root, "blockedCacheTtlSeconds"),
+    blockedCacheTtlSeconds: requirePositiveNumber(
+      root,
+      "blockedCacheTtlSeconds"
+    ),
     partners: root.partners as Record<string, string>,
   };
 }

--- a/elliptic-proxy/tests/cache.test.ts
+++ b/elliptic-proxy/tests/cache.test.ts
@@ -1,5 +1,5 @@
 // tests/cache.test.ts
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { BlockedAddressCache } from "../src/cache.js";
 
 describe("BlockedAddressCache", () => {
@@ -14,17 +14,19 @@ describe("BlockedAddressCache", () => {
     expect(cache.isBlocked("0xabc")).toBe(true);
   });
 
-  it("expires after TTL", () => {
-    vi.useFakeTimers();
-    const cache = new BlockedAddressCache(1000);
+  it("expires after TTL", async () => {
+    // Start non-zero: lru-cache treats a start time of 0 as "no TTL set".
+    let now = 1000;
+    const cache = new BlockedAddressCache(100, undefined, { now: () => now });
     cache.markBlocked("0xabc");
 
     expect(cache.isBlocked("0xabc")).toBe(true);
 
-    vi.advanceTimersByTime(1001);
+    // lru-cache caches "now" for ttlResolution (1ms by default); wait past it
+    // before advancing the mock clock so the next check re-reads it.
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    now = 1101;
     expect(cache.isBlocked("0xabc")).toBe(false);
-
-    vi.useRealTimers();
   });
 
   it("does not cross-contaminate addresses", () => {

--- a/elliptic-proxy/tests/scoring-replay.test.ts
+++ b/elliptic-proxy/tests/scoring-replay.test.ts
@@ -21,12 +21,12 @@ interface EllipticRecord {
 
 const RESPONSES_PATH = process.env.ELLIPTIC_RESPONSES;
 
-const records: EllipticRecord[] = RESPONSES_PATH && existsSync(RESPONSES_PATH)
-  ? JSON.parse(readFileSync(RESPONSES_PATH, "utf-8"))
-  : [];
+const records: EllipticRecord[] =
+  RESPONSES_PATH && existsSync(RESPONSES_PATH)
+    ? JSON.parse(readFileSync(RESPONSES_PATH, "utf-8"))
+    : [];
 
 describe.runIf(records.length > 0)(`scoring replay (${RESPONSES_PATH})`, () => {
-
   it("scores every record without throwing", () => {
     for (const record of records) {
       expect(() => scoreResponse(JSON.stringify(record))).not.toThrow();

--- a/proof-interceptor/package-lock.json
+++ b/proof-interceptor/package-lock.json
@@ -8,14 +8,13 @@
       "name": "@starkware-libs/proof-interceptor",
       "version": "0.1.0",
       "dependencies": {
-        "@starknet-io/types-js": "^0.10.2",
         "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+        "prom-client": "^15.1.3",
         "starknet": "^9.4.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@google-cloud/functions-framework": "^5.0.2",
-        "@starknet-io/types-js": "^0.7.10",
         "@types/node": "^20.14.0",
         "eslint": "^9.39.2",
         "lru-cache": "^11.3.2",
@@ -32,6 +31,7 @@
       "license": "ISC",
       "dependencies": {
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
+        "ohttp-ts": "^0.3.0",
         "starknet": "^10.0.0-beta.6",
         "starknet-devnet": "^0.7.2",
         "zod": "^3.24.0"
@@ -717,25 +717,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -814,10 +828,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -829,9 +852,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -843,9 +866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -857,9 +880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -871,9 +894,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -885,9 +908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -899,9 +922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -913,9 +936,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -927,9 +950,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -941,9 +964,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -955,9 +978,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -969,9 +992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -983,9 +1006,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -997,9 +1020,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1011,9 +1034,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -1025,9 +1048,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1039,9 +1062,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -1053,9 +1076,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -1067,9 +1090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -1081,9 +1104,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -1095,9 +1118,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -1109,9 +1132,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -1123,9 +1146,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -1137,9 +1160,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -1151,9 +1174,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -1264,6 +1287,12 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
     "node_modules/@starknet-io/starknet-types-010": {
       "name": "@starknet-io/types-js",
       "version": "0.10.0",
@@ -1276,12 +1305,6 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.9.2.tgz",
       "integrity": "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==",
-      "license": "MIT"
-    },
-    "node_modules/@starknet-io/types-js": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT"
     },
     "node_modules/@starkware-libs/starknet-privacy-sdk": {
@@ -2030,6 +2053,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -3176,9 +3205,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3969,9 +3998,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -4008,9 +4037,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4031,6 +4060,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/proxy-addr": {
@@ -4176,9 +4218,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4192,31 +4234,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -4615,6 +4657,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/tinybench": {

--- a/proof-interceptor/package.json
+++ b/proof-interceptor/package.json
@@ -13,20 +13,21 @@
     "lint": "prettier --check src/ tests/ && eslint src/ tests/ && tsc --noEmit",
     "format": "prettier --write src/ tests/ && eslint --fix src/ tests/"
   },
+  "dependencies": {
+    "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+    "prom-client": "^15.1.3",
+    "starknet": "^9.4.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@google-cloud/functions-framework": "^5.0.2",
     "@types/node": "^20.14.0",
     "eslint": "^9.39.2",
+    "lru-cache": "^11.3.2",
     "prettier": "^3.7.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.51.0",
     "vite": "^6.4.2",
     "vitest": "^3.2.1"
-  },
-  "dependencies": {
-    "@starknet-io/types-js": "^0.10.2",
-    "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
-    "starknet": "^9.4.2"
   }
 }

--- a/proof-interceptor/src/interceptor.ts
+++ b/proof-interceptor/src/interceptor.ts
@@ -1,5 +1,10 @@
 // src/interceptor.ts
 import type { ProveTxnV3 } from "./types.js";
+import {
+  interceptorVerdicts,
+  interceptorDuration,
+  errorsTotal,
+} from "./metrics.js";
 
 export type Verdict = { action: "allow" } | { action: "block"; reason: string };
 
@@ -11,6 +16,7 @@ export interface TransactionInterceptor {
 /**
  * Runs all interceptors in parallel. Returns immediately on the first "block"
  * or error. Returns "allow" only if all interceptors return "allow".
+ * Records per-interceptor metrics (verdict count and duration).
  */
 export async function runInterceptors(
   interceptors: TransactionInterceptor[],
@@ -18,13 +24,30 @@ export async function runInterceptors(
 ): Promise<Verdict> {
   if (interceptors.length === 0) return { action: "allow" };
 
-  const promises = interceptors.map((interceptor) =>
-    interceptor.intercept(transaction).catch((error): Verdict => {
+  const promises = interceptors.map(async (interceptor) => {
+    const startTime = Date.now();
+    let verdict: Verdict;
+    try {
+      verdict = await interceptor.intercept(transaction);
+    } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(JSON.stringify({ error: "interceptor_error", message }));
-      return { action: "block", reason: message };
-    })
-  );
+      errorsTotal.inc({ type: "interceptor_error" });
+      verdict = { action: "block", reason: message };
+    }
+    const durationSeconds = (Date.now() - startTime) / 1000;
+
+    interceptorVerdicts.inc({
+      interceptor: interceptor.name,
+      verdict: verdict.action,
+    });
+    interceptorDuration.observe(
+      { interceptor: interceptor.name, verdict: verdict.action },
+      durationSeconds
+    );
+
+    return verdict;
+  });
 
   // Race: first "block" wins immediately; if all allow, Promise.all resolves
   const blockPromises = promises.map(async (promise) => {

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -1,0 +1,76 @@
+// src/metrics.ts
+import {
+  Registry,
+  Counter,
+  Histogram,
+  Gauge,
+  collectDefaultMetrics,
+} from "prom-client";
+
+export const registry = new Registry();
+
+collectDefaultMetrics({ register: registry });
+
+export const rpcRequestsTotal = new Counter({
+  name: "proof_interceptor_rpc_requests_total",
+  help: "Total JSON-RPC requests by verdict action and method",
+  labelNames: ["action", "method"] as const,
+  registers: [registry],
+});
+
+export const interceptorVerdicts = new Counter({
+  name: "proof_interceptor_interceptor_verdicts_total",
+  help: "Total interceptor verdicts by interceptor name and verdict",
+  labelNames: ["interceptor", "verdict"] as const,
+  registers: [registry],
+});
+
+export const screeningResults = new Counter({
+  name: "proof_interceptor_screening_results_total",
+  help: "Total screening outcomes",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+export const screeningRetries = new Counter({
+  name: "proof_interceptor_screening_retries_total",
+  help: "Total screening retry attempts (not counting first attempt)",
+  registers: [registry],
+});
+
+export const errorsTotal = new Counter({
+  name: "proof_interceptor_errors_total",
+  help: "Total error events by type",
+  labelNames: ["type"] as const,
+  registers: [registry],
+});
+
+export const requestDuration = new Histogram({
+  name: "proof_interceptor_request_duration_seconds",
+  help: "Total request latency by RPC action",
+  labelNames: ["action"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry],
+});
+
+export const screeningDuration = new Histogram({
+  name: "proof_interceptor_screening_duration_seconds",
+  help: "Elliptic-proxy screening call latency by result",
+  labelNames: ["result"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry],
+});
+
+export const interceptorDuration = new Histogram({
+  name: "proof_interceptor_interceptor_duration_seconds",
+  help: "Per-interceptor execution latency",
+  labelNames: ["interceptor", "verdict"] as const,
+  buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [registry],
+});
+
+export const inFlightRequests = new Gauge({
+  name: "proof_interceptor_in_flight_requests",
+  help: "Currently processing requests",
+  registers: [registry],
+});

--- a/proof-interceptor/src/proxy.ts
+++ b/proof-interceptor/src/proxy.ts
@@ -1,9 +1,16 @@
 // src/proxy.ts
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { RpcAction, validateRpcRequest } from "./rpc.js";
+import { validateRpcRequest } from "./rpc.js";
 import { runInterceptors, type TransactionInterceptor } from "./interceptor.js";
 import { jsonRpcError } from "./types.js";
 import { DEFAULT_MAX_BODY_BYTES } from "./config.js";
+import {
+  registry,
+  rpcRequestsTotal,
+  requestDuration,
+  errorsTotal,
+  inFlightRequests,
+} from "./metrics.js";
 
 const TRANSACTION_REJECTED = 10000;
 
@@ -23,8 +30,19 @@ export function createHandler(options: HandlerOptions = {}) {
       return;
     }
 
+    if (req.url === "/metrics" && req.method === "GET") {
+      const metricsBody = await registry.metrics();
+      res.writeHead(200, { "content-type": registry.contentType });
+      res.end(metricsBody);
+      return;
+    }
+
+    inFlightRequests.inc();
     const startTime = Date.now();
-    function logRequest(fields: object) {
+    function finishRequest(rpcAction: string, fields: object) {
+      const durationSeconds = (Date.now() - startTime) / 1000;
+      inFlightRequests.dec();
+      requestDuration.observe({ action: rpcAction }, durationSeconds);
       console.log(
         JSON.stringify({
           method: req.method,
@@ -35,13 +53,10 @@ export function createHandler(options: HandlerOptions = {}) {
       );
     }
 
-    function finishRequest(fields: object, statusCode: number) {
-      logRequest({ ...fields, statusCode });
-    }
-
     const declaredLength = parseInt(req.headers["content-length"] ?? "", 10);
     if (!Number.isNaN(declaredLength) && declaredLength > maxBodyBytes) {
-      finishRequest({ error: "payload_too_large" }, 413);
+      errorsTotal.inc({ type: "payload_too_large" });
+      finishRequest("error", { error: "payload_too_large" });
       res.writeHead(413, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: "payload too large" }));
       req.destroy();
@@ -52,45 +67,43 @@ export function createHandler(options: HandlerOptions = {}) {
     try {
       body = await readBody(req, maxBodyBytes);
     } catch {
-      finishRequest({ error: "payload_too_large" }, 413);
+      errorsTotal.inc({ type: "payload_too_large" });
+      finishRequest("error", { error: "payload_too_large" });
       res.writeHead(413, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: "payload too large" }));
       return;
     }
 
+    // Only accept JSON-RPC POST requests
     if (req.method !== "POST" || !isJsonContent(req)) {
-      finishRequest({ error: "not_json_rpc" }, 400);
+      errorsTotal.inc({ type: "invalid_request" });
+      finishRequest("error", { error: "invalid_request" });
       res.writeHead(400, { "content-type": "application/json" });
       res.end(
-        JSON.stringify({ error: "only JSON-RPC POST requests are supported" })
+        JSON.stringify({ error: "only JSON-RPC POST requests accepted" })
       );
       return;
     }
 
     const verdict = validateRpcRequest(body.toString());
 
-    if (verdict.action === RpcAction.Error) {
-      finishRequest({ rpcAction: "error" }, 200);
+    if (!verdict.ok) {
+      rpcRequestsTotal.inc({ action: "error", method: "" });
+      errorsTotal.inc({ type: verdict.errorType });
+      finishRequest("error", {
+        rpcAction: "error",
+        errorType: verdict.errorType,
+      });
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify(verdict.response));
       return;
     }
 
-    if (verdict.action === RpcAction.ForwardAsIs) {
-      // starknet_specVersion: return a static response without upstream
-      finishRequest({ rpcAction: "forward_as_is" }, 200);
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          id: verdict.requestId,
-          result: "0.10.1",
-        })
-      );
-      return;
-    }
+    rpcRequestsTotal.inc({
+      action: "check_with_interceptors",
+      method: "starknet_checkTransaction",
+    });
 
-    // RpcAction.CheckWithInterceptors
     const interceptorVerdict = await runInterceptors(
       interceptors,
       verdict.transaction
@@ -98,10 +111,10 @@ export function createHandler(options: HandlerOptions = {}) {
 
     if (interceptorVerdict.action === "block") {
       console.error(JSON.stringify({ error: "transaction_rejected" }));
-      finishRequest(
-        { rpcAction: "check_with_interceptors", interceptorVerdict: "block" },
-        200
-      );
+      finishRequest("check_with_interceptors", {
+        rpcAction: "check_with_interceptors",
+        interceptorVerdict: "block",
+      });
       res.writeHead(200, { "content-type": "application/json" });
       res.end(
         JSON.stringify(
@@ -116,10 +129,11 @@ export function createHandler(options: HandlerOptions = {}) {
       return;
     }
 
-    finishRequest(
-      { rpcAction: "check_with_interceptors", interceptorVerdict: "allow" },
-      200
-    );
+    // All interceptors allowed the transaction
+    finishRequest("check_with_interceptors", {
+      rpcAction: "check_with_interceptors",
+      interceptorVerdict: "allow",
+    });
     res.writeHead(200, { "content-type": "application/json" });
     res.end(
       JSON.stringify({

--- a/proof-interceptor/src/rpc.ts
+++ b/proof-interceptor/src/rpc.ts
@@ -12,25 +12,24 @@ const METHOD_NOT_FOUND = -32601;
 const BLOCK_NOT_FOUND = 24;
 const UNSUPPORTED_TX_VERSION = 61;
 
-export enum RpcAction {
-  ForwardAsIs = "forward_as_is",
-  CheckWithInterceptors = "check_with_interceptors",
-  Error = "error",
-}
+export type RpcErrorType =
+  | "parse_error"
+  | "invalid_request"
+  | "method_not_found"
+  | "block_not_found"
+  | "unsupported_tx_version";
 
 export type RpcVerdict =
-  | { action: RpcAction.ForwardAsIs; requestId: string | number | null }
   | {
-      action: RpcAction.CheckWithInterceptors;
+      ok: true;
       transaction: ProveTxnV3;
       requestId: string | number | null;
     }
-  | { action: RpcAction.Error; response: JsonRpcErrorResponse };
+  | { ok: false; errorType: RpcErrorType; response: JsonRpcErrorResponse };
 
 /**
- * Validates a JSON-RPC request body. Returns ForwardAsIs (for
- * starknet_specVersion), CheckWithInterceptors (parsed transaction for
- * interceptors), or Error (return error response to the caller).
+ * Validates a JSON-RPC request body. On success returns the parsed transaction
+ * and request id; on failure returns a ready-to-send JSON-RPC error response.
  */
 export function validateRpcRequest(body: string): RpcVerdict {
   let request: JsonRpcRequest;
@@ -42,14 +41,16 @@ export function validateRpcRequest(body: string): RpcVerdict {
       Array.isArray(parsed)
     ) {
       return {
-        action: RpcAction.Error,
+        ok: false,
+        errorType: "invalid_request",
         response: jsonRpcError(null, INVALID_REQUEST, "Invalid Request"),
       };
     }
     request = parsed as JsonRpcRequest;
   } catch {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "parse_error",
       response: jsonRpcError(null, INVALID_REQUEST, "Parse error"),
     };
   }
@@ -60,7 +61,8 @@ export function validateRpcRequest(body: string): RpcVerdict {
     request.id === undefined
   ) {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "invalid_request",
       response: jsonRpcError(
         request.id ?? null,
         INVALID_REQUEST,
@@ -70,15 +72,13 @@ export function validateRpcRequest(body: string): RpcVerdict {
   }
 
   switch (request.method) {
-    case "starknet_specVersion":
-      return { action: RpcAction.ForwardAsIs, requestId: request.id };
-
     case "starknet_checkTransaction":
       return validateCheckTransaction(request);
 
     default:
       return {
-        action: RpcAction.Error,
+        ok: false,
+        errorType: "method_not_found",
         response: jsonRpcError(
           request.id,
           METHOD_NOT_FOUND,
@@ -92,7 +92,8 @@ function validateCheckTransaction(request: JsonRpcRequest): RpcVerdict {
   const params = request.params;
   if (!Array.isArray(params) || params.length < 2) {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "invalid_request",
       response: jsonRpcError(request.id, INVALID_REQUEST, "Invalid Request"),
     };
   }
@@ -100,7 +101,8 @@ function validateCheckTransaction(request: JsonRpcRequest): RpcVerdict {
   const blockId = params[0];
   if (blockId === "pending") {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "block_not_found",
       response: jsonRpcError(request.id, BLOCK_NOT_FOUND, "Block not found"),
     };
   }
@@ -112,14 +114,16 @@ function validateCheckTransaction(request: JsonRpcRequest): RpcVerdict {
     Array.isArray(transaction)
   ) {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "invalid_request",
       response: jsonRpcError(request.id, INVALID_REQUEST, "Invalid Request"),
     };
   }
 
   if (transaction.type !== "INVOKE") {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "unsupported_tx_version",
       response: jsonRpcError(
         request.id,
         UNSUPPORTED_TX_VERSION,
@@ -131,7 +135,8 @@ function validateCheckTransaction(request: JsonRpcRequest): RpcVerdict {
 
   if (transaction.version !== "0x3") {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "unsupported_tx_version",
       response: jsonRpcError(
         request.id,
         UNSUPPORTED_TX_VERSION,
@@ -143,13 +148,14 @@ function validateCheckTransaction(request: JsonRpcRequest): RpcVerdict {
 
   if (!Array.isArray(transaction.calldata)) {
     return {
-      action: RpcAction.Error,
+      ok: false,
+      errorType: "invalid_request",
       response: jsonRpcError(request.id, INVALID_REQUEST, "Invalid Request"),
     };
   }
 
   return {
-    action: RpcAction.CheckWithInterceptors,
+    ok: true,
     transaction: transaction as unknown as ProveTxnV3,
     requestId: request.id,
   };

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -4,6 +4,11 @@ import { CallData } from "starknet";
 import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import type { TransactionInterceptor, Verdict } from "./interceptor.js";
 import type { ProveTxnV3 } from "./types.js";
+import {
+  screeningResults,
+  screeningRetries,
+  screeningDuration,
+} from "./metrics.js";
 
 export interface ScreeningConfig {
   ellipticProxyUrl: string;
@@ -124,6 +129,7 @@ export class ScreeningInterceptor implements TransactionInterceptor {
     for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
       finalAttempt = attempt;
       if (attempt > 0) {
+        screeningRetries.inc();
         const backoffMs = exponentialBackoff(attempt);
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) break;
@@ -138,12 +144,15 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         const callStart = Date.now();
         const blocked = await this.callEllipticProxy(address, perCallTimeout);
         const result: ScreenResult = blocked ? "blocked" : "allowed";
+        const screeningLatencyMs = Date.now() - callStart;
+        screeningResults.inc({ result });
+        screeningDuration.observe({ result }, screeningLatencyMs / 1000);
         console.log(
           JSON.stringify({
             screening: "complete",
             result,
             attempts: attempt + 1,
-            screeningLatencyMs: Date.now() - callStart,
+            screeningLatencyMs,
           })
         );
         return result;
@@ -162,7 +171,9 @@ export class ScreeningInterceptor implements TransactionInterceptor {
     );
 
     // fail-closed by default: if we can't screen, block the transaction
-    return this.config.failOpen ? "allowed" : "unavailable";
+    const failResult = this.config.failOpen ? "allowed" : "unavailable";
+    screeningResults.inc({ result: failResult });
+    return failResult;
   }
 
   private async callEllipticProxy(

--- a/proof-interceptor/src/types.ts
+++ b/proof-interceptor/src/types.ts
@@ -1,7 +1,4 @@
 // src/types.ts
-import type { API } from "@starknet-io/types-js";
-
-export type ProveTxnV3 = API.INVOKE_TXN_V3;
 
 export interface JsonRpcRequest {
   jsonrpc: "2.0";

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -208,31 +208,4 @@ describe("e2e: proof-interceptor → elliptic-proxy → mock Elliptic API", () =
     expect(body.error.message).toBe("Transaction rejected");
     expect(body.error.data).toContain("0xbad0");
   }, 15000);
-
-  it("starknet_specVersion bypasses screening", async () => {
-    const handler = createHandler({
-      interceptors: [
-        new ScreeningInterceptor({
-          ellipticProxyUrl: "http://127.0.0.1:1",
-          partnerName: PARTNER_NAME,
-          partnerSecret: PARTNER_SECRET,
-          timeoutMs: 1000,
-          failOpen: false,
-          maxRetries: 0,
-          totalTimeoutMs: 5000,
-        }),
-      ],
-    });
-
-    interceptorServer = createServer(handler);
-    interceptorPort = await listen(interceptorServer);
-
-    const response = await rpcPost(interceptorPort, {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "starknet_specVersion",
-    });
-    const body = await response.json();
-    expect(body.result).toBe("0.10.1");
-  });
 });

--- a/proof-interceptor/tests/interceptor.test.ts
+++ b/proof-interceptor/tests/interceptor.test.ts
@@ -5,7 +5,14 @@ import {
   type TransactionInterceptor,
   type Verdict,
 } from "../src/interceptor.js";
+import { errorsTotal } from "../src/metrics.js";
 import type { ProveTxnV3 } from "../src/types.js";
+
+async function errorsTotalValue(type: string): Promise<number> {
+  const data = await errorsTotal.get();
+  const sample = data.values.find((entry) => entry.labels.type === type);
+  return sample?.value ?? 0;
+}
 
 const sampleTransaction = {
   type: "INVOKE",
@@ -22,20 +29,17 @@ const sampleTransaction = {
   fee_data_availability_mode: "L1",
 } as unknown as ProveTxnV3;
 
-function allowAll(): TransactionInterceptor {
-  return { name: "allow-all", intercept: async () => ({ action: "allow" }) };
+function allowAll(name = "test"): TransactionInterceptor {
+  return { name, intercept: async () => ({ action: "allow" }) };
 }
 
-function blockWith(reason: string): TransactionInterceptor {
-  return {
-    name: "blocker",
-    intercept: async () => ({ action: "block", reason }),
-  };
+function blockWith(reason: string, name = "test"): TransactionInterceptor {
+  return { name, intercept: async () => ({ action: "block", reason }) };
 }
 
 function delayedAllow(delayMs: number): TransactionInterceptor {
   return {
-    name: "delayed-allow",
+    name: "delayed",
     intercept: () =>
       new Promise<Verdict>((resolve) =>
         setTimeout(() => resolve({ action: "allow" }), delayMs)
@@ -45,7 +49,7 @@ function delayedAllow(delayMs: number): TransactionInterceptor {
 
 function delayedBlock(delayMs: number, reason: string): TransactionInterceptor {
   return {
-    name: "delayed-block",
+    name: "delayed",
     intercept: () =>
       new Promise<Verdict>((resolve) =>
         setTimeout(() => resolve({ action: "block", reason }), delayMs)
@@ -70,7 +74,7 @@ describe("runInterceptors", () => {
 
   it("returns allow when all interceptors allow", async () => {
     const result = await runInterceptors(
-      [allowAll(), allowAll(), allowAll()],
+      [allowAll("a"), allowAll("b"), allowAll("c")],
       sampleTransaction
     );
     expect(result.action).toBe("allow");
@@ -95,7 +99,8 @@ describe("runInterceptors", () => {
     expect(result.action).toBe("block");
   });
 
-  it("treats thrown errors as block", async () => {
+  it("treats thrown errors as block and increments errors_total", async () => {
+    const before = await errorsTotalValue("interceptor_error");
     const result = await runInterceptors(
       [throwing("connection failed")],
       sampleTransaction
@@ -104,6 +109,8 @@ describe("runInterceptors", () => {
       action: "block",
       reason: "connection failed",
     });
+    const after = await errorsTotalValue("interceptor_error");
+    expect(after).toBe(before + 1);
   });
 
   it("returns block immediately on first block (does not wait for slow interceptors)", async () => {

--- a/proof-interceptor/tests/proxy.test.ts
+++ b/proof-interceptor/tests/proxy.test.ts
@@ -3,13 +3,20 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { createServer, type Server } from "node:http";
 import { createHandler, type HandlerOptions } from "../src/proxy.js";
 import type { TransactionInterceptor } from "../src/interceptor.js";
+import { errorsTotal } from "../src/metrics.js";
+
+async function errorsTotalValue(type: string): Promise<number> {
+  const data = await errorsTotal.get();
+  const sample = data.values.find((entry) => entry.labels.type === type);
+  return sample?.value ?? 0;
+}
 
 let proxy: Server;
 let proxyPort: number;
 
-function startProxy(options?: HandlerOptions): Promise<void> {
+function startProxy(options?: Partial<HandlerOptions>): Promise<void> {
   return new Promise((resolve) => {
-    const handler = createHandler(options);
+    const handler = createHandler({ ...options });
     proxy = createServer(handler);
     proxy.listen(0, "127.0.0.1", () => {
       const addr = proxy.address();
@@ -63,10 +70,21 @@ afterEach(async () => {
   });
 });
 
-describe("proxy", () => {
-  it("returns 400 for non-JSON POST body", async () => {
+describe("handler", () => {
+  it("returns 400 for GET request to root", async () => {
     await startProxy();
 
+    const response = await fetch(proxyUrl("/"));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "only JSON-RPC POST requests accepted",
+    });
+  });
+
+  it("returns 400 for non-JSON POST body and increments errors_total", async () => {
+    await startProxy();
+
+    const before = await errorsTotalValue("invalid_request");
     const response = await fetch(proxyUrl("/"), {
       method: "POST",
       headers: { "content-type": "text/plain" },
@@ -75,25 +93,23 @@ describe("proxy", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
-      error: "only JSON-RPC POST requests are supported",
+      error: "only JSON-RPC POST requests accepted",
     });
+    const after = await errorsTotalValue("invalid_request");
+    expect(after).toBe(before + 1);
   });
 
-  it("returns 400 for GET request to non-health path", async () => {
+  it("returns JSON-RPC error for unknown method and increments errors_total{method_not_found}", async () => {
     await startProxy();
 
-    const response = await fetch(proxyUrl("/some/path"));
-    expect(response.status).toBe(400);
-  });
-
-  it("returns JSON-RPC error for unknown method", async () => {
-    await startProxy();
-
+    const before = await errorsTotalValue("method_not_found");
     const response = await rpcPost(proxyUrl("/"), {
       jsonrpc: "2.0",
       id: 1,
       method: "unknown_method",
     });
+    const after = await errorsTotalValue("method_not_found");
+    expect(after).toBe(before + 1);
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -108,6 +124,17 @@ describe("proxy", () => {
     expect(await response.json()).toEqual({ status: "ok" });
   });
 
+  it("serves Prometheus metrics at /metrics", async () => {
+    await startProxy();
+
+    const response = await fetch(proxyUrl("/metrics"));
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("proof_interceptor_rpc_requests_total");
+    expect(body).toContain("proof_interceptor_request_duration_seconds");
+    expect(body).toContain("proof_interceptor_in_flight_requests");
+  });
+
   it("returns 413 when body exceeds maxBodyBytes", async () => {
     await startProxy({ maxBodyBytes: 10 });
 
@@ -119,39 +146,25 @@ describe("proxy", () => {
     expect(response.status).toBe(413);
     expect(await response.json()).toEqual({ error: "payload too large" });
   });
-
-  it("returns specVersion result for starknet_specVersion", async () => {
-    await startProxy();
-
-    const response = await rpcPost(proxyUrl("/"), {
-      jsonrpc: "2.0",
-      id: 42,
-      method: "starknet_specVersion",
-    });
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.result).toBe("0.10.1");
-    expect(body.id).toBe(42);
-  });
 });
 
-describe("proxy with interceptors", () => {
-  it("returns allowed:true when interceptor allows", async () => {
+describe("handler with interceptors", () => {
+  it("returns allowed:true when interceptor allows checkTransaction", async () => {
     const allowAll: TransactionInterceptor = {
-      name: "allow-all",
+      name: "test",
       intercept: async () => ({ action: "allow" }),
     };
     await startProxy({ interceptors: [allowAll] });
 
     const response = await rpcPost(proxyUrl("/"), checkRequest());
+    expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.result).toEqual({ allowed: true });
   });
 
   it("returns 10000 when interceptor blocks", async () => {
     const blocker: TransactionInterceptor = {
-      name: "blocker",
+      name: "test",
       intercept: async () => ({ action: "block", reason: "sanctioned" }),
     };
     await startProxy({ interceptors: [blocker] });
@@ -164,30 +177,9 @@ describe("proxy with interceptors", () => {
     expect(body.id).toBe(1);
   });
 
-  it("does not run interceptors for starknet_specVersion", async () => {
-    let interceptorCalled = false;
-    const spy: TransactionInterceptor = {
-      name: "spy",
-      intercept: async () => {
-        interceptorCalled = true;
-        return { action: "block", reason: "should not be called" };
-      },
-    };
-    await startProxy({ interceptors: [spy] });
-
-    const response = await rpcPost(proxyUrl("/"), {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "starknet_specVersion",
-    });
-    const body = await response.json();
-    expect(body.result).toBe("0.10.1");
-    expect(interceptorCalled).toBe(false);
-  });
-
   it("returns 10000 when interceptor throws", async () => {
     const thrower: TransactionInterceptor = {
-      name: "thrower",
+      name: "test",
       intercept: async () => {
         throw new Error("network timeout");
       },
@@ -200,58 +192,5 @@ describe("proxy with interceptors", () => {
     expect(body.error.code).toBe(10000);
     expect(body.error.data).toBe("network timeout");
     spy.mockRestore();
-  });
-
-  it("returns allowed:true when no interceptors are configured", async () => {
-    await startProxy();
-
-    const response = await rpcPost(proxyUrl("/"), checkRequest());
-    const body = await response.json();
-    expect(body.result).toEqual({ allowed: true });
-  });
-
-  it("logs structured JSON for check_with_interceptors path", async () => {
-    const allowAll: TransactionInterceptor = {
-      name: "allow-all",
-      intercept: async () => ({ action: "allow" }),
-    };
-    await startProxy({ interceptors: [allowAll] });
-
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await rpcPost(proxyUrl("/"), checkRequest());
-
-    const logCall = logSpy.mock.calls.find((call) => {
-      const parsed = JSON.parse(call[0] as string);
-      return parsed.rpcAction === "check_with_interceptors";
-    });
-    expect(logCall).toBeDefined();
-    const logData = JSON.parse(logCall![0] as string);
-    expect(logData.interceptorVerdict).toBe("allow");
-    expect(typeof logData.latencyMs).toBe("number");
-    expect(logData.statusCode).toBe(200);
-    logSpy.mockRestore();
-  });
-
-  it("logs structured JSON for blocked transactions", async () => {
-    const blocker: TransactionInterceptor = {
-      name: "blocker",
-      intercept: async () => ({ action: "block", reason: "sanctioned" }),
-    };
-    await startProxy({ interceptors: [blocker] });
-
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await rpcPost(proxyUrl("/"), checkRequest());
-
-    const logCall = logSpy.mock.calls.find((call) => {
-      const parsed = JSON.parse(call[0] as string);
-      return parsed.rpcAction === "check_with_interceptors";
-    });
-    expect(logCall).toBeDefined();
-    const logData = JSON.parse(logCall![0] as string);
-    expect(logData.interceptorVerdict).toBe("block");
-
-    errorSpy.mockRestore();
-    logSpy.mockRestore();
   });
 });

--- a/proof-interceptor/tests/rpc.test.ts
+++ b/proof-interceptor/tests/rpc.test.ts
@@ -1,6 +1,6 @@
 // tests/rpc.test.ts
 import { describe, it, expect } from "vitest";
-import { RpcAction, validateRpcRequest } from "../src/rpc.js";
+import { validateRpcRequest } from "../src/rpc.js";
 
 function rpcBody(
   method: string,
@@ -37,8 +37,8 @@ describe("validateRpcRequest", () => {
   describe("parse errors", () => {
     it("returns error for invalid JSON", () => {
       const result = validateRpcRequest("not json");
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(-32600);
       }
     });
@@ -47,71 +47,54 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         JSON.stringify({ id: 1, method: "foo" })
       );
-      expect(result.action).toBe(RpcAction.Error);
+      expect(result.ok).toBe(false);
     });
 
     it("returns error for missing method", () => {
       const result = validateRpcRequest(
         JSON.stringify({ jsonrpc: "2.0", id: 1 })
       );
-      expect(result.action).toBe(RpcAction.Error);
-    });
-  });
-
-  describe("starknet_specVersion", () => {
-    it("returns ForwardAsIs for starknet_specVersion", () => {
-      const result = validateRpcRequest(rpcBody("starknet_specVersion"));
-      expect(result.action).toBe(RpcAction.ForwardAsIs);
-    });
-
-    it("preserves request id for starknet_specVersion", () => {
-      const result = validateRpcRequest(
-        rpcBody("starknet_specVersion", undefined, { id: "my-id" })
-      );
-      expect(result.action).toBe(RpcAction.ForwardAsIs);
-      if (result.action === RpcAction.ForwardAsIs) {
-        expect(result.requestId).toBe("my-id");
-      }
+      expect(result.ok).toBe(false);
     });
   });
 
   describe("starknet_checkTransaction", () => {
-    it("returns CheckWithInterceptors for valid INVOKE V3 transaction", () => {
+    it("validates valid INVOKE V3 transaction with request id", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", sampleInvokeV3()])
       );
-      expect(result.action).toBe(RpcAction.CheckWithInterceptors);
-      if (result.action === RpcAction.CheckWithInterceptors) {
+      expect(result.ok).toBe(true);
+      if (result.ok) {
         expect(result.requestId).toBe(1);
       }
     });
 
-    it("accepts block hash", () => {
+    it("validates with block hash", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", [
           { block_hash: "0xabc" },
           sampleInvokeV3(),
         ])
       );
-      expect(result.action).toBe(RpcAction.CheckWithInterceptors);
+      expect(result.ok).toBe(true);
     });
 
-    it("accepts block number", () => {
+    it("validates with block number", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", [
           { block_number: 42 },
           sampleInvokeV3(),
         ])
       );
-      expect(result.action).toBe(RpcAction.CheckWithInterceptors);
+      expect(result.ok).toBe(true);
     });
 
     it("rejects pending block with BLOCK_NOT_FOUND (24)", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["pending", sampleInvokeV3()])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(24);
       }
     });
@@ -121,8 +104,8 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", tx])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(61);
         expect(result.response.error.data).toContain("DECLARE");
       }
@@ -133,8 +116,8 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", tx])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(61);
       }
     });
@@ -144,8 +127,8 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", tx])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(61);
         expect(result.response.error.data).toContain("0x1");
       }
@@ -153,8 +136,8 @@ describe("validateRpcRequest", () => {
 
     it("rejects missing params", () => {
       const result = validateRpcRequest(rpcBody("starknet_checkTransaction"));
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(-32600);
       }
     });
@@ -163,7 +146,7 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", "not-an-object"])
       );
-      expect(result.action).toBe(RpcAction.Error);
+      expect(result.ok).toBe(false);
     });
 
     it("rejects transaction with missing calldata", () => {
@@ -172,8 +155,8 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", tx])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(-32600);
       }
     });
@@ -183,20 +166,86 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_checkTransaction", ["latest", tx])
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(-32600);
       }
     });
   });
 
   describe("unknown methods", () => {
-    it("rejects unknown method with METHOD_NOT_FOUND (-32601)", () => {
+    it("rejects unknown method", () => {
       const result = validateRpcRequest(rpcBody("starknet_unknownMethod"));
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.error.code).toBe(-32601);
       }
+    });
+
+    it("rejects starknet_specVersion as unsupported", () => {
+      const result = validateRpcRequest(rpcBody("starknet_specVersion"));
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.response.error.code).toBe(-32601);
+      }
+    });
+  });
+
+  describe("error type discriminator", () => {
+    it("tags invalid JSON as parse_error", () => {
+      const result = validateRpcRequest("not json");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("parse_error");
+    });
+
+    it("tags missing jsonrpc field as invalid_request", () => {
+      const result = validateRpcRequest(
+        JSON.stringify({ id: 1, method: "foo" })
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("invalid_request");
+    });
+
+    it("tags unknown method as method_not_found", () => {
+      const result = validateRpcRequest(rpcBody("starknet_unknownMethod"));
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("method_not_found");
+    });
+
+    it("tags pending block as block_not_found", () => {
+      const result = validateRpcRequest(
+        rpcBody("starknet_checkTransaction", ["pending", sampleInvokeV3()])
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("block_not_found");
+    });
+
+    it("tags wrong tx type as unsupported_tx_version", () => {
+      const tx = { ...sampleInvokeV3(), type: "DECLARE" };
+      const result = validateRpcRequest(
+        rpcBody("starknet_checkTransaction", ["latest", tx])
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("unsupported_tx_version");
+    });
+
+    it("tags wrong invoke version as unsupported_tx_version", () => {
+      const tx = { ...sampleInvokeV3(), version: "0x1" };
+      const result = validateRpcRequest(
+        rpcBody("starknet_checkTransaction", ["latest", tx])
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("unsupported_tx_version");
+    });
+
+    it("tags missing calldata as invalid_request", () => {
+      const tx = { ...sampleInvokeV3() };
+      delete tx.calldata;
+      const result = validateRpcRequest(
+        rpcBody("starknet_checkTransaction", ["latest", tx])
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorType).toBe("invalid_request");
     });
   });
 
@@ -207,8 +256,8 @@ describe("validateRpcRequest", () => {
           id: "my-request-id",
         })
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.id).toBe("my-request-id");
       }
     });
@@ -217,8 +266,8 @@ describe("validateRpcRequest", () => {
       const result = validateRpcRequest(
         rpcBody("starknet_unknownMethod", undefined, { id: 42 })
       );
-      expect(result.action).toBe(RpcAction.Error);
-      if (result.action === RpcAction.Error) {
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
         expect(result.response.id).toBe(42);
       }
     });


### PR DESCRIPTION
Add prom-client with counters, histograms, and a gauge:
- rpc_requests_total (action, method)
- interceptor_verdicts_total (interceptor, verdict)
- interceptor_duration_seconds (interceptor, verdict)
- screening_results_total (result)
- screening_retries_total
- screening_duration_seconds (result)
- request_duration_seconds (action)
- errors_total (type)
- in_flight_requests gauge

Also adds `name` field to TransactionInterceptor interface
and enriches runInterceptors to return per-interceptor timings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/690)
<!-- Reviewable:end -->
