### PR TITLE
feat(discovery-service): support optional oblivious http envelope encryption 

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -78,6 +78,7 @@ jobs:
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         uses: asdf-vm/actions/install@v3
         with:
+          asdf_branch: v0.14.1
           tool_versions: |
             starknet-foundry nightly-2026-02-20
       - name: Generate Cairo reference data

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,9 @@ jobs:
       - name: Install starknet-foundry via asdf
         uses: asdf-vm/actions/install@v3
         with:
-          tool_versions: starknet-foundry nightly-2026-02-20
+          asdf_branch: v0.14.1
+          tool_versions: |
+            starknet-foundry nightly-2026-02-20
 
       - name: Run tests
         run: scarb test -w

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -60,8 +60,9 @@ jobs:
       - name: Install starknet-foundry via asdf
         uses: asdf-vm/actions/install@v3
         with:
+          asdf_branch: v0.14.1
           tool_versions: |
-            starknet-foundry nightly-2026-02-03
+            starknet-foundry nightly-2026-02-20
 
       - name: Regenerate Cairo contract artifacts
         run: npm run generate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bhttp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d305a54bcb99974213b4c78a486c34091e83c5d6d6572f7f4331c904ea9d127"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +351,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +384,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -496,7 +575,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -595,6 +709,8 @@ dependencies = [
  "dotenv",
  "expect-test",
  "flate2",
+ "hex",
+ "http-body-util",
  "libc",
  "moka",
  "nix",
