### PR TITLE
feat(demo): support register event in history feed

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -30,23 +30,28 @@ jobs:
 
       - name: Pull Vercel env and build
         working-directory: demo
+        # Pull preview env but rename the file to .env.production.local so
+        # `vercel build --prod` classifies the artifact as production-target
+        # (required for manual "Promote to Production") while still baking in
+        # preview env values.
         run: |
           # Try branch-named custom env first, fall back to preview
           # Vercel env names: underscores -> hyphens, truncated to 32 chars
           BRANCH=$(echo "$BRANCH_RAW" | tr '_' '-' | cut -c1-32)
           if npx vercel pull --yes --environment="$BRANCH" --token=${{ secrets.VERCEL_TOKEN }}; then
-            cp ".vercel/.env.$BRANCH.local" .vercel/.env.preview.local
+            cp ".vercel/.env.$BRANCH.local" .vercel/.env.production.local
           else
             npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+            mv .vercel/.env.preview.local .vercel/.env.production.local
           fi
 
           # Generate vercel.json with rewrites to proxy HTTP backends through
           # the Vercel deployment, avoiding mixed HTTP/HTTPS content errors.
-          eval "$(grep '^BACKEND_' ".vercel/.env.preview.local")"
+          eval "$(grep '^BACKEND_' ".vercel/.env.production.local")"
           printf '{"installCommand":"echo skipped","outputDirectory":"dist","rewrites":[{"source":"/api/rpc/:path*","destination":"%s/rpc/:path*"},{"source":"/api/indexer/:path*","destination":"%s/:path*"},{"source":"/api/prover/:path*","destination":"%s/:path*"},{"source":"/api/gateway/:path*","destination":"%s/:path*"}]}\n' \
             "$BACKEND_RPC_URL" "$BACKEND_INDEXER_URL" "$BACKEND_PROVER_URL" "$BACKEND_GATEWAY_URL" > vercel.json
 
