### PR TITLE
feat: allow to run discovery for a specified block number or tag

### DIFF
--- a/crates/discovery-core/src/history/transactions.rs
+++ b/crates/discovery-core/src/history/transactions.rs
@@ -107,7 +107,7 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
         cursor.history_complete = false;
     }
 
-    result.sort_by(|a, b| b.block_number.cmp(&a.block_number));
+    result.sort_by_key(|tx| std::cmp::Reverse(tx.block_number));
 
     debug!(
         num_transactions = result.len(),

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -14,16 +14,26 @@ Async jobs remain an option for extreme backfills, but they introduce operationa
 
 ## 6.2 Block Reference Parameter
 
-All discovery methods accept a `block_ref` parameter (a block hash) to fix the head so that all requests within the current cursor "session" are queried against the same state. This block must have a block number greater than `last_synced_block`.
+All discovery methods accept a `block_ref` parameter — a block identifier that pins all storage reads to a specific chain state. It can be:
 
-The `block_ref` becomes the next sync's `last_synced_block`, reducing the search scope for future queries.
+- A **block hash**: `"0x..."` — pins reads to a specific confirmed block.
+- A **block number**: `12345` — pins reads to a specific block height.
+- A **block tag**: `"latest"`, `"pre_confirmed"`, `"l1_accepted"` — pins reads to a dynamic head.
+
+Clients may specify `block_ref` on any request, including the first. When omitted, the server resolves to the current head hash. Explicit values (hash, number, or tag) pass through to the RPC node as-is. On pagination, pass back the `block_ref` from the previous response to ensure consistent reads across pages.
+
+**Consistency guarantees:**
+- **Block hash**: Full consistency — all paginated reads are pinned to the exact same block state. Reorg detection via `last_known_block` works.
+- **Block number**: Best-effort — reads are pinned to a block height, but reorg detection does not apply.
+- **Block tag**: Best-effort — the underlying block may change between paginated requests. Suitable for one-shot queries.
+
+The hash-based `block_ref` from a completed sync becomes the next session's `last_known_block`, reducing the search scope for future queries. If the final `block_ref` is not a block hash, it cannot be used for reorg detection.
 
 **Validation rules:**
 
-- If `block_ref` is null, the service queries against the latest RPC head.
-- If `block_ref` references an unknown block, return error `BLOCK_NOT_FOUND`.
-- If `block_ref` references a block that has been reorged out, return error `BLOCK_REORGED`.
-- If `block_ref` block number is not greater than `last_synced_block` block number, return error `INVALID_BLOCK_RANGE`.
+- If `block_ref` is null, the server resolves to the current head hash.
+- If `block_ref` references an unknown block, the RPC call fails with an error.
+- `block_ref` is not validated for canonicity — that check is done via `last_known_block`.
 
 ## 6.3 Global Cursor Persistence
 
@@ -76,7 +86,7 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 - `recipient_address`: The recipient's on-chain address.
 - `viewing_key`: The recipient's private viewing key (used for server-side decryption). Validated against the on-chain public key for the given address.
 - `last_known_block`: Optional. Block hash from last completed sync session. Used for reorg detection on first request. Server returns `409 BLOCK_REORGED` if this block is no longer canonical. Leave empty on fresh syncs or pagination requests.
-- `block_ref`: Optional. Block hash to query state at. Ensures consistent reads across paginated requests. Leave empty on first request (server uses current head and sets it in response).
+- `block_ref`: Optional. Block identifier — a hex string (`"0x..."`), a block number (`12345`), or a tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Pins storage reads to a specific block. When omitted, the server uses the current head hash.
 - `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
 
 **Progress fields in cursor:**
@@ -121,7 +131,7 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 
 **Response fields:**
 
-- `block_ref`: Block hash pinning all reads. Pass back as `block_ref` in subsequent requests.
+- `block_ref`: Block identifier pinning all reads. Pass back as `block_ref` in subsequent requests.
 - `channels`: Discovered incoming channels (one per sender).
 - `subchannels`: Discovered incoming subchannels (one per sender×token pair).
 - `notes`: Discovered notes with sender and token context.
@@ -131,9 +141,9 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 
 **User flow:**
 
-1. **First request**: Send with `last_known_block` set to previous session's block hash (or empty if fresh sync).
+1. **First request**: Send with `last_known_block` set to previous session's block hash (or empty if fresh sync). Optionally include `block_ref` to pin reads to a specific block.
 2. **Pagination**: Pass back `block_ref` and `cursor` from response until complete.
-3. **Store for next session**: Save final `block_ref` as your `last_known_block`.
+3. **Store for next session**: If the final `block_ref` is a block hash, save it as your `last_known_block` for reorg detection. Block number or tag refs cannot be used for reorg detection.
 
 **Note filtering:** For each decrypted note, the service derives the nullifier and checks if it exists in contract state. Only unspent notes (those whose nullifier does not exist) are included in the response.
 
@@ -163,7 +173,7 @@ Uses the same `block_ref`/`last_known_block` reorg-detection pattern and composi
 - `sender_address`: The sender's on-chain address.
 - `viewing_key`: The sender's private viewing key (used for server-side decryption of outgoing channel data). Validated against the on-chain public key for the given address.
 - `last_known_block`: Optional. For reorg detection on first request of a new sync session.
-- `block_ref`: Optional. Block hash for consistent reads across paginated requests.
+- `block_ref`: Optional. Block identifier for consistent reads across requests. Can be specified on any request, including the first.
 - `cursor`: Composite `DiscoveryCursor` for pagination. Default (empty) on first request.
 - `recipients`: Optional. When set, only return channels for these recipient addresses.
 
@@ -191,7 +201,7 @@ Uses the same `block_ref`/`last_known_block` reorg-detection pattern and composi
 }
 ```
 
-- `block_ref`: Block hash pinning all reads. Pass back as `block_ref` in subsequent requests.
+- `block_ref`: Block identifier pinning all reads. Pass back as `block_ref` in subsequent requests.
 - `channels`: Discovered outgoing channels (one per recipient). `precomputed: true` for recipients requested via `recipients` filter that don't yet have an on-chain channel.
 - `subchannels`: Discovered subchannels (one per recipient×token pair). `last_note_index` is the last note index in the subchannel, or `null` if no notes exist.
 - `cursor`: Updated cursor for continuation.
@@ -233,7 +243,7 @@ A non-paginated readiness check that reports what on-chain setup exists for a `(
 }
 ```
 
-- `block_ref`: Block hash pinning the reads. Clients can use this for consistency.
+- `block_ref`: Block identifier pinning the reads. Clients can use this for consistency.
 - `sender_registered`: Whether the sender has a public key registered on-chain.
 - `channel_exists`: Whether the channel from sender to recipient exists. Always `false` if `sender_registered` is `false`.
 - `subchannel_exists`: Whether the token subchannel exists within the channel. Always `false` if `channel_exists` is `false`.
@@ -281,7 +291,7 @@ Retrieves paginated transaction history by scanning backward through note subcha
 - `user_address`: The user's on-chain address (used for withdrawal event filtering).
 - `max_transactions`: Maximum number of transactions to return per page. Capped by server `max_history_transactions` limit.
 - `last_known_block`: Optional. Block hash from last completed sync session. Used for reorg detection on first request.
-- `block_ref`: Optional. Block hash for consistent storage reads across paginated requests. Leave empty on first request.
+- `block_ref`: Optional. Block identifier for consistent storage reads across requests. Can be specified on any request, including the first.
 - `cursor`: History cursor for pagination.
   - `subchannels`: List of subchannels to scan. Each contains the `channel_key`, `token`, `channel_kind` (`incoming`, `outgoing`, `self_channel`), `counterparty` address, and `next_index` (next note index to read descending, `null` if exhausted).
   - `begin_block_number`: Inclusive upper bound for event queries. Set to `0` on first request (server resolves from chain head). On subsequent requests, use the value from the previous response cursor.
@@ -322,7 +332,7 @@ Retrieves paginated transaction history by scanning backward through note subcha
 }
 ```
 
-- `block_ref`: Block hash pinning all storage reads. Pass back as `block_ref` in subsequent requests.
+- `block_ref`: Block identifier pinning all storage reads. Pass back as `block_ref` in subsequent requests.
 - `transactions`: Transactions sorted by `block_number` descending. Each contains matched notes, deposits, withdrawals, and open note deposits from the same transaction.
 - `cursor`: Updated cursor for continuation. Pass back in next request.
 

--- a/crates/discovery-service/src/api/block_id_serde.rs
+++ b/crates/discovery-service/src/api/block_id_serde.rs
@@ -1,0 +1,216 @@
+//! Flat wire format for `BlockId`: `"0x..."` (hash), `123` (number),
+//! or `"latest"` / `"pre_confirmed"` / `"l1_accepted"` (tag).
+
+use serde::de::{self, Deserializer};
+use serde::ser::Serializer;
+use serde::Serialize;
+use starknet_core::types::{BlockId, BlockTag, Felt};
+
+pub fn serialize<S: Serializer>(id: &BlockId, serializer: S) -> Result<S::Ok, S::Error> {
+    match id {
+        BlockId::Hash(felt) => serializer.serialize_str(&format!("{felt:#x}")),
+        BlockId::Number(n) => serializer.serialize_u64(*n),
+        BlockId::Tag(tag) => tag.serialize(serializer),
+    }
+}
+
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<BlockId, D::Error> {
+    deserializer.deserialize_any(FlatBlockIdVisitor)
+}
+
+struct FlatBlockIdVisitor;
+
+impl<'de> de::Visitor<'de> for FlatBlockIdVisitor {
+    type Value = BlockId;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a hex string (\"0x...\"), an integer, or a block tag string")
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<BlockId, E> {
+        Ok(BlockId::Number(value))
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<BlockId, E> {
+        match value {
+            "latest" => Ok(BlockId::Tag(BlockTag::Latest)),
+            "pre_confirmed" => Ok(BlockId::Tag(BlockTag::PreConfirmed)),
+            "l1_accepted" => Ok(BlockId::Tag(BlockTag::L1Accepted)),
+            hex if hex.starts_with("0x") || hex.starts_with("0X") => Felt::from_hex(hex)
+                .map(BlockId::Hash)
+                .map_err(de::Error::custom),
+            other => Err(de::Error::custom(format!(
+                "unknown block tag or invalid hex: {other}"
+            ))),
+        }
+    }
+}
+
+/// For `Option<BlockId>` fields.
+pub mod option {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(
+        id: &Option<BlockId>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        match id {
+            Some(id) => super::serialize(id, serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<BlockId>, D::Error> {
+        struct OptionVisitor;
+
+        impl<'de> de::Visitor<'de> for OptionVisitor {
+            type Value = Option<BlockId>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("null, a hex string, an integer, or a block tag string")
+            }
+
+            fn visit_none<E: de::Error>(self) -> Result<Option<BlockId>, E> {
+                Ok(None)
+            }
+
+            fn visit_unit<E: de::Error>(self) -> Result<Option<BlockId>, E> {
+                Ok(None)
+            }
+
+            fn visit_some<D2: Deserializer<'de>>(
+                self,
+                deserializer: D2,
+            ) -> Result<Option<BlockId>, D2::Error> {
+                super::deserialize(deserializer).map(Some)
+            }
+
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Option<BlockId>, E> {
+                Ok(Some(BlockId::Number(value)))
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Option<BlockId>, E> {
+                FlatBlockIdVisitor.visit_str(value).map(Some)
+            }
+        }
+
+        deserializer.deserialize_any(OptionVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Required {
+        #[serde(with = "super")]
+        block_ref: BlockId,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Optional {
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            with = "super::option"
+        )]
+        block_ref: Option<BlockId>,
+    }
+
+    #[test]
+    fn round_trip_hash() {
+        let original = Required {
+            block_ref: BlockId::Hash(Felt::from_hex_unchecked("0xdeadbeef")),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":"0xdeadbeef"}"#);
+        let decoded: Required = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_number() {
+        let original = Required {
+            block_ref: BlockId::Number(42),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":42}"#);
+        let decoded: Required = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_latest() {
+        let original = Required {
+            block_ref: BlockId::Tag(BlockTag::Latest),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":"latest"}"#);
+        let decoded: Required = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_pre_confirmed() {
+        let original = Required {
+            block_ref: BlockId::Tag(BlockTag::PreConfirmed),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":"pre_confirmed"}"#);
+        let decoded: Required = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_l1_accepted() {
+        let original = Required {
+            block_ref: BlockId::Tag(BlockTag::L1Accepted),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":"l1_accepted"}"#);
+        let decoded: Required = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn option_none_omitted() {
+        let original = Optional { block_ref: None };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, "{}");
+        let decoded: Optional = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn option_some_round_trips() {
+        let original = Optional {
+            block_ref: Some(BlockId::Hash(Felt::from_hex_unchecked("0xabc"))),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        assert_eq!(json, r#"{"block_ref":"0xabc"}"#);
+        let decoded: Optional = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn option_null_is_none() {
+        let decoded: Optional = serde_json::from_str(r#"{"block_ref":null}"#).unwrap();
+        assert_eq!(decoded.block_ref, None);
+    }
+
+    #[test]
+    fn rejects_unknown_tag() {
+        let result = serde_json::from_str::<Required>(r#"{"block_ref":"bogus"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_hex() {
+        let result = serde_json::from_str::<Required>(r#"{"block_ref":"0xZZZ"}"#);
+        assert!(result.is_err());
+    }
+}

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -63,7 +63,7 @@ where
 
 /// Validated and resolved shared context for sync handlers.
 struct SyncContext<S> {
-    block_ref: Felt,
+    block_ref: BlockId,
     snapshot: S,
     budget: IoBudget,
     cursor_limits: CursorLimits,
@@ -89,7 +89,7 @@ where
 
     let snapshot = state
         .backend
-        .snapshot(base.contract_address, Some(BlockId::Hash(block_ref)))
+        .snapshot(base.contract_address, Some(block_ref))
         .await;
 
     validate_viewing_key(
@@ -139,7 +139,7 @@ where
 
     debug!(
         recipient = %format!("{:#x}", request.recipient_address),
-        block = %context.block_ref,
+        block = ?context.block_ref,
         "incoming_sync request"
     );
 
@@ -203,7 +203,7 @@ where
     debug!(
         sender = felt_hex(&request.sender_address),
         recipients = ?request.recipients.as_ref().map(|r| r.len()),
-        block = %context.block_ref,
+        block = ?context.block_ref,
         "outgoing_sync request"
     );
 
@@ -263,13 +263,11 @@ where
             ApiErrorResponse::new(error_codes::SERVICE_UNAVAILABLE, "No block indexed yet"),
         )
     })?;
+    let block_ref = BlockId::Hash(head.block_hash);
 
     let snapshot = state
         .backend
-        .snapshot(
-            request.contract_address,
-            Some(BlockId::Hash(head.block_hash)),
-        )
+        .snapshot(request.contract_address, Some(block_ref))
         .await;
 
     validate_viewing_key(
@@ -284,7 +282,7 @@ where
         sender = felt_hex(&request.sender_address),
         recipient = felt_hex(&request.recipient),
         token = felt_hex(&request.token),
-        block = %head.block_hash,
+        block = ?block_ref,
         "preflight_check request"
     );
 
@@ -299,7 +297,7 @@ where
     .map_err(crate::api::types::discovery_error_to_response)?;
 
     Ok(PreflightCheckResponse {
-        block_ref: head.block_hash,
+        block_ref,
         sender_registered: result.sender_registered,
         channel_exists: result.channel_exists,
         subchannel_exists: result.subchannel_exists,
@@ -340,7 +338,7 @@ where
 
     let snapshot = state
         .backend
-        .snapshot(request.contract_address, Some(BlockId::Hash(block_ref)))
+        .snapshot(request.contract_address, Some(block_ref))
         .await;
 
     let mut cursor = request.cursor;
@@ -359,7 +357,7 @@ where
 
     debug!(
         user = %format!("{:#x}", request.user_address),
-        block = %block_ref,
+        block = ?block_ref,
         num_subchannels = cursor.subchannels.len(),
         begin_block = cursor.begin_block_number,
         "history request"

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! Axum API server for the discovery service.
 
+pub mod block_id_serde;
 pub mod handlers;
 pub mod types;
 pub mod validators;

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -14,9 +14,10 @@ use discovery_core::privacy_pool::types::{secret_felt_serde, SecretFelt};
 use discovery_core::sync::incoming_state::IncomingSubchannel;
 use discovery_core::sync::outgoing_state::OutgoingSubchannel;
 use serde::{Deserialize, Serialize};
-use starknet_core::types::Felt;
+use starknet_core::types::{BlockId, Felt};
 use tracing::warn;
 
+use super::block_id_serde;
 use crate::chain_state::ChainHead;
 
 /// Response for the health endpoint.
@@ -152,11 +153,16 @@ pub struct SyncRequestBase {
     /// Leave empty on pagination requests or fresh syncs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_known_block: Option<Felt>,
-    /// Block hash to query state at. Ensures consistent reads across
-    /// paginated requests. Leave empty on first request (server uses
-    /// current head). On pagination, use the value from previous response.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub block_ref: Option<Felt>,
+    /// Block identifier to pin storage reads to. Can be a block hash, number,
+    /// or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). When omitted,
+    /// resolves to the current head hash. Explicit values pass through as-is.
+    /// Only a block hash guarantees consistent reads across paginated requests.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "block_id_serde::option"
+    )]
+    pub block_ref: Option<BlockId>,
     /// Discovery cursor for pagination. Use the cursor from previous
     /// response to continue discovery.
     #[serde(default)]
@@ -198,9 +204,10 @@ pub struct IncomingSyncRequest {
 /// Response body for POST /v1/sync/incoming_state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingSyncResponse {
-    /// Block hash pinning all reads in this response. Pass back as
+    /// Block identifier pinning all reads in this response. Pass back as
     /// `block_ref` in subsequent requests for consistency.
-    pub block_ref: Felt,
+    #[serde(with = "block_id_serde")]
+    pub block_ref: BlockId,
     /// Discovered incoming channels (one per sender).
     pub channels: Vec<IncomingChannel>,
     /// Discovered incoming subchannels (one per sender×token pair).
@@ -251,9 +258,10 @@ pub struct OutgoingSyncRequest {
 /// Response body for POST /v1/sync/outgoing_state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutgoingSyncResponse {
-    /// Block hash pinning all reads in this response. Pass back as
+    /// Block identifier pinning all reads in this response. Pass back as
     /// `block_ref` in subsequent requests for consistency.
-    pub block_ref: Felt,
+    #[serde(with = "block_id_serde")]
+    pub block_ref: BlockId,
     /// Discovered outgoing channels (one per recipient). Includes both
     /// on-chain channels (`precomputed: false`) and precomputed channels
     /// for requested recipients (`precomputed: true`).
@@ -289,8 +297,9 @@ pub struct PreflightCheckRequest {
 /// Response body for POST /v1/sync/preflight_check.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PreflightCheckResponse {
-    /// Block hash pinning the reads in this response.
-    pub block_ref: Felt,
+    /// Block identifier pinning the reads in this response.
+    #[serde(with = "block_id_serde")]
+    pub block_ref: BlockId,
     /// Whether the sender has a public key registered on-chain.
     pub sender_registered: bool,
     /// Whether the channel from sender to recipient exists.
@@ -312,10 +321,14 @@ pub struct HistoryRequest {
     /// on first request. Leave empty on fresh syncs or pagination requests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_known_block: Option<Felt>,
-    /// Block hash for consistent storage reads across paginated requests.
-    /// Leave empty on first request (server uses current head).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub block_ref: Option<Felt>,
+    /// Block identifier for storage reads. See [`SyncRequestBase::block_ref`]
+    /// for consistency semantics of hash vs number vs tag.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "block_id_serde::option"
+    )]
+    pub block_ref: Option<BlockId>,
     /// History cursor for pagination. Use the cursor from previous response
     /// to continue scanning.
     #[serde(default)]
@@ -325,8 +338,9 @@ pub struct HistoryRequest {
 /// Response body for POST /v1/history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryResponse {
-    /// Block hash pinning all storage reads.
-    pub block_ref: Felt,
+    /// Block identifier pinning all storage reads.
+    #[serde(with = "block_id_serde")]
+    pub block_ref: BlockId,
     /// History transactions for the current page.
     pub transactions: Vec<HistoryTransaction>,
     /// Updated cursor for continuation.

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -6,7 +6,7 @@ use axum::http::StatusCode;
 use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::history::types::HistoryCursor;
 use discovery_core::storage_backend::{StorageError, StorageSnapshot};
-use starknet_core::types::Felt;
+use starknet_core::types::{BlockId, Felt};
 use tracing::warn;
 
 use crate::api::types::{error_codes, ApiErrorResponse};
@@ -16,14 +16,14 @@ use crate::public_key_cache::PublicKeyCache;
 
 /// Validates block reference for sync endpoints.
 ///
-/// Performs the following:
-/// 1. Checks last_known_block hasn't been reorged (if provided)
-/// 2. Resolves block_ref (if provided) or uses current head
+/// 1. Checks `last_known_block` hasn't been reorged (if provided)
+/// 2. Explicit `block_ref` passes through as-is (hash, number, or tag)
+/// 3. When omitted, resolves to the current head hash for pagination consistency
 pub async fn validate_block_ref<B: ChainState>(
     last_known_block: Option<Felt>,
-    block_ref: Option<Felt>,
+    block_ref: Option<BlockId>,
     backend: &B,
-) -> Result<Felt, (StatusCode, ApiErrorResponse)> {
+) -> Result<BlockId, (StatusCode, ApiErrorResponse)> {
     // last_known_block is for first requests, block_ref is for pagination — never both.
     if last_known_block.is_some() && block_ref.is_some() {
         return Err((
@@ -61,28 +61,22 @@ pub async fn validate_block_ref<B: ChainState>(
         }
     }
 
-    // 2. Resolve query block
-    //
-    // If block_ref is specified, use it directly without validation.
-    // It's the client's responsibility to use a valid block_ref (typically
-    // from the cursor returned in a previous response). If invalid, the RPC
-    // call will fail and discovery will return an error.
-    let block_ref = if let Some(block_ref) = block_ref {
-        block_ref
-    } else {
-        let head = backend.get_head().await.ok_or_else(|| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                ApiErrorResponse::new(
-                    error_codes::SERVICE_UNAVAILABLE,
-                    "No indexed head available yet",
-                ),
-            )
-        })?;
-        head.block_hash
-    };
-
-    Ok(block_ref)
+    // 2. Explicit block_ref passes through; None resolves to head hash.
+    match block_ref {
+        Some(id) => Ok(id),
+        None => {
+            let head = backend.get_head().await.ok_or_else(|| {
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    ApiErrorResponse::new(
+                        error_codes::SERVICE_UNAVAILABLE,
+                        "No indexed head available yet",
+                    ),
+                )
+            })?;
+            Ok(BlockId::Hash(head.block_hash))
+        }
+    }
 }
 
 /// Rejects a value that exceeds an upper bound.
@@ -265,38 +259,15 @@ mod tests {
     use discovery_core::privacy_pool::types::SecretFelt;
 
     #[tokio::test]
-    async fn test_valid_request_uses_head_as_block_ref() {
+    async fn test_none_resolves_to_head_hash() {
         let backend = MockChainState::new();
 
         let block_ref = validate_block_ref(None, None, &backend).await.unwrap();
-        assert_ne!(block_ref, Felt::ZERO);
+        assert_eq!(block_ref, BlockId::Hash(Felt::from_hex_unchecked("0x123")));
     }
 
     #[tokio::test]
-    async fn test_block_ref_used_directly() {
-        let backend = MockChainState::new();
-
-        let block_ref = validate_block_ref(None, Some(Felt::from_hex_unchecked("0xabc")), &backend)
-            .await
-            .unwrap();
-        assert_eq!(block_ref, Felt::from_hex_unchecked("0xabc"));
-    }
-
-    #[tokio::test]
-    async fn test_block_reorged() {
-        let backend = MockChainState::new();
-
-        let result =
-            validate_block_ref(Some(Felt::from_hex_unchecked("0x999")), None, &backend).await;
-        assert!(result.is_err());
-
-        let (status, error) = result.unwrap_err();
-        assert_eq!(status, StatusCode::CONFLICT);
-        assert_eq!(error.error.code, error_codes::BLOCK_REORGED);
-    }
-
-    #[tokio::test]
-    async fn test_no_head_available_without_block_ref() {
+    async fn test_none_fails_without_head() {
         let backend = MockChainState::with_no_head();
 
         let result = validate_block_ref(None, None, &backend).await;
@@ -311,10 +282,27 @@ mod tests {
     async fn test_block_ref_works_without_head() {
         let backend = MockChainState::with_no_head();
 
-        let block_ref = validate_block_ref(None, Some(Felt::from_hex_unchecked("0xabc")), &backend)
-            .await
-            .unwrap();
-        assert_eq!(block_ref, Felt::from_hex_unchecked("0xabc"));
+        let block_ref = validate_block_ref(
+            None,
+            Some(BlockId::Hash(Felt::from_hex_unchecked("0xabc"))),
+            &backend,
+        )
+        .await
+        .unwrap();
+        assert_eq!(block_ref, BlockId::Hash(Felt::from_hex_unchecked("0xabc")));
+    }
+
+    #[tokio::test]
+    async fn test_block_reorged() {
+        let backend = MockChainState::new();
+
+        let result =
+            validate_block_ref(Some(Felt::from_hex_unchecked("0x999")), None, &backend).await;
+        assert!(result.is_err());
+
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(error.error.code, error_codes::BLOCK_REORGED);
     }
 
     #[tokio::test]
@@ -386,7 +374,7 @@ mod tests {
 
         let result = validate_block_ref(
             Some(Felt::from_hex_unchecked("0x111")),
-            Some(Felt::from_hex_unchecked("0x222")),
+            Some(BlockId::Hash(Felt::from_hex_unchecked("0x222"))),
             &backend,
         )
         .await;

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -14,7 +14,7 @@ use discovery_service::api::{
     HealthResponse, HistoryRequest, IncomingSyncRequest, OutgoingSyncRequest,
     PreflightCheckRequest, SyncRequestBase,
 };
-use starknet_core::types::Felt;
+use starknet_core::types::{BlockId, Felt};
 
 #[tokio::test]
 async fn test_health_endpoint_returns_ok() {
@@ -58,7 +58,10 @@ async fn test_incoming_sync_basic() {
     let response = indexer.incoming_sync(&request).await.unwrap();
 
     // block_ref is always present
-    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+    assert!(
+        matches!(response.block_ref, BlockId::Hash(_)),
+        "block_ref should be a block hash"
+    );
 
     // With a large budget, all discovery should complete
     assert!(
@@ -82,6 +85,50 @@ async fn test_incoming_sync_basic() {
     for subchannel in &response.subchannels {
         assert!(subchannel.token != Felt::ZERO, "Token should not be zero");
     }
+
+    indexer.signal_shutdown().unwrap();
+    indexer.wait().await.unwrap();
+}
+
+/// Verifies that sync works when the client pins reads to `pre_confirmed`.
+#[tokio::test]
+async fn test_incoming_sync_with_pre_confirmed_block_ref() {
+    let (devnet, metadata) = setup_devnet_with_dump().await;
+    let indexer = setup_indexer(&devnet, Some(&metadata)).await;
+
+    let request = IncomingSyncRequest {
+        recipient_address: metadata.alice_address,
+        base: SyncRequestBase {
+            contract_address: metadata.contract_address,
+            viewing_key: metadata.alice_viewing_key,
+            last_known_block: None,
+            block_ref: Some(BlockId::Tag(starknet_core::types::BlockTag::PreConfirmed)),
+            cursor: Default::default(),
+        },
+    };
+
+    let response = indexer.incoming_sync(&request).await.unwrap();
+
+    // Server passes the pre_confirmed tag through unchanged — it cannot
+    // be resolved to a stable block number or hash.
+    assert!(
+        matches!(
+            response.block_ref,
+            BlockId::Tag(starknet_core::types::BlockTag::PreConfirmed)
+        ),
+        "pre_confirmed tag should pass through unchanged, got {:?}",
+        response.block_ref
+    );
+
+    // Discovery should still complete and find Alice's notes
+    assert!(
+        response.cursor.is_complete(),
+        "Discovery should complete with pre_confirmed block_ref"
+    );
+    assert!(
+        !response.notes.is_empty(),
+        "Alice should have notes with pre_confirmed reads"
+    );
 
     indexer.signal_shutdown().unwrap();
     indexer.wait().await.unwrap();
@@ -193,8 +240,6 @@ async fn test_incoming_sync_no_head() {
     let (status, error) = indexer.incoming_sync_error(&request).await.unwrap();
 
     // Should return 503 SERVICE_UNAVAILABLE since no head is indexed yet
-    // (fresh devnet genesis block is pre-confirmed, so the RPC fallback
-    // returns None and the validator rejects with SERVICE_UNAVAILABLE)
     assert_eq!(status, 503);
     assert_eq!(error.error.code, "SERVICE_UNAVAILABLE");
 
@@ -246,7 +291,10 @@ async fn test_outgoing_sync_basic() {
 
     let response = indexer.outgoing_sync(&request).await.unwrap();
 
-    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+    assert!(
+        matches!(response.block_ref, BlockId::Hash(_)),
+        "block_ref should be a block hash"
+    );
 
     // Alice has 2 outgoing channels: self-channel (deposit) + Bob (transfer)
     assert_eq!(
@@ -352,7 +400,10 @@ async fn test_preflight_check_basic() {
     };
 
     let response = indexer.preflight_check(&request).await.unwrap();
-    assert!(response.block_ref != Felt::ZERO, "block_ref should be set");
+    assert!(
+        matches!(response.block_ref, BlockId::Hash(_)),
+        "block_ref should be a block hash"
+    );
     assert!(response.sender_registered, "Alice should be registered");
     assert!(response.channel_exists, "Alice→Bob channel should exist");
     assert!(
@@ -462,8 +513,8 @@ async fn test_history_basic() {
     let history_response = indexer.history(&history_request).await.unwrap();
 
     assert!(
-        history_response.block_ref != Felt::ZERO,
-        "block_ref should be set"
+        matches!(history_response.block_ref, BlockId::Hash(_)),
+        "block_ref should be a block hash"
     );
     assert!(
         !history_response.transactions.is_empty(),

--- a/e2e/tests/devnet/proving-block-id.test.ts
+++ b/e2e/tests/devnet/proving-block-id.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
+import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+
+describe("E2E provingBlockId", () => {
+  let devnet: Devnet;
+  let env: E2eTestEnv;
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await createE2eTestEnv(devnet);
+  });
+
+  afterAll(async () => {
+    await env?.indexer.shutdown();
+    await devnet?.cleanup();
+  });
+
+  it("discovery and prover respect provingBlockId", async () => {
+    const { env: de, transfers } = env;
+
+    // 1. Approve + deposit 100 STRK to Alice
+    await de.alice.execute({
+      contractAddress: de.strk,
+      entrypoint: "approve",
+      calldata: [de.privacy.address, 100n, 0n],
+    });
+
+    const { callAndProof: deposit1 } = await transfers.alice
+      .build({
+        autoRegister: true,
+        autoSetup: true,
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+      })
+      .with(de.strk)
+      .deposit({ amount: 100n })
+      .surplusTo(de.alice.address)
+      .execute();
+
+    await devnet.executeOutside(deposit1);
+    await env.indexer.waitForBlock(devnet.url);
+
+    // 2. Record current block number (after first deposit is confirmed)
+    const oldBlock = await de.provider.getBlockNumber();
+
+    // 3. Mine 10 empty blocks to advance the chain
+    for (let blockIndex = 0; blockIndex < 10; blockIndex++) {
+      await env.indexer.waitForBlock(devnet.url);
+    }
+
+    // 4. Approve + deposit 200 more STRK to Alice
+    await de.alice.execute({
+      contractAddress: de.strk,
+      entrypoint: "approve",
+      calldata: [de.privacy.address, 200n, 0n],
+    });
+
+    const { callAndProof: deposit2 } = await transfers.alice
+      .build({
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+      })
+      .with(de.strk)
+      .deposit({ amount: 200n })
+      .surplusTo(de.alice.address)
+      .execute();
+
+    await devnet.executeOutside(deposit2);
+    await env.indexer.waitForBlock(devnet.url);
+
+    // 5. Withdraw the 100 STRK from the first deposit using old block as provingBlockId.
+    //    Discovery at oldBlock should only see the 100 STRK note.
+    const { callAndProof: withdrawal } = await transfers.alice
+      .build({
+        autoSelectNotes: "naive",
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+        provingBlockId: oldBlock,
+      })
+      .with(de.strk)
+      .withdraw({ amount: 100n, recipient: de.alice.address })
+      .surplusTo(de.alice.address)
+      .execute();
+
+    await devnet.executeOutside(withdrawal);
+    await env.indexer.waitForBlock(devnet.url);
+
+    // 6. Discover notes at the latest state — Alice should still have the
+    //    200 STRK from the second deposit (which was invisible at oldBlock).
+    const { notes } = await transfers.alice.discoverNotes();
+    const strkNotes = notes.get(BigInt(de.strk));
+    expect(strkNotes).toBeDefined();
+    expect(strkNotes!.length).toBeGreaterThanOrEqual(1);
+
+    const totalPrivateBalance = strkNotes!.reduce(
+      (sum, note) => sum + note.amount,
+      0n,
+    );
+    expect(totalPrivateBalance).toBe(200n);
+  });
+});

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -8,6 +8,14 @@
 - `ProofInvocation` type now imports `INVOKE_TXN_V3` from `@starknet-io/starknet-types-0101` (was `@starknet-io/starknet-types-010`)
 - Removed `@starknet-io/starknet-types-09` direct dependency (now resolved transitively via starknet)
 - **Node.js >= 24** now required (due to `ohttp-ts` dependency using WebCrypto APIs)
+- `fetchHistory` `blockRef` option changed from `string` to `BlockIdentifier`
+- `HistoryPage.blockRef` changed from `string` to `BlockIdentifier`
+
+### Changed
+
+- `block_ref` in API models now accepts block hash (hex string), block number (integer), or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Wire format is backwards compatible — block hashes remain plain hex strings.
+- `discoverNotes` and `discoverChannels` accept optional `blockIdentifier` param to pin discovery reads to a specific block
+- Compiler passes `ExecuteOptions.provingBlockId` to discovery as `blockIdentifier`, ensuring discovery and proving use the same block state
 
 ### Added
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -328,15 +328,15 @@ const result = await transfers
   .execute();
 ```
 
