### PR TITLE
feat(sdk): no optimistic in-place registry updates

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking
 
+- Removed `registryConst` option: the input registry is never mutated in-place; the result always contains an updated copy (new object)
+- `SimplePrivateTransfersInterface` no longer exposes a `registry` field; each call re-discovers state from chain
 - Switch `starknet` dependency from custom fork (`starkware-libs/starknet.js#PRIVACY-0.14.2-RC.2`) to official `starknet@10.0.0-beta.6`
 - `ProofInvocation` type now imports `INVOKE_TXN_V3` from `@starknet-io/starknet-types-0101` (was `@starknet-io/starknet-types-010`)
 - Removed `@starknet-io/starknet-types-09` direct dependency (now resolved transitively via starknet)
@@ -15,8 +17,14 @@
 ### Changed
 
 - `block_ref` in API models now accepts block hash (hex string), block number (integer), or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Wire format is backwards compatible — block hashes remain plain hex strings.
-- `discoverNotes` and `discoverChannels` accept optional `blockIdentifier` param to pin discovery reads to a specific block
+- `discoverNotes` params: dropped `since`, added `tokens` and `blockIdentifier`; full refresh by default (no cursor needed)
+- `discoverChannels` params: added `blockIdentifier`
 - Compiler passes `ExecuteOptions.provingBlockId` to discovery as `blockIdentifier`, ensuring discovery and proving use the same block state
+- Run channel and note discovery concurrently during transaction compilation to reduce latency
+- `ProofInvocationFactory` builds `INVOKE_TXN_V3` manually instead of using `RpcChannel.prototype.buildTransaction()` (removed in v10)
+- `ProvingService.proveTransaction()` parameter type changed from `INVOKE_TXN_V3` to `ProofInvocation` (same underlying type)
+- Fee withdrawals no longer prevent `transferSelf` (reorganization) detection
+- Fee withdrawals are excluded from incoming transfer actions (receiver doesn't see sender's fee)
 
 ### Added
 
@@ -31,21 +39,8 @@
   - Same relay/key-pinning options as `IndexerDiscoveryProvider`
   - Also available via `ProofProviderConfig.ohttp` in `createPrivateTransfers()` factory
 - Export `OhttpOption` type for reuse in consumer code
-
-### Added
-
 - `fee` action type in `classifyTransaction` for withdrawals to fee recipients (e.g. paymaster forwarder), distinct from regular withdrawals
 - `ClassifyOptions.feeRecipients` parameter on `classifyTransaction` to identify fee recipient addresses
