### PR TITLE
docs(privacy): document audit gap on auditor key rotation

### DIFF
--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -666,7 +666,6 @@ pub trait IViews<T> {
     /// - (`felt252`): The auditor public key.
     fn get_auditor_public_key(self: @T) -> felt252;
 
-
     /// Returns the fee amount charged per `apply_actions` call.
     ///
     /// #### Parameters
@@ -718,6 +717,14 @@ pub trait IAdmin<T> {
     ///
     /// #### Access Control
     /// - Only token admin.
+    ///
+    /// #### Notes
+    /// - Rotating the auditor key creates a persistent audit gap:
+    /// `enc_private_key` is encrypted to the auditor key active at registration, so a new auditor
+    /// cannot derive channel keys for pre-rotation users and cannot decrypt their activity —
+    /// even activity occurring after the rotation. Full continuity requires out-of-band
+    /// coordination (e.g., the retiring auditor re-encrypting historical viewing keys to the
+    /// new auditor before rotation).
     fn set_auditor_public_key(ref self: T, auditor_public_key: felt252);
 
     /// Sets the fee amount in FRI per `apply_actions` call.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/703)
<!-- Reviewable:end -->