-| Option            | Type                    | Description                                                                           |
-| ----------------- | ----------------------- | ------------------------------------------------------------------------------------- |
-| `autoRegister`    | `boolean`               | Automatically register if user has no viewing key on-chain                            |
-| `autoSetup`       | `boolean`               | Automatically open channels and token subchannels as needed                           |
-| `autoSelectNotes` | `"all" \| "naive"`      | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum) |
-| `autoDiscover`    | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`)        |
-| `registry`        | `PrivateRegistry`       | User's private state (channels, notes, cursor)                                        |
-| `registryConst`   | `boolean`               | If true, returns a new registry instead of mutating the provided one                  |
-| `provingBlockId`  | `ProvingBlockId`        | Block identifier to use for proving                                                   |
+| Option            | Type                    | Description                                                                                                                                                      |
+| ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoRegister`    | `boolean`               | Automatically register if user has no viewing key on-chain                                                                                                       |
+| `autoSetup`       | `boolean`               | Automatically open channels and token subchannels as needed                                                                                                      |
+| `autoSelectNotes` | `"all" \| "naive"`      | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum)                                                                            |
+| `autoDiscover`    | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`)                                                                                   |
+| `registry`        | `PrivateRegistry`       | User's private state (channels, notes, cursor)                                                                                                                   |
+| `registryConst`   | `boolean`               | If true, returns a new registry instead of mutating the provided one                                                                                             |
+| `provingBlockId`  | `ProvingBlockId`        | Block identifier for proving and discovery — pins both note/channel discovery and proof generation to the same block state. Can be a block hash, number, or tag. |
 
 ## Discovery
 
@@ -353,6 +353,7 @@ const requirement = await transfers.discoverRequirement(recipient, token);
 const { notes, timestamp } = await transfers.discoverNotes({
   tokens: [STRK],
   cursor: previousCursor,
+  blockIdentifier: 42, // optional: pin reads to a specific block
 });
 // notes: AddressMap<Note[]> — unspent notes keyed by token address
 ```