@@ -618,6 +734,7 @@ dependencies = [
  "toml",
  "tower",
  "tower-http",
+ "tower_ohttp",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -725,6 +842,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -932,6 +1055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,12 +1117,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hpke"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "rand_core 0.9.5",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1310,6 +1472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1768,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ohttp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a03aaaf57495c75ce66aee6a7c3b21abf046c9d4cca3d45b22cdbf0de1bfba"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "byteorder",
+ "chacha20poly1305",
+ "hex",
+ "hkdf",
+ "hpke",
+ "log",
+ "rand 0.9.2",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1800,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1692,6 +1891,29 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2056,6 +2278,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2980,6 +3211,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tower_ohttp"
+version = "0.18.0-rc.1"
+source = "git+https://github.com/starkware-libs/sequencer.git?rev=f2d0af15734d97dbd29e59942da637d8daa48305#f2d0af15734d97dbd29e59942da637d8daa48305"
+dependencies = [
+ "bhttp",
+ "bytes",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "ohttp",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3345,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -3735,6 +3994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3812,6 +4081,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -28,6 +28,7 @@ url = "2"
 
 # HTTP
 axum = "0.8"
+http-body-util = "0.1"
 reqwest = { version = "0.13", features = ["json"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
@@ -39,6 +40,7 @@ tower-http = { version = "0.6", features = ["cors", "timeout"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+hex = "0.4"
 
 # Error handling
 thiserror = "2"
@@ -46,6 +48,9 @@ backoff = { version = "0.4", features = ["tokio"] }
 
 # Crypto
 starknet-crypto = { package = "starknet-rust-crypto", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
+
+# OHTTP (RFC 9458)
+tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "f2d0af15734d97dbd29e59942da637d8daa48305" }
 
 # Cache
 moka = { version = "0.12", features = ["sync"] }
@@ -62,6 +67,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 anyhow = "1.0"
+tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "f2d0af15734d97dbd29e59942da637d8daa48305", features = ["testing"] }
 expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"

--- a/crates/discovery-service/README.md
+++ b/crates/discovery-service/README.md
@@ -23,6 +23,23 @@ Detailed design specs: [`specs/`](specs/README.md)
 - `POST /v1/sync/preflight_check` — Non-paginated readiness check for a (sender, recipient, token) tuple. Returns registration, channel, and subchannel existence flags.
 - `GET /health` — Health check with chain head lag reporting.
 
+## OHTTP (Oblivious HTTP)
+
+When enabled, the service supports Oblivious HTTP (RFC 9458) for IP-metadata privacy. A privacy relay (e.g. Cloudflare Privacy Gateway) sits between the client and the service: the relay sees the client IP but not the request content; the service sees the request content but not the client IP.
+
+- `GET /ohttp-keys` — server's HPKE public key configuration.
+- `POST /` — OHTTP gateway endpoint; all API endpoints are accessible through this single endpoint. The target path is encrypted inside the request payload.
+
+Configuration:
+
+| Setting | Env / TOML | Default | Description |
+|---------|------------|---------|-------------|
+| Enable | `OHTTP_ENABLED` / `ohttp.enabled` | `false` | Enable OHTTP support |
+| Key | `OHTTP_KEY` / — | — | Hex-encoded 32-byte X25519 private key (required when enabled) |
+| Key cache | — / `ohttp.key_cache_max_age_secs` | `3600` | `Cache-Control` max-age for `/ohttp-keys` response |
+
+See [spec 20](specs/20-ohttp-integration.md) for details.
+
 ## Operational characteristics
 - Security: TLS termination (planned), input validation, sensitive field filtering in logs.
 - Resilience: reorg detection via `last_known_block` / `block_ref`, RPC health monitoring, graceful backfill.
@@ -36,6 +53,9 @@ Detailed design specs: [`specs/`](specs/README.md)
 - `RPC_UNAVAILABLE`: upstream RPC is unavailable.
 - `SERVICE_UNAVAILABLE`: retry with exponential backoff.
 - `INTERNAL_ERROR`: internal discovery error.
+- `OHTTP_DECAPSULATION_FAILED`: invalid OHTTP envelope (422).
+- `OHTTP_INVALID_FORMAT`: malformed Binary HTTP message (422).
+- `OHTTP_BODY_TOO_LARGE`: request body exceeds size limit (413).
 
 ## Technology stack (target)
 Rust with Tokio runtime and Axum HTTP server. Packaged as static binaries (Linux x86, macOS ARM) and Docker image.

--- a/crates/discovery-service/specs/05-security-considerations.md
+++ b/crates/discovery-service/specs/05-security-considerations.md
@@ -49,7 +49,7 @@ The following vectors have been identified and mitigated:
 | Vector | Severity | Status |
 |--------|----------|--------|
 | Unbounded task spawning from `cursor.channels` / `cursor.subchannels` HashMaps — each entry spawns a tokio task, attacker can pack ~50K entries in a 2MB body | CRITICAL | mitigated by body size limit (C1) |
-| No explicit request body size limit — Axum 2MB default is ~4000× larger than a legitimate request | CRITICAL | DONE — `DefaultBodyLimit` configurable via `max_request_body_bytes` (default 100KB) |
+| No explicit request body size limit — Axum 2MB default is ~4000× larger than a legitimate request | CRITICAL | DONE — `DefaultBodyLimit` configurable via `max_request_body_bytes` (default 100KB). OHTTP-encapsulated requests enforce the same limit via `http_body_util::Limited` inside the OHTTP layer (returns 413 before decapsulation). |
 | No HTTP-level request timeout — slow RPC responses block worker threads up to 100min per request | HIGH | DONE — `TimeoutLayer` configurable via `api.request_timeout` (default 30s) |
 | HashMap deserialization memory spike from large cursors | MEDIUM | mitigated by body size limit |
 | `max_reads: 0` accepted, wastes snapshot creation | LOW | DONE — `min_server_budget()` clamp (minimum 67 with default config, derived from full discovery pipeline costs) |
@@ -67,11 +67,13 @@ The following request fields are validated by the service:
 
 ## 5.5 Privacy Model
 
-Users trust the service operator. The operator can observe:
+Users trust the service operator with request content. The operator can observe:
 
 - Which recipients are active and when.
 - How many channels, subchannels, and notes each recipient has.
 - Token addresses used per channel.
 - Timing of sync activity.
 
-This metadata exposure is accepted given the trust model. Users requiring stronger privacy guarantees should run their own instance.
+**With OHTTP and a privacy relay** (see [20-ohttp-integration.md](20-ohttp-integration.md)), the operator can no longer correlate this content with client IP addresses. The relay sees the client IP but cannot read the encrypted request; the operator sees the decrypted request but not the client IP. This eliminates IP-level metadata correlation.
+
+OHTTP does not protect against traffic analysis, content-level metadata (which the operator already observes), or relay-operator collusion. Users requiring stronger privacy guarantees should run their own instance.

--- a/crates/discovery-service/specs/20-ohttp-integration.md
+++ b/crates/discovery-service/specs/20-ohttp-integration.md
@@ -1,0 +1,118 @@
+# 20. Oblivious HTTP (OHTTP) Integration
+
+## 20.1 Purpose
+
+OHTTP (RFC 9458) provides application-layer encryption of HTTP requests and responses, independent of TLS. This serves two deployment modes:
+
+1. **With a privacy relay** (e.g. Cloudflare Privacy Gateway): separates knowledge of _who_ is making a request from _what_ the request contains. The relay sees the client IP but cannot read the encrypted request; the discovery service sees the decrypted request but not the client IP. This eliminates IP-level metadata correlation.
+
+2. **Without a relay** (direct client-to-service): decouples sensitive data encryption from TLS. Viewing keys and decrypted note data are protected by HPKE encryption at the application layer, so TLS can be terminated at a load balancer or CDN edge without exposing request content to the terminating infrastructure. This allows late TLS termination without sacrificing confidentiality of the payload.
+
+   **Trust caveat:** the client fetches the server's OHTTP public key via `GET /ohttp-keys`. Any entity that can intercept this request (e.g., a TLS-terminating proxy) can substitute the key and decrypt subsequent requests. In the relay-less mode, the client MUST either fetch the key config over a TLS connection terminated at a trusted entity, or pin the `publicKeyConfig` out-of-band. Without one of these, the payload encryption guarantee does not hold.
+
+## 20.2 Network Topology
+
+**With relay (full privacy):**
+```
+SDK (Client) ──── Privacy Relay ──── Discovery Service
+                  (e.g. Cloudflare     (Gateway + Target)
+                   Privacy Gateway)
+```
+
+**Without relay (payload encryption only):**
+```
+SDK (Client) ──── [TLS termination] ──── Discovery Service
+                  (CDN / load balancer)    (Gateway + Target)
+```
+
+The intended production deployment uses a third-party privacy relay such as [Cloudflare Privacy Gateway](https://blog.cloudflare.com/oblivious-http-application-gateway/) between the SDK and the discovery service. The relay forwards `message/ohttp-req` payloads without being able to decrypt them.
+
+In the relay-less mode, the client sends OHTTP-encapsulated requests directly to the service (or through a TLS-terminating proxy). The operator can still correlate requests with client IPs, but the payload is encrypted end-to-end between the client and the gateway — a TLS-terminating proxy in between cannot read viewing keys or decrypted data.
+
+The discovery service acts as both the OHTTP **gateway** (decapsulates requests) and the **target resource** (processes them). This is a single-hop OHTTP deployment — no separate gateway-to-target leg is needed.
+
+## 20.3 Gateway Endpoint
+
+The discovery service exposes two OHTTP-related endpoints:
+
+- `GET /ohttp-keys` — serves the server's HPKE public key configuration (plaintext, cacheable).
+- `POST /` — the OHTTP gateway. Accepts `message/ohttp-req` encapsulated requests, decapsulates them, routes internally, and returns `message/ohttp-res`.
+
+Per RFC 9458, the relay is configured with the service's base URL and forwards all encapsulated requests to `POST /`. The **target API path** (e.g., `/v1/sync/incoming_state`) is inside the encrypted Binary HTTP payload — invisible to the relay. After decapsulation, the gateway extracts the inner path and routes through the API router.
+
+Plaintext `application/json` requests to specific API paths (e.g., `POST /v1/sync/incoming_state`) continue to work unchanged — this supports direct client-to-service access without a relay.
+
+## 20.4 Request Flow
+
+1. Client fetches `GET /ohttp-keys` to obtain the server's HPKE public key configuration.
+2. Client constructs a Binary HTTP request (RFC 9292) containing the JSON API call.
+3. Client encapsulates the Binary HTTP request using the server's key config → produces an OHTTP-encrypted blob.
+4. Client sends the blob as `POST /` with `Content-Type: message/ohttp-req` to the relay's configured gateway URL.
+5. The relay forwards the opaque blob to `POST /` on the discovery service.
+6. The `OhttpLayer` middleware (from the `tower_ohttp` crate) processes the request:
+   a. Buffers the encrypted body (enforcing `max_request_body_bytes` limit).
+   b. Decapsulates the HPKE envelope using the server's private key.
+   c. Parses the inner Binary HTTP message.
+   d. Rebuilds a standard `http::Request` preserving method, path, headers, and body from the BHTTP payload.
+   e. Routes through the API router (handler is unaware of OHTTP).
+7. The handler produces a response as usual.
+8. The middleware encodes the response as Binary HTTP (preserving status code and headers), encrypts it with the OHTTP response context, and returns `Content-Type: message/ohttp-res`.
+9. The relay forwards the encrypted response to the client.
+10. Client decapsulates to obtain the plaintext JSON response.
+
+## 20.5 Key Configuration
+
+| Parameter | Value |
+|-----------|-------|
+| KEM | X25519 + HKDF-SHA256 (`Kem::X25519Sha256`) |
+| KDF | HKDF-SHA256 |
+| AEAD | AES-128-GCM |
+| Key ID | 0 (single key per instance) |
+| Key source | `OHTTP_KEY` env var (hex-encoded 32-byte X25519 private key) |
+| Key config endpoint | `GET /ohttp-keys` (`application/ohttp-keys`, `Cache-Control: public, max-age=<key_cache_max_age_secs>`) |
+
+The server derives the full HPKE key pair from the IKM seed. The public key is encoded in the RFC 9458 key configuration format and served at `/ohttp-keys`.
+
+Key rotation requires restarting the service with a new `OHTTP_KEY` value. The server sets `Cache-Control: public, max-age=<key_cache_max_age_secs>` on the `/ohttp-keys` response (default 3600s). Clients SHOULD respect this header to determine when to re-fetch. During rotation, clients holding the old config will receive decapsulation failures and must re-fetch.
+
+**Note:** the current SDK implementation does not read `Cache-Control` and uses a hardcoded 1-hour TTL. Until this is addressed, changing `key_cache_max_age_secs` below 3600 will not accelerate key rotation for SDK clients.
+
+## 20.6 Body Size Limit
+
+The `OhttpLayer` enforces the same `max_request_body_bytes` limit on all incoming request bodies (both OHTTP and plaintext). Oversized requests receive a plaintext `413 Payload Too Large` response with error code `OHTTP_BODY_TOO_LARGE` — this error cannot be encrypted since decapsulation has not yet occurred.
+
+## 20.7 Configuration
+
+OHTTP is opt-in. All settings live under `[ohttp]` in TOML config:
+
+| Setting | Env var | TOML key | Default | Description |
+|---------|---------|----------|---------|-------------|
+| Enable | `OHTTP_ENABLED` | `ohttp.enabled` | `false` | Enable OHTTP gateway and `/ohttp-keys` endpoints |
+| Key | `OHTTP_KEY` | — | — | Hex-encoded 32-byte X25519 private key (required when enabled) |
+| Key cache max-age | — | `ohttp.key_cache_max_age_secs` | `3600` | `Cache-Control` max-age (seconds) for the `/ohttp-keys` response |
+
+When disabled, no OHTTP middleware is installed. When enabled but `OHTTP_KEY` is missing or invalid, the service exits on startup.
+
+## 20.8 Transparent Gateway
+
+The OHTTP gateway is implemented as a tower middleware layer (`OhttpLayer` from the `tower_ohttp` crate) installed as a fallback service on the Axum router. Unmatched requests (including `POST /` from a relay) hit the fallback, where the layer decapsulates the OHTTP envelope and re-routes the inner request through a cloned API router. Matched plaintext requests bypass OHTTP entirely. Handlers receive normal requests and return normal responses with no knowledge of OHTTP.
+
+The gateway preserves the inner request's HTTP method, path, and all BHTTP headers. All API endpoints — both `POST` (`/v1/sync/incoming_state`, `/v1/sync/outgoing_state`, `/v1/sync/preflight_check`, `/v1/history`) and `GET` (`/health`) — are reachable through OHTTP.
+
+## 20.9 Privacy Properties
+
+| Property | Without OHTTP | OHTTP without relay | OHTTP with relay |
+|----------|---------------|---------------------|-------------------|
+| Client IP visible to operator | Yes | Yes | No — relay terminates the connection |
+| Request content visible to operator | Yes | Yes | Yes — operator decrypts the OHTTP envelope |
+| Request content visible to TLS proxy | Yes | No — HPKE encrypted | No — HPKE encrypted |
+| Request content visible to relay | N/A | N/A | No — relay cannot decrypt |
+| Target API path visible to relay | N/A | N/A | No — encrypted inside Binary HTTP |
+| Timing correlation | Possible | Possible | Reduced but not eliminated |
+
+OHTTP does **not** protect against:
+- Traffic analysis (request sizes, timing patterns) by a relay-operator collusion.
+- Content-level metadata the operator already observes (viewing keys, channel counts, token addresses).
+- Timing correlation by a passive network observer who can see both client→relay and relay→service traffic.
+
+For stronger guarantees, users should run their own discovery service instance.

--- a/crates/discovery-service/specs/README.md
+++ b/crates/discovery-service/specs/README.md
@@ -25,6 +25,7 @@ This folder contains the design specifications for the Privacy Pool Discovery Se
 | [17-cold-start-and-backfill.md](17-cold-start-and-backfill.md) | Behavior during cache backfill, snapshot import/export, and recovery time considerations. |
 | [18-configuration.md](18-configuration.md) | Layered configuration system (env var > config file > code default), TOML format, and env var overrides. |
 | [19-scaling-and-capacity.md](19-scaling-and-capacity.md) | Bottleneck analysis, capacity estimates, RPC node comparison, scaling strategy, and validated default config. |
+| [20-ohttp-integration.md](20-ohttp-integration.md) | Oblivious HTTP integration: privacy relay topology, request flow, key configuration, and privacy properties. |
 
 ## See also
 

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -19,7 +19,11 @@ use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
 use tracing::info;
 
+use tower::Layer;
+use tower_ohttp::{OhttpGateway, OhttpLayer};
+
 use crate::chain_state::ChainState;
+use crate::config::OhttpConfig;
 use crate::config::{ApiServerConfig, ValidationLimits};
 use crate::public_key_cache::PublicKeyCache;
 
@@ -38,6 +42,8 @@ pub struct ApiServer<B> {
     rx_shutdown: broadcast::Receiver<()>,
     config: ApiServerConfig,
     backend: B,
+    ohttp_gateway: Option<Arc<OhttpGateway>>,
+    ohttp_config: OhttpConfig,
 }
 
 /// Errors that can occur in the API server.
@@ -65,11 +71,19 @@ where
     B::Snapshot: RawEventAccess + Clone + Send + Sync + 'static,
 {
     /// Creates a new API server.
-    pub fn new(config: ApiServerConfig, rx_shutdown: broadcast::Receiver<()>, backend: B) -> Self {
+    pub fn new(
+        config: ApiServerConfig,
+        rx_shutdown: broadcast::Receiver<()>,
+        backend: B,
+        ohttp_gateway: Option<Arc<OhttpGateway>>,
+        ohttp_config: OhttpConfig,
+    ) -> Self {
         Self {
             rx_shutdown,
             config,
             backend,
+            ohttp_gateway,
+            ohttp_config,
         }
     }
 
@@ -84,7 +98,7 @@ where
             validation_limits: self.config.validation_limits.clone(),
         });
 
-        let app = Router::new()
+        let api_router = Router::new()
             .route("/health", get(health_handler::<B>))
             .route("/v1/sync/incoming_state", post(incoming_sync_handler::<B>))
             .route("/v1/sync/outgoing_state", post(outgoing_sync_handler::<B>))
@@ -93,6 +107,29 @@ where
                 post(preflight_check_handler::<B>),
             )
             .route("/v1/history", post(history_handler::<B>))
+            .with_state(app_state);
+
+        // Conditionally add OHTTP envelope encryption.
+        // The OhttpLayer wraps a clone of the API router and is installed as
+        // the fallback service. Unmatched paths (e.g. `POST /` from a relay)
+        // hit the fallback, which decapsulates the OHTTP envelope and re-routes
+        // the inner request through the cloned router. Matched plaintext
+        // requests bypass OHTTP entirely.
+        let app = if let Some(gateway) = &self.ohttp_gateway {
+            let ohttp_layer = OhttpLayer::new(
+                gateway.clone(),
+                self.config.validation_limits.max_request_body_bytes,
+                self.ohttp_config.key_cache_max_age_secs,
+                axum::body::Body::new,
+            );
+            let ohttp_service = ohttp_layer.layer(api_router.clone());
+            info!("OHTTP envelope encryption enabled");
+            api_router.fallback_service(ohttp_service)
+        } else {
+            api_router
+        };
+
+        let app = app
             .layer(CorsLayer::permissive())
             .layer(DefaultBodyLimit::max(
                 self.config.validation_limits.max_request_body_bytes,
@@ -100,8 +137,7 @@ where
             .layer(TimeoutLayer::with_status_code(
                 axum::http::StatusCode::REQUEST_TIMEOUT,
                 self.config.request_timeout,
-            ))
-            .with_state(app_state);
+            ));
 
         let tcp_listener = TcpListener::bind(&self.config.host)
             .await
@@ -164,5 +200,86 @@ where
 
         info!("API server has shut down");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod ohttp_layer_tests {
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use tower::{Layer, ServiceExt};
+    use tower_ohttp::test_utils::{
+        decapsulate_bhttp_response, encapsulate_bhttp_request, test_gateway,
+    };
+    use tower_ohttp::OhttpLayer;
+
+    const BODY_LIMIT: usize = 102_400;
+    const KEY_CACHE_SECS: u64 = 3600;
+
+    async fn echo_handler(body: axum::body::Bytes) -> impl IntoResponse {
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+    }
+
+    fn test_router() -> Router {
+        let gateway = test_gateway();
+        let ohttp_layer = OhttpLayer::new(gateway, BODY_LIMIT, KEY_CACHE_SECS, Body::new);
+        let api_router = Router::new().route("/v1/echo", post(echo_handler));
+        let ohttp_service = ohttp_layer.layer(api_router.clone());
+        api_router.fallback_service(ohttp_service)
+    }
+
+    #[tokio::test]
+    async fn ohttp_round_trip_through_axum_router() {
+        let app = test_router();
+        let gateway = test_gateway();
+
+        let json_body = br#"{"viewing_key":"0xabc"}"#;
+        let (encapsulated, client_response) =
+            encapsulate_bhttp_request(&gateway, "POST", "/v1/echo", json_body, &[]);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header(header::CONTENT_TYPE, "message/ohttp-req")
+            .body(Body::from(encapsulated))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "message/ohttp-res"
+        );
+
+        let encrypted_body = response.into_body().collect().await.unwrap().to_bytes();
+        let decapsulated = decapsulate_bhttp_response(client_response, &encrypted_body);
+        assert_eq!(decapsulated.status, 200);
+        assert_eq!(decapsulated.body, json_body);
+    }
+
+    #[tokio::test]
+    async fn plaintext_request_passes_through() {
+        let app = test_router();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/echo")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(br#"{"hello":"world"}"#.to_vec()))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), br#"{"hello":"world"}"#);
     }
 }

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -342,4 +342,6 @@ pub mod error_codes {
     pub const CONTRACT_NOT_FOUND: &str = "CONTRACT_NOT_FOUND";
     pub const RPC_UNAVAILABLE: &str = "RPC_UNAVAILABLE";
     pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+    pub const OHTTP_DECAPSULATION_FAILED: &str = "OHTTP_DECAPSULATION_FAILED";
+    pub const OHTTP_INVALID_FORMAT: &str = "OHTTP_INVALID_FORMAT";
 }

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -185,6 +185,30 @@ pub struct LoggingConfig {
     pub level: Option<String>,
 }
 
+/// Configuration for Oblivious HTTP (OHTTP) envelope encryption.
+///
+/// When enabled, the service accepts `message/ohttp-req` requests and
+/// returns `message/ohttp-res` responses. The HPKE private key is loaded
+/// from the `OHTTP_KEY` environment variable (hex-encoded, 32 bytes).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct OhttpConfig {
+    /// Enable OHTTP support. When false, the service only accepts plain JSON.
+    pub enabled: bool,
+    /// Cache-Control max-age for the `/ohttp-keys` endpoint, in seconds.
+    /// Clients cache the key config for this duration before re-fetching.
+    pub key_cache_max_age_secs: u64,
+}
+
+impl Default for OhttpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            key_cache_max_age_secs: 3600,
+        }
+    }
+}
+
 /// Top-level service configuration deserialized from TOML.
 /// Omitted fields get defaults from `#[serde(default)]` on each struct.
 #[derive(Debug, Default, Deserialize)]
