### PR TITLE
feat(history): include pool registration event in history feed

### DIFF
--- a/crates/discovery-core/src/history/transactions.rs
+++ b/crates/discovery-core/src/history/transactions.rs
@@ -11,7 +11,8 @@ use tracing::{debug, trace};
 use super::notes::BufferedNoteScanner;
 use super::types::{HistoryCursor, HistoryNote, HistoryTransaction};
 use crate::discovery::{
-    DiscoveryError, COST_BLOCK_EVENTS_QUERY, COST_EVENTS_CHUNK, EVENTS_COST_CHUNK_SIZE,
+    DiscoveryError, COST_BLOCK_EVENTS_QUERY, COST_EVENTS_CHUNK, COST_PUBLIC_KEY,
+    EVENTS_COST_CHUNK_SIZE,
 };
 use crate::io_budget::IoBudget;
 use crate::privacy_pool::events::{IEvents, PrivacyPoolEventContent};
@@ -82,21 +83,39 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
     }
 
     cursor.begin_block_number = previous_block_bound;
-    cursor.history_complete = scanner_complete;
-
-    debug!(
-        num_transactions = transactions.len(),
-        history_complete = cursor.history_complete,
-        budget_remaining = budget.remaining(),
-        begin_block_number = cursor.begin_block_number,
-        "history: fetch_transactions done"
-    );
 
     let mut result: Vec<HistoryTransaction> = transactions.into_values().collect();
     if !scanner_complete {
         result.retain(|tx| completed_blocks.contains(&tx.block_number));
     }
+
+    // Append the synthetic registration transaction when the note scan is
+    // complete and there is room on this page. When the page is already full,
+    // keep history_complete false so the client fetches one more page.
+    // InsufficientBudget from fetch_registration also defers to the next page.
+    if scanner_complete && result.len() < max_transactions {
+        match fetch_registration(backend, user_address, budget).await {
+            Ok(Some(registration)) => result.push(registration),
+            Ok(None) => {}
+            Err(e) if matches!(e, DiscoveryError::InsufficientBudget { .. }) => {
+                budget_error = Some(e);
+            }
+            Err(e) => return Err(e),
+        }
+        cursor.history_complete = budget_error.is_none();
+    } else {
+        cursor.history_complete = false;
+    }
+
     result.sort_by(|a, b| b.block_number.cmp(&a.block_number));
+
+    debug!(
+        num_transactions = result.len(),
+        history_complete = cursor.history_complete,
+        budget_remaining = budget.remaining(),
+        begin_block_number = cursor.begin_block_number,
+        "history: fetch_transactions done"
+    );
 
     if result.is_empty() {
         if let Some(error) = budget_error {
@@ -235,7 +254,8 @@ async fn fetch_aggregated_block_events<E: IEvents>(
                 PrivacyPoolEventContent::OpenNoteDeposited(open_note) => {
                     tx.open_note_deposits.push(open_note);
                 }
-                PrivacyPoolEventContent::EncNoteCreated(_) => {}
+                PrivacyPoolEventContent::EncNoteCreated(_)
+                | PrivacyPoolEventContent::ViewingKeySet(_) => {}
             }
         }
     }
@@ -293,6 +313,44 @@ async fn fetch_aggregated_withdrawal_events<E: IEvents>(
     Ok(())
 }
 