@@ -362,9 +363,22 @@ const { notes, timestamp } = await transfers.discoverNotes({
 ```typescript
 const { timestamp, channels, total } = await transfers.discoverChannels("all", {
   cursor: previousCursor,
+  blockIdentifier: "pre_confirmed", // optional: pin reads to a specific block
 });
 // channels: AddressMap<Channel> — channels keyed by recipient address
 ```
+
+### Block identifier consistency
+
+The optional `blockIdentifier` parameter pins storage reads to a specific block. Consistency guarantees depend on the type:
+
+| Type                         | Consistency                                                          | Reorg detection              |
+| ---------------------------- | -------------------------------------------------------------------- | ---------------------------- |
+| Block hash (`"0x..."`)       | Full — identical state across all paginated requests                 | Yes (via `last_known_block`) |
+| Block number (`42`)          | Stable height, but may reference a different branch after reorg      | No                           |
+| Block tag (`"latest"`, etc.) | Best-effort — underlying block may change between paginated requests | No                           |
+
+When `provingBlockId` is set in `ExecuteOptions`, the compiler automatically passes it as `blockIdentifier` to `discoverNotes` and `discoverChannels`, ensuring discovery and proving use the same block state.
 
 ### Transaction history
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -405,7 +405,11 @@ export interface PrivateTransfersInterface {
    * Discover unspent notes per token
    *
    */
-  discoverNotes(params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }): Promise<{
+  discoverNotes(params?: {
+    cursor?: NotesCursor;
+    tokens?: StarknetAddressBigint[];
+    blockIdentifier?: BlockIdentifier;
+  }): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
   }>;
@@ -415,7 +419,7 @@ export interface PrivateTransfersInterface {
    */
   discoverChannels(
     recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
 
   /**
@@ -649,7 +653,11 @@ export interface DiscoveryProviderInterface {
   discoverNotes(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }
+    params?: {
+      cursor?: NotesCursor;
+      tokens?: StarknetAddressBigint[];
+      blockIdentifier?: BlockIdentifier;
+    }
   ): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
@@ -664,7 +672,7 @@ export interface DiscoveryProviderInterface {
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
 
   /**

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -19,6 +19,7 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
       since?: BlockIdentifier;
       known?: AddressMap<Note[]>;
       tokens?: StarknetAddressBigint[];
+      blockIdentifier?: BlockIdentifier;
     }
   ): Promise<{
     timestamp: BlockIdentifier;
@@ -30,7 +31,7 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
 
   // Default implementation provided by the abstract class

--- a/sdk/src/internal/channel.ts
+++ b/sdk/src/internal/channel.ts
@@ -32,17 +32,17 @@ function assert(condition: unknown, message: () => string): asserts condition {
 }
 
 export type IncomingChannelCursor = {
-  /** @internal */ channelKey: ChannelKey;
-  /** @internal */ subchannelIdIndex: number;
-  /** @internal */ noteIndexes: AddressMap<number>; // token -> i
-  /** @internal */ totalNoteCounts: AddressMap<number>; // token -> total notes found by boundary finder
+  channelKey: ChannelKey;
+  subchannelIdIndex: number;
+  noteIndexes: AddressMap<number>; // token -> i
+  totalNoteCounts: AddressMap<number>; // token -> total notes found by boundary finder
 };
 
 export type NotesCursor = {
   /* when was this cursor valid */
-  /** @internal */ blockId: BlockIdentifier;
+  blockId: BlockIdentifier;
   /* per sender, a cursor to the subcahnels they opened and notes they created */
-  /** @internal */ incomingChannels: AddressMap<IncomingChannelCursor>; // sender -> cursor
+  incomingChannels: AddressMap<IncomingChannelCursor>; // sender -> cursor
 };
 
 export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
@@ -74,8 +74,8 @@ export function cloneNotesCursor(cursor?: NotesCursor): NotesCursor {
 export type RecipientsFilter<T = StarknetAddressBigint> = T[] | "all" | "total-only";
 
 export type ChannelCursor = {
-  /** @internal */ channels?: AddressMap<Channel>;
-  /** @internal */ total?: number;
+  channels?: AddressMap<Channel>;
+  total?: number;
 };
 export function cloneChannelCursor(cursor?: ChannelCursor): ChannelCursor {
   if (!cursor) {
@@ -102,9 +102,9 @@ type ChannelKey = bigint;
 
 /** Channel containing nonces for token and note creation. */
 export class Channel {
-  /** @internal */ readonly publicKey: PublicKey;
-  /** @internal */ key?: ChannelKey;
-  /** @internal */ readonly tokens: AddressMap<TokenChannel>; // for the next note for each token
+  readonly publicKey: PublicKey;
+  key?: ChannelKey;
+  readonly tokens: AddressMap<TokenChannel>; // for the next note for each token
 
   constructor(
     publicKey: PublicKey,
@@ -183,9 +183,9 @@ export const channelSerde: ChannelSerde = {
 
 /** Witness for a note, containing channel key and nonce. */
 export class Witness {
-  /** @internal */ readonly channelKey: ChannelKey;
-  /** @internal */ readonly nonce: number;
-  /** @internal */ readonly r: bigint;
+  readonly channelKey: ChannelKey;
+  readonly nonce: number;
+  readonly r: bigint;
 
   constructor(channelKey: ChannelKey, nonce: number, r: bigint) {
     this.channelKey = channelKey;

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -517,7 +517,8 @@ export class ActionCompiler {
     const { channels } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      recipientsToDiscover
+      recipientsToDiscover,
+      { blockIdentifier: options?.provingBlockId }
     );
 
     // see if all recipients were discoveredall
@@ -528,7 +529,8 @@ export class ActionCompiler {
     const { total } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
-      "total-only"
+      "total-only",
+      { blockIdentifier: options?.provingBlockId }
     );
 
     return { channels, total };
@@ -629,7 +631,11 @@ export class ActionCompiler {
         const { notes, cursor } = await this.discoveryProvider.discoverNotes(
           this.userAddress,
           this.userViewingKey,
-          { cursor: registry.cursor, tokens: tokensToDiscover }
+          {
+            cursor: registry.cursor,
+            tokens: tokensToDiscover,
+            blockIdentifier: options?.provingBlockId,
+          }
         );
 
         // Replace registry notes (don't merge - some may have been spent)

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -394,7 +394,11 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverNotes(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }
+    params?: {
+      cursor?: NotesCursor;
+      tokens?: StarknetAddressBigint[];
+      blockIdentifier?: BlockIdentifier;
+    }
   ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
     const discovery = new NotesDiscovery(
       address,
@@ -410,7 +414,7 @@ export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }> {
     const discovery = new ChannelsDiscovery(
       address,

--- a/sdk/src/internal/history.ts
+++ b/sdk/src/internal/history.ts
@@ -1,3 +1,4 @@
+import type { BlockIdentifier } from "starknet";
 import type { StarknetAddressBigint } from "../interfaces.js";
 import { toHex } from "../utils/convert.js";
 import type { NotesCursor, ChannelCursor } from "./channel.js";
@@ -61,7 +62,7 @@ export type HistoryTransaction = {
 };
 
 export type HistoryPage = {
-  blockRef: string;
+  blockRef: BlockIdentifier;
   transactions: HistoryTransaction[];
   cursor: HistoryCursor;
 };
@@ -122,7 +123,7 @@ type ApiHistoryTransaction = {
 };
 
 export type ApiHistoryResponse = {
-  block_ref: string;
+  block_ref: BlockIdentifier;
   transactions: ApiHistoryTransaction[];
   cursor: ApiHistoryCursor;
 };

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -81,7 +81,7 @@ type ApiOutgoingSubchannelInfo = {
 };
 
 type ApiIncomingSyncResponse = {
-  block_ref: string;
+  block_ref: BlockIdentifier;
   channels: ApiIncomingChannel[];
   subchannels: ApiIncomingSubchannelInfo[];
   notes: ApiIncomingNoteInfo[];
@@ -89,7 +89,7 @@ type ApiIncomingSyncResponse = {
 };
 
 type ApiOutgoingSyncResponse = {
-  block_ref: string;
+  block_ref: BlockIdentifier;
   channels: ApiOutgoingChannel[];
   subchannels: ApiOutgoingSubchannelInfo[];
   cursor: ApiDiscoveryCursor;
@@ -135,7 +135,11 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
   async discoverNotes(
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
-    params?: { cursor?: NotesCursor; tokens?: StarknetAddressBigint[] }
+    params?: {
+      cursor?: NotesCursor;
+      tokens?: StarknetAddressBigint[];
+      blockIdentifier?: BlockIdentifier;
+    }
   ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
     const tokenFilter = params?.tokens ? new Set(params.tokens.map((t) => toBigInt(t))) : null;
     const cursor = params?.cursor;
@@ -144,7 +148,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     // last_known_block is sent once on the first request for reorg detection.
     // block_ref (from the first response) pins subsequent pagination requests.
     const lastKnownBlock = cursor?.blockId as string | undefined;
-    let blockRef: string | undefined;
+    let blockRef: BlockIdentifier | undefined;
 
     const allNotes = new AddressMap<Note[]>(() => []);
     const incomingChannels = new AddressMap<IncomingChannelCursor>();
@@ -159,6 +163,8 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       };
       if (blockRef) {
         body.block_ref = blockRef;
+      } else if (params?.blockIdentifier !== undefined) {
+        body.block_ref = params.blockIdentifier;
       } else if (lastKnownBlock) {
         body.last_known_block = lastKnownBlock;
       }
@@ -199,10 +205,11 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     // suboptimal incremental updates — the next call re-scans already-discovered
     // (but now spent) note indices.
 
+    const blockIdentifier = blockRef!;
     return {
-      timestamp: blockRef!,
+      timestamp: blockIdentifier,
       notes: allNotes,
-      cursor: { blockId: blockRef!, incomingChannels },
+      cursor: { blockId: blockIdentifier, incomingChannels },
     };
   }
 
@@ -210,7 +217,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     address: StarknetAddressBigint,
     viewingKey: ViewingKey,
     recipients: RecipientsFilter,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{
     timestamp: BlockIdentifier;
     channels?: AddressMap<ChannelInterface>;
@@ -224,8 +231,14 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
         viewing_key: toHex(viewingKey),
         cursor: { channel_discovery_complete: false },
       };
+      if (params?.blockIdentifier !== undefined) {
+        body.block_ref = params.blockIdentifier;
+      }
       const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return { timestamp: resp.block_ref, total: resp.cursor.total_n_channels! };
+      return {
+        timestamp: resp.block_ref,
+        total: resp.cursor.total_n_channels!,
+      };
     }
 
     const cursorMap = params?.cursor?.channels;
@@ -275,7 +288,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       Map<string, { token: bigint; lastIndex: number | null }>
     >();
     const nonCreatedChannelMap = new Map<string, { publicKey: bigint; channelKey: bigint }>();
-    let blockRef: string | undefined;
+    let blockRef: BlockIdentifier | undefined;
 
     let complete = false;
     do {
@@ -287,6 +300,8 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       };
       if (blockRef) {
         body.block_ref = blockRef;
+      } else if (params?.blockIdentifier !== undefined) {
+        body.block_ref = params.blockIdentifier;
       }
       if (recipients !== "all") {
         body.recipients = recipients.map((r) => toHex(r));
@@ -356,7 +371,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     options?: {
       maxTransactions?: number;
       lastKnownBlock?: string;
-      blockRef?: string;
+      blockRef?: BlockIdentifier;
       /** Pass the cursor from a previous HistoryPage to continue pagination. */
       historyCursor?: HistoryCursor;
     }
@@ -369,7 +384,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       max_transactions: options?.maxTransactions ?? 50,
       cursor: historyCursorToApi(cursor),
     };
-    if (options?.blockRef) {
+    if (options?.blockRef !== undefined) {
       body.block_ref = options.blockRef;
     } else if (options?.lastKnownBlock) {
       body.last_known_block = options.lastKnownBlock;
@@ -470,7 +485,7 @@ export function notesCursorToApiCursor(
 /** Converts API cursor from an incoming sync response → SDK `NotesCursor`. */
 export function apiCursorToNotesCursor(
   apiCursor: ApiDiscoveryCursor,
-  blockRef: string
+  blockRef: BlockIdentifier
 ): NotesCursor {
   const incomingChannels = new AddressMap<IncomingChannelCursor>();
   if (apiCursor.channels) {

--- a/sdk/src/testing/mock-proving.ts
+++ b/sdk/src/testing/mock-proving.ts
@@ -5,7 +5,7 @@
  * to execute the invocation and capture the output.
  */
 
-import type { constants, ETransactionVersion3, ProviderInterface } from "starknet";
+import type { BlockIdentifier, constants, ETransactionVersion3, ProviderInterface } from "starknet";
 import { EDAMode, encode, hash, num, stark } from "starknet";
 import type { Proof, ProofInvocation, ProofProviderInterface } from "../interfaces.js";
 import { getDefaultProofDetails } from "../internal/proof-invocation-factory.js";
@@ -31,7 +31,7 @@ export class CallMockProofProvider implements ProofProviderInterface {
     return getDefaultProofDetails(this.chainId);
   }
 
-  async prove(invocation: ProofInvocation): Promise<Proof> {
+  async prove(invocation: ProofInvocation, blockIdentifier?: BlockIdentifier): Promise<Proof> {
     // Validate signature similar to how __execute__ does in the contract.
     // compile_actions skips this since view functions don't have tx_info.
     await this.validateSignature(invocation);
@@ -40,13 +40,19 @@ export class CallMockProofProvider implements ProofProviderInterface {
     // Layout: [1, to, selector, inner_len, ...inner_calldata]
     const executeViewCalldata = extractExecuteViewCalldata(invocation.calldata as string[]);
 
-    const result = await this.provider.callContract({
-      contractAddress: invocation.sender_address,
-      entrypoint: "compile_actions",
-      calldata: executeViewCalldata,
-    });
+    const result = await this.provider.callContract(
+      {
+        contractAddress: invocation.sender_address,
+        entrypoint: "compile_actions",
+        calldata: executeViewCalldata,
+      },
+      blockIdentifier
+    );
 
-    const poolClassHash = await this.provider.getClassHashAt(invocation.sender_address);
+    const poolClassHash = await this.provider.getClassHashAt(
+      invocation.sender_address,
+      blockIdentifier
+    );
 
     // Build proof facts for on-chain validation when provider supports getBlock (e.g. e2e with RpcProvider).
     // Blockifier requires base_block_number to be at least STORED_BLOCK_HASH_BUFFER blocks behind current.


### PR DESCRIPTION
## Summary

- Add `block_ref` parameter (block hash, number, or tag) to all discovery API endpoints, enabling clients to pin storage reads to a specific chain state
- Explicit block identifiers pass through to the RPC node as-is; when omitted, resolves to the current head hash for pagination consistency
- Custom flat wire format for `BlockId` — backwards compatible with existing clients that send hex strings
- Wire `provingBlockId` from `ExecuteOptions` through the compiler to discovery, so proving and discovery use the same block state

## Motivation

Clients need to pin discovery reads to specific blocks for two reasons:
1. **Proving at historical state** — discovery must see the same contract state the prover will verify against
2. **Pre-confirmed reads** — `pre_confirmed` blocks are tag-addressable only on Starknet nodes; resolving the tag to a block number breaks because pre-confirmed blocks live in memory only

## Wire format

Flat values, backwards compatible with the old hex-string-only format:
- `"0xabcdef..."` — block hash (hex string)
- `12345` — block number (integer)
- `"latest"` / `"pre_confirmed"` / `"l1_accepted"` — block tag (string)

## Consistency guarantees

| Type | Consistency | Reorg detection |
|------|------------|-----------------|
| Block hash | Full — identical state across all paginated requests | Yes |
| Block number | Stable height, may reference different branch after reorg | No |
| Block tag | Best-effort — underlying block may change between requests | No |

## Test plan

- [x] `cargo fmt --check -p discovery-service`
- [x] `cargo clippy -p discovery-service --all-targets` (0 warnings)
- [x] `cargo test -p discovery-service` (55 tests pass)
- [x] `cd sdk && npm run lint` (prettier, eslint, tsc)
- [x] `cd sdk && npm test` (208 tests pass)
- [x] `cd e2e && npm test -- devnet` (16 tests pass)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/705)
<!-- Reviewable:end -->