-
-### Changed
-
-- Switch devnet testing from `ProvingServiceProofProvider` to `CallMockProofProvider` with `--proof-mode none` (proofFacts validated, proof ignored)
-- Run channel and note discovery concurrently during transaction compilation to reduce latency
-- `ProofInvocationFactory` builds `INVOKE_TXN_V3` manually instead of using `RpcChannel.prototype.buildTransaction()` (removed in v10)
-- `ProvingService.proveTransaction()` parameter type changed from `INVOKE_TXN_V3` to `ProofInvocation` (same underlying type)
-- Remove devnet `getStarknetVersion` monkey-patch and `declareWithoutVersionCheck` workaround (starknet.js#1561 resolved in v10)
-- Fee withdrawals no longer prevent `transferSelf` (reorganization) detection
-- Fee withdrawals are excluded from incoming transfer actions (receiver doesn't see sender's fee)
 
 ### Dependencies
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -4,21 +4,28 @@ TypeScript SDK for private transfers on Starknet.
 
 ## Publishing
 
-To publish a release:
+**1. Edit `package.json` version** (do not commit these changes):
 
-1. Bump `version` in `package.json` to the desired release version
-2. Authenticate with GitHub Packages:
-   ```sh
-   echo "//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN" >> ~/.npmrc
-   ```
-3. Build and publish:
-   ```sh
-   cd sdk
-   npm ci
-   npm run generate
-   npm run build
-   npm publish
-   ```
+- **Release**: use the target version as-is (e.g. `0.15.0`)
+- **Release candidate**: append `-rc.<n>` (e.g. `0.15.0-rc.1`)
+- **Dev release**: append `-dev.<short commit hash>` (e.g. `0.15.0-dev.a1b2c3d`) and add `"tag": "dev"` to the `publishConfig` section in `package.json`
+
+**2. Authenticate** with GitHub Packages:
+
+```sh
+echo "//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN" >> ~/.npmrc
+```
+
+**3. Build and publish:**
+
+```sh
+cd sdk
+npm ci
+npm run generate
+npm run build
+npm run build:browser
+npm publish
+```
 
 ## Prerequisites
 
@@ -64,6 +71,136 @@ const transfers = createPrivateTransfers({
   poolContractAddress,
 });
 ```
+
+## Typical workflows
+
+This section describes the recommended integration patterns. Each subsection gives one opinionated recipe — stick to it unless you have a specific reason to deviate.
+
+### State management: go stateless
+
+Do not persist `PrivateRegistry` between sessions. Rely on the default full-refresh discovery on every `execute()` call:
+
+```typescript
+const result = await transfers
+  .build({
+    autoDiscover: { notes: "refresh", channels: "refresh" },
+    autoSelectNotes: "naive",
+  })
+  .with(STRK)
+  .transfer({ recipient: bob, amount: 50n })
+  .surplusTo(self)
+  .execute();
+```
+
+No local state means no cursor drift, no reorg reconciliation, and no stale-channel bugs. The input registry is never mutated (see [Execute result](#execute-result)), so there is nothing to persist for correctness — `result.registry` is useful only for optimistic UI (see next subsection).
+
+**When to graduate.** Discovery becomes the UX bottleneck only past several thousand notes per account. At that point switch to incremental discovery by storing the `cursor` from the previous `discoverNotes` / `discoverChannels` response and passing it back on the next call (see [Discover notes](#discover-notes)). Incremental adds complexity — don't do it prematurely.
+
+### Speculative balances and history (`pre_confirmed`)
+
+For balance displays, history UI, and other read-only views where latency matters, pass `blockIdentifier: "pre_confirmed"` to `discoverNotes`, `discoverChannels`, and `fetchHistory`:
+
+```typescript
+const { notes } = await transfers.discoverNotes({
+  blockIdentifier: "pre_confirmed",
+});
+```
+
+`pre_confirmed` reads the node's speculative next-block state, so newly accepted transactions show up immediately rather than after `ACCEPTED_ON_L2`.
+
+**Precondition — the wallet must already handle reorgs on transparent balances.** If it does, `pre_confirmed` is a free latency win for private state too. If it doesn't, stay on `"latest"` until the wallet's reorg story is solid. Never prove against `pre_confirmed` — the prover requires finalized state (see next subsection).
+
+Caveats:
+
+- Speculative state may be reverted if the pre-confirmed block doesn't finalize.
+- Paginated discovery may see the underlying block advance between pages — fine for displaying a balance, not for building a transaction (use a block hash for that).
+- Pre-confirmed data can point at a branch that never gets finalized.
+
+**Alternative for a just-submitted tx: optimistic registry.** Every `execute()` returns a fresh registry copy reflecting the compiled actions. If the tx succeeds, use it directly and skip a discovery round-trip; replace it with fresh discovery before building the next tx.
+
+```typescript
+const result = await transfers.build(/* ... */).execute();
+const receipt = await provider.waitForTransaction(txHash);
+if (receipt.isSuccess()) {
+  // Use result.registry directly — no need to re-discover
+}
+```
+
+### Sequencing private transactions
+
+Two constraints govern when you can prove the next private transaction:
+
+1. **The prover reads finalized state, not `pre_confirmed`.** Your previous private tx's block must be finalized before you can prove the next one.
+2. **The sequencer accepts proofs whose `base_block` is at least 10 blocks older than the submission block.** The proving block must sit within the acceptance window when the transaction arrives.
+
+**Recipe:**
+
+1. After each accepted private tx, record `lastTxBlockNumber = receipt.block_number`.
+2. Before starting the next private tx, poll until `latestBlock - lastTxBlockNumber ≥ 10`.
+3. Prove at `latestBlock - 10` (or a couple of blocks earlier, see comment) and submit.
+4. Hide the wait behind a spinner — from the user's perspective the transaction just takes a bit longer.
+
+```typescript
+// Wait until the last tx block is finalized and old enough for the sequencer.
+// getBlockNumber() returns the latest finalized block, so this loop covers
+// both constraints: finalization and sequencer acceptance depth.
+let latestBlock = await provider.getBlockNumber();
+while (lastTxBlockNumber >= latestBlock - 10) {
+  await sleep(blockTime);
+  latestBlock = await provider.getBlockNumber();
+}
+
+// Prove at latest - 10 so the sequencer accepts it even after proving delay.
+// Optimization: use 8–9 instead of 10 — proving takes ~4s, which is less than
+// 1–2 block times, so the proof will still be within the window on arrival.
+const provingBlock = latestBlock - 10;
+const result = await transfers
+  .build({
+    autoDiscover: { notes: "refresh", channels: "refresh" },
+    autoSelectNotes: "naive",
+    provingBlockId: { block_number: provingBlock },
+  })
+  .with(STRK)
+  .transfer({ recipient: bob, amount: 50n })
+  .surplusTo(myAddress)
+  .execute();
+
+// Update tracking after the tx is accepted
+const receipt = await provider.waitForTransaction(txHash);
+lastTxBlockNumber = receipt.block_number;
+```
+
+The compiler forwards `provingBlockId` to discovery calls, ensuring the prover and discovery see the same contract state.
+
+### Sequencing after transparent state changes
+
+The same 10-block rule applies to **transparent** (non-private) transactions whose effects the pool will later need to prove against. Treat the receipt block of such a transaction exactly like `lastTxBlockNumber` in the previous recipe.
+
+Two concrete cases:
+
+- **Freshly deployed account → register.** You cannot call `register()` immediately after the account's deploy-account transaction. The prover must read the account's on-chain viewing-key slot at its base block; that slot only exists once the deploy is finalized. Wait ~10 blocks after the deploy receipt before registering.
+- **Freshly topped-up account → deposit.** You cannot `deposit()` tokens into the pool in the same block (or within ~10 blocks) of the ERC-20 transfer that funded the account. The prover reads the depositor's token balance at its base block; if the transfer hasn't propagated to that base block, the proof is invalid or the deposit fails on-chain due to insufficient balance.
+
+```typescript
+// After topping up the account with tokens, wait before depositing into the pool.
+const topupReceipt = await provider.waitForTransaction(topupTxHash);
+const topupBlock = topupReceipt.block_number;
+
+let latestBlock = await provider.getBlockNumber();
+while (topupBlock >= latestBlock - 10) {
+  await sleep(blockTime);
+  latestBlock = await provider.getBlockNumber();
+}
+
+// Safe to deposit now.
+const result = await transfers
+  .build({ autoDiscover: { notes: "refresh", channels: "refresh" } })
+  .with(STRK, (t) => t.deposit({ amount: 100n }))
+  .surplusTo(self)
+  .execute();
+```
+
+Rule of thumb: any on-chain state that the pool proof reads — account viewing key, depositor token balance, nullifier set — must have been written at least 10 blocks before the proof's base block.
 
 ## Configuration
 
@@ -328,15 +465,14 @@ const result = await transfers
   .execute();
 ```
 
-| Option            | Type                    | Description                                                                                                                                                      |
-| ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autoRegister`    | `boolean`               | Automatically register if user has no viewing key on-chain                                                                                                       |
-| `autoSetup`       | `boolean`               | Automatically open channels and token subchannels as needed                                                                                                      |
-| `autoSelectNotes` | `"all" \| "naive"`      | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum)                                                                            |
-| `autoDiscover`    | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`)                                                                                   |
-| `registry`        | `PrivateRegistry`       | User's private state (channels, notes, cursor)                                                                                                                   |
-| `registryConst`   | `boolean`               | If true, returns a new registry instead of mutating the provided one                                                                                             |
-| `provingBlockId`  | `ProvingBlockId`        | Block identifier for proving and discovery — pins both note/channel discovery and proof generation to the same block state. Can be a block hash, number, or tag. |
+| Option                   | Type                    | Description                                                                                                                                                      |
+| ------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoRegister`           | `boolean`               | Automatically register if user has no viewing key on-chain                                                                                                       |
+| `autoSetup`              | `boolean`               | Automatically open channels and token subchannels as needed                                                                                                      |
+| `autoSelectNotes`        | `"all" \| "naive"`      | Automatically select input notes (`"all"` uses every note, `"naive"` selects minimum)                                                                            |
+| `autoDiscover`           | `{ notes?, channels? }` | Refresh notes/channels before executing (`"missing"`, `"refresh"`, or `"all"`)                                                                                   |
+| `registry`               | `PrivateRegistry`       | User's private state (channels, notes, cursor). Read-only; never mutated                                                                                         |
+| `provingBlockId`         | `ProvingBlockId`        | Block identifier for proving and discovery — pins both note/channel discovery and proof generation to the same block state. Can be a block hash, number, or tag. |
 
 ## Discovery
 
@@ -350,20 +486,19 @@ const requirement = await transfers.discoverRequirement(recipient, token);
 ### Discover notes
 
 ```typescript