+/// Fetches the synthetic registration transaction for the user.
+///
+/// Reads the `public_key` storage slot with block info to find when the user
+/// registered, then queries the `ViewingKeySet` event at that block to get the
+/// real transaction hash.
+///
+/// Returns `Ok(None)` when the registration block is unavailable (block 0).
+/// Budget and backend errors propagate to the caller.
+async fn fetch_registration<B: IViews + IEvents>(
+    backend: &B,
+    user_address: Felt,
+    budget: &IoBudget,
+) -> Result<Option<HistoryTransaction>, DiscoveryError> {
+    budget.try_consume(COST_PUBLIC_KEY)?;
+    let storage_result = backend.get_public_key_with_block(user_address).await?;
+    if storage_result.last_update_block == 0 {
+        return Ok(None);
+    }
+    let block = storage_result.last_update_block;
+
+    budget.try_consume(COST_EVENTS_CHUNK)?;
+    let events = backend
+        .get_viewing_key_set_events(user_address, block, block)
+        .await?;
+    let transaction_hash = events
+        .first()
+        .map(|event| event.transaction_hash)
+        .ok_or_else(|| {
+            DiscoveryError::EventError(format!(
+                "ViewingKeySet event not found at block {block} for user {user_address:#x}"
+            ))
+        })?;
+
+    let mut registration = HistoryTransaction::new(block, transaction_hash);
+    registration.registered_pubkey = Some(storage_result.value);
+    Ok(Some(registration))
+}
+
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
@@ -314,6 +372,7 @@ mod tests {
     const TOKEN: Felt = Felt::from_hex_unchecked("0x12345");
     const TX_HASH_1: Felt = Felt::from_hex_unchecked("0x1001");
     const TX_HASH_2: Felt = Felt::from_hex_unchecked("0x1002");
+    const TX_HASH_REG: Felt = Felt::from_hex_unchecked("0x2001");
     const NOTE_ID: Felt = Felt::from_hex_unchecked("0xAABB");
     const PACKED: Felt = Felt::from_hex_unchecked("0xDEAD");
 
@@ -344,6 +403,21 @@ mod tests {
             transaction_hash,
             vec![selector, note_id],
             vec![Felt::from(0xDEADu64)],
+        )
+    }
+
+    fn viewing_key_set_event(
+        user_address: Felt,
+        pubkey: Felt,
+        block_number: u64,
+        transaction_hash: Felt,
+    ) -> EmittedEvent {
+        let selector = starknet_keccak(b"ViewingKeySet");
+        mock_event(
+            block_number,
+            transaction_hash,
+            vec![selector, user_address, pubkey],
+            vec![Felt::ZERO, Felt::ZERO, Felt::ZERO],
         )
     }
 
@@ -452,6 +526,14 @@ mod tests {
         ) -> Self {
             self.events
                 .push(deposit_event_from(user_address, amount, block, tx_hash));
+            self
+        }
+
+        fn pubkey(mut self, user_address: Felt, pubkey: Felt, block: u64, tx_hash: Felt) -> Self {
+            self.storage
+                .insert_with_block(storage_slots::public_key(user_address), pubkey, block);
+            self.events
+                .push(viewing_key_set_event(user_address, pubkey, block, tx_hash));
             self
         }
 
@@ -910,5 +992,103 @@ mod tests {
 
         assert_eq!(cursor.begin_block_number, 9);
         assert!(cursor.history_complete);
+    }
+
+    // -- registration event tests --
+
+    const PUBKEY: Felt = Felt::from_hex_unchecked("0xBEE1");
+
+    #[tokio::test]
+    async fn registration_appended_on_complete_scan() {
+        let (backend, mut cursor) = FixtureBuilder::new()
+            .note(0, 10, TX_HASH_1)
+            .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
+            .build(Some(0));
+
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(cursor.history_complete);
+
+        let registration = &result[1];
+        assert_eq!(registration.registered_pubkey, Some(PUBKEY));
+        assert_eq!(registration.block_number, 5);
+        assert_eq!(registration.transaction_hash, TX_HASH_REG);
+        assert!(registration.notes.is_empty());
+        assert!(registration.deposits.is_empty());
+        assert!(registration.withdrawals.is_empty());
+        assert!(registration.open_note_deposits.is_empty());
+    }
+
+    #[tokio::test]
+    async fn registration_not_appended_on_partial_scan() {
+        let (backend, mut cursor) = FixtureBuilder::new()
+            .note(0, 10, TX_HASH_1)
+            .note(1, 20, TX_HASH_2)
+            .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
+            .build(Some(1));
+
+        let one_block_budget = 2 * COST_NOTE + COST_BLOCK_EVENTS_QUERY + COST_EVENTS_CHUNK;
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            &IoBudget::new(one_block_budget),
+        )
+        .await
+        .unwrap();
+
+        assert!(!cursor.history_complete);
+        assert!(result.iter().all(|tx| tx.registered_pubkey.is_none()));
+    }
+
+    #[tokio::test]
+    async fn registration_deferred_when_page_full() {
+        let (backend, mut cursor) = FixtureBuilder::new()
+            .note(0, 10, TX_HASH_1)
+            .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
+            .build(Some(0));
+
+        // First page: max_transactions=1, note tx fills the page.
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 1, &IoBudget::new(1000))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].registered_pubkey.is_none());
+        assert!(!cursor.history_complete);
+
+        // Second page: scanner is already exhausted, only registration returned.
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 1, &IoBudget::new(1000))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].registered_pubkey, Some(PUBKEY));
+        assert!(cursor.history_complete);
+    }
+
+    #[tokio::test]
+    async fn registration_sorted_last() {
+        let (backend, mut cursor) = FixtureBuilder::new()
+            .note(0, 10, TX_HASH_1)
+            .note(1, 20, TX_HASH_2)
+            .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
+            .build(Some(1));
+
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].block_number, 20);
+        assert!(result[0].registered_pubkey.is_none());
+        assert_eq!(result[1].block_number, 10);
+        assert!(result[1].registered_pubkey.is_none());
+        assert_eq!(result[2].block_number, 5);
+        assert_eq!(result[2].registered_pubkey, Some(PUBKEY));
     }
 }

