### PR TITLE
feat: ohttp with p256 kem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +567,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -653,6 +677,16 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -776,6 +810,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.5.5",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +895,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1012,6 +1075,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1062,6 +1126,17 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1147,6 +1222,7 @@ dependencies = [
  "generic-array",
  "hkdf",
  "hmac",
+ "p256",
  "rand_core 0.9.5",
  "sha2",
  "subtle",
@@ -1770,8 +1846,7 @@ dependencies = [
 [[package]]
 name = "ohttp"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a03aaaf57495c75ce66aee6a7c3b21abf046c9d4cca3d45b22cdbf0de1bfba"
+source = "git+https://github.com/m-kus/ohttp?rev=dc636c1#dc636c16f75650de8e3bc14e4aab920a2c53a315"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1812,6 +1887,16 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -1953,6 +2038,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2448,6 +2542,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,7 +2797,7 @@ version = "0.19.0-rc.0"
 source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "base64",
- "crypto-bigint",
+ "crypto-bigint 0.6.1",
  "flate2",
  "foldhash 0.2.0",
  "hex",
@@ -2723,7 +2830,7 @@ version = "0.19.0-rc.0"
 source = "git+https://github.com/software-mansion/starknet-rust.git?rev=7caedfe#7caedfef85a4d748f8e9e5a159c87c31b6fe9d71"
 dependencies = [
  "blake2",
- "crypto-bigint",
+ "crypto-bigint 0.6.1",
  "digest",
  "hex",
  "hmac",

--- a/crates/discovery-service/src/ohttp/gateway.rs
+++ b/crates/discovery-service/src/ohttp/gateway.rs
@@ -1,0 +1,143 @@
+//! OHTTP gateway: loads keys from environment and manages the
+//! `ohttp::Server` instance for request decapsulation and response
+//! encapsulation (RFC 9458).
+
+use ohttp::hpke::{Aead, Kdf, Kem};
+use ohttp::{KeyConfig, KeyId, Server, SymmetricSuite};
+use tracing::info;
+
+/// OHTTP gateway that holds the server key configuration and
+/// decapsulates/encapsulates requests (RFC 9458).
+pub struct OhttpGateway {
+    server: Server,
+    encoded_key_config: Vec<u8>,
+}
+
+/// Errors during OHTTP gateway initialization.
+#[derive(Debug, thiserror::Error)]
+pub enum OhttpGatewayError {
+    #[error("OHTTP_KEY environment variable not set")]
+    MissingEnvVar,
+    #[error("OHTTP_KEY must be exactly 64 hex characters (32 bytes): {0}")]
+    InvalidHex(String),
+    #[error("failed to build OHTTP key config: {0}")]
+    Config(#[source] ohttp::Error),
+}
+
+impl OhttpGateway {
+    /// Load a single OHTTP key from the `OHTTP_KEY` environment variable.
+    ///
+    /// The value must be a hex-encoded 32-byte P-256 IKM seed (64 hex chars).
+    /// The public key is derived automatically and keyID is set to 0.
+    pub fn from_env() -> Result<Self, OhttpGatewayError> {
+        let hex_key = std::env::var("OHTTP_KEY").map_err(|_| OhttpGatewayError::MissingEnvVar)?;
+        Self::from_hex_key(&hex_key)
+    }
+
+    /// Build from a hex-encoded P-256 IKM seed string.
+    pub fn from_hex_key(hex_key: &str) -> Result<Self, OhttpGatewayError> {
+        let hex_key = hex_key.trim();
+        let ikm = hex::decode(hex_key)
+            .map_err(|_| OhttpGatewayError::InvalidHex(format!("invalid hex: {hex_key}")))?;
+        if ikm.len() != 32 {
+            return Err(OhttpGatewayError::InvalidHex(format!(
+                "expected 32 bytes, got {}",
+                ikm.len()
+            )));
+        }
+
+        Self::from_ikm(0, &ikm)
+    }
+
+    /// Build from raw input keying material with a given key ID.
+    fn from_ikm(key_id: KeyId, ikm: &[u8]) -> Result<Self, OhttpGatewayError> {
+        let symmetric_suite = SymmetricSuite::new(Kdf::HkdfSha256, Aead::Aes128Gcm);
+        let key_config = KeyConfig::derive(key_id, Kem::P256Sha256, vec![symmetric_suite], ikm)
+            .map_err(OhttpGatewayError::Config)?;
+
+        let encoded_key_config =
+            KeyConfig::encode_list(&[&key_config]).map_err(OhttpGatewayError::Config)?;
+
+        let server = Server::new(key_config).map_err(OhttpGatewayError::Config)?;
+
+        info!("OHTTP key loaded (keyID={key_id})");
+
+        Ok(Self {
+            server,
+            encoded_key_config,
+        })
+    }
+
+    /// Returns the encoded key config bytes for the `GET /ohttp-keys` endpoint.
+    /// Format: `application/ohttp-keys` (concatenated key configs with length prefixes).
+    pub fn encoded_config(&self) -> &[u8] {
+        &self.encoded_key_config
+    }
+
+    /// Returns a reference to the OHTTP server for decapsulating requests.
+    pub fn server(&self) -> &Server {
+        &self.server
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ikm() -> [u8; 32] {
+        let mut ikm = [0u8; 32];
+        ikm[0] = 1; // non-zero so key derivation produces a valid key
+        ikm
+    }
+
+    #[test]
+    fn from_ikm_produces_valid_config() {
+        let manager = OhttpGateway::from_ikm(0, &test_ikm()).unwrap();
+        let config_bytes = manager.encoded_config();
+        assert!(!config_bytes.is_empty());
+    }
+
+    #[test]
+    fn from_hex_key_roundtrip() {
+        let hex = hex::encode(test_ikm());
+        let manager = OhttpGateway::from_hex_key(&hex).unwrap();
+        assert!(!manager.encoded_config().is_empty());
+    }
+
+    #[test]
+    fn from_hex_key_rejects_short() {
+        let result = OhttpGateway::from_hex_key("aabb");
+        assert!(matches!(result, Err(OhttpGatewayError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn from_hex_key_rejects_invalid_hex() {
+        let result = OhttpGateway::from_hex_key("zzzz");
+        assert!(matches!(result, Err(OhttpGatewayError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn decapsulate_roundtrip() {
+        let manager = OhttpGateway::from_ikm(0, &test_ikm()).unwrap();
+
+        // Client side: create a request using the server's key config
+        let config_bytes = manager.encoded_config();
+        let client_request = ohttp::ClientRequest::from_encoded_config_list(config_bytes).unwrap();
+
+        let plaintext_request = b"test request body";
+        let (encapsulated, client_response) =
+            client_request.encapsulate(plaintext_request).unwrap();
+
+        // Server side: decapsulate
+        let (decapsulated, server_response) = manager.server().decapsulate(&encapsulated).unwrap();
+        assert_eq!(decapsulated, plaintext_request);
+
+        // Server side: encapsulate response
+        let plaintext_response = b"test response body";
+        let encapsulated_response = server_response.encapsulate(plaintext_response).unwrap();
+
+        // Client side: decapsulate response
+        let decapsulated_response = client_response.decapsulate(&encapsulated_response).unwrap();
+        assert_eq!(decapsulated_response, plaintext_response);
+    }
+}

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@starkware-libs/starknet-privacy-sdk";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
 
-// Deterministic 32-byte X25519 private key for testing (hex-encoded).
+// Deterministic 32-byte P-256 IKM seed for testing (hex-encoded).
 const OHTTP_TEST_KEY =
   "0101010101010101010101010101010101010101010101010101010101010101";
 

--- a/sdk/src/internal/ohttp-client.ts
+++ b/sdk/src/internal/ohttp-client.ts
@@ -6,7 +6,7 @@
  */
 
 import { OHTTPClient, KeyConfig } from "ohttp-ts";
-import { CipherSuite, KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM } from "hpke";
+import { CipherSuite, KEM_DHKEM_P256_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM } from "hpke";
 import { ReorgError } from "./errors.js";
 
 /** HTTP 409 — the discovery service returns this exclusively for block reorgs (BLOCK_REORGED). */
@@ -142,7 +142,7 @@ export class OhttpClient {
       throw new Error("OHTTP key config response contained no key configurations");
     }
     const publicKeyConfig = publicKeyConfigs[0];
-    const suite = new CipherSuite(KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM);
+    const suite = new CipherSuite(KEM_DHKEM_P256_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM);
     this.ohttpClient = new OHTTPClient(suite, publicKeyConfig);
   }
 


### PR DESCRIPTION
### TL;DR

Switched OHTTP encryption from X25519 to P-256 elliptic curve cryptography across the discovery service and SDK.

### What changed?

- Updated the `ohttp` dependency to use a forked version that supports P-256
- Modified the OHTTP key manager to use `Kem::P256Sha256` instead of `Kem::X25519Sha256`
- Changed the SDK's OHTTP client to use `KEM_DHKEM_P256_HKDF_SHA256` cipher suite
- Updated documentation and comments to reflect P-256 IKM seed usage instead of X25519 private keys
- Added P-256 cryptographic dependencies (`p256`, `elliptic-curve`, `sec1`, etc.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/695)
<!-- Reviewable:end -->