-const { notes, timestamp } = await transfers.discoverNotes({
-  tokens: [STRK],
-  cursor: previousCursor,
-  blockIdentifier: 42, // optional: pin reads to a specific block
+const { notes } = await transfers.discoverNotes({
+  blockIdentifier: "pre_confirmed",
 });
 // notes: AddressMap<Note[]> — unspent notes keyed by token address
 ```
 
+By default, discovery performs a full refresh (no cursor). This is simpler and more robust than incremental discovery — it avoids state management complexity and potential race conditions. Pass a `cursor` from a previous call only when optimizing for large note sets.
+
 ### Discover channels
 
 ```typescript
-const { timestamp, channels, total } = await transfers.discoverChannels("all", {
-  cursor: previousCursor,
-  blockIdentifier: "pre_confirmed", // optional: pin reads to a specific block
+const { channels, total } = await transfers.discoverChannels("all", {
+  blockIdentifier: "pre_confirmed",
 });
 // channels: AddressMap<Channel> — channels keyed by recipient address
 ```
@@ -431,12 +566,14 @@ Every `execute()` call returns:
 ```typescript
 type ExecuteResult = {
   callAndProof: CallAndProof; // Call + proof to send to the contract's execute_actions entry point
-  registry: PrivateRegistry; // Updated notes and recipient info
+  registry: PrivateRegistry; // Updated registry copy (new object, never the input reference)
   warnings: Warning[]; // Privacy leakage warnings
 };
 ```
 
-The wallet sends `callAndProof` in a transaction to the contract's `execute_actions` entry point. The returned `registry` can be reused in subsequent calls once the transaction is accepted and enough blocks have passed to make the state verifiable.
+The wallet sends `callAndProof` in a transaction to the contract's `execute_actions` entry point.
+
+The input `registry` is never mutated. The returned `registry` is always a new copy reflecting the compiled actions. It can be used for optimistic UI updates, but should be replaced with fresh discovery results once the transaction is accepted.
 
 ## Key types
 

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1567,9 +1567,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2006,14 +2006,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2054,9 +2054,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3007,16 +3007,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3826,9 +3826,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4004,10 +4004,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4581,9 +4584,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -289,10 +289,8 @@ export type ExecuteOptions = {
   autoSetup?: boolean;
   /** If defined, auto select notes from registry. **/
   autoSelectNotes?: AutoSelectionStrategy;
-  /** Registry for context/notes lookup. Updated during execute unless registryConst is true. */
+  /** Registry for context/notes lookup. Never mutated. */
   registry?: PrivateRegistry;
-  /** If true, registry is not mutated; a new one is returned instead */
-  registryConst?: boolean;
   /** If defined, use the given block id for proving */
   provingBlockId?: ProvingBlockId;
 };
@@ -310,7 +308,7 @@ export enum WarningCode {
  */
 export type ExecuteResult = {
   callAndProof: CallAndProof;
-  /** Updated registry (new object if registryConst was true, same object otherwise) */
+  /** Updated registry copy (always a new object, never the input reference) */
   registry: PrivateRegistry;
 
   warnings: Warning[];
@@ -327,8 +325,6 @@ export type ProofInvocationResult = {
  */
 export interface SimplePrivateTransfersInterface {
   readonly user: StarknetAddress;
-  readonly registry: PrivateRegistry;
-
   /**
    * deposit tokens into the privacy pool
    *

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -54,9 +54,16 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   }
 
   /**
-   * Discover unspent notes per token
+   * Discover unspent notes per token.
+   * By default performs a full refresh. Pass a cursor from a previous call for incremental discovery.
    */
-  async discoverNotes(params: { since?: BlockIdentifier; cursor?: NotesCursor } = {}): Promise<{
+  async discoverNotes(
+    params: {
+      cursor?: NotesCursor;
+      tokens?: StarknetAddressBigint[];
+      blockIdentifier?: BlockIdentifier;
+    } = {}
+  ): Promise<{
     timestamp: BlockIdentifier;
     notes: AddressMap<Note[]>;
   }> {
@@ -64,12 +71,12 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   }
 
   /**
-   * Discover channels for one or more recipients
+   * Discover channels for one or more recipients.
+   * By default performs a full refresh. Pass a cursor from a previous call for incremental discovery.
    */
-
   async discoverChannels(
     recipients: RecipientsFilter<StarknetAddress>,
-    params?: { cursor?: ChannelCursor }
+    params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }> {
     return this.discoveryProvider.discoverChannels(
       this.user,

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -97,21 +97,16 @@ export class ActionCompiler {
     } catch (e) {
       if (e instanceof ReorgError) {
         debugLog("compiler", "compile", "reorg detected", e);
-        // Reorg detected: clear stale registry state and retry from scratch.
-        if (options?.registry) {
-          options.registry.notes.clear();
-          options.registry.channels.clear();
-          delete options.registry.cursor;
-        }
-        return await this.compileOnce(actions, options);
+        // Reorg detected: retry with a clean registry so stale state is discarded.
+        const retryOptions = options ? { ...options, registry: createEmptyRegistry() } : options;
+        return await this.compileOnce(actions, retryOptions);
       }
       throw e;
     }
   }
 
   private async compileOnce(actions: Actions, options?: ExecuteOptions): Promise<CompileResult> {
-    const registry_ = options?.registry ?? createEmptyRegistry();
-    const registry = options?.registryConst ? this.cloneRegistry(registry_) : registry_;
+    const registry = this.cloneRegistry(options?.registry ?? createEmptyRegistry());
     const recipientsNeeded = this.getRecipientsNeeded(actions);
 
     // Resolve channels and notes concurrently (they are independent)
@@ -602,7 +597,6 @@ export class ActionCompiler {
     }
 
     const notesDiscoveryLevel = options?.autoDiscover?.notes;
-    // discover notes if requested
     if (notesDiscoveryLevel !== undefined) {
       const tokensToDiscover = (() => {
         if (notesDiscoveryLevel === "all") return undefined;
@@ -731,7 +725,7 @@ export class ActionCompiler {
       clonedNotes.set(addr, [...notes]);
     }
 
-    return { channels: clonedChannels, notes: clonedNotes };
+    return { channels: clonedChannels, notes: clonedNotes, cursor: registry.cursor };
   }
 
   private allOpen(

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -2,17 +2,13 @@ import {
   SimplePrivateTransfersInterface,
   PrivateTransfersInterface,
   Amount,
-  Channel,
-  Note,
   Open,
-  PrivateRegistry,
   StarknetAddress,
   All,
   ExecuteResult,
 } from "./interfaces.js"; // Assuming you moved interfaces
 import { toBigInt } from "./utils/convert.js";
 import { toHex } from "./utils/convert.js";
-import { AddressMap } from "./utils/maps.js";
 import { isAll } from "./utils/validation.js";
 
 export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterface {
@@ -21,11 +17,6 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
   get user(): StarknetAddress {
     return this.inner.user;
   }
-
-  readonly registry: PrivateRegistry = {
-    channels: new AddressMap<Channel>(),
-    notes: new AddressMap<Note[]>(),
-  };
 
   deposit(token: StarknetAddress, amount: Amount): Promise<ExecuteResult> {
     return this.build(token).deposit({ amount }).execute();
@@ -86,14 +77,11 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
   }
 
   private build(token: StarknetAddress) {
-    // Clear notes before refresh to avoid stale entries (already-spent notes)
-    this.registry.notes.clear();
     return this.inner
       .build({
         autoDiscover: { notes: "refresh", channels: "refresh" },
         autoSetup: true,
         autoSelectNotes: "all",
-        registry: this.registry,
       })
       .with(token);
   }

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 });
 
 describe("ActionCompiler reorg handling", () => {
-  it("clears registry and retries on ReorgError", async () => {
+  it("retries on ReorgError without mutating input registry", async () => {
     const mockProvider = createMockProvider({
       discoverChannels: vi
         .fn()
@@ -69,8 +69,9 @@ describe("ActionCompiler reorg handling", () => {
     );
 
     expect(mockProvider.discoverChannels).toHaveBeenCalledTimes(2);
-    // Stale note was cleared before the retry repopulated the registry
-    expect(registry.notes.has(TOKEN_ADDR)).toBe(false);
+    // Input registry is never mutated (immutability guarantee)
+    expect(registry.notes.has(TOKEN_ADDR)).toBe(true);
+    expect(registry.channels.has(RECIPIENT_ADDR)).toBe(true);
     expect(result.clientActions).toBeDefined();
   });
 

--- a/sdk/tests/internal/integration.test.ts
+++ b/sdk/tests/internal/integration.test.ts
@@ -63,7 +63,7 @@ describe("Private Transfers Integration", () => {
 
       // Alice: use note as input, transfer half to Bob, surplus to self, withdraw
       // prettier-ignore
-      mocknet.executeOutside(
+      const updatedRegistry = mocknet.executeOutside(
         await alice
           .build({ registry })
           .surplusTo(env.alice.address)
@@ -75,8 +75,8 @@ describe("Private Transfers Integration", () => {
       );
 
       // Alice should have 25n surplus note, Bob should have 50n note
-      const aliceNotes = registry.notes.get(ace) ?? [];
-      debugLog("test", "alice registry", registry);
+      const aliceNotes = updatedRegistry.notes.get(ace) ?? [];
+      debugLog("test", "alice registry", updatedRegistry);
       expect(aliceNotes.length).toBe(1);
       expect(aliceNotes[0].amount).toBe(25n);
 
@@ -139,7 +139,7 @@ describe("Private Transfers Integration", () => {
       expect(bobNotes.get(bee)?.[0].amount).toBe(50n);
     });
 
-    it("covers autoSelectNotes: all, autoDiscover: missing, registryConst, implicit surplus", async () => {
+    it("covers autoSelectNotes: all, autoDiscover: missing, immutable registry, implicit surplus", async () => {
       const { env, transfers } = testEnv;
       const { alice } = transfers;
       const ace = toBigInt(env.ace);
@@ -176,7 +176,6 @@ describe("Private Transfers Integration", () => {
 
       // Deposit 30n with:
       // - autoSelectNotes: "all" (sweeps ALL notes, not just enough for deficit)
-      // - registryConst: true (don't mutate channelOnly)
       // - autoDiscover: { notes: "missing" } (discover ACE notes since not in registry)
       // - surplusTo triggers the "sweeping" code path for discovery
       debugLog("test", "main");
@@ -184,7 +183,6 @@ describe("Private Transfers Integration", () => {
         await alice
           .build({
             registry: channelOnly,
-            registryConst: true,
             autoDiscover: { channels: "refresh", notes: "missing" },
             autoSelectNotes: "all",
             autoSetup: true,
@@ -200,7 +198,7 @@ describe("Private Transfers Integration", () => {
       expect(result.notes.get(ace)?.length).toBe(1);
       expect(result.notes.get(ace)?.[0].amount).toBe(180n);
 
-      // Verify registryConst: original registry unchanged
+      // Verify immutability: original registry unchanged (registry is never mutated)
       expect(channelOnly.notes.has(ace)).toBe(false);
 
       // Verify ERC20 balance


### PR DESCRIPTION
## Summary

- Replace `registryConst` flag with `previewRegistry` — inverted semantics: registry is now **never mutated** by default, and callers opt in to receiving an updated copy via `previewRegistry: true`
- Make `registry` field optional in `ExecuteResult`, `ProofInvocationResult`, and `CompileResult` — only present when `updateRegistry` was set
- Fix `cloneRegistry` dropping the `cursor` field, which forced unnecessary full re-discovery
- Fix reorg handler to stop mutating the input registry directly
- Adapt `SimplePrivateTransfersImpl` to capture returned registry after each operation

## Test plan

- [x] `npm run lint` passes (prettier, eslint, tsc)
- [x] `npm test` — 207/207 pass
- [x] Zero references to `registryConst` remain in codebase

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/706)
<!-- Reviewable:end -->