--- a/crates/discovery-core/src/history/types.rs
+++ b/crates/discovery-core/src/history/types.rs
@@ -38,6 +38,10 @@ pub struct HistoryTransaction {
     pub deposits: Vec<DepositEvent>,
     pub withdrawals: Vec<WithdrawalEvent>,
     pub open_note_deposits: Vec<OpenNoteDepositedEvent>,
+    /// The user's registered public key. Present only on the synthetic
+    /// registration transaction appended at the end of history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registered_pubkey: Option<Felt>,
 }
 
 impl HistoryTransaction {
@@ -49,6 +53,7 @@ impl HistoryTransaction {
             deposits: Vec::new(),
             withdrawals: Vec::new(),
             open_note_deposits: Vec::new(),
+            registered_pubkey: None,
         }
     }
 }
@@ -126,6 +131,7 @@ mod tests {
                 note_id: Felt::from(0x42u64),
                 amount: 0,
             }],
+            registered_pubkey: None,
         };
 
         let json = serde_json::to_value(&transaction).unwrap();
@@ -135,5 +141,30 @@ mod tests {
 
         let restored: HistoryTransaction = serde_json::from_value(json).unwrap();
         assert_eq!(restored, transaction);
+    }
+
+    #[test]
+    fn test_registered_pubkey_omitted_when_none() {
+        let transaction = HistoryTransaction::new(10, Felt::from(0x999u64));
+        let json = serde_json::to_value(&transaction).unwrap();
+        assert!(
+            json.get("registered_pubkey").is_none(),
+            "registered_pubkey must be omitted when None"
+        );
+
+        let restored: HistoryTransaction = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.registered_pubkey, None);
+    }
+
+    #[test]
+    fn test_registered_pubkey_round_trips_when_present() {
+        let mut transaction = HistoryTransaction::new(5, Felt::ZERO);
+        transaction.registered_pubkey = Some(Felt::from(0xCAFEu64));
+
+        let json = serde_json::to_value(&transaction).unwrap();
+        assert!(json.get("registered_pubkey").is_some());
+
+        let restored: HistoryTransaction = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.registered_pubkey, Some(Felt::from(0xCAFEu64)));
     }
 }

--- a/crates/discovery-core/src/privacy_pool/events.rs
+++ b/crates/discovery-core/src/privacy_pool/events.rs
@@ -21,6 +21,8 @@ static ENC_NOTE_CREATED_SELECTOR: LazyLock<Felt> =
     LazyLock::new(|| starknet_keccak(b"EncNoteCreated"));
 static OPEN_NOTE_DEPOSITED_SELECTOR: LazyLock<Felt> =
     LazyLock::new(|| starknet_keccak(b"OpenNoteDeposited"));
+static VIEWING_KEY_SET_SELECTOR: LazyLock<Felt> =
+    LazyLock::new(|| starknet_keccak(b"ViewingKeySet"));
 
 /// A typed privacy pool contract event with block context.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,6 +71,14 @@ pub struct OpenNoteDepositedEvent {
     pub amount: u128,
 }
 
+/// Decoded fields for a Cairo `ViewingKeySet` event.
+/// Keys = `[selector, user_addr, public_key]`, data = `[enc_private_key(3)]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewingKeySetEvent {
+    pub user_address: Felt,
+    pub public_key: Felt,
+}
+
 /// Event-specific content for privacy pool contract events.
 ///
 /// Each variant corresponds to a Cairo event type with its decoded fields.
@@ -78,6 +88,7 @@ pub enum PrivacyPoolEventContent {
     Withdrawal(WithdrawalEvent),
     EncNoteCreated(EncNoteCreatedEvent),
     OpenNoteDeposited(OpenNoteDepositedEvent),
+    ViewingKeySet(ViewingKeySetEvent),
 }
 
 /// Typed event access for privacy pool contract events.
