### PR TITLE
feat(sdk): add ohttp support to proving service provider

### DIFF
--- a/e2e/tests/integration/privacy-starknet-integration.test.ts
+++ b/e2e/tests/integration/privacy-starknet-integration.test.ts
@@ -129,7 +129,9 @@ describe("Privacy StarkNet integration", () => {
     poolAddress = deployResult.contract_address;
     console.log("[debug] privacy pool deployed at:", poolAddress);
 
-    discovery = new IndexerDiscoveryProvider(INDEXER_URL, poolAddress);
+    discovery = new IndexerDiscoveryProvider(INDEXER_URL, poolAddress, {
+      ohttp: true,
+    });
   }, 300_000);
 
   it("preflight returns a valid SetupRequirement", async () => {
@@ -160,6 +162,7 @@ describe("Privacy StarkNet integration", () => {
       provingProvider: new ProvingServiceProofProvider(
         PROVING_SERVICE_URL,
         CHAIN_ID,
+        { ohttp: true },
       ),
       discoveryProvider: discovery,
       poolContractAddress: poolAddress,
@@ -169,7 +172,7 @@ describe("Privacy StarkNet integration", () => {
     log("estimating mint fee...");
     const mintCall = {
       contractAddress: TOKEN,
-      entrypoint: "mint",
+      entrypoint: "permissionedMint",
       calldata: [alice.address, "100", "0"],
     };
     const mintFee = await adminAccount.estimateInvokeFee(mintCall);

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -17,6 +17,11 @@
   - Optional OHTTP relay support via `{ ohttp: { relayUrl: "..." } }` for client IP hiding; relay URL is used as-is (target API path is encrypted inside the OHTTP envelope)
   - Warns at construction time when `gatewayUrl` is plain HTTP and no key config is pinned (TOFU key discovery is vulnerable to MITM over unencrypted transport)
 - Export `OhttpClient` class for advanced OHTTP usage outside `IndexerDiscoveryProvider`
+- OHTTP envelope encryption support for `ProvingServiceProofProvider` — encrypts proving requests and decrypts compressed responses (decrypt-then-decompress)
+  - Enable with `new ProvingServiceProofProvider(url, chainId, { ohttp: true })`
+  - Same relay/key-pinning options as `IndexerDiscoveryProvider`
+  - Also available via `ProofProviderConfig.ohttp` in `createPrivateTransfers()` factory
+- Export `OhttpOption` type for reuse in consumer code
 
 ### Added
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -687,9 +687,24 @@ is encrypted inside the OHTTP envelope and is not visible to the relay. The
 relay still sees request/response sizes and timing. The discovery service
 itself decrypts and processes the full request.
 
+### Proving service
+
+`ProvingServiceProofProvider` supports the same OHTTP options:
+
+```typescript
+const prover = new ProvingServiceProofProvider(proverUrl, chainId, {
+  ohttp: true,
+});
+
+// With relay and/or pinned key config:
+const prover = new ProvingServiceProofProvider(proverUrl, chainId, {
+  ohttp: { relayUrl: "https://relay.example.com", publicKeyConfig: keyBytes },
+});
+```
+
 ### Server requirements
 
-The discovery service must have OHTTP enabled:
+Both the discovery service and the proving service must have OHTTP enabled:
 
 ```
 OHTTP_ENABLED=true OHTTP_KEY=<hex-encoded-32-byte-x25519-private-key>

--- a/sdk/src/factory.ts
+++ b/sdk/src/factory.ts
@@ -79,6 +79,7 @@ export function createPrivateTransfers(params: {
         blockIdentifier: params.provingProvider.blockIdentifier,
         nodeUrl: params.provingProvider.nodeUrl,
         poolAddress: params.poolContractAddress,
+        ohttp: params.provingProvider.ohttp,
       })
     : params.provingProvider;
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,6 +16,7 @@ export type { DiscoveryOptions } from "./internal/contract-discovery.js";
 export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
 export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";
 export { OhttpClient } from "./internal/ohttp-client.js";
+export type { OhttpOption } from "./internal/ohttp-client.js";
 export { buildHistoryCursor } from "./internal/history.js";
 export { classifyTransaction } from "./internal/action-classifier.js";
 export type { ClassifyOptions } from "./internal/action-classifier.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -10,6 +10,7 @@ import type {
 } from "starknet";
 import { ec } from "starknet";
 import { AddressMap } from "./utils/index.js";
+import type { OhttpOption } from "./internal/ohttp-client.js";
 
 export type Amount = bigint;
 
@@ -115,6 +116,8 @@ export type ProofProviderConfig = {
    * When set, the nonce is fetched once and cached; call invalidateProofNonceCache() to force a refresh.
    */
   nodeUrl?: string;
+  /** Enable OHTTP envelope encryption for the proving service. Pass `true` for defaults, or an object for custom relay/key config. */
+  ohttp?: OhttpOption;
 };
 
 /**

--- a/sdk/src/internal/ohttp-client.ts
+++ b/sdk/src/internal/ohttp-client.ts
@@ -1,5 +1,5 @@
 /**
- * OHTTP (Oblivious HTTP, RFC 9458) client for encrypting discovery service
+ * OHTTP (Oblivious HTTP, RFC 9458) client for encrypting service
  * requests and decrypting responses using HPKE.
  *
  * Wraps the `ohttp-ts` library by Thibault Meunier (Cloudflare).
@@ -12,6 +12,9 @@ import { ReorgError } from "./errors.js";
 /** HTTP 409 — the discovery service returns this exclusively for block reorgs (BLOCK_REORGED). */
 const REORG_STATUS = 409;
 
+/** Configuration for enabling OHTTP. `true` uses defaults; an object allows custom relay/key config. */
+export type OhttpOption = boolean | { relayUrl?: string; publicKeyConfig?: Uint8Array };
+
 /**
  * OHTTP client that encrypts requests and decrypts responses.
  *
@@ -23,7 +26,9 @@ export class OhttpClient {
   private readonly pinnedKeyConfig: Uint8Array | undefined;
 
   /**
-   * @param gatewayUrl - Discovery service base URL (used for `/ohttp-keys` and as default target)
+   * @param gatewayUrl - Discovery service base URL (used for `/ohttp-keys` and as default target).
+   *   Must be HTTPS in production — without it (or a pinned `publicKeyConfig`), an active
+   *   network attacker can replace the OHTTP key config.
    * @param options.relayUrl - Optional OHTTP relay URL. When set, encapsulated requests are sent here instead of the gateway.
    * @param options.publicKeyConfig - Optional pinned key config bytes (`application/ohttp-keys` format). When set, `/ohttp-keys` is never fetched.
    */
@@ -34,18 +39,6 @@ export class OhttpClient {
     this.pinnedKeyConfig = options?.publicKeyConfig;
     if (options?.relayUrl) {
       this.relayUrl = options.relayUrl;
-    }
-
-    if (!this.pinnedKeyConfig) {
-      const url = new URL(gatewayUrl);
-      const isLocalDev = url.hostname === "localhost" || url.hostname === "127.0.0.1";
-      if (url.protocol !== "https:" && !isLocalDev) {
-        console.warn(
-          "OhttpClient: gatewayUrl is not HTTPS and no publicKeyConfig is pinned. " +
-            "An active network attacker could replace the OHTTP key config. " +
-            "Use HTTPS or pin a publicKeyConfig for production deployments."
-        );
-      }
     }
   }
 
@@ -99,7 +92,10 @@ export class OhttpClient {
 
     // Decrypt the OHTTP response
     const innerResponse = await context.decapsulateResponse(response);
-    const innerBody = await innerResponse.text();
+
+    // The reconstructed Response from decapsulateResponse does not auto-decompress
+    // Content-Encoding (unlike fetch). Handle gzip/deflate explicitly.
+    const innerBody = await readResponseText(innerResponse);
 
     // The OHTTP server encapsulates all API responses (including errors) inside the
     // envelope with outer status 200. A 409 BLOCK_REORGED from the discovery API
@@ -109,7 +105,9 @@ export class OhttpClient {
     }
 
     if (innerResponse.status !== 200) {
-      throw new Error(`Indexer API ${path} failed (${innerResponse.status}): ${innerBody}`);
+      throw new Error(
+        `OHTTP inner response ${path} failed (${innerResponse.status}): ${innerBody}`
+      );
     }
 
     return JSON.parse(innerBody) as T;
@@ -149,4 +147,31 @@ export class OhttpClient {
   private invalidate(): void {
     this.ohttpClient = null;
   }
+}
+
+/** Supported Content-Encoding → DecompressionStream format mapping. */
+const ENCODING_TO_FORMAT: Record<string, CompressionFormat> = {
+  gzip: "gzip",
+  "x-gzip": "gzip",
+  deflate: "deflate",
+};
+
+/**
+ * Read the body text from a Response, decompressing if Content-Encoding is set.
+ * The Response objects from ohttp-ts decapsulateResponse do not auto-decompress
+ * like fetch() responses do, so we handle gzip/deflate explicitly via DecompressionStream.
+ */
+async function readResponseText(response: Response): Promise<string> {
+  const encoding = response.headers.get("content-encoding")?.toLowerCase();
+  if (!encoding || !response.body || encoding === "identity") {
+    return response.text();
+  }
+  const format = ENCODING_TO_FORMAT[encoding];
+  if (!format) {
+    // DecompressionStream only supports gzip and deflate per the Compression Streams spec.
+    // Brotli (br) and zstd are not universally available across runtimes.
+    throw new Error(`Unsupported Content-Encoding in OHTTP response: ${encoding}`);
+  }
+  const decompressed = response.body.pipeThrough(new DecompressionStream(format));
+  return new Response(decompressed).text();
 }

--- a/sdk/src/internal/proving-service-provider.ts
+++ b/sdk/src/internal/proving-service-provider.ts
@@ -14,6 +14,7 @@ import type {
 } from "../interfaces.js";
 import { toHex } from "../utils/convert.js";
 import { getDefaultProofDetails } from "./proof-invocation-factory.js";
+import { OhttpClient, type OhttpOption } from "./ohttp-client.js";
 import { DEFAULT_REQUEST_TIMEOUT_MS, ProvingService } from "./proving-service.js";
 
 /** Options for ProvingServiceProofProvider. */
@@ -37,6 +38,8 @@ export type ProvingServiceProofProviderOptions = {
    * Pool contract address used for nonce fetching. Required when `nodeUrl` is set.
    */
   poolAddress?: StarknetAddress;
+  /** Enable OHTTP envelope encryption. Pass `true` for defaults, or an object for custom relay/key config. */
+  ohttp?: OhttpOption;
 };
 
 /**
@@ -58,9 +61,19 @@ export class ProvingServiceProofProvider implements ProofProviderInterface {
     private readonly chainId: constants.StarknetChainId,
     options: ProvingServiceProofProviderOptions = {}
   ) {
+    let ohttpClient: OhttpClient | undefined;
+    if (options.ohttp) {
+      const ohttpOptions =
+        typeof options.ohttp === "object"
+          ? { relayUrl: options.ohttp.relayUrl, publicKeyConfig: options.ohttp.publicKeyConfig }
+          : undefined;
+      ohttpClient = new OhttpClient(provingServiceUrl, ohttpOptions);
+    }
+
     this.provingService = new ProvingService({
       baseUrl: provingServiceUrl,
       requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      ohttpClient,
     });
     this.blockIdentifier = options.blockIdentifier ?? "latest";
     if (options.nodeUrl != null) {

--- a/sdk/src/internal/proving-service.ts
+++ b/sdk/src/internal/proving-service.ts
@@ -6,6 +6,7 @@
 import type { BlockIdentifier } from "starknet";
 import type { ProofInvocation } from "../interfaces.js";
 import { z } from "zod";
+import type { OhttpClient } from "./ohttp-client.js";
 
 /** Default request timeout: 30s (proofs typically take a few seconds). */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -17,6 +18,8 @@ export interface ProvingServiceConfig {
   baseUrl: string;
   /** Request timeout in ms. Default 30_000 (30 seconds). */
   requestTimeoutMs?: number;
+  /** When set, requests are encrypted via OHTTP instead of plain fetch. */
+  ohttpClient?: OhttpClient;
 }
 
 /** Result of starknet_proveTransaction. */
@@ -52,10 +55,12 @@ const ProveTransactionResultSchema = z
 export class ProvingService {
   private baseUrl: string;
   private requestTimeoutMs: number;
+  private ohttpClient?: OhttpClient;
 
   constructor(config: ProvingServiceConfig) {
     this.baseUrl = config.baseUrl;
     this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.ohttpClient = config.ohttpClient;
   }
 
   private async call<T>(method: string, params: unknown): Promise<T> {
@@ -66,24 +71,32 @@ export class ProvingService {
       params,
     };
 
-    const res = await fetch(this.baseUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(this.requestTimeoutMs),
-    });
-
-    const text = await res.text();
-    if (!res.ok) {
-      throw new Error(`Proving service HTTP ${res.status}: ${text}`);
-    }
-
-    const json = JSON.parse(text) as {
+    type JsonRpcResponse = {
       jsonrpc: string;
       id: number;
       result?: T;
       error?: { code: number; message: string; data?: string };
     };
+
+    let json: JsonRpcResponse;
+
+    if (this.ohttpClient) {
+      json = await this.ohttpClient.post<JsonRpcResponse>("", body);
+    } else {
+      const res = await fetch(this.baseUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(this.requestTimeoutMs),
+      });
+
+      const text = await res.text();
+      if (!res.ok) {
+        throw new Error(`Proving service HTTP ${res.status}: ${text}`);
+      }
+
+      json = JSON.parse(text) as JsonRpcResponse;
+    }
 
     if (json.error) {
       const { code, message, data } = json.error;

--- a/sdk/tests/internal/ohttp-client.test.ts
+++ b/sdk/tests/internal/ohttp-client.test.ts
@@ -1,23 +1,33 @@
+import { gzipSync, deflateSync } from "node:zlib";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { OhttpClient } from "../../src/internal/ohttp-client.js";
+
+// Module-level factory for customizing decapsulateResponse per test.
+let decapsulateResponseFactory: () => Promise<unknown>;
+
+function defaultDecapsulateResponse(): Promise<unknown> {
+  return Promise.resolve({
+    status: 200,
+    headers: new Headers(),
+    body: null,
+    text: () => Promise.resolve('{"ok":true}'),
+  });
+}
 
 // Mock ohttp-ts and hpke — OhttpClient imports them at module level.
 // We provide minimal stubs so ensureClient() and encapsulateRequest() succeed.
 vi.mock("ohttp-ts", () => {
   class MockOHTTPClient {
-    encapsulateRequest = vi.fn().mockResolvedValue({
+    encapsulateRequest = vi.fn().mockImplementation(async () => ({
       init: {
         method: "POST",
         headers: { "Content-Type": "message/ohttp-req" },
         body: new Uint8Array(),
       },
       context: {
-        decapsulateResponse: vi.fn().mockResolvedValue({
-          status: 200,
-          text: () => Promise.resolve('{"ok":true}'),
-        }),
+        decapsulateResponse: vi.fn().mockImplementation(() => decapsulateResponseFactory()),
       },
-    });
+    }));
   }
   return {
     OHTTPClient: MockOHTTPClient,
@@ -35,47 +45,15 @@ vi.mock("hpke", () => {
 });
 
 describe("OhttpClient", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
   let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     originalFetch = globalThis.fetch;
+    decapsulateResponseFactory = defaultDecapsulateResponse;
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
     globalThis.fetch = originalFetch;
-  });
-
-  describe("HTTPS warning (Finding 2)", () => {
-    it("warns when gatewayUrl is plain HTTP without pinned key", () => {
-      new OhttpClient("http://evil.example.com");
-      expect(warnSpy).toHaveBeenCalledOnce();
-      expect(warnSpy.mock.calls[0][0]).toContain("not HTTPS");
-    });
-
-    it("does not warn for http://localhost", () => {
-      new OhttpClient("http://localhost:8080");
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    it("does not warn for http://127.0.0.1", () => {
-      new OhttpClient("http://127.0.0.1:8080");
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    it("does not warn for HTTPS gateway", () => {
-      new OhttpClient("https://example.com");
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    it("does not warn when publicKeyConfig is pinned", () => {
-      new OhttpClient("http://evil.example.com", {
-        publicKeyConfig: new Uint8Array([1, 2, 3]),
-      });
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
   });
 
   describe("outer URL construction (Finding 3)", () => {
@@ -128,6 +106,103 @@ describe("OhttpClient", () => {
 
       expect(fetchMock.mock.calls[0][0]).toBe("https://relay.example.com/ohttp-relay");
       expect(fetchMock.mock.calls[1][0]).toBe("https://relay.example.com/ohttp-relay");
+    });
+  });
+
+  describe("Content-Encoding decompression", () => {
+    function mockFetch() {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => "message/ohttp-res" },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+      globalThis.fetch = fetchMock;
+      return fetchMock;
+    }
+
+    function makeCompressedResponse(
+      jsonData: unknown,
+      encoding: string,
+      compressFn: (input: Buffer) => Buffer
+    ): Response {
+      const compressed = compressFn(Buffer.from(JSON.stringify(jsonData)));
+      return new Response(new Uint8Array(compressed), {
+        status: 200,
+        headers: { "Content-Encoding": encoding },
+      });
+    }
+
+    it("decompresses gzip-encoded inner response", async () => {
+      const expected = { proof: "abc123", result: 42 };
+      decapsulateResponseFactory = async () => makeCompressedResponse(expected, "gzip", gzipSync);
+
+      mockFetch();
+      const client = new OhttpClient("https://gw.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      const result = await client.post("/test", {});
+      expect(result).toEqual(expected);
+    });
+
+    it("decompresses deflate-encoded inner response", async () => {
+      const expected = { data: [1, 2, 3] };
+      decapsulateResponseFactory = async () =>
+        makeCompressedResponse(expected, "deflate", deflateSync);
+
+      mockFetch();
+      const client = new OhttpClient("https://gw.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      const result = await client.post("/test", {});
+      expect(result).toEqual(expected);
+    });
+
+    it("handles uncompressed response (no Content-Encoding)", async () => {
+      // Default factory returns no Content-Encoding — verify backwards compatibility
+      mockFetch();
+      const client = new OhttpClient("https://gw.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      const result = await client.post("/test", {});
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("passes through identity Content-Encoding without decompression", async () => {
+      const expected = { value: "test" };
+      decapsulateResponseFactory = async () =>
+        new Response(JSON.stringify(expected), {
+          status: 200,
+          headers: { "Content-Encoding": "identity" },
+        });
+
+      mockFetch();
+      const client = new OhttpClient("https://gw.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      const result = await client.post("/test", {});
+      expect(result).toEqual(expected);
+    });
+
+    it("throws on unsupported Content-Encoding", async () => {
+      decapsulateResponseFactory = async () =>
+        new Response("compressed-bytes", {
+          status: 200,
+          headers: { "Content-Encoding": "br" },
+        });
+
+      mockFetch();
+      const client = new OhttpClient("https://gw.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      await expect(client.post("/test", {})).rejects.toThrow(
+        "Unsupported Content-Encoding in OHTTP response: br"
+      );
     });
   });
 });

--- a/sdk/tests/internal/proving-service-ohttp.test.ts
+++ b/sdk/tests/internal/proving-service-ohttp.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ProvingService, type MessageToL1 } from "../../src/internal/proving-service.js";
+import type { OhttpClient } from "../../src/internal/ohttp-client.js";
+
+const PROVER_URL = "https://prover.test";
+
+/** Minimal INVOKE v3 transaction for request tests. */
+const MINIMAL_INVOKE_TX = {
+  type: "INVOKE" as const,
+  sender_address: "0x1",
+  calldata: [] as string[],
+  version: "0x3" as const,
+  signature: [] as string[],
+  nonce: "0x0",
+  resource_bounds: {
+    l1_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+    l2_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+    l1_data_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+  },
+  tip: "0x0",
+  paymaster_data: [] as string[],
+  account_deployment_data: [] as string[],
+  nonce_data_availability_mode: "L2" as const,
+  fee_data_availability_mode: "L2" as const,
+};
+
+const DEFAULT_PROVE_RESULT = {
+  proof: "YQ==",
+  proof_facts: [] as string[],
+  l2_to_l1_messages: [] as Array<{ from_address: string; to_address: string; payload: string[] }>,
+};
+
+function mockOhttpClient(returnValue: unknown): OhttpClient {
+  return {
+    post: vi.fn().mockResolvedValue(returnValue),
+  } as unknown as OhttpClient;
+}
+
+describe("ProvingService with OHTTP", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes requests through ohttpClient when configured", async () => {
+    const ohttpClient = mockOhttpClient({ jsonrpc: "2.0", id: 1, result: "0.10.0" });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+    const result = await service.getSpecVersion();
+
+    expect(result).toBe("0.10.0");
+    expect(ohttpClient.post).toHaveBeenCalledOnce();
+    const [path, body] = (ohttpClient.post as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(path).toBe("");
+    expect(body).toMatchObject({ method: "starknet_specVersion", params: [] });
+  });
+
+  it("does not call fetch when ohttpClient is configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const ohttpClient = mockOhttpClient({ jsonrpc: "2.0", id: 1, result: "0.10.0" });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+    await service.getSpecVersion();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles JSON-RPC errors through OHTTP path", async () => {
+    const ohttpClient = mockOhttpClient({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: 24, message: "Block not found" },
+    });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /Proving service error \(code 24\)/
+    );
+  });
+
+  it("throws when OHTTP response has no result", async () => {
+    const ohttpClient = mockOhttpClient({ jsonrpc: "2.0", id: 1 });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /Proving service returned no result/
+    );
+  });
+
+  it("validates proveTransaction result schema through OHTTP path", async () => {
+    const ohttpClient = mockOhttpClient({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { proof: "", proof_facts: [], l2_to_l1_messages: [] },
+    });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+
+  it("proveTransaction succeeds through OHTTP path with valid result", async () => {
+    const ohttpClient = mockOhttpClient({
+      jsonrpc: "2.0",
+      id: 1,
+      result: DEFAULT_PROVE_RESULT,
+    });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+    const result = await service.proveTransaction("latest", MINIMAL_INVOKE_TX);
+
+    expect(result.proof).toBe("YQ==");
+    expect(result.proof_facts).toEqual([]);
+    expect(result.l2_to_l1_messages).toEqual([]);
+  });
+
+  it("rejects extra fields in proveTransaction result through OHTTP path", async () => {
+    const ohttpClient = mockOhttpClient({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { ...DEFAULT_PROVE_RESULT, extra_field: "ignored" },
+    });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+
+  it("rejects invalid l2_to_l1_messages through OHTTP path", async () => {
+    const ohttpClient = mockOhttpClient({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        ...DEFAULT_PROVE_RESULT,
+        l2_to_l1_messages: [{ from_address: "0x1", to_address: "0x2" } as MessageToL1],
+      },
+    });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+
+  it("isHealthy returns true through OHTTP path", async () => {
+    const ohttpClient = mockOhttpClient({ jsonrpc: "2.0", id: 1, result: "0.10.0" });
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+    const healthy = await service.isHealthy();
+
+    expect(healthy).toBe(true);
+  });
+
+  it("isHealthy returns false when OHTTP request fails", async () => {
+    const ohttpClient = {
+      post: vi.fn().mockRejectedValue(new Error("OHTTP error")),
+    } as unknown as OhttpClient;
+
+    const service = new ProvingService({ baseUrl: PROVER_URL, ohttpClient });
+    const healthy = await service.isHealthy();
+
+    expect(healthy).toBe(false);
+  });
+});

--- a/sdk/tests/internal/proving-service-provider.test.ts
+++ b/sdk/tests/internal/proving-service-provider.test.ts
@@ -2,6 +2,18 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { constants, RpcProvider } from "starknet";
 import { ProvingServiceProofProvider } from "../../src/internal/proving-service-provider.js";
 
+// Mock ohttp-ts and hpke so OhttpClient can be instantiated without real crypto.
+vi.mock("ohttp-ts", () => ({
+  OHTTPClient: vi.fn(),
+  KeyConfig: { parseMultiple: vi.fn().mockReturnValue([{}]) },
+}));
+vi.mock("hpke", () => ({
+  CipherSuite: vi.fn(),
+  KEM_DHKEM_X25519_HKDF_SHA256: 0x20,
+  KDF_HKDF_SHA256: 0x01,
+  AEAD_AES_128_GCM: 0x01,
+}));
+
 const PROVER_URL = "https://prover.test";
 const NODE_URL = "https://node.test";
 const POOL_ADDRESS = "0x1234";
@@ -122,5 +134,41 @@ describe("ProvingServiceProofProvider.getDefaultDetails", () => {
       const details = await provider.getDefaultDetails();
       expect(details.nonce).toBe(0n);
     });
+  });
+});
+
+describe("ProvingServiceProofProvider with ohttp option", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("constructs without error when ohttp is true", () => {
+    expect(
+      () => new ProvingServiceProofProvider(PROVER_URL, CHAIN_ID, { ohttp: true })
+    ).not.toThrow();
+  });
+
+  it("constructs without error when ohttp has relayUrl and publicKeyConfig", () => {
+    expect(
+      () =>
+        new ProvingServiceProofProvider(PROVER_URL, CHAIN_ID, {
+          ohttp: {
+            relayUrl: "https://relay.example.com",
+            publicKeyConfig: new Uint8Array([1, 2, 3]),
+          },
+        })
+    ).not.toThrow();
+  });
+
+  it("constructs without error when ohttp is combined with other options", () => {
+    expect(
+      () =>
+        new ProvingServiceProofProvider(PROVER_URL, CHAIN_ID, {
+          ohttp: true,
+          nodeUrl: NODE_URL,
+          poolAddress: POOL_ADDRESS,
+          requestTimeoutMs: 60_000,
+        })
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
### TL;DR

Added OHTTP envelope encryption support to `ProvingServiceProofProvider` for encrypting proving requests and decrypting compressed responses.

### What changed?

- Added OHTTP encryption capability to `ProvingServiceProofProvider` via new `ohttp` option that accepts boolean or configuration object
- Enhanced `OhttpClient` to handle compressed responses (gzip/deflate) by implementing explicit decompression since OHTTP responses don't auto-decompress
- Updated `ProvingService` to route requests through `OhttpClient` when configured instead of using direct fetch
- Added `ohttp` field to `ProofProviderConfig` interface and factory function support
- Exported `OhttpOption` type for reuse in consumer code
- Updated OHTTP client error messages to clarify they're from inner responses

### How to test?

- Enable OHTTP for proving service: `new ProvingServiceProofProvider(url, chainId, { ohttp: true })`
- Use custom relay/key config: `new ProvingServiceProofProvider(url, chainId, { ohttp: { relayUrl: "...", publicKeyConfig: new Uint8Array([...]) } })`
- Test via factory: `createPrivateTransfers()` with `ProofProviderConfig.ohttp` set
- Verify compressed response handling works with gzip/deflate encoded proving service responses

### Why make this change?

This extends OHTTP privacy protection from the indexer discovery service to the proving service, allowing users to hide their IP addresses when generating proofs. The compression handling ensures compatibility with proving services that return compressed responses, which the OHTTP decapsulation process doesn't automatically decompress.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/696)
<!-- Reviewable:end -->
