### PR TITLE
feat(sdk): tx simulation & fee estimation

### DIFF
--- a/demo/src/proof-provider.ts
+++ b/demo/src/proof-provider.ts
@@ -1,7 +1,7 @@
 import type { RpcProvider, constants } from "starknet";
 // Direct import avoids pulling in Node-only modules from the testing barrel
 // @ts-expect-error — deep import into dist, not part of the declared exports
-import { CallMockProofProvider } from "starknet-sdk/dist/testing/mock-proving.js";
+import { CallMockProofProvider } from "starknet-sdk/dist/internal/mock-proving.js";
 import type {
   Proof,
   ProofInvocation,

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
     // bundler agreeing on a single Account class identity.
     dedupe: ["starknet"],
     alias: {
-      // Remap testing imports to avoid pulling in Node-only devnet module
-      "starknet-sdk/dist/testing/mock-proving.js": resolve(
+      // Remap the mock-proving import to avoid pulling in Node-only devnet module
+      "starknet-sdk/dist/internal/mock-proving.js": resolve(
         sdkDist,
-        "testing/mock-proving.js",
+        "internal/mock-proving.js",
       ),
       "starknet-sdk/dist/internal/indexer-discovery.js": resolve(
         sdkDist,

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -20,6 +20,12 @@
   transports; an HTTP 503 is retried on plain fetch only. Exported the
   `ProvingRetryOptions` type and a new `ProvingServiceHttpError` (carries
   `status`) thrown for non-2xx HTTP responses on the plain-fetch transport.
+- `simulate()` method on `PrivateTransfersInterface`, `PrivateTransfersBuilder`,
+  and `TokenOperationsBuilder` for gas fee estimation without real proof
+  generation.
+- `SimulateOptions` type with a required `provider` (node provider the mock
+  prover calls to build proof facts — the minimal `{ address, signer }` account
+  carries none) and an optional `validateSignature` flag.
 - Testing: exported `ScreeningCallMockProofProvider` from the `/testing` entry
   point. It extends `CallMockProofProvider` to sign each deposit's screening
   attestation with the canonical test screener key, so integration suites can

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -470,6 +470,63 @@ const result = await transfers
 | `registryConst`   | `boolean`               | If true, returns a new registry instead of mutating the provided one                                                                                             |
 | `provingBlockId`  | `ProvingBlockId`        | Block identifier for proving and discovery — pins both note/channel discovery and proof generation to the same block state. Can be a block hash, number, or tag. |
 
+## Fee estimation
+
+Simulate a private transaction to estimate gas costs before proving. `simulate()` uses a mock proof provider internally — no real proof is generated, but the returned `CallAndProof` has the same calldata structure as a real transaction, making it suitable for gas estimation. Pass a node `provider` in the options: the mock prover calls the pool's view function to build the proof facts, and the minimal account (`{ address, signer }`) carries no provider of its own.
+
+### Basic fee estimation
+
+```typescript
+const { callAndProof } = await transfers
+  .build({ autoSelectNotes: "naive", autoDiscover: { notes: "refresh" } })
+  .with(STRK, (t) => t.inputs(note).transfer({ recipient: bob, amount: 50n }))
+  .surplusTo(self)
+  .simulate({ provider });
+
+const fee = await account.estimateInvokeFee(callAndProof.call, {
+  proofFacts: callAndProof.proof.proofFacts,
+  proof: callAndProof.proof.data,
+});
+```
+
+### Gasless mode (paymaster)
+
+For gasless transactions via a paymaster (e.g. Avnu), the wallet adds a dust withdrawal to the paymaster and uses the simulated transaction to get a gas quote, then rebuilds the transaction with the withdrawal action with the right amount:
+
+1. Build actions including a withdrawal to a dummy account
+2. call `simulate()` to get a `CallAndProof`
+3. Send the `CallAndProof` to the paymaster to get a gas fee quote
+4. Update the withdrawal action amount
+5. Call `execute()` with the real proving service
+
+```typescript
+// 1. Simulate to get gas estimate
+const { callAndProof: simulated } = await transfers
+  .build(options)
+  .with(USDC, (t) =>
+    t
+      .transfer({ recipient: bob, amount: 50n })
+      .withdraw({ recipient: 0x1, amount: 1n }))
+  .surplusTo(self)
+  .simulate({ provider });
+
+// 2. Get paymaster quote
+const quote = await paymaster.getQuote(simulated);
+
+// 3. Rebuild with fee withdrawal and execute for real
+const { callAndProof } = await transfers
+  .build(options)
+  .with(USDC, (t) =>
+    t
+      .transfer({ recipient: bob, amount: 50n })
+      .withdraw({ recipient: quote.feeRecipient, amount: quote.fee })
+  )
+  .surplusTo(self)
+  .execute();
+```
+
+When using gasfree mode (the user's account pays gas directly), steps 2-3 are not needed — use `simulate()` only to preview the cost, then call `execute()` with the original actions.
+
 ## Discovery
 
 ### Check transfer readiness

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -7,6 +7,7 @@ import type {
   Call,
   CallDetails,
   constants,
+  ProviderInterface,
   SignerInterface,
 } from "starknet";
 import { ec } from "starknet";
@@ -321,6 +322,17 @@ export type ExecuteOptions = {
   provingBlockId?: ProvingBlockId;
 };
 
+export type SimulateOptions = {
+  /**
+   * Node provider used to call the pool's view function for fee estimation.
+   * Required because the minimal `PrivateTransfersUser` ({ address, signer })
+   * carries no provider of its own.
+   */
+  provider: ProviderInterface;
+  /** When true, validate the user's signature during simulation. Default: false. */
+  validateSignature?: boolean;
+};
+
 export type Warning = {
   code: WarningCode;
   message: string;
@@ -456,6 +468,13 @@ export interface PrivateTransfersInterface {
   execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult>;
 
   /**
+   * Simulate a private transaction to estimate gas costs without real proof generation.
+   * Uses a mock proof provider internally — the returned CallAndProof has the same
+   * calldata structure as a real transaction, suitable for fee estimation.
+   */
+  simulate(actions: Actions, options: ExecuteOptions & SimulateOptions): Promise<ExecuteResult>;
+
+  /**
    * Return the transaction to be proven so it can be sent independently to the prover
    */
   createProofInvocation(
@@ -545,6 +564,9 @@ export interface TokenOperationsBuilder {
 
   /** Build proof invocation without executing */
   createProofInvocation(options?: ExecuteOptions): Promise<ProofInvocationResult>;
+
+  /** Simulate all queued operations for fee estimation without real proof generation */
+  simulate(options: SimulateOptions): Promise<ExecuteResult>;
 }
 
 /**
@@ -643,6 +665,9 @@ export interface PrivateTransfersBuilder {
 
   /** Build proof invocation without executing */
   createProofInvocation(options?: ExecuteOptions): Promise<ProofInvocationResult>;
+
+  /** Simulate all queued operations for fee estimation without real proof generation */
+  simulate(options: SimulateOptions): Promise<ExecuteResult>;
 }
 
 /** INVOKE branch of AccountInvocationItem; used for proof invocations and buildTransaction. */

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -17,6 +17,7 @@ import type {
   PrivateTransfersInterface,
   ProofInvocationResult,
   ProvingBlockId,
+  SimulateOptions,
   StarknetAddress,
   StarknetAddressBigint,
   ViewingKey,
@@ -107,6 +108,13 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   async execute(actions: Actions, options?: ExecuteOptions): Promise<ExecuteResult> {
     const invocationResult = await this.createProofInvocation(actions, options);
     return this.executeWithInvocation(invocationResult, options?.provingBlockId);
+  }
+
+  async simulate(
+    _actions: Actions,
+    _options: ExecuteOptions & SimulateOptions
+  ): Promise<ExecuteResult> {
+    throw new Error("simulate() is not supported by this implementation");
   }
 
   /**

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -26,6 +26,7 @@ import {
   type InvokeAction,
   type Amount,
   type InvokeCalldataBuilderArgs,
+  type SimulateOptions,
   Open,
   PrivateTransfersInterface,
 } from "../interfaces.js";
@@ -143,6 +144,10 @@ export class TokenOperationsBuilderImpl implements TokenOperationsBuilder {
 
   async createProofInvocation(options?: ExecuteOptions): Promise<ProofInvocationResult> {
     return this.parentBuilder.createProofInvocation(options);
+  }
+
+  async simulate(options: SimulateOptions): Promise<ExecuteResult> {
+    return this.parentBuilder.simulate(options);
   }
 }
 
@@ -271,5 +276,11 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     debugLog("builder", "PrivateTransfersBuilderImpl.createProofInvocation called");
     const { actions, mergedOptions } = this.collectActionsAndOptions(options);
     return this.transfers.createProofInvocation(actions, mergedOptions);
+  }
+
+  async simulate(options: SimulateOptions): Promise<ExecuteResult> {
+    debugLog("builder", "PrivateTransfersBuilderImpl.simulate called");
+    const { actions, mergedOptions } = this.collectActionsAndOptions();
+    return this.transfers.simulate(actions, { ...mergedOptions, ...options });
   }
 }

--- a/sdk/src/internal/mock-proving.ts
+++ b/sdk/src/internal/mock-proving.ts
@@ -8,11 +8,10 @@
 import type { BlockIdentifier, constants, ETransactionVersion3, ProviderInterface } from "starknet";
 import { EDAMode, encode, hash, num, stark } from "starknet";
 import type { Proof, ProofInvocation, ProofProviderInterface } from "../interfaces.js";
-import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js";
-import { ProvingServiceError } from "../internal/proving-service.js";
+import { getDefaultProofDetails, extractExecuteViewCalldata } from "./proof-invocation-factory.js";
+import { ProvingServiceError } from "./proving-service.js";
 import { buildProofFacts, buildMessagePayload } from "../utils/proof-facts.js";
 import { toBigInt } from "../utils/convert.js";
-import { extractExecuteViewCalldata } from "../internal/proof-invocation-factory.js";
 
 /** VALIDATED constant - 'VALID' encoded as short string felt252 */
 const VALIDATED = encode.utf8ToBigInt("VALID");
@@ -25,7 +24,8 @@ const VALIDATED = encode.utf8ToBigInt("VALID");
 export class CallMockProofProvider implements ProofProviderInterface {
   constructor(
     protected readonly provider: ProviderInterface,
-    protected readonly chainId: constants.StarknetChainId
+    protected readonly chainId: constants.StarknetChainId,
+    private readonly options?: { validateSignature?: boolean }
   ) {}
 
   async getDefaultDetails() {
@@ -35,7 +35,9 @@ export class CallMockProofProvider implements ProofProviderInterface {
   async prove(invocation: ProofInvocation, blockIdentifier?: BlockIdentifier): Promise<Proof> {
     // Validate signature similar to how __execute__ does in the contract.
     // compile_actions skips this since view functions don't have tx_info.
-    await this.validateSignature(invocation);
+    if (this.options?.validateSignature !== false) {
+      await this.validateSignature(invocation);
+    }
 
     // __execute__ calldata is Array<Call> with one Call targeting compile_actions.
     // Layout: [1, to, selector, inner_len, ...inner_calldata]
@@ -55,16 +57,23 @@ export class CallMockProofProvider implements ProofProviderInterface {
       blockIdentifier
     );
 
-    // Build proof facts for on-chain validation when provider supports getBlock (e.g. e2e with RpcProvider).
-    // Blockifier requires base_block_number to be at least STORED_BLOCK_HASH_BUFFER blocks behind current.
-    // TODO: Use latest-verifiable.
-    let proofFacts: string[] = [];
-    const latestBlock = await this.provider.getBlock("latest");
-    const currentBlockNumber = BigInt(latestBlock.block_number);
-    const blocksBack = BigInt(10);
-    const baseBlockNumber = currentBlockNumber > blocksBack ? currentBlockNumber - blocksBack : 1n;
+    // Build proof facts for on-chain validation.
+    // When the caller provides an explicit blockIdentifier, use it as the base block directly
+    // (the caller is responsible for picking a block old enough for the blockifier to accept).
+    // When falling back to "latest", subtract STORED_BLOCK_HASH_BUFFER so the blockifier
+    // can verify the block hash from state.
+    let baseBlockNumber: bigint;
+    if (blockIdentifier != null) {
+      const block = await this.provider.getBlock(blockIdentifier);
+      baseBlockNumber = BigInt(block.block_number);
+    } else {
+      const latestBlock = await this.provider.getBlock("latest");
+      const currentBlockNumber = BigInt(latestBlock.block_number);
+      const blocksBack = 10n;
+      baseBlockNumber = currentBlockNumber > blocksBack ? currentBlockNumber - blocksBack : 1n;
+    }
     const baseBlock = await this.provider.getBlock(Number(baseBlockNumber));
-    proofFacts = buildProofFacts(
+    const proofFacts = buildProofFacts(
       invocation.sender_address,
       poolClassHash,
       result,

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -13,11 +13,14 @@ import type {
   ProofInvocationResult,
   ProvingBlockId,
   PrivateTransfersUser,
+  SimulateOptions,
+  Proof,
 } from "../interfaces.js";
 import type { TypedContractV2 } from "starknet";
 import { ActionCompiler } from "./compiler.js";
 import { PrivacyPoolABI } from "./abi.js";
 import { AbstractPrivateTransfers } from "./abstract-private-transfers.js";
+import { CallMockProofProvider } from "./mock-proving.js";
 import { debugLog } from "../utils/logging.js";
 import type { ProofInvocationFactoryInterface } from "./proof-invocation-factory.js";
 import { toBigInt, toHex } from "../utils/convert.js";
@@ -89,7 +92,19 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     provingBlockId?: ProvingBlockId
   ): Promise<ExecuteResult> {
     const proof = await this.params.provingProvider.prove(invocation, provingBlockId);
+    return this.buildExecuteResult(proof, registry, warnings);
+  }
 
+  /**
+   * Assemble the `apply_actions` call and `ExecuteResult` from a proof. Shared
+   * by `executeWithInvocation` (real proof) and `simulate` (mock proof) so both
+   * produce identical calldata — notably the trailing screening attestation.
+   */
+  private buildExecuteResult(
+    proof: Proof,
+    registry: ProofInvocationResult["registry"],
+    warnings: ProofInvocationResult["warnings"]
+  ): ExecuteResult {
     // proof.output is the L2-to-L1 message payload: [class_hash, ...serialized_actions].
     // Strip the class_hash prefix — apply_actions expects only Span<ServerAction>.
     const serverActionsCalldata = proof.output.slice(1);
@@ -119,5 +134,24 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       registry,
       warnings,
     };
+  }
+
+  async simulate(
+    actions: Actions,
+    options: ExecuteOptions & SimulateOptions
+  ): Promise<ExecuteResult> {
+    const { invocation, registry, warnings } = await this.createProofInvocation(actions, options);
+
+    // Source chainId from the same provider the mock prover calls, so proof
+    // facts and signature validation are computed for the chain that actually
+    // executes the view call.
+    const chainId = await options.provider.getChainId();
+
+    const mockProvider = new CallMockProofProvider(options.provider, chainId, {
+      validateSignature: options.validateSignature ?? false,
+    });
+
+    const proof = await mockProvider.prove(invocation, options.provingBlockId);
+    return this.buildExecuteResult(proof, registry, warnings);
   }
 }

--- a/sdk/src/testing/browser.ts
+++ b/sdk/src/testing/browser.ts
@@ -28,7 +28,7 @@ export {
   compute_enc_channel_key_hash,
   compute_enc_sender_addr_hash,
 } from "../utils/hashes.js";
-export { CallMockProofProvider } from "./mock-proving.js";
+export { CallMockProofProvider } from "../internal/mock-proving.js";
 export { TracingRpcProvider, TracedRpcError, type DecodedError } from "./tracing-provider.js";
 export {
   ContractDiscoveryProvider,

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -24,7 +24,7 @@ import {
 import { TracingRpcProvider } from "./tracing-provider.js";
 import type { CallAndProof, PrivateTransfersInterface } from "../interfaces.js";
 import { createPrivateTransfers } from "../factory.js";
-import { CallMockProofProvider } from "./mock-proving.js";
+import { CallMockProofProvider } from "../internal/mock-proving.js";
 import { ScreeningCallMockProofProvider } from "./screening-mock-proving.js";
 import { SCREENING_SIGNER_PUBLIC_KEY } from "./screening-signer.js";
 import {

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -27,7 +27,7 @@ export {
   compute_enc_channel_key_hash,
   compute_enc_sender_addr_hash,
 } from "../utils/hashes.js";
-export { CallMockProofProvider } from "./mock-proving.js";
+export { CallMockProofProvider } from "../internal/mock-proving.js";
 export { ScreeningCallMockProofProvider } from "./screening-mock-proving.js";
 export { ProvingServiceProofProvider } from "../internal/proving-service-provider.js";
 export { TracingRpcProvider, TracedRpcError, type DecodedError } from "./tracing-provider.js";

--- a/sdk/src/testing/screening-mock-proving.ts
+++ b/sdk/src/testing/screening-mock-proving.ts
@@ -16,7 +16,7 @@ import { CallData, num, type BlockIdentifier } from "starknet";
 import { PrivacyPoolABI } from "../internal/abi.js";
 import type { Proof, ProofInvocation } from "../interfaces.js";
 import { extractExecuteViewCalldata } from "../internal/proof-invocation-factory.js";
-import { CallMockProofProvider } from "./mock-proving.js";
+import { CallMockProofProvider } from "../internal/mock-proving.js";
 import { signScreeningAttestation, SCREENING_SIGNER_PRIVATE_KEY } from "./screening-signer.js";
 
 const CLIENT_ACTIONS_TYPE = "core::array::Span::<privacy::actions::ClientAction>" as const;

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -249,4 +249,99 @@ describe("Devnet Integration", () => {
     const strkAfter = strkNotes.reduce((sum, note) => sum + note.amount, 0n);
     expect(strkAfter - strkBefore).toBe(depositAmount - swapAmount);
   }, 120000);
+
+  // ============ Fee Simulation ============
+  // simulate() returns a mock CallAndProof suitable for gas estimation without real proving.
+  // End-to-end flow: simulate at a historical block → check structure → estimate fee →
+  // execute for real and verify simulate didn't consume state.
+
+  it("simulate → structure + historical block + fee estimate + execute without collision", async () => {
+    const { env, transfers } = testEnv;
+
+    // Fresh deposit so alice has a known note to spend.
+    await env.alice.execute({
+      contractAddress: env.strk,
+      entrypoint: "approve",
+      calldata: [env.privacy.address, 100n, 0n],
+    });
+    const depositResult = await transfers.alice
+      .build({
+        autoRegister: true,
+        autoSetup: true,
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+      })
+      .with(env.strk)
+      .deposit({ amount: 100n })
+      .surplusTo(env.alice.address)
+      .execute();
+    const depositReceipt = await devnet.executeOutside(depositResult.callAndProof);
+    expect(depositReceipt.isReverted()).toBe(false);
+
+    // Advance empty blocks so olderBlock (used as provingBlockId and base block for proof
+    // facts) is sufficiently behind latest for the blockifier to accept it.
+    const rpcUrl = devnet.url;
+    for (let blockIndex = 0; blockIndex < 15; blockIndex++) {
+      await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "devnet_createBlock" }),
+      });
+    }
+    const latestBlock = await env.provider.getBlockNumber();
+    const olderBlock = latestBlock - 10;
+
+    const buildOptions = {
+      autoDiscover: { notes: "refresh", channels: "refresh" } as const,
+      autoSelectNotes: "naive" as const,
+      registryConst: true,
+    };
+
+    // Simulate a withdraw at olderBlock — wallet gets a CallAndProof with mock proofFacts.
+    const simResult = await transfers.alice
+      .build({ ...buildOptions, provingBlockId: olderBlock })
+      .with(env.strk)
+      .withdraw({ amount: 50n, recipient: env.alice.address })
+      .surplusTo(env.alice.address)
+      .simulate({ provider: env.provider });
+
+    // Structure checks
+    expect(simResult.callAndProof.call.entrypoint).toBe("apply_actions");
+    expect(simResult.callAndProof.call.contractAddress).toBeDefined();
+    expect(simResult.callAndProof.proof.proofFacts.length).toBe(9);
+
+    // Explicit provingBlockId used as-is for base_block_number in proofFacts[4].
+    const baseBlockNumber = BigInt(simResult.callAndProof.proof.proofFacts[4]);
+    expect(baseBlockNumber).toBe(BigInt(olderBlock));
+
+    // Wallet feeds the simulated CallAndProof into starknet.js's native fee estimation.
+    // proofFacts flow into the transaction-level fields; proof data is ignored under
+    // devnet's --proof-mode none. skipValidate bypasses account-signature validation.
+    const fee = await env.alice.estimateInvokeFee(simResult.callAndProof.call, {
+      proofFacts: simResult.callAndProof.proof.proofFacts,
+      skipValidate: true,
+    });
+    expect(BigInt(fee.overall_fee)).toBeGreaterThan(0n);
+
+    // Execute the same withdrawal for real — must succeed because simulate didn't consume the note.
+    const execResult = await transfers.alice
+      .build(buildOptions)
+      .with(env.strk)
+      .withdraw({ amount: 50n, recipient: env.alice.address })
+      .surplusTo(env.alice.address)
+      .execute();
+
+    // Same call shape as the simulation (same contract, entrypoint, calldata length).
+    expect(simResult.callAndProof.call.contractAddress).toBe(
+      execResult.callAndProof.call.contractAddress
+    );
+    expect(simResult.callAndProof.call.entrypoint).toBe(execResult.callAndProof.call.entrypoint);
+    expect(simResult.callAndProof.call.calldata!.length).toBe(
+      execResult.callAndProof.call.calldata!.length
+    );
+    expect(execResult.callAndProof.proof.proofFacts.length).toBe(9);
+
+    // Submit the execute — must not revert (proves simulate didn't touch on-chain state).
+    const execReceipt = await devnet.executeOutside(execResult.callAndProof);
+    expect(execReceipt.isReverted()).toBe(false);
+  }, 120000);
 });


### PR DESCRIPTION
Added the ability to simulate the tx and in particular estimate the fee
before creating the proof. The idea is to create just the proof facts by
calling the contract's view function which allows to estimate the public
tx fees

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/698)
<!-- Reviewable:end -->