@@ -98,6 +109,16 @@ pub trait IEvents: Send + Sync {
     async fn get_withdrawal_events(
         &self,
         address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+
+    /// Fetches `ViewingKeySet` events for the given user within a block range (inclusive).
+    ///
+    /// The address matches the user (key position 1 in `ViewingKeySet`).
+    async fn get_viewing_key_set_events(
+        &self,
+        user_address: Felt,
         from_block: u64,
         to_block: u64,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
@@ -161,6 +182,11 @@ impl TryFrom<EmittedEvent> for PrivacyPoolEvent {
                 note_id: required_key(&event, 3, "note_id")?,
                 amount: required_amount(&event, 0)?,
             })
+        } else if selector == *VIEWING_KEY_SET_SELECTOR {
+            PrivacyPoolEventContent::ViewingKeySet(ViewingKeySetEvent {
+                user_address: required_key(&event, 1, "user_addr")?,
+                public_key: required_key(&event, 2, "public_key")?,
+            })
         } else {
             return Err(EventParseError::UnknownSelector);
         };
@@ -218,6 +244,22 @@ impl<T: RawEventAccess> IEvents for T {
         let raw_events = self
             .get_events(
                 &[vec![*WITHDRAWAL_SELECTOR], vec![address]],
+                from_block,
+                to_block,
+            )
+            .await?;
+        parse_events(raw_events)
+    }
+
+    async fn get_viewing_key_set_events(
+        &self,
+        user_address: Felt,
+        from_block: u64,
+        to_block: u64,
+    ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
+        let raw_events = self
+            .get_events(
+                &[vec![*VIEWING_KEY_SET_SELECTOR], vec![user_address]],
                 from_block,
                 to_block,
             )

--- a/crates/discovery-core/src/privacy_pool/views.rs
+++ b/crates/discovery-core/src/privacy_pool/views.rs
@@ -114,6 +114,12 @@ pub trait IViews: Send + Sync {
         &self,
         note_ids: &[Felt],
     ) -> Result<Vec<StorageResult>, StorageError>;
+
+    /// Returns a user's public key with its last-update block number.
+    async fn get_public_key_with_block(
+        &self,
+        user_addr: Felt,
+    ) -> Result<StorageResult, StorageError>;
 }
 
 /// Blanket implementation of `IViews` for any type implementing `RawStorageAccess`.
@@ -276,5 +282,18 @@ impl<T: RawStorageAccess> IViews for T {
             .map(|&nid| storage_slots::notes(nid))
             .collect();
         self.read_slots_with_block(slots).await
+    }
+
+    #[tracing::instrument(name = "get_public_key_with_block", level = "debug", skip(self))]
+    async fn get_public_key_with_block(
+        &self,
+        user_addr: Felt,
+    ) -> Result<StorageResult, StorageError> {
+        let slot = storage_slots::public_key(user_addr);
+        let results = self.read_slots_with_block(vec![slot]).await?;
+        results
+            .into_iter()
+            .next()
+            .ok_or(StorageError::SlotCountMismatch)
     }
 }

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -477,11 +477,23 @@ async fn test_history_basic() {
     // Verify transactions have expected structure
     for transaction in &history_response.transactions {
         assert!(transaction.block_number > 0, "block_number should be set");
-        assert!(
-            transaction.transaction_hash != Felt::ZERO,
-            "transaction_hash should be set"
-        );
+        if transaction.registered_pubkey.is_some() {
+            // Registration transaction carries the real tx hash from the ViewingKeySet event.
+            assert_ne!(transaction.transaction_hash, Felt::ZERO);
+        } else {
+            assert!(
+                transaction.transaction_hash != Felt::ZERO,
+                "transaction_hash should be set"
+            );
+        }
     }
+
+    // The last transaction (chronologically oldest) should be the registration event.
+    let last_transaction = history_response.transactions.last().unwrap();
+    assert!(
+        last_transaction.registered_pubkey.is_some(),
+        "last history entry should be the registration event"
+    );
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();

--- a/sdk/src/internal/action-classifier.ts
+++ b/sdk/src/internal/action-classifier.ts
@@ -18,7 +18,8 @@ export type HistoryAction =
       noteCount: number;
     }
   | { type: "swap"; executor: bigint; sent: SwapLeg[]; received: SwapLeg[] }
-  | { type: "transferSelf"; token: bigint; amount: bigint; noteCount: number };
+  | { type: "transferSelf"; token: bigint; amount: bigint; noteCount: number }
+  | { type: "register"; pubkey: bigint };
 
 export type HistoryActionKind = HistoryAction["type"];
 