@@ -195,6 +219,7 @@ pub struct ServiceConfig {
     pub api: ApiServerConfig,
     pub logging: LoggingConfig,
     pub limits: ValidationLimits,
+    pub ohttp: OhttpConfig,
 }
 
 impl ServiceConfig {
@@ -225,6 +250,10 @@ impl ServiceConfig {
             }
         }
 
+        if let Ok(v) = std::env::var("OHTTP_ENABLED") {
+            self.ohttp.enabled = v == "true" || v == "1";
+        }
+
         let cert_path = std::env::var("TLS_CERT_PATH").ok();
         let key_path = std::env::var("TLS_KEY_PATH").ok();
         match (cert_path, key_path) {
@@ -247,7 +276,7 @@ impl ServiceConfig {
     /// Defaults were already applied at deserialization time via `#[serde(default)]`,
     /// so this just injects `limits` into `api`.
     /// Must be called after `apply_env_overrides()`.
-    pub fn build_configs(mut self) -> (RpcConfig, IndexerConfig, ApiServerConfig) {
+    pub fn build_configs(mut self) -> (RpcConfig, IndexerConfig, ApiServerConfig, OhttpConfig) {
         let min_budget = min_server_budget(self.limits.cursor_limits.max_note_log_index);
         if self.limits.server_budget < min_budget {
             warn!(
@@ -258,7 +287,7 @@ impl ServiceConfig {
             self.limits.server_budget = min_budget;
         }
         self.api.validation_limits = self.limits;
-        (self.rpc, self.indexer, self.api)
+        (self.rpc, self.indexer, self.api, self.ohttp)
     }
 }
 
@@ -424,7 +453,7 @@ host = "127.0.0.1:8080"
     fn test_build_configs_uses_component_defaults() {
         let config = ServiceConfig::default();
 
-        let (rpc, idx, api) = config.build_configs();
+        let (rpc, idx, api, _) = config.build_configs();
 
         let rpc_defaults = RpcConfig::default();
         assert_eq!(rpc.url, rpc_defaults.url);
@@ -448,7 +477,7 @@ host = "127.0.0.1:8080"
         let min_budget = min_server_budget(config.limits.cursor_limits.max_note_log_index);
         config.limits.server_budget = 1;
 
-        let (_, _, api) = config.build_configs();
+        let (_, _, api, _) = config.build_configs();
 
         assert_eq!(
             api.validation_limits.server_budget, min_budget,
@@ -462,7 +491,7 @@ host = "127.0.0.1:8080"
         let min_budget = min_server_budget(config.limits.cursor_limits.max_note_log_index);
         config.limits.server_budget = min_budget;
 
-        let (_, _, api) = config.build_configs();
+        let (_, _, api, _) = config.build_configs();
 
         assert_eq!(api.validation_limits.server_budget, min_budget);
     }
@@ -472,7 +501,7 @@ host = "127.0.0.1:8080"
         let mut config = ServiceConfig::default();
         config.limits.server_budget = 200;
 
-        let (_, _, api) = config.build_configs();
+        let (_, _, api, _) = config.build_configs();
 
         assert_eq!(api.validation_limits.server_budget, 200);
     }
@@ -485,7 +514,7 @@ host = "127.0.0.1:8080"
         config.api.host = "0.0.0.0:3000".to_string();
         config.limits.server_budget = 200;
 
-        let (_rpc, idx, api) = config.build_configs();
+        let (_rpc, idx, api, _) = config.build_configs();
 
         assert_eq!(idx.connect_timeout, Duration::from_secs(42));
         assert_eq!(api.host, "0.0.0.0:3000");

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -3,12 +3,15 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use std::sync::Arc;
+
 use discovery_service::api::ApiServer;
 use discovery_service::config::ServiceConfig;
 use discovery_service::indexer::Indexer;
 use discovery_service::rpc_backend::RpcBackend;
 use discovery_service::shutdown::Shutdown;
 use tokio::task::JoinHandle;
+use tower_ohttp::OhttpGateway;
 use tracing::{error, info, subscriber::set_global_default};
 use tracing_subscriber::filter::EnvFilter;
 
@@ -65,12 +68,31 @@ async fn main() {
     let shutdown = Shutdown::default();
 
     // Build component configs from the unified service config
-    let (rpc_config, indexer_config, api_server_config) = config.build_configs();
+    let (rpc_config, indexer_config, api_server_config, ohttp_config) = config.build_configs();
+
+    // Initialize OHTTP key manager if enabled.
+    let ohttp_gateway = if ohttp_config.enabled {
+        match OhttpGateway::from_env() {
+            Ok(manager) => Some(Arc::new(manager)),
+            Err(error) => {
+                eprintln!("Failed to initialize OHTTP: {error}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
 
     let rpc_backend = RpcBackend::new(rpc_config).expect("Failed to create RPC backend");
 
     let mut indexer = Indexer::new(indexer_config, shutdown.subscribe(), rpc_backend.clone());
-    let mut api_server = ApiServer::new(api_server_config, shutdown.subscribe(), rpc_backend);
+    let mut api_server = ApiServer::new(
+        api_server_config,
+        shutdown.subscribe(),
+        rpc_backend,
+        ohttp_gateway,
+        ohttp_config,
+    );
 
     let indexer_handle = tokio::spawn(async move { indexer.run().await });
     let api_server_handle = tokio::spawn(async move { api_server.run().await });

--- a/deploy/discovery-service/README.md
+++ b/deploy/discovery-service/README.md
@@ -59,6 +59,9 @@ Precedence: env var > config file > code default.
 | `SERVER_BUDGET` | `limits.server_budget` | `10000` |
 | `TLS_CERT_PATH` | `api.tls.cert_path` | — (TLS disabled) |
 | `TLS_KEY_PATH` | `api.tls.key_path` | — (TLS disabled) |
+| `OHTTP_ENABLED` | `ohttp.enabled` | `false` |
+| `OHTTP_KEY` | — | — (required when OHTTP enabled) |
+| — | `ohttp.key_cache_max_age_secs` | `3600` |
 
 Other settings (RPC pool, indexer timeouts, cursor limits) can only be configured via the TOML file.
 

--- a/deploy/discovery-service/config.example.toml
+++ b/deploy/discovery-service/config.example.toml
@@ -36,6 +36,10 @@ request_timeout = 30
 [logging]
 level = "info"
 
+# [ohttp]
+# enabled = true
+# key_cache_max_age_secs = 3600
+
 [limits]
 max_channels = 256
 max_subchannels_per_channel = 64


### PR DESCRIPTION
## Summary

Add Oblivious HTTP (OHTTP, [RFC 9458](https://datatracker.ietf.org/doc/html/rfc9458)) envelope encryption to the discovery service as an opt-in Tower middleware layer.

### Problem

The discovery service receives the user's `viewing_key` — a Stark curve private key — as plaintext hex in JSON request bodies on every sync call. Transit confidentiality relies entirely on TLS. In cloud deployments where TLS terminates at a load balancer or reverse proxy, the viewing key is exposed in plaintext between the termination point and the service.

### Solution

OHTTP wraps the *entire* HTTP request in HPKE encryption at the application layer, independent of TLS. The client encrypts the request to the server's public key; the server decrypts, processes normally, and encrypts the response back.

Key properties:
- **Standards-based**: RFC 9458 (OHTTP) + RFC 9292 (Binary HTTP) + RFC 9180 (HPKE)
- **Relay-compatible**: Wire format works with OHTTP relays (e.g., [Cloudflare Privacy Gateway](https://github.com/cloudflare/privacy-gateway-relay)), enabling IP-hiding from the discovery service
- **Zero handler changes**: Implemented as a Tower `Layer` that transparently converts `message/ohttp-req` ↔ `application/json` at the transport boundary. All existing handlers remain untouched
- **Fully optional**: Disabled by default (`ohttp.enabled = false`). When disabled, the router is identical to today — zero runtime overhead

### HPKE Suite

DHKEM(X25519, HKDF-SHA256) + HKDF-SHA256 + AES-128-GCM, Base mode. Uses the `ohttp` crate (v0.7) by Martin Thomson, co-author of RFC 9458, used in Firefox.

### Wire Format

**Key distribution:**
```
GET /ohttp-keys → application/ohttp-keys (binary, cacheable 1h)
```

**Requests:**
```
POST /v1/sync/incoming_state
Content-Type: message/ohttp-req

[keyID(1B) || kemID(2B) || kdfID(2B) || aeadID(2B) || enc(32B) || AEAD ciphertext]
```

The ciphertext contains a Binary HTTP (RFC 9292) encoded request with the JSON body inside.

**Responses:**
```
Content-Type: message/ohttp-res

[response_nonce || AEAD ciphertext]
```

Response encryption uses HPKE Export, per the OHTTP spec.

**Backward compatibility:** Content-Type routing — `application/json` passes through unchanged, `message/ohttp-req` triggers OHTTP decapsulation. Both coexist on the same endpoints.

### Configuration

```toml
[ohttp]
enabled = true  # default: false
```

Key loaded from `OHTTP_KEY` env var (hex-encoded 32-byte X25519 private key):
```
OHTTP_KEY=a3b2c1d0e4f5...  # 64 hex chars
```

### Error Handling

Per OHTTP spec:
- Pre-decryption errors (malformed OHTTP, decryption failure) → plain HTTP 422
- Post-decryption errors (business logic) → encrypted in OHTTP response (outer HTTP 200)

### What's NOT in this PR

- **TypeScript SDK OHTTP client** — will be a follow-up PR
- **Zero-downtime key rotation** — currently single key; multi-key rotation is a documented TODO
- **Cloud KMS envelope encryption** — key loading from env var only; KMS integration is a documented TODO
- **E2E test with Cloudflare relay** — planned for after SDK integration

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/ohttp/mod.rs` | Module root |
| `src/ohttp/key_manager.rs` | Load X25519 key from `OHTTP_KEY` env var, build `ohttp::Server`, serialize key config |
| `src/ohttp/layer.rs` | Tower `Layer`/`Service` — decapsulate requests, encapsulate responses, pass-through for JSON |
| `src/ohttp/handlers.rs` | `GET /ohttp-keys` endpoint |

### Modified files
| File | Change |
|------|--------|
| `Cargo.toml` | Add `ohttp`, `bhttp`, `hex`, `http-body-util` |
| `src/lib.rs` | `pub mod ohttp` |
| `src/config.rs` | `OhttpConfig` struct, `build_configs` returns 4-tuple |
| `src/api/mod.rs` | Conditional `OhttpLayer` + `/ohttp-keys` route when OHTTP enabled |
| `src/api/types.rs` | `OHTTP_DECAPSULATION_FAILED`, `OHTTP_INVALID_FORMAT` error codes |
| `src/main.rs` | Initialize `OhttpKeyManager` from env when `ohttp.enabled = true` |

### Unchanged
- All handler functions (`handlers.rs`) — the Tower layer handles OHTTP transparently
- All `_impl` business logic functions
- `discovery-core/` — no changes to internal decryption/types

## Test Plan

10 new tests (45 total, all passing):

**Key manager (5 tests):**
- [x] Key config creation from raw key material
- [x] Hex env var parsing round-trip
- [x] Rejects keys shorter than 32 bytes
- [x] Rejects non-hex input
- [x] Full HPKE round-trip: client encrypt → server decrypt → server encrypt response → client decrypt

**Tower layer (5 tests):**
- [x] `application/json` request passes through unchanged, response is plain JSON
- [x] `message/ohttp-req` → decapsulate → echo handler → encapsulate response → client decrypts successfully
- [x] Malformed OHTTP body → 422 with `OHTTP_DECAPSULATION_FAILED`
- [x] Missing Content-Type header → passes through like JSON
- [x] Inner Binary HTTP path is preserved on the rebuilt request

**Verification:**
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test --lib` — 45/45 pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/692)
<!-- Reviewable:end -->
