### PR TITLE
feat(sdk): structured ProvingServiceError with error codes

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,7 +2,7 @@ export * from "./interfaces.js";
 export { AddressMap } from "./utils/index.js";
 export { createPrivateTransfers } from "./factory.js";
 export { SimplePrivateTransfersImpl } from "./simple-private-transfers.js";
-export { ProvingService } from "./internal/proving-service.js";
+export { ProvingService, ProvingServiceError } from "./internal/proving-service.js";
 export type {
   MessageToL1,
   ProvingServiceConfig,

--- a/sdk/src/internal/proving-service.ts
+++ b/sdk/src/internal/proving-service.ts
@@ -11,6 +11,34 @@ import type { OhttpClient } from "./ohttp-client.js";
 /** Default request timeout: 30s (proofs typically take a few seconds). */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+/**
+ * Structured error from the proving service JSON-RPC endpoint.
+ *
+ * The `code` field is a numeric JSON-RPC error code that callers can switch on:
+ *
+ * **Prover codes (Starknet RPC v0.10):**
+ * - `24`    — Block not found
+ * - `55`    — Account validation failed
+ * - `61`    — Unsupported transaction version
+ * - `1000`  — Invalid transaction input
+ * - `-32005` — Service busy (retry later)
+ * - `-32603` — Internal prover error
+ *
+ * **Proxy interceptor codes (1xxxx range):**
+ * - `10000` — Transaction rejected (e.g. screening/compliance)
+ */
+export class ProvingServiceError extends Error {
+  override readonly name = "ProvingServiceError";
+
+  constructor(
+    public readonly code: number,
+    message: string,
+    public readonly data?: string
+  ) {
+    super(data ? `${message}: ${data}` : message);
+  }
+}
+
 // TODO: Support "latest-verifiable" and { blocksBack: number } server-side; then accept them here and pass through.
 // Current server only supports block_id: "latest" | { block_number: N } | { block_hash: "0x..." }.
 
@@ -100,8 +128,7 @@ export class ProvingService {
 
     if (json.error) {
       const { code, message, data } = json.error;
-      const detail = typeof data === "string" ? `${message}: ${data}` : message;
-      throw new Error(`Proving service error (code ${code}) ${detail}`);
+      throw new ProvingServiceError(code, message, typeof data === "string" ? data : undefined);
     }
 
     const result = json.result;

--- a/sdk/src/testing/mock-proof-provider.ts
+++ b/sdk/src/testing/mock-proof-provider.ts
@@ -8,6 +8,7 @@
 import type { Proof, ProofInvocation, ProofProviderInterface } from "../interfaces.js";
 import type { ClientAction } from "../internal/client-actions.js";
 import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js";
+import { ProvingServiceError } from "../internal/proving-service.js";
 import type { MockPoolContract } from "./mock-pool-contract.js";
 import { bigintReviver } from "./mock-proof-invocation-factory.js";
 import { constants } from "starknet";
@@ -37,13 +38,23 @@ export class MockProofProvider implements ProofProviderInterface {
     const clientActions: ClientAction[] = JSON.parse(calldata[2], bigintReviver);
 
     // Execute on mock pool - returns MockServerAction[] (serialized as string[])
-    const callbacks = this.pool.execute(userAddress, privateKey, ...clientActions);
+    let callbacks: string[];
+    try {
+      callbacks = this.pool.execute(
+        userAddress,
+        privateKey,
+        ...clientActions
+      ) as unknown as string[];
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ProvingServiceError(-32603, "Internal error", message);
+    }
 
     return {
       data: "",
       // L2-to-L1 message payload: [class_hash, ...callbacks].
       // The consumer strips the class_hash prefix before passing to apply_actions.
-      output: buildMessagePayload("0x0", callbacks as unknown as string[]),
+      output: buildMessagePayload("0x0", callbacks),
       proofFacts: [],
     };
   }

--- a/sdk/src/testing/mock-proving.ts
+++ b/sdk/src/testing/mock-proving.ts
@@ -9,6 +9,7 @@ import type { BlockIdentifier, constants, ETransactionVersion3, ProviderInterfac
 import { EDAMode, encode, hash, num, stark } from "starknet";
 import type { Proof, ProofInvocation, ProofProviderInterface } from "../interfaces.js";
 import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js";
+import { ProvingServiceError } from "../internal/proving-service.js";
 import { buildProofFacts, buildMessagePayload } from "../utils/proof-facts.js";
 import { toBigInt } from "../utils/convert.js";
 import { extractExecuteViewCalldata } from "../internal/proof-invocation-factory.js";
@@ -125,7 +126,11 @@ export class CallMockProofProvider implements ProofProviderInterface {
 
     // Check result equals VALIDATED ('VALID' as felt252)
     if (toBigInt(result[0]) !== VALIDATED) {
-      throw new Error(`Signature validation failed: expected ${VALIDATED}, got ${result[0]}`);
+      throw new ProvingServiceError(
+        55,
+        "Account validation failed",
+        `Signature validation failed: expected ${VALIDATED}, got ${result[0]}`
+      );
     }
   }
 }

--- a/sdk/tests/internal/proving-service-ohttp.test.ts
+++ b/sdk/tests/internal/proving-service-ohttp.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { ProvingService, type MessageToL1 } from "../../src/internal/proving-service.js";
+import {
+  ProvingService,
+  ProvingServiceError,
+  type MessageToL1,
+} from "../../src/internal/proving-service.js";
 import type { OhttpClient } from "../../src/internal/ohttp-client.js";
 
 const PROVER_URL = "https://prover.test";
@@ -73,9 +77,13 @@ describe("ProvingService with OHTTP", () => {
 
     const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
 
-    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
-      /Proving service error \(code 24\)/
-    );
+    const error = await service
+      .proveTransaction("latest", MINIMAL_INVOKE_TX)
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ProvingServiceError);
+    expect((error as ProvingServiceError).code).toBe(24);
+    expect((error as ProvingServiceError).message).toBe("Block not found");
+    expect((error as ProvingServiceError).data).toBeUndefined();
   });
 
   it("throws when OHTTP response has no result", async () => {

--- a/sdk/tests/internal/proving-service-openrpc.test.ts
+++ b/sdk/tests/internal/proving-service-openrpc.test.ts
@@ -10,7 +10,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeAll, afterEach } from "vitest";
 import { Ajv } from "ajv";
-import { ProvingService, type MessageToL1 } from "../../src/internal/proving-service.js";
+import {
+  ProvingService,
+  ProvingServiceError,
+  type MessageToL1,
+} from "../../src/internal/proving-service.js";
 
 const PROVER_URL = "https://prover.test";
 
@@ -450,7 +454,7 @@ describe("ProvingService (proving-service.ts) vs OpenRPC spec", () => {
   });
 
   describe("getSpecVersion / proveTransaction — RPC and HTTP unhappy", () => {
-    it("proveTransaction throws when response is JSON-RPC error (e.g. block not found)", async () => {
+    it("proveTransaction throws ProvingServiceError on JSON-RPC error (e.g. block not found)", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
         status: 200,
@@ -465,9 +469,70 @@ describe("ProvingService (proving-service.ts) vs OpenRPC spec", () => {
       } as Response);
 
       const service = new ProvingService({ baseUrl: PROVER_URL });
-      await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
-        /Proving service error \(code 24\)/
+      const error = await service
+        .proveTransaction("latest", MINIMAL_INVOKE_TX)
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ProvingServiceError);
+      expect((error as ProvingServiceError).code).toBe(24);
+      expect((error as ProvingServiceError).message).toBe("Block not found");
+      expect((error as ProvingServiceError).data).toBeUndefined();
+    });
+
+    it("ProvingServiceError exposes code and data for screening rejection", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              error: {
+                code: 10000,
+                message: "Transaction rejected",
+                data: "address screening: 0xbad blocked",
+              },
+            })
+          ),
+      } as Response);
+
+      const service = new ProvingService({ baseUrl: PROVER_URL });
+      const error = await service
+        .proveTransaction("latest", MINIMAL_INVOKE_TX)
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ProvingServiceError);
+      expect((error as ProvingServiceError).code).toBe(10000);
+      expect((error as ProvingServiceError).data).toBe("address screening: 0xbad blocked");
+      expect((error as ProvingServiceError).message).toBe(
+        "Transaction rejected: address screening: 0xbad blocked"
       );
+    });
+
+    it("ProvingServiceError exposes code for service busy", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              error: {
+                code: -32005,
+                message: "Service is busy",
+                data: "retry later",
+              },
+            })
+          ),
+      } as Response);
+
+      const service = new ProvingService({ baseUrl: PROVER_URL });
+      const error = await service
+        .proveTransaction("latest", MINIMAL_INVOKE_TX)
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ProvingServiceError);
+      expect((error as ProvingServiceError).code).toBe(-32005);
+      expect((error as ProvingServiceError).data).toBe("retry later");
     });
 
     it("proveTransaction throws when response has no result", async () => {


### PR DESCRIPTION
Replace plain Error with ProvingServiceError class that exposes
code, message, and data fields. Allows SDK consumers to switch on
numeric JSON-RPC error codes from both the prover (24, 55, 61, 1000,
-32005, -32603) and proxy interceptors (10000 for screening rejection).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/691)
<!-- Reviewable:end -->