@@ -39,6 +40,14 @@ export function classifyTransaction(
   transaction: HistoryTransaction,
   options?: ClassifyOptions
 ): ClassifiedTransaction {
+  if (transaction.registeredPubkey != null) {
+    return {
+      blockNumber: transaction.blockNumber,
+      transactionHash: transaction.transactionHash,
+      actions: [{ type: "register", pubkey: transaction.registeredPubkey }],
+    };
+  }
+
   const actions: HistoryAction[] = [];
 
   // Step 1: Detect swaps — openNoteDeposits are swap received legs, grouped by depositor (executor).

--- a/sdk/src/internal/history.ts
+++ b/sdk/src/internal/history.ts
@@ -56,6 +56,8 @@ export type HistoryTransaction = {
   deposits: HistoryDeposit[];
   withdrawals: HistoryWithdrawal[];
   openNoteDeposits: HistoryOpenNoteDeposit[];
+  /** Present only on the synthetic registration transaction (last in history). */
+  registeredPubkey?: bigint;
 };
 
 export type HistoryPage = {
@@ -116,6 +118,7 @@ type ApiHistoryTransaction = {
   deposits: ApiHistoryDeposit[];
   withdrawals: ApiHistoryWithdrawal[];
   open_note_deposits: ApiHistoryOpenNoteDeposit[];
+  registered_pubkey?: string;
 };
 
 export type ApiHistoryResponse = {
@@ -215,6 +218,7 @@ export function apiResponseToHistoryPage(resp: ApiHistoryResponse): HistoryPage 
         noteId: BigInt(deposit.note_id),
         amount: BigInt(deposit.amount),
       })),
+      ...(tx.registered_pubkey && { registeredPubkey: BigInt(tx.registered_pubkey) }),
     })),
     cursor: {
       subchannels: resp.cursor.subchannels.map((sc) => ({

--- a/sdk/tests/internal/action-classifier.test.ts
+++ b/sdk/tests/internal/action-classifier.test.ts
@@ -364,4 +364,22 @@ describe("classifyTransaction", () => {
       { type: "transferSent", toAddress: BOB, token: STRK, amount: 50n, noteCount: 1 },
     ]);
   });
+
+  it("classifies a registration transaction", () => {
+    const result = classifyTransaction(emptyTransaction({ registeredPubkey: 0xcafen }));
+
+    expect(result.blockNumber).toBe(1);
+    expect(result.actions).toEqual([{ type: "register", pubkey: 0xcafen }]);
+  });
+
+  it("registration skips normal classification", () => {
+    const result = classifyTransaction(
+      emptyTransaction({
+        registeredPubkey: 0xcafen,
+        deposits: [{ fromAddress: ALICE, token: STRK, amount: 100n }],
+      })
+    );
+
+    expect(result.actions).toEqual([{ type: "register", pubkey: 0xcafen }]);
+  });
 });


### PR DESCRIPTION
## feat(history): include pool registration event in history feed

### Rationale

The history feed tracks deposits, withdrawals, transfers, and swaps — but omits the initial registration event (`set_viewing_key()`), which is the chronologically first action any user takes with the privacy pool. Without it, the history is incomplete: the user has no record of when they joined the pool.

### Approach

Registration is not an on-chain event we can discover through the normal note/event scanning pipeline. Instead, we derive it from storage: reading the `public_key(user_address)` slot with `read_slots_with_block()` tells us both the public key value and the block at which it was written.

The registration transaction is **synthetic** — it has `transaction_hash = 0x0`, empty note/event arrays, and a new `registered_pubkey` field carrying the actual public key. This naturally sorts last in the descending block-number ordering since registration predates all channel activity.

### Key design decisions

**`registered_pubkey: Option<Felt>` instead of a boolean flag** — Carries the actual data and doubles as the discriminant (`Some` = registration, `None` = regular tx). More useful to consumers than a bare flag.

**Deferred pagination for full pages** — When the note scan completes but the current page is already at `max_transactions`, we keep `history_complete = false` so the client fetches one more page containing just the registration. This avoids silently dropping the event when the last page is exactly full.

**Best-effort** — The registration query is non-fatal: budget exhaustion or RPC errors are logged and skipped. Since registration is an invariant (you can't have channels without it), this only matters for degraded backend scenarios.

### Changes

**Rust (discovery-core)**
- `types.rs` — `registered_pubkey: Option<Felt>` on `HistoryTransaction` (serde: omitted when `None`)
- `views.rs` — `get_public_key_with_block()` on `IViews` trait
- `transactions.rs` — `try_append_registration()` helper called after scan completion; deferred `history_complete` logic

**TypeScript (SDK)**
- `history.ts` — `registeredPubkey?: bigint` on `HistoryTransaction` + wire type
- `action-classifier.ts` — `{ type: "register"; pubkey: bigint }` action variant with early-return classification

### Tests

- 4 Rust integration tests: appended on complete scan, skipped on partial, deferred when page full, sorted last
- 2 Rust serde tests: round-trip with/without `registered_pubkey`
- 2 TypeScript classifier tests: basic classification, skips normal classification

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/700)
<!-- Reviewable:end -->