-          npx vercel build
+          npx vercel build --prod
         env:
           BRANCH_RAW: ${{ github.head_ref || github.ref_name }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -59,6 +64,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-version: latest
+          # Personal-scope token needs --scope for inspect after a team deploy,
+          # otherwise vercel inspect falls back to the token's default scope.
+          scope: keep-starknet-strange
           working-directory: demo
-          vercel-args: '--prebuilt'
+          # --prod matches the production target of the `vercel build --prod`
+          # artifact; --skip-domain prevents auto-aliasing to the production
+          # domain, so the deployment lands at a preview URL and can be
+          # promoted manually from the Vercel UI.
+          vercel-args: '--prebuilt --prod --skip-domain'
           github-comment: true

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -31,6 +31,7 @@
       "license": "ISC",
       "dependencies": {
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
+        "ohttp-ts": "^0.3.0",
         "starknet": "^10.0.0-beta.6",
         "starknet-devnet": "^0.7.2",
         "zod": "^3.24.0"
@@ -3071,12 +3072,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3453,12 +3448,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/demo/src/App.css
+++ b/demo/src/App.css
@@ -1065,3 +1065,35 @@ input[type="number"] {
   margin: 4px 0 0;
   text-align: center;
 }
+
+@keyframes glow-pulse {
+  0% {
+    box-shadow: 0 0 4px rgba(88, 166, 255, 0.6), inset 0 0 4px rgba(88, 166, 255, 0.1);
+    border-color: #58a6ff88;
+  }
+  50% {
+    box-shadow: 0 0 12px rgba(88, 166, 255, 0.4), inset 0 0 8px rgba(88, 166, 255, 0.05);
+    border-color: #58a6ff44;
+  }
+  100% {
+    box-shadow: none;
+    border-color: #30363d;
+  }
+}
+
+.history-row.glow {
+  animation: glow-pulse 2s ease-out;
+}
+
+@keyframes row-glow {
+  0% {
+    background: rgba(88, 166, 255, 0.15);
+  }
+  100% {
+    background: transparent;
+  }
+}
+
+.balances tr.glow td {
+  animation: row-glow 2s ease-out;
+}

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -17,6 +17,7 @@ import { TransactionBuilder } from "./components/TransactionBuilder.tsx";
 import { StatusBar } from "./components/StatusBar.tsx";
 import { ServiceHealthBar } from "./components/ServiceHealthBar.tsx";
 import { useTransactionBuilder } from "./hooks/useTransactionBuilder.ts";
+import { useLastTxBlockNumber } from "./hooks/useLastTxBlock.ts";
 import { useServiceHealth } from "./hooks/useServiceHealth.ts";
 import { DefiPanel } from "./components/DefiPanel.tsx";
 import { useTokenMetadata } from "./hooks/useTokenMetadata.ts";
@@ -99,9 +100,9 @@ export function App() {
 
   const registry = useRef(createEmptyRegistry());
 
-  // Reset registry in-place when account or pool changes so discovery starts
-  // fresh. Mutating the existing object (rather than replacing it) ensures that
-  // callbacks captured during this render cycle see the cleared state.
+  // Reset registry BEFORE useHistory's auto-fetch effect runs on account/pool
+  // switch. Otherwise useHistory captures the previous account's cursor and
+  // calls fetchHistory against the new account's address, producing mixed data.
   useEffect(() => {
     const reg = registry.current;
     reg.cursor = undefined;
@@ -128,6 +129,11 @@ export function App() {
     refreshLatest: refreshHistoryLatest,
   } = useHistory(provider, poolAddress, effectiveConfig, activeAccount, accounts, registry.current);
 
+  const { lastTxBlockNumberRef, updateLastTxBlockNumber } = useLastTxBlockNumber(
+    activeAccount?.address,
+    historyTransactions,
+  );
+
   const refreshAll = useCallback(async () => {
     // Reset cursors so refresh does a full re-sync — incremental discovery
     // only returns new notes, so stale cursors would yield empty results
@@ -140,7 +146,16 @@ export function App() {
     refreshHistoryLatest();
   }, [refresh, refreshHistoryLatest]);
 
+  // Reset registry in-place before each refresh. Incremental discovery returns
+  // only delta notes past registry.cursor, so any change that rebuilds refresh
+  // (account, pool, config, transfers) must first clear cursors or balances
+  // will zero out. Mutating (not replacing) preserves the ref identity that
+  // captured callbacks rely on.
   useEffect(() => {
+    const reg = registry.current;
+    reg.cursor = undefined;
+    reg.channels = createEmptyRegistry().channels;
+    reg.notes = createEmptyRegistry().notes;
     refresh();
   }, [refresh]);
 
@@ -153,6 +168,8 @@ export function App() {
     accounts,
     refreshAll,
     refreshBalances,
+    lastTxBlockNumberRef,
+    updateLastTxBlockNumber,
   );
 
   const { status: builderStatus, executeBatch } = useTransactionBuilder(
@@ -163,6 +180,8 @@ export function App() {
     effectiveConfig,
     accounts,
     refreshAll,
+    lastTxBlockNumberRef,
+    updateLastTxBlockNumber,
   );
 
   const serviceHealth = useServiceHealth(provider, effectiveConfig);

--- a/demo/src/components/HistoryPanel.tsx
+++ b/demo/src/components/HistoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { TransactionDisplay, ActionDisplay } from "../hooks/useHistory.ts";
 import { formatTokenAmount, formatRelativeTime } from "../format.ts";
 
@@ -33,6 +33,21 @@ export function HistoryPanel({
   const [expandedIndexes, setExpandedIndexes] = useState<Set<number>>(
     new Set(),
   );
+  const [glowHashes, setGlowHashes] = useState<Set<string>>(new Set());
+  const prevCountRef = useRef(transactions.length);
+
+  useEffect(() => {
+    const prevCount = prevCountRef.current;
+    prevCountRef.current = transactions.length;
+    if (transactions.length > prevCount && prevCount > 0) {
+      const newHashes = new Set(
+        transactions.slice(0, transactions.length - prevCount).map((tx) => tx.transactionHash),
+      );
+      setGlowHashes(newHashes);
+      const timer = setTimeout(() => setGlowHashes(new Set()), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [transactions]);
 
   function toggleExpanded(index: number) {
     setExpandedIndexes((previous) => {
@@ -59,7 +74,7 @@ export function HistoryPanel({
         return (
           <div
             key={transactionIndex}
-            className={`history-row ${expanded ? "history-row-expanded" : ""}`}
+            className={`history-row ${expanded ? "history-row-expanded" : ""} ${glowHashes.has(transaction.transactionHash) ? "glow" : ""}`}
           >
             <div
               className="history-row-summary"

--- a/demo/src/components/InfoPanel.tsx
+++ b/demo/src/components/InfoPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import type {
   IncomingChannelCard,
   OutgoingChannelCard,
@@ -187,6 +187,26 @@ export function InfoPanel({
   onFetchHistory,
 }: Props) {
   const [view, setView] = useState<"notes" | "channels" | "activity">("activity");
+  const [glowAddresses, setGlowAddresses] = useState<Set<string>>(new Set());
+  const prevBalancesRef = useRef<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const changed = new Set<string>();
+    for (const tb of state.tokenBalances) {
+      const key = tb.address;
+      const current = `${tb.private}:${tb.transparent}`;
+      const previous = prevBalancesRef.current.get(key);
+      if (previous !== undefined && previous !== current) {
+        changed.add(key);
+      }
+      prevBalancesRef.current.set(key, current);
+    }
+    if (changed.size > 0) {
+      setGlowAddresses(changed);
+      const timer = setTimeout(() => setGlowAddresses(new Set()), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [state.tokenBalances]);
 
   return (
     <div className="island">
@@ -223,7 +243,7 @@ export function InfoPanel({
           </thead>
           <tbody>
             {state.tokenBalances.map((tb) => (
-              <tr key={tb.address}>
+              <tr key={tb.address} className={glowAddresses.has(tb.address) ? "glow" : ""}>
                 <td>
                   {tb.name}
                   {tb.fee && <span className="chip">fee</span>}

--- a/demo/src/components/StatusBar.tsx
+++ b/demo/src/components/StatusBar.tsx
@@ -37,7 +37,7 @@ export function StatusBar({ status }: Props) {
 
   return (
     <div className="status-bar">
-      {status.pending && <span className="pending">{status.action ?? "Transaction"} pending...</span>}
+      {status.pending && <span className="pending">{status.action ?? "Transaction"}...</span>}
       {status.lastTxHash && (
         <span className="success">
           Tx: <code>{status.lastTxHash}</code>

--- a/demo/src/hooks/useHistory.ts
+++ b/demo/src/hooks/useHistory.ts
@@ -41,7 +41,7 @@ function formatActionLabel(
   nameByAddress: Map<bigint, string>,
   tokenNameByAddress: Map<bigint, string>,
   tokenDecimalsByAddress: Map<bigint, number>,
-  executorNames: Map<bigint, string>,
+  executorNames: Map<bigint, string>
 ): { label: string; chipClass: string; chipLabel?: string; isFee?: boolean } {
   const tokenName = (token: bigint) =>
     tokenNameByAddress.get(token) ?? truncateAddress(token.toString(16));
@@ -69,8 +69,7 @@ function formatActionLabel(
       };
     case "transferSent": {
       const name =
-        nameByAddress.get(action.toAddress) ??
-        truncateAddress(action.toAddress.toString(16));
+        nameByAddress.get(action.toAddress) ?? truncateAddress(action.toAddress.toString(16));
       return {
         label: `Sent ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)} to ${name}`,
         chipClass: "chip-no",
@@ -78,21 +77,20 @@ function formatActionLabel(
     }
     case "transferReceived": {
       const name =
-        nameByAddress.get(action.fromAddress) ??
-        truncateAddress(action.fromAddress.toString(16));
+        nameByAddress.get(action.fromAddress) ?? truncateAddress(action.fromAddress.toString(16));
       return {
         label: `Received ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)} from ${name}`,
         chipClass: "chip-ok",
       };
     }
     case "swap": {
-      const executorLabel = executorNames.get(action.executor)
-        ?? truncateAddress(action.executor.toString(16));
+      const executorLabel =
+        executorNames.get(action.executor) ?? truncateAddress(action.executor.toString(16));
       const sentParts = action.sent.map(
-        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`,
+        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`
       );
       const receivedParts = action.received.map(
-        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`,
+        (leg) => `${fmtAmount(leg.amount, leg.token)} ${tokenName(leg.token)}`
       );
       return {
         label: `Swapped ${sentParts.join(", ")} for ${receivedParts.join(", ")} via ${executorLabel}`,
@@ -105,6 +103,11 @@ function formatActionLabel(
         label: `Reorganized ${fmtAmount(action.amount, action.token)} ${tokenName(action.token)}`,
         chipClass: "chip",
       };
+    case "register":
+      return {
+        label: "Registered with the privacy pool",
+        chipClass: "chip",
+      };
   }
 }
 
@@ -112,7 +115,7 @@ function computeBalanceUpdates(
   actions: HistoryAction[],
   viewerAddress: bigint,
   tokenNameByAddress: Map<bigint, string>,
-  tokenDecimalsByAddress: Map<bigint, number>,
+  tokenDecimalsByAddress: Map<bigint, number>
 ): BalanceUpdate[] {
   const netByToken = new Map<bigint, bigint>();
 
@@ -122,45 +125,29 @@ function computeBalanceUpdates(
         break;
       case "withdrawal":
         if (action.toAddress !== viewerAddress) {
-          netByToken.set(
-            action.token,
-            (netByToken.get(action.token) ?? 0n) - action.amount,
-          );
+          netByToken.set(action.token, (netByToken.get(action.token) ?? 0n) - action.amount);
         }
         break;
       case "fee":
-        netByToken.set(
-          action.token,
-          (netByToken.get(action.token) ?? 0n) - action.amount,
-        );
+        netByToken.set(action.token, (netByToken.get(action.token) ?? 0n) - action.amount);
         break;
       case "transferSent":
-        netByToken.set(
-          action.token,
-          (netByToken.get(action.token) ?? 0n) - action.amount,
-        );
+        netByToken.set(action.token, (netByToken.get(action.token) ?? 0n) - action.amount);
         break;
       case "transferReceived":
-        netByToken.set(
-          action.token,
-          (netByToken.get(action.token) ?? 0n) + action.amount,
-        );
+        netByToken.set(action.token, (netByToken.get(action.token) ?? 0n) + action.amount);
         break;
       case "swap":
         for (const leg of action.sent) {
-          netByToken.set(
-            leg.token,
-            (netByToken.get(leg.token) ?? 0n) - leg.amount,
-          );
+          netByToken.set(leg.token, (netByToken.get(leg.token) ?? 0n) - leg.amount);
         }
         for (const leg of action.received) {
-          netByToken.set(
-            leg.token,
-            (netByToken.get(leg.token) ?? 0n) + leg.amount,
-          );
+          netByToken.set(leg.token, (netByToken.get(leg.token) ?? 0n) + leg.amount);
         }
         break;
       case "transferSelf":
+        break;
+      case "register":
         break;
     }
   }
@@ -178,7 +165,7 @@ function computeBalanceUpdates(
 function buildDisplayMaps(
   account: AccountConfig,
   allAccounts: AccountConfig[],
-  config: AppConfig,
+  config: AppConfig
 ): {
   nameByAddress: Map<bigint, string>;
   tokenNameByAddress: Map<bigint, string>;
@@ -190,7 +177,7 @@ function buildDisplayMaps(
     const accAddress = BigInt(acc.address);
     nameByAddress.set(
       accAddress,
-      accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase(),
+      accAddress === BigInt(account.address) ? "self" : acc.name.toLowerCase()
     );
   }
   const tokenNameByAddress = new Map<bigint, string>();
@@ -211,13 +198,14 @@ function buildDisplayMaps(
 }
 
 const ACTION_ORDER: Record<string, number> = {
-  deposit: 0,
-  transferReceived: 1,
-  transferSelf: 2,
-  transferSent: 3,
-  swap: 4,
-  withdrawal: 5,
-  fee: 6,
+  register: 0,
+  deposit: 1,
+  transferReceived: 2,
+  transferSelf: 3,
+  transferSent: 4,
+  swap: 5,
+  withdrawal: 6,
+  fee: 7,
 };
 
 function toDisplayTransactions(
@@ -227,7 +215,7 @@ function toDisplayTransactions(
   tokenNameByAddress: Map<bigint, string>,
   tokenDecimalsByAddress: Map<bigint, number>,
   executorNames: Map<bigint, string>,
-  paymasterForwarderAddress: bigint | undefined,
+  paymasterForwarderAddress: bigint | undefined
 ): TransactionDisplay[] {
   const classifyOptions: ClassifyOptions | undefined = paymasterForwarderAddress
     ? { feeRecipients: [paymasterForwarderAddress] }
@@ -241,19 +229,17 @@ function toDisplayTransactions(
           nameByAddress,
           tokenNameByAddress,
           tokenDecimalsByAddress,
-          executorNames,
+          executorNames
         );
         const noteCount = "noteCount" in action ? action.noteCount : undefined;
         return { type: action.type, label, chipClass, chipLabel, noteCount, isFee };
       })
-      .sort(
-        (a, b) => (ACTION_ORDER[a.type] ?? 99) - (ACTION_ORDER[b.type] ?? 99),
-      );
+      .sort((a, b) => (ACTION_ORDER[a.type] ?? 99) - (ACTION_ORDER[b.type] ?? 99));
     const balanceUpdates = computeBalanceUpdates(
       classified.actions,
       viewerAddress,
       tokenNameByAddress,
-      tokenDecimalsByAddress,
+      tokenDecimalsByAddress
     );
     return {
       blockNumber: classified.blockNumber,
@@ -268,14 +254,14 @@ function toDisplayTransactions(
 
 async function resolveTimestamps(
   provider: RpcProvider,
-  transactions: TransactionDisplay[],
+  transactions: TransactionDisplay[]
 ): Promise<TransactionDisplay[]> {
   const blockNumbers = [...new Set(transactions.map((tx) => tx.blockNumber))];
   const entries = await Promise.all(
     blockNumbers.map(async (blockNumber) => {
       const block = await provider.getBlock(blockNumber);
       return [blockNumber, block.timestamp] as const;
-    }),
+    })
   );
   const timestampByBlock = new Map(entries);
   return transactions.map((tx) => ({
@@ -290,7 +276,7 @@ export function useHistory(
   config: AppConfig,
   account: AccountConfig | undefined,
   allAccounts: AccountConfig[],
-  registry: PrivateRegistry,
+  registry: PrivateRegistry
 ) {
   const [transactions, setTransactions] = useState<TransactionDisplay[]>([]);
   const [loading, setLoading] = useState(false);
@@ -335,18 +321,15 @@ export function useHistory(
           maxTransactions: 5,
           historyCursor: historyCursorRef.current,
           blockRef: blockRefValue.current,
-        },
+        }
       );
 
       historyCursorRef.current = page.cursor;
       blockRefValue.current = page.blockRef;
       setHistoryComplete(page.cursor.historyComplete);
 
-      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress, executorNames } = buildDisplayMaps(
-        account,
-        allAccounts,
-        config,
-      );
+      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress, executorNames } =
+        buildDisplayMaps(account, allAccounts, config);
       let newTransactions = toDisplayTransactions(
         page.transactions,
         BigInt(account.address),
@@ -354,7 +337,7 @@ export function useHistory(
         tokenNameByAddress,
         tokenDecimalsByAddress,
         executorNames,
-        config.paymasterForwarderAddress ? BigInt(config.paymasterForwarderAddress) : undefined,
+        config.paymasterForwarderAddress ? BigInt(config.paymasterForwarderAddress) : undefined
       );
       if (provider) {
         newTransactions = await resolveTimestamps(provider, newTransactions);
@@ -386,36 +369,26 @@ export function useHistory(
         BigInt(account.address),
         registry.cursor,
         { channels: registry.channels },
-        { maxTransactions: 1 },
+        { maxTransactions: 1, blockIdentifier: "pre_confirmed" },
       );
 
       if (page.transactions.length === 0) return;
 
-      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress, executorNames } = buildDisplayMaps(
-        account,
-        allAccounts,
-        config,
-      );
-      let freshTransactions = toDisplayTransactions(
+      const { nameByAddress, tokenNameByAddress, tokenDecimalsByAddress, executorNames } =
+        buildDisplayMaps(account, allAccounts, config);
+      const freshTransactions = toDisplayTransactions(
         page.transactions,
         BigInt(account.address),
         nameByAddress,
         tokenNameByAddress,
         tokenDecimalsByAddress,
         executorNames,
-        config.paymasterForwarderAddress ? BigInt(config.paymasterForwarderAddress) : undefined,
-      );
-      if (provider) {
-        freshTransactions = await resolveTimestamps(provider, freshTransactions);
-      }
+        config.paymasterForwarderAddress ? BigInt(config.paymasterForwarderAddress) : undefined
+      ).map((tx) => ({ ...tx, timestamp: Math.floor(Date.now() / 1000) }));
 
       setTransactions((previous) => {
-        const existingHashes = new Set(
-          previous.map((tx) => tx.transactionHash),
-        );
-        const newOnly = freshTransactions.filter(
-          (tx) => !existingHashes.has(tx.transactionHash),
-        );
+        const existingHashes = new Set(previous.map((tx) => tx.transactionHash));
+        const newOnly = freshTransactions.filter((tx) => !existingHashes.has(tx.transactionHash));
         if (newOnly.length === 0) return previous;
         return [...newOnly, ...previous];
       });

--- a/demo/src/hooks/useLastTxBlock.ts
+++ b/demo/src/hooks/useLastTxBlock.ts
@@ -1,0 +1,39 @@
+import { useRef, useEffect, useCallback } from "react";
+import type { TransactionDisplay } from "./useHistory.ts";
+
+/**
+ * Tracks the block number of the most recent privacy pool transaction for
+ * the active account. Used as a floor when computing `provingBlockId`.
+ *
+ * - Initialized from the latest history transaction's block number.
+ * - Updated after each successful privacy pool tx.
+ * - Reset on account change.
+ */
+export function useLastTxBlockNumber(
+  activeAddress: string | undefined,
+  historyTransactions: TransactionDisplay[],
+) {
+  const lastTxBlockNumberRef = useRef<number | undefined>(undefined);
+
+  // Reset on account change.
+  useEffect(() => {
+    lastTxBlockNumberRef.current = undefined;
+  }, [activeAddress]);
+
+  // Initialize from history when first transactions arrive.
+  useEffect(() => {
+    if (lastTxBlockNumberRef.current === undefined && historyTransactions.length > 0) {
+      const maxBlockNumber = Math.max(...historyTransactions.map((transaction) => transaction.blockNumber));
+      lastTxBlockNumberRef.current = maxBlockNumber;
+    }
+  }, [historyTransactions]);
+
+  const updateLastTxBlockNumber = useCallback((blockNumber: number) => {
+    const current = lastTxBlockNumberRef.current;
+    if (current === undefined || blockNumber > current) {
+      lastTxBlockNumberRef.current = blockNumber;
+    }
+  }, []);
+
+  return { lastTxBlockNumberRef, updateLastTxBlockNumber };
+}

--- a/demo/src/hooks/usePrivateState.ts
+++ b/demo/src/hooks/usePrivateState.ts
@@ -100,7 +100,7 @@ export function usePrivateState(
   allAccounts: AccountConfig[],
   poolAddress: string,
   config: AppConfig,
-  registry: PrivateRegistry,
+  registry: PrivateRegistry
 ) {
   const [state, setState] = useState<PrivateState>(EMPTY_STATE);
   const [loading, setLoading] = useState(false);
@@ -119,29 +119,26 @@ export function usePrivateState(
       const indexer = createDiscoveryProvider(config, poolAddress);
       const tokenBigInts = config.tokens.map((t) => BigInt(t.address));
 
-      const [notesResult, channelsResult, requirement, ...transparentBalances] =
-        await Promise.all([
-          indexer.discoverNotes(
-            BigInt(account.address),
-            BigInt(account.viewingKey),
-            { cursor: registry.cursor, tokens: tokenBigInts },
-          ),
-          indexer.discoverChannels(
-            BigInt(account.address),
-            BigInt(account.viewingKey),
-            "all",
-            { cursor: { channels: registry.channels } },
-          ),
-          indexer.discoverRequirement(
-            BigInt(account.address),
-            BigInt(account.viewingKey),
-            BigInt(account.address),
-            BigInt(config.tokens[0].address),
-          ),
-          ...config.tokens.map((t) =>
-            getErc20Balance(provider, t.address, account.address, "pre_confirmed"),
-          ),
-        ]);
+      const [notesResult, channelsResult, requirement, ...transparentBalances] = await Promise.all([
+        indexer.discoverNotes(BigInt(account.address), BigInt(account.viewingKey), {
+          cursor: registry.cursor,
+          tokens: tokenBigInts,
+          blockIdentifier: "pre_confirmed",
+        }),
+        indexer.discoverChannels(BigInt(account.address), BigInt(account.viewingKey), "all", {
+          cursor: { channels: registry.channels },
+          blockIdentifier: "pre_confirmed",
+        }),
+        indexer.discoverRequirement(
+          BigInt(account.address),
+          BigInt(account.viewingKey),
+          BigInt(account.address),
+          BigInt(config.tokens[0].address)
+        ),
+        ...config.tokens.map((t) =>
+          getErc20Balance(provider, t.address, account.address, "pre_confirmed")
+        ),
+      ]);
       const isRegistered = requirement !== SetupRequirement.Register;
 
       registry.cursor = notesResult.cursor;
@@ -152,7 +149,7 @@ export function usePrivateState(
         const tokenNotes = notesResult.notes.get(BigInt(tokenConfig.address)) ?? [];
         const privateBalance = tokenNotes.reduce(
           (sum: bigint, note: Note) => sum + note.amount,
-          0n,
+          0n
         );
         return {
           name: tokenConfig.name,
@@ -252,9 +249,7 @@ export function usePrivateState(
       });
 
       // Build outgoing cards
-      const tokenNameByBigInt = new Map(
-        config.tokens.map((t) => [BigInt(t.address), t.name]),
-      );
+      const tokenNameByBigInt = new Map(config.tokens.map((t) => [BigInt(t.address), t.name]));
       const outgoingCards: OutgoingChannelCard[] = [];
       for (const [recipient, channel] of channelsResult.channels) {
         const internal = readChannel(channel);
@@ -302,28 +297,29 @@ export function usePrivateState(
     if (!provider || !account) return;
     const transparentBalances = await Promise.all(
       config.tokens.map((t) =>
-        getErc20Balance(provider, t.address, account.address, "pre_confirmed"),
-      ),
+        getErc20Balance(provider, t.address, account.address, "pre_confirmed")
+      )
     );
     const balanceByAddress = new Map(
-      config.tokens.map((t, index) => [t.address, transparentBalances[index]]),
+      config.tokens.map((t, index) => [t.address, transparentBalances[index]])
     );
     setState((previous) => ({
       ...previous,
-      tokenBalances: previous.tokenBalances.length > 0
-        ? previous.tokenBalances.map((tb) => ({
-            ...tb,
-            transparent: balanceByAddress.get(tb.address) ?? tb.transparent,
-          }))
-        : config.tokens.map((t, index) => ({
-            name: t.name,
-            address: t.address,
-            decimals: t.decimals,
-            fee: t.fee ?? false,
-            transparent: transparentBalances[index],
-            private: 0n,
-            noteCount: 0,
-          })),
+      tokenBalances:
+        previous.tokenBalances.length > 0
+          ? previous.tokenBalances.map((tb) => ({
+              ...tb,
+              transparent: balanceByAddress.get(tb.address) ?? tb.transparent,
+            }))
+          : config.tokens.map((t, index) => ({
+              name: t.name,
+              address: t.address,
+              decimals: t.decimals,
+              fee: t.fee ?? false,
+              transparent: transparentBalances[index],
+              private: 0n,
+              noteCount: 0,
+            })),
     }));
   }, [provider, account, config.tokens]);
 

--- a/demo/src/hooks/useTransactionBuilder.ts
+++ b/demo/src/hooks/useTransactionBuilder.ts
@@ -1,8 +1,8 @@
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo, useRef, type RefObject } from "react";
 import { Account, TransactionFinalityStatus, hash, type RpcProvider } from "starknet";
 import type { PrivateTransfersInterface } from "starknet-sdk";
 import type { AccountConfig, AppConfig } from "../config.ts";
-import type { TransactionStatus } from "./useTransactions.ts";
+import { type TransactionStatus, waitForProvingBlock } from "./useTransactions.ts";
 import type { BuilderOperation } from "../components/TransactionBuilder.tsx";
 import { Timeline } from "../timeline.ts";
 import { toRawAmount } from "../format.ts";
@@ -40,6 +40,8 @@ export function useTransactionBuilder(
   config: AppConfig,
   accounts: AccountConfig[],
   onSettled: () => void,
+  lastTxBlockNumberRef: RefObject<number | undefined>,
+  updateLastTxBlockNumber: (blockNumber: number) => void
 ) {
   const [status, setStatus] = useState<TransactionStatus>({
     pending: false,
@@ -55,9 +57,7 @@ export function useTransactionBuilder(
 
   const userAccount = useMemo(() => {
     if (!provider || !activeAddress) return undefined;
-    const accountConfig = accounts.find(
-      (account) => account.address === activeAddress,
-    );
+    const accountConfig = accounts.find((account) => account.address === activeAddress);
     if (!accountConfig) return undefined;
     return new Account({
       provider,
@@ -71,7 +71,17 @@ export function useTransactionBuilder(
     (operations: BuilderOperation[]) => {
       const action = "Builder";
       const timeline = new Timeline();
-      setStatus({ pending: true, action, lastTxHash: null, lastError: null, proofSizeBytes: null, timeline });
+      timeline.onStepChange = (label) => {
+        setStatus((previous) => (previous.pending ? { ...previous, action: label } : previous));
+      };
+      setStatus({
+        pending: true,
+        action,
+        lastTxHash: null,
+        lastError: null,
+        proofSizeBytes: null,
+        timeline,
+      });
 
       void (async () => {
         try {
@@ -106,24 +116,35 @@ export function useTransactionBuilder(
                     to: token,
                     selector: hash.getSelectorFromName("approve"),
                     calldata: [poolAddress, "0x" + totalAmount.toString(16), "0x0"],
-                  }),
+                  })
                 );
                 const buildResult = await timeline.step("Get paymaster fee", () =>
                   paymasterBuildInvokeAndApplyAction(
-                    config.paymasterUrl!, poolAddress, getFeeMode(config),
-                    activeAddress, approveCalls, config.avnuApiKey,
-                  ),
+                    config.paymasterUrl!,
+                    poolAddress,
+                    getFeeMode(config),
+                    activeAddress,
+                    approveCalls,
+                    config.avnuApiKey
+                  )
                 );
                 feeAction = buildResult.fee_action;
                 invokeTypedData = buildResult.typed_data;
                 const signature = await timeline.step("Sign approvals", () =>
-                  userAccount.signMessage(buildResult.typed_data),
+                  userAccount.signMessage(buildResult.typed_data)
                 );
                 invokeSignature = normalizeSignature(signature);
               } else {
-                feeAction = (await timeline.step("Get paymaster fee", () =>
-                  paymasterBuildApplyAction(config.paymasterUrl!, poolAddress, getFeeMode(config), config.avnuApiKey),
-                )).fee_action;
+                feeAction = (
+                  await timeline.step("Get paymaster fee", () =>
+                    paymasterBuildApplyAction(
+                      config.paymasterUrl!,
+                      poolAddress,
+                      getFeeMode(config),
+                      config.avnuApiKey
+                    )
+                  )
+                ).fee_action;
               }
             } else if (hasDeposits) {
               // Direct execution: approve separately
@@ -135,10 +156,10 @@ export function useTransactionBuilder(
                     calldata: [poolAddress, totalAmount.toString(), "0"],
                   };
                   const approveTx = await timeline.step(`Approve ${token.slice(0, 10)}...`, () =>
-                    userAccount.execute(approveCall, { tip: 0n }),
+                    userAccount.execute(approveCall, { tip: 0n })
                   );
                   await timeline.step("Wait for receipt", () =>
-                    provider.waitForTransaction(approveTx.transaction_hash, WAIT_OPTIONS),
+                    provider.waitForTransaction(approveTx.transaction_hash, WAIT_OPTIONS)
                   );
                 }
               });
@@ -155,7 +176,7 @@ export function useTransactionBuilder(
               })
               .surplusTo(
                 surplusOperation?.recipient ?? activeAddress,
-                surplusOperation?.withdrawSurplus,
+                surplusOperation?.withdrawSurplus
               );
 
             // Group token ops by token address
@@ -192,19 +213,21 @@ export function useTransactionBuilder(
 
             if (feeAction) {
               chain.with(feeAction.token, (t) =>
-                t.withdraw({ amount: BigInt(feeAction!.amount), recipient: feeAction!.recipient }),
+                t.withdraw({ amount: BigInt(feeAction!.amount), recipient: feeAction!.recipient })
               );
             }
 
-            const provingBlockId = await timeline.step("Get block number",
-              () => provider.getBlockNumber(),
-            ) - 10;
+            const provingBlockId = await waitForProvingBlock(
+              timeline,
+              provider,
+              lastTxBlockNumberRef.current
+            );
 
             const invocation = await timeline.step("Build transaction", () =>
-              chain.createProofInvocation({ provingBlockId }),
+              chain.createProofInvocation({ provingBlockId })
             );
             const { callAndProof } = await timeline.step("Prove", () =>
-              transfers.executeWithInvocation(invocation, provingBlockId),
+              transfers.executeWithInvocation(invocation, provingBlockId)
             );
 
             let txHash: string;
@@ -220,8 +243,8 @@ export function useTransactionBuilder(
                     activeAddress,
                     invokeTypedData as Parameters<typeof paymasterExecuteInvokeAndApplyAction>[6],
                     invokeSignature!,
-                    config.avnuApiKey,
-                  ),
+                    config.avnuApiKey
+                  )
                 );
                 txHash = response.transaction_hash;
               } else {
@@ -232,8 +255,8 @@ export function useTransactionBuilder(
                     callAndProof.proof.data,
                     callAndProof.proof.proofFacts,
                     getFeeMode(config),
-                    config.avnuApiKey,
-                  ),
+                    config.avnuApiKey
+                  )
                 );
                 txHash = response.transaction_hash;
               }
@@ -243,41 +266,49 @@ export function useTransactionBuilder(
                 : {};
               // execute() estimates fee internally; splitting estimate+submit would double RPC calls
               const executeTx = await timeline.step("Estimate + submit", () =>
-                userAccount.execute(callAndProof.call, { tip: 0n, ...proofDetails }),
+                userAccount.execute(callAndProof.call, { tip: 0n, ...proofDetails })
               );
               txHash = executeTx.transaction_hash;
             }
 
             const receipt = await timeline.step("Wait for receipt", () =>
-              provider.waitForTransaction(txHash, WAIT_OPTIONS),
+              provider.waitForTransaction(txHash, WAIT_OPTIONS)
             );
             if (!receipt.isSuccess()) {
               throw new Error(`Transaction reverted: ${JSON.stringify(receipt)}`);
             }
 
+            updateLastTxBlockNumber(receipt.block_number);
+
             const proofSizeBytes = callAndProof.proof.data
               ? base64ByteLength(callAndProof.proof.data)
               : null;
-            setStatus({ pending: false, action: null, lastTxHash: txHash, lastError: null, proofSizeBytes, timeline });
+            setStatus({
+              pending: false,
+              action: null,
+              lastTxHash: txHash,
+              lastError: null,
+              proofSizeBytes,
+              timeline,
+            });
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           console.error(`[${action}] failed:`, err);
-          setStatus({ pending: false, action: null, lastTxHash: null, lastError: `${action}: ${message}`, proofSizeBytes: null, timeline });
+          setStatus({
+            pending: false,
+            action: null,
+            lastTxHash: null,
+            lastError: `${action}: ${message}`,
+            proofSizeBytes: null,
+            timeline,
+          });
         } finally {
           onSettledRef.current();
         }
       })();
     },
-    [
-      userAccount,
-      transfers,
-      provider,
-      activeAddress,
-      config,
-      poolAddress,
-      accounts,
-    ],
+    [userAccount, transfers, provider, activeAddress, config, poolAddress, accounts]
   );
 
   return { status, executeBatch };

--- a/demo/src/hooks/useTransactions.ts
+++ b/demo/src/hooks/useTransactions.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo, useRef, type RefObject } from "react";
 import { Account, TransactionFinalityStatus, type RpcProvider } from "starknet";
 import { Open, type PrivateTransfersInterface, type PrivateTransfersBuilder } from "starknet-sdk";
 import type { AccountConfig, AppConfig } from "../config.ts";
@@ -27,20 +27,51 @@ function base64ByteLength(base64: string): number {
 }
 
 async function fetchPaymasterFee(
-  config: AppConfig, timeline: Timeline, poolAddress: string,
+  config: AppConfig,
+  timeline: Timeline,
+  poolAddress: string
 ): Promise<FeeAction | undefined> {
   if (!config.paymasterUrl) return undefined;
-  return (await timeline.step("Get paymaster fee", () =>
-    paymasterBuildApplyAction(config.paymasterUrl!, poolAddress, getFeeMode(config), config.avnuApiKey),
-  )).fee_action;
+  return (
+    await timeline.step("Get paymaster fee", () =>
+      paymasterBuildApplyAction(
+        config.paymasterUrl!,
+        poolAddress,
+        getFeeMode(config),
+        config.avnuApiKey
+      )
+    )
+  ).fee_action;
 }
 
 function addFeeWithdraw(builder: PrivateTransfersBuilder, feeAction: FeeAction | undefined): void {
   if (feeAction) {
     builder.with(feeAction.token, (t) =>
-      t.withdraw({ amount: BigInt(feeAction.amount), recipient: feeAction.recipient }),
+      t.withdraw({ amount: BigInt(feeAction.amount), recipient: feeAction.recipient })
     );
   }
+}
+
+// Sequencer accepts proofs for at most latest-10. We use latest-8 as the
+// proving block — proving takes ~4s which is less than 2 block times, so
+// the proof is still within the acceptance window when the tx arrives.
+const PROVING_BLOCK_DEPTH = 8;
+
+export async function waitForProvingBlock(
+  timeline: Timeline,
+  provider: RpcProvider,
+  lastTxBlockNumber: number | undefined
+): Promise<number> {
+  let latestBlock = await timeline.step("Get block number", () => provider.getBlockNumber());
+  if (lastTxBlockNumber !== undefined && lastTxBlockNumber >= latestBlock - PROVING_BLOCK_DEPTH) {
+    await timeline.step("Wait for blocks", async () => {
+      while (lastTxBlockNumber >= latestBlock - PROVING_BLOCK_DEPTH) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        latestBlock = await provider.getBlockNumber();
+      }
+    });
+  }
+  return latestBlock - PROVING_BLOCK_DEPTH;
 }
 
 async function buildProveSubmit(
@@ -51,50 +82,54 @@ async function buildProveSubmit(
   timeline: Timeline,
   userAccount: Account,
   provider: RpcProvider,
-  provingBlockId: number,
-): Promise<{ txHash: string; proofSizeBytes?: number }> {
+  lastTxBlockNumber: number | undefined
+): Promise<{ txHash: string; proofSizeBytes?: number; blockNumber: number }> {
   addFeeWithdraw(builder, feeAction);
 
+  const provingBlockId = await waitForProvingBlock(timeline, provider, lastTxBlockNumber);
+
   const invocation = await timeline.step("Build transaction", () =>
-    builder.createProofInvocation({ provingBlockId }),
+    builder.createProofInvocation({ provingBlockId })
   );
   const { callAndProof } = await timeline.step("Prove", () =>
-    transfers.executeWithInvocation(invocation, provingBlockId),
+    transfers.executeWithInvocation(invocation, provingBlockId)
   );
 
   let txHash: string;
   if (feeAction) {
-    txHash = (await timeline.step("Submit via paymaster", () =>
-      paymasterExecuteApplyAction(
-        config.paymasterUrl!,
-        toPaymasterCall(callAndProof.call),
-        callAndProof.proof.data,
-        callAndProof.proof.proofFacts,
-        getFeeMode(config),
-        config.avnuApiKey,
-      ),
-    )).transaction_hash;
+    txHash = (
+      await timeline.step("Submit via paymaster", () =>
+        paymasterExecuteApplyAction(
+          config.paymasterUrl!,
+          toPaymasterCall(callAndProof.call),
+          callAndProof.proof.data,
+          callAndProof.proof.proofFacts,
+          getFeeMode(config),
+          config.avnuApiKey
+        )
+      )
+    ).transaction_hash;
   } else {
     const proofDetails = callAndProof.proof.proofFacts?.length
       ? { proofFacts: callAndProof.proof.proofFacts, proof: callAndProof.proof.data }
       : {};
     // execute() estimates fee internally; splitting estimate+submit would double RPC calls
-    txHash = (await timeline.step("Estimate + submit", () =>
-      userAccount.execute(callAndProof.call, { tip: 0n, ...proofDetails }),
-    )).transaction_hash;
+    txHash = (
+      await timeline.step("Estimate + submit", () =>
+        userAccount.execute(callAndProof.call, { tip: 0n, ...proofDetails })
+      )
+    ).transaction_hash;
   }
 
-  await timeline.step("Wait for receipt", () =>
-    provider.waitForTransaction(txHash, WAIT_OPTIONS),
-  ).then((receipt) => {
-    if (!receipt.isSuccess())
-      throw new Error(`Transaction reverted: ${JSON.stringify(receipt)}`);
-  });
+  const receipt = await timeline.step("Wait for receipt", () =>
+    provider.waitForTransaction(txHash, WAIT_OPTIONS)
+  );
+  if (!receipt.isSuccess()) throw new Error(`Transaction reverted: ${JSON.stringify(receipt)}`);
 
   const proofSizeBytes = callAndProof.proof.data
     ? base64ByteLength(callAndProof.proof.data)
     : undefined;
-  return { txHash, proofSizeBytes };
+  return { txHash, proofSizeBytes, blockNumber: receipt.block_number };
 }
 
 export type TransactionStatus = {
@@ -114,7 +149,9 @@ export function useTransactions(
   config: AppConfig,
   accounts: AccountConfig[],
   onSettled: () => void,
-  onBalancesChanged?: () => Promise<void>,
+  onBalancesChanged: (() => Promise<void>) | undefined,
+  lastTxBlockNumberRef: RefObject<number | undefined>,
+  updateLastTxBlockNumber: (blockNumber: number) => void
 ) {
   const [status, setStatus] = useState<TransactionStatus>({
     pending: false,
@@ -144,9 +181,7 @@ export function useTransactions(
 
   const userAccount = useMemo(() => {
     if (!provider || !activeAddress) return undefined;
-    const accountConfig = accounts.find(
-      (a) => a.address === activeAddress,
-    );
+    const accountConfig = accounts.find((a) => a.address === activeAddress);
     if (!accountConfig) return undefined;
     return new Account({
       provider,
@@ -158,7 +193,7 @@ export function useTransactions(
 
   const decimalsByToken = useMemo(
     () => new Map(config.tokens.map((t) => [t.address, t.decimals])),
-    [config.tokens],
+    [config.tokens]
   );
 
   function scaleAmount(token: string, humanAmount: string): bigint {
@@ -167,11 +202,29 @@ export function useTransactions(
   }
 
   const execute = useCallback(
-    async (action: string, fn: (tl: Timeline) => Promise<{ txHash: string; proofSizeBytes?: number }>) => {
+    async (
+      action: string,
+      fn: (
+        tl: Timeline
+      ) => Promise<{ txHash: string; proofSizeBytes?: number; blockNumber?: number }>
+    ) => {
       const timeline = new Timeline();
-      setStatus({ pending: true, action, lastTxHash: null, lastError: null, proofSizeBytes: null, timeline });
+      timeline.onStepChange = (label) => {
+        setStatus((previous) => (previous.pending ? { ...previous, action: label } : previous));
+      };
+      setStatus({
+        pending: true,
+        action,
+        lastTxHash: null,
+        lastError: null,
+        proofSizeBytes: null,
+        timeline,
+      });
       try {
         const result = await timeline.step(action, () => fn(timeline));
+        if (result.blockNumber !== undefined) {
+          updateLastTxBlockNumber(result.blockNumber);
+        }
         setStatus({
           pending: false,
           action,
@@ -183,35 +236,47 @@ export function useTransactions(
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error(`[${action}] failed:`, err);
-        setStatus({ pending: false, action, lastTxHash: null, lastError: `${action}: ${message}`, proofSizeBytes: null, timeline });
+        setStatus({
+          pending: false,
+          action,
+          lastTxHash: null,
+          lastError: `${action}: ${message}`,
+          proofSizeBytes: null,
+          timeline,
+        });
       } finally {
         onSettledRef.current();
       }
     },
-    [],
+    [updateLastTxBlockNumber]
   );
 
   const register = useCallback(
     () =>
       execute("Register", async (tl) => {
-        if (!userAccount || !transfers || !provider)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider) throw new Error("Not ready");
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers.build().register();
-        return buildProveSubmit(builder, undefined, transfers, config, tl, userAccount, provider, provingBlockId);
+        return buildProveSubmit(
+          builder,
+          undefined,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, config, execute],
+    [userAccount, transfers, provider, config, execute, lastTxBlockNumberRef]
   );
 
   const mint = useCallback(
     (token: string, amount: string) =>
       execute("Mint", async (tl) => {
-        if (!adminAccount || !activeAddress || !provider)
-          throw new Error("Not ready");
+        if (!adminAccount || !activeAddress || !provider) throw new Error("Not ready");
         const rawAmount = scaleAmount(token, amount);
 
         const tokenConfig = config.tokens.find((t) => t.address === token);
@@ -222,24 +287,23 @@ export function useTransactions(
         };
 
         const tx = await tl.step("Estimate + submit", () =>
-          adminAccount.execute(mintCall, { tip: 0n }),
+          adminAccount.execute(mintCall, { tip: 0n })
         );
 
         await tl.step("Wait for receipt", () =>
-          provider.waitForTransaction(tx.transaction_hash, WAIT_OPTIONS),
+          provider.waitForTransaction(tx.transaction_hash, WAIT_OPTIONS)
         );
 
         if (onBalancesChangedRef.current) await onBalancesChangedRef.current();
         return { txHash: tx.transaction_hash };
       }),
-    [adminAccount, activeAddress, provider, execute],
+    [adminAccount, activeAddress, provider, execute]
   );
 
   const deposit = useCallback(
     (token: string, amount: string) =>
       execute("Deposit", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         const rawAmount = scaleAmount(token, amount);
 
         await tl.step("Approve", async () => {
@@ -249,16 +313,14 @@ export function useTransactions(
             calldata: [poolAddress, rawAmount.toString(), "0"],
           };
           const approveTx = await tl.step("Estimate + submit", () =>
-            userAccount.execute(approveCall, { tip: 0n }),
+            userAccount.execute(approveCall, { tip: 0n })
           );
           await tl.step("Wait for receipt", () =>
-            provider.waitForTransaction(approveTx.transaction_hash, WAIT_OPTIONS),
+            provider.waitForTransaction(approveTx.transaction_hash, WAIT_OPTIONS)
           );
         });
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -266,25 +328,38 @@ export function useTransactions(
             autoSetup: true,
             autoDiscover: { notes: "refresh", channels: "refresh" },
           })
-          .with(token, (t) =>
-            t.deposit({ amount: rawAmount, recipient: activeAddress }),
-          );
-        return buildProveSubmit(builder, undefined, transfers, config, tl, userAccount, provider, provingBlockId);
+          .with(token, (t) => t.deposit({ amount: rawAmount, recipient: activeAddress }));
+        return buildProveSubmit(
+          builder,
+          undefined,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   const withdraw = useCallback(
     (token: string, amount: string) =>
       execute("Withdraw", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         const rawAmount = scaleAmount(token, amount);
         const feeAction = await fetchPaymasterFee(config, tl, poolAddress);
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -292,25 +367,38 @@ export function useTransactions(
             autoSelectNotes: "naive",
           })
           .surplusTo(activeAddress)
-          .with(token, (t) =>
-            t.withdraw({ amount: rawAmount, recipient: activeAddress }),
-          );
-        return buildProveSubmit(builder, feeAction, transfers, config, tl, userAccount, provider, provingBlockId);
+          .with(token, (t) => t.withdraw({ amount: rawAmount, recipient: activeAddress }));
+        return buildProveSubmit(
+          builder,
+          feeAction,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   const transfer = useCallback(
     (token: string, recipient: string, amount: string) =>
       execute("Transfer", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         const rawAmount = scaleAmount(token, amount);
         const feeAction = await fetchPaymasterFee(config, tl, poolAddress);
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -319,32 +407,51 @@ export function useTransactions(
             autoSelectNotes: "naive",
           })
           .surplusTo(activeAddress)
-          .with(token, (t) =>
-            t.transfer({ recipient, amount: rawAmount }),
-          );
-        return buildProveSubmit(builder, feeAction, transfers, config, tl, userAccount, provider, provingBlockId);
+          .with(token, (t) => t.transfer({ recipient, amount: rawAmount }));
+        return buildProveSubmit(
+          builder,
+          feeAction,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   const swap = useCallback(
     (fromToken: string, toToken: string, amount: string) =>
       execute("Swap", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         if (!config.ekubo) throw new Error("Ekubo config not set");
         const rawAmount = scaleAmount(fromToken, amount);
 
         const {
-          executorAddress, routerAddress,
-          poolToken0, poolToken1, poolFee, tickSpacing, extension, skipAhead,
+          executorAddress,
+          routerAddress,
+          poolToken0,
+          poolToken1,
+          poolFee,
+          tickSpacing,
+          extension,
+          skipAhead,
         } = config.ekubo;
 
         const feeAction = await fetchPaymasterFee(config, tl, poolAddress);
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -369,39 +476,54 @@ export function useTransactions(
               calldata: [
                 routerAddress,
                 fromToken,
-                rawAmount,  // i129 mag
-                0n,         // i129 sign (positive = sell)
+                rawAmount, // i129 mag
+                0n, // i129 sign (positive = sell)
                 poolToken0,
                 poolToken1,
                 poolFee,
                 tickSpacing,
                 extension,
-                0n,         // minimum_received (low)
-                0n,         // minimum_received (high)
+                0n, // minimum_received (low)
+                0n, // minimum_received (high)
                 skipAhead,
                 openNote.noteId,
               ],
             };
           });
-        return buildProveSubmit(builder, feeAction, transfers, config, tl, userAccount, provider, provingBlockId);
+        return buildProveSubmit(
+          builder,
+          feeAction,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   const vesuSupply = useCallback(
     (token: string, vTokenAddress: string, amount: string) =>
       execute("Vesu Supply", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         if (!config.vesu) throw new Error("Vesu config not set");
         const rawAmount = scaleAmount(token, amount);
         const { helperAddress } = config.vesu;
 
         const feeAction = await fetchPaymasterFee(config, tl, poolAddress);
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -419,33 +541,48 @@ export function useTransactions(
           .invoke((args) => ({
             contractAddress: helperAddress,
             calldata: [
-              0n,           // LendingOperation::Deposit
-              token,        // in_token (underlying)
+              0n, // LendingOperation::Deposit
+              token, // in_token (underlying)
               vTokenAddress, // out_token (vToken)
-              rawAmount,    // assets (u256 low)
-              0n,           // assets (u256 high)
+              rawAmount, // assets (u256 low)
+              0n, // assets (u256 high)
               args.openNotes[0].noteId,
             ],
           }));
-        return buildProveSubmit(builder, feeAction, transfers, config, tl, userAccount, provider, provingBlockId);
+        return buildProveSubmit(
+          builder,
+          feeAction,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   const vesuWithdraw = useCallback(
     (token: string, vTokenAddress: string, amount: string) =>
       execute("Vesu Withdraw", async (tl) => {
-        if (!userAccount || !transfers || !provider || !activeAddress)
-          throw new Error("Not ready");
+        if (!userAccount || !transfers || !provider || !activeAddress) throw new Error("Not ready");
         if (!config.vesu) throw new Error("Vesu config not set");
         const rawAmount = scaleAmount(token, amount);
         const { helperAddress } = config.vesu;
 
         const feeAction = await fetchPaymasterFee(config, tl, poolAddress);
 
-        const provingBlockId = await tl.step("Get block number",
-          () => provider.getBlockNumber(),
-        ) - 10;
+        const lastTxBlockNumber = lastTxBlockNumberRef.current;
 
         const builder = transfers
           .build({
@@ -463,17 +600,35 @@ export function useTransactions(
           .invoke((args) => ({
             contractAddress: helperAddress,
             calldata: [
-              1n,           // LendingOperation::Withdraw
+              1n, // LendingOperation::Withdraw
               vTokenAddress, // in_token (vToken)
-              token,        // out_token (underlying)
-              rawAmount,    // assets (u256 low)
-              0n,           // assets (u256 high)
+              token, // out_token (underlying)
+              rawAmount, // assets (u256 low)
+              0n, // assets (u256 high)
               args.openNotes[0].noteId,
             ],
           }));
-        return buildProveSubmit(builder, feeAction, transfers, config, tl, userAccount, provider, provingBlockId);
+        return buildProveSubmit(
+          builder,
+          feeAction,
+          transfers,
+          config,
+          tl,
+          userAccount,
+          provider,
+          lastTxBlockNumber
+        );
       }),
-    [userAccount, transfers, provider, activeAddress, config, poolAddress, execute],
+    [
+      userAccount,
+      transfers,
+      provider,
+      activeAddress,
+      config,
+      poolAddress,
+      execute,
+      lastTxBlockNumberRef,
+    ]
   );
 
   return { status, register, mint, deposit, withdraw, transfer, swap, vesuSupply, vesuWithdraw };

--- a/demo/src/starknet.ts
+++ b/demo/src/starknet.ts
@@ -15,7 +15,7 @@ export function createDiscoveryProvider(
   poolAddress: string,
 ): InstanceType<typeof IndexerDiscoveryProvider> {
   if (config.ohttpEnabled === false) {
-    return new IndexerDiscoveryProvider(config.backendIndexerUrl ?? config.indexerUrl, poolAddress);
+    return new IndexerDiscoveryProvider(config.indexerUrl, poolAddress);
   }
   if (config.backendIndexerUrl) {
     return new IndexerDiscoveryProvider(config.backendIndexerUrl, poolAddress, {

--- a/demo/src/timeline.ts
+++ b/demo/src/timeline.ts
@@ -11,6 +11,7 @@ export class Timeline {
   readonly spans: Span[] = [];
   private stack: Span[] = [];
   private enriched = false;
+  onStepChange?: (label: string) => void;
 
   begin(label: string): void {
     const span: Span = { label, startMs: performance.now(), endMs: null, children: [] };
@@ -21,6 +22,7 @@ export class Timeline {
       this.spans.push(span);
     }
     this.stack.push(span);
+    this.onStepChange?.(label);
   }
 
   end(): void {


### PR DESCRIPTION
Fix proving block selection and add post-transaction UX improvements
Introduces a waitForProvingBlock helper that replaces the hardcoded latestBlock - 10 approach. The sequencer accepts proofs for at most latest - 10, so the new logic uses latest - 8 as the proving block floor and actively polls until the chain has advanced far enough past the last confirmed transaction's block number before building a proof. This prevents proof rejections when submitting back-to-back transactions.

A new useLastTxBlockNumber hook tracks the block number of the most recently confirmed privacy pool transaction per account. It initializes from history on first load, resets on account switch, and is updated after each successful transaction. Both useTransactions and useTransactionBuilder accept this ref and updater so every transaction path participates in the floor calculation.

The Timeline class gains an onStepChange callback, wired up in both transaction hooks so the status bar label updates live as each step begins rather than staying fixed at the initial action name.

History polling for the latest transaction now passes blockIdentifier: "pre_confirmed" and uses the current wall-clock time as the timestamp instead of fetching block metadata, making new entries appear immediately. Note and channel discovery also use pre_confirmed so balances reflect pending state. Balance rows and new history entries animate with a brief glow when they change.

The register action type is now handled in history classification with a display label and an action order entry, and the registry reset logic is moved to run before each refresh rather than only on account or pool change, preventing stale cursors from producing mixed data across account switches.

The Vercel deploy workflow is updated to pull preview environment variables but rename the file to .env.production.local and build with --prod, then deploy with --prebuilt --prod --skip-domain. This marks the artifact as production-target (enabling manual promotion from the Vercel UI) while keeping it at a preview URL until explicitly promoted. The scope parameter is set to avoid token scope fallback issues during vercel inspect.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" alt="Reviewable">](https://reviewable.io/reviews/starkware-libs/starknet-privacy/701)

<!-- Reviewable:end -->