### PR TITLE
feat: allow to fetch history up to a preconfirmed block

### DIFF
--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -79,6 +79,9 @@ pub enum DiscoveryError {
     /// The I/O budget is too small to make progress.
     #[error("insufficient budget: needed {needed}, available {available}")]
     InsufficientBudget { needed: usize, available: usize },
+    /// A computed cost exceeds `usize` (only reachable on 32-bit targets).
+    #[error("cost overflow: {0} exceeds usize")]
+    CostOverflow(u64),
     /// Expected event not found on-chain.
     #[error("missing event: {0}")]
     EventError(String),

--- a/crates/discovery-core/src/events_backend.rs
+++ b/crates/discovery-core/src/events_backend.rs
@@ -4,6 +4,7 @@
 //! access trait and a mock backend for testing.
 
 use async_trait::async_trait;
+use starknet_core::types::BlockId;
 pub use starknet_core::types::EmittedEvent;
 use starknet_types_core::felt::Felt;
 
@@ -12,7 +13,7 @@ use crate::storage_backend::StorageError;
 /// Low-level event access for reading contract events.
 #[async_trait]
 pub trait RawEventAccess: Send + Sync {
-    /// Fetches events matching the given key filters within a block range (inclusive).
+    /// Fetches events matching the given key filters within a block range.
     ///
     /// Each element of `keys` is a set of accepted values for that key position.
     /// An event matches if, for every non-empty filter, the event's key at that
@@ -20,17 +21,35 @@ pub trait RawEventAccess: Send + Sync {
     async fn get_events(
         &self,
         keys: &[Vec<Felt>],
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<EmittedEvent>, StorageError>;
+
+    /// Returns the `BlockId` this view is pinned to (number, hash, or tag).
+    ///
+    /// Use this for RPC queries that need to preserve tag semantics (e.g.
+    /// `Tag(PreConfirmed)` to include pre-confirmed events).
+    fn block_id(&self) -> BlockId;
+
+    /// Returns the concrete block number this view is pinned to.
+    ///
+    /// Resolved once at snapshot creation and stable thereafter. Used as an
+    /// upper-bound estimator for event-range cost accounting.
+    fn block_number(&self) -> u64;
 }
 
 #[cfg(test)]
 /// Mock event backend backed by an in-memory `Vec<EmittedEvent>`.
+///
+/// The mock pretends to be pinned to a fixed block number (`MOCK_BLOCK_NUMBER`)
+/// — large enough that all test ranges are valid against it.
 #[derive(Clone, Default)]
 pub struct MockEventBackend {
     events: Vec<EmittedEvent>,
 }
+
+#[cfg(test)]
+const MOCK_BLOCK_NUMBER: u64 = 1_000;
 
 #[cfg(test)]
 impl MockEventBackend {
@@ -49,16 +68,24 @@ impl RawEventAccess for MockEventBackend {
     async fn get_events(
         &self,
         keys: &[Vec<Felt>],
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<EmittedEvent>, StorageError> {
+        let from = match from_block {
+            BlockId::Number(n) => n,
+            _ => 0,
+        };
+        let to = match to_block {
+            BlockId::Number(n) => n,
+            _ => u64::MAX,
+        };
         Ok(self
             .events
             .iter()
             .filter(|event| {
                 let block = event.block_number.unwrap_or(0);
-                block >= from_block
-                    && block <= to_block
+                block >= from
+                    && block <= to
                     && keys.iter().enumerate().all(|(position, accepted)| {
                         accepted.is_empty()
                             || event
@@ -69,6 +96,14 @@ impl RawEventAccess for MockEventBackend {
             })
             .cloned()
             .collect())
+    }
+
+    fn block_id(&self) -> BlockId {
+        BlockId::Number(MOCK_BLOCK_NUMBER)
+    }
+
+    fn block_number(&self) -> u64 {
+        MOCK_BLOCK_NUMBER
     }
 }
 
@@ -102,7 +137,10 @@ mod tests {
     #[tokio::test]
     async fn empty_mock_returns_no_events() {
         let backend = MockEventBackend::empty();
-        let events = backend.get_events(&[], 0, 100).await.unwrap();
+        let events = backend
+            .get_events(&[], BlockId::Number(0), BlockId::Number(100))
+            .await
+            .unwrap();
         assert!(events.is_empty());
     }
 
@@ -114,7 +152,10 @@ mod tests {
             mock_event(25, Felt::from(0x3u64), vec![Felt::from(0xCu64)], vec![]),
         ]);
 
-        let events = backend.get_events(&[], 5, 15).await.unwrap();
+        let events = backend
+            .get_events(&[], BlockId::Number(5), BlockId::Number(15))
+            .await
+            .unwrap();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].block_number, Some(5));
         assert_eq!(events[1].block_number, Some(15));
@@ -133,7 +174,11 @@ mod tests {
 
         // Filter by selector_a at position 0
         let events = backend
-            .get_events(&[vec![selector_a]], 0, 100)
+            .get_events(
+                &[vec![selector_a]],
+                BlockId::Number(0),
+                BlockId::Number(100),
+            )
             .await
             .unwrap();
         assert_eq!(events.len(), 1);
@@ -141,7 +186,11 @@ mod tests {
 
         // Filter by user at position 1 (any selector)
         let events = backend
-            .get_events(&[vec![], vec![user]], 0, 100)
+            .get_events(
+                &[vec![], vec![user]],
+                BlockId::Number(0),
+                BlockId::Number(100),
+            )
             .await
             .unwrap();
         assert_eq!(events.len(), 2);

--- a/crates/discovery-core/src/history/notes.rs
+++ b/crates/discovery-core/src/history/notes.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_cursor(subchannels: Vec<HistorySubchannel>) -> HistoryCursor {
         HistoryCursor {
             subchannels,
-            begin_block_number: u64::MAX,
+            begin_block_number: Some(u64::MAX),
             history_complete: false,
         }
     }

--- a/crates/discovery-core/src/history/transactions.rs
+++ b/crates/discovery-core/src/history/transactions.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use starknet_core::types::{BlockId, BlockTag};
 use starknet_types_core::felt::Felt;
 use tracing::{debug, trace};
 
@@ -36,7 +37,8 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
 ) -> Result<Vec<HistoryTransaction>, DiscoveryError> {
     debug!(
         num_subchannels = cursor.subchannels.len(),
-        begin_block_number = cursor.begin_block_number,
+        begin_block_number = ?cursor.begin_block_number,
+        snapshot_block_id = ?backend.block_id(),
         budget_remaining = budget.remaining(),
         max_transactions,
         "history: starting fetch_transactions"
@@ -45,7 +47,6 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
     let mut note_scanner = BufferedNoteScanner::new();
     let mut transactions: HashMap<Felt, HistoryTransaction> = HashMap::new();
     let mut completed_blocks: HashSet<u64> = HashSet::new();
-    let mut previous_block_bound = cursor.begin_block_number;
     let mut budget_error: Option<DiscoveryError> = None;
     let mut scanner_complete = false;
 
@@ -61,14 +62,13 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
             &mut note_scanner,
             cursor,
             budget,
-            previous_block_bound,
             &mut transactions,
         )
         .await
         {
             Ok(Some(block_number)) => {
                 completed_blocks.insert(block_number);
-                previous_block_bound = block_number.saturating_sub(1);
+                cursor.begin_block_number = Some(block_number.saturating_sub(1));
             }
             Ok(None) => {
                 scanner_complete = true;
@@ -81,8 +81,6 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
             Err(e) => return Err(e),
         }
     }
-
-    cursor.begin_block_number = previous_block_bound;
 
     let mut result: Vec<HistoryTransaction> = transactions.into_values().collect();
     if !scanner_complete {
@@ -113,7 +111,7 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
         num_transactions = result.len(),
         history_complete = cursor.history_complete,
         budget_remaining = budget.remaining(),
-        begin_block_number = cursor.begin_block_number,
+        begin_block_number = ?cursor.begin_block_number,
         "history: fetch_transactions done"
     );
 
@@ -136,13 +134,31 @@ async fn process_next_block<B: IViews + IEvents>(
     note_scanner: &mut BufferedNoteScanner,
     cursor: &mut HistoryCursor,
     budget: &IoBudget,
-    previous_block_bound: u64,
     transactions: &mut HashMap<Felt, HistoryTransaction>,
 ) -> Result<Option<u64>, DiscoveryError> {
-    let Some((block_number, block_notes)) =
-        note_scanner.next_block(backend, cursor, budget).await?
-    else {
-        return Ok(None);
+    let previous_block_number = cursor
+        .begin_block_number
+        .unwrap_or_else(|| backend.block_number());
+
+    // Drop notes whose block sits *above* the cursor/snapshot upper bound.
+    // Both `cursor.begin_block_number` and the snapshot's `block_id` are
+    // user-controlled, so they may disagree with the actual on-chain block of a
+    // discovered note (stale cursor, malicious input, or chain drift). Skip
+    // silently and advance the scanner.
+    let (block_number, block_notes) = loop {
+        let Some((block_number, block_notes)) =
+            note_scanner.next_block(backend, cursor, budget).await?
+        else {
+            return Ok(None);
+        };
+        if block_number <= previous_block_number {
+            break (block_number, block_notes);
+        }
+        trace!(
+            block_number,
+            previous_block_number,
+            "history: skipping note above upper bound"
+        );
     };
 
     trace!(
@@ -162,18 +178,15 @@ async fn process_next_block<B: IViews + IEvents>(
     )
     .await?;
 
-    let withdrawal_range_start = block_number + 1;
-    if withdrawal_range_start <= previous_block_bound {
-        fetch_aggregated_withdrawal_events(
-            backend,
-            user_address,
-            withdrawal_range_start,
-            previous_block_bound,
-            budget,
-            transactions,
-        )
-        .await?;
-    }
+    fetch_aggregated_withdrawal_events(
+        backend,
+        user_address,
+        block_number + 1,
+        cursor.begin_block_number,
+        budget,
+        transactions,
+    )
+    .await?;
 
     Ok(Some(block_number))
 }
@@ -203,7 +216,22 @@ async fn fetch_aggregated_block_events<E: IEvents>(
 ) -> Result<(), DiscoveryError> {
     budget.try_consume(COST_BLOCK_EVENTS_QUERY)?;
 
-    let block_events = backend.get_block_events(block_number).await?;
+    let mut block_events = backend
+        .get_block_events(BlockId::Number(block_number))
+        .await?;
+
+    // If the by-number fetch returned nothing, the block may still be
+    // pre-confirmed (events only accessible by tag). Retry with the
+    // pre_confirmed tag.
+    if block_events.is_empty() {
+        debug!(
+            block_number,
+            "block_events: no events by number, retrying with pre_confirmed tag"
+        );
+        block_events = backend
+            .get_block_events(BlockId::Tag(BlockTag::PreConfirmed))
+            .await?;
+    }
 
     // Build note_id → tx_hash index from note creation events.
     let mut note_id_to_tx_hash: HashMap<Felt, Felt> = HashMap::new();
@@ -230,6 +258,12 @@ async fn fetch_aggregated_block_events<E: IEvents>(
                 .entry(transaction_hash)
                 .or_insert_with(|| HistoryTransaction::new(block_number, transaction_hash));
             tx.notes.push(note);
+        } else {
+            debug!(
+                note_id = %format!("{:#x}", note.note_id),
+                block_number,
+                "history: no matching event found for note"
+            );
         }
     }
 
@@ -272,31 +306,57 @@ async fn fetch_aggregated_block_events<E: IEvents>(
 /// already keyed on the querying account's address.
 ///
 /// Budget cost scales with the range size:
-/// `ceil(num_blocks / EVENTS_COST_CHUNK_SIZE) * COST_EVENTS_CHUNK`.
+/// `ceil((to_block_number + 1 - from_block_number) / EVENTS_COST_CHUNK_SIZE) * COST_EVENTS_CHUNK`,
+/// where `to_block_number` defaults to the snapshot's resolved `block_number`
+/// when the caller passes `None`. An empty range
+/// (`to_block_number < from_block_number`) is skipped without an RPC.
+///
+/// When `to_block_number` is `None` (first page of a fresh scan), the upper
+/// bound passed to the RPC is the snapshot's pinned `block_id` so any tag/hash
+/// semantics (e.g. `PreConfirmed`) are preserved.
 ///
 /// Returns `Err(InsufficientBudget)` if budget is insufficient (no work done).
 async fn fetch_aggregated_withdrawal_events<E: IEvents>(
     backend: &E,
     user_address: Felt,
-    from_block: u64,
-    to_block: u64,
+    from_block_number: u64,
+    to_block_number: Option<u64>,
     budget: &IoBudget,
     transactions: &mut HashMap<Felt, HistoryTransaction>,
 ) -> Result<(), DiscoveryError> {
-    let num_blocks = (to_block - from_block + 1) as usize;
-    let num_queries = num_blocks.div_ceil(EVENTS_COST_CHUNK_SIZE);
-    let cost = num_queries * COST_EVENTS_CHUNK;
+    let (to_block_number, to_block) = match to_block_number {
+        Some(n) => (n, BlockId::Number(n)),
+        None => (backend.block_number(), backend.block_id()),
+    };
+
+    // Empty / inverted range — `from_block_number` is `block_number + 1` of the
+    // last processed note, so the gap can be empty for adjacent note blocks
+    // (normal) or for a stale/inconsistent cursor (`to_block_number` below the
+    // scanner's actual blocks). Either way, skip the RPC.
+    if to_block_number < from_block_number {
+        trace!(
+            from_block_number,
+            to_block_number,
+            "withdrawal_events: empty range, skipping RPC"
+        );
+        return Ok(());
+    }
+
+    let num_blocks = to_block_number - from_block_number + 1;
+    let cost_u64 = num_blocks.div_ceil(EVENTS_COST_CHUNK_SIZE as u64) * COST_EVENTS_CHUNK as u64;
+    let cost: usize = cost_u64
+        .try_into()
+        .map_err(|_| DiscoveryError::CostOverflow(cost_u64))?;
 
     budget.try_consume(cost)?;
 
     let events = backend
-        .get_withdrawal_events(user_address, from_block, to_block)
+        .get_withdrawal_events(user_address, BlockId::Number(from_block_number), to_block)
         .await?;
 
     trace!(
-        from_block,
-        to_block,
-        num_blocks,
+        from_block_number,
+        to_block = ?to_block,
         num_withdrawal_events = events.len(),
         "withdrawal_events: fetched"
     );
@@ -331,22 +391,23 @@ async fn fetch_registration<B: IViews + IEvents>(
     if storage_result.last_update_block == 0 {
         return Ok(None);
     }
-    let block = storage_result.last_update_block;
+    let block_number = storage_result.last_update_block;
 
     budget.try_consume(COST_EVENTS_CHUNK)?;
+    let block_id = BlockId::Number(block_number);
     let events = backend
-        .get_viewing_key_set_events(user_address, block, block)
+        .get_viewing_key_set_events(user_address, block_id, block_id)
         .await?;
     let transaction_hash = events
         .first()
         .map(|event| event.transaction_hash)
         .ok_or_else(|| {
             DiscoveryError::EventError(format!(
-                "ViewingKeySet event not found at block {block} for user {user_address:#x}"
+                "ViewingKeySet event not found at block {block_number} for user {user_address:#x}"
             ))
         })?;
 
-    let mut registration = HistoryTransaction::new(block, transaction_hash);
+    let mut registration = HistoryTransaction::new(block_number, transaction_hash);
     registration.registered_pubkey = Some(storage_result.value);
     Ok(Some(registration))
 }
@@ -354,6 +415,7 @@ async fn fetch_registration<B: IViews + IEvents>(
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use starknet_core::types::BlockId;
     use starknet_core::utils::starknet_keccak;
 
     use super::*;
@@ -480,10 +542,18 @@ mod tests {
         async fn get_events(
             &self,
             keys: &[Vec<Felt>],
-            from_block: u64,
-            to_block: u64,
+            from_block: BlockId,
+            to_block: BlockId,
         ) -> Result<Vec<EmittedEvent>, StorageError> {
             self.events.get_events(keys, from_block, to_block).await
+        }
+
+        fn block_id(&self) -> BlockId {
+            RawEventAccess::block_id(&self.events)
+        }
+
+        fn block_number(&self) -> u64 {
+            RawEventAccess::block_number(&self.events)
         }
     }
 
@@ -555,7 +625,7 @@ mod tests {
                     counterparty: Felt::from_hex_unchecked("0xBEEF"),
                     next_index: last_index,
                 }],
-                begin_block_number: 100,
+                begin_block_number: Some(100),
                 history_complete: false,
             };
             (backend, cursor)
@@ -789,9 +859,16 @@ mod tests {
         let budget = IoBudget::new(100);
         let mut transactions = HashMap::new();
 
-        fetch_aggregated_withdrawal_events(&backend, ADDRESS, 10, 25, &budget, &mut transactions)
-            .await
-            .unwrap();
+        fetch_aggregated_withdrawal_events(
+            &backend,
+            ADDRESS,
+            10,
+            Some(25),
+            &budget,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(transactions.len(), 2);
     }
@@ -802,9 +879,16 @@ mod tests {
         let budget = IoBudget::new(100);
         let mut transactions = HashMap::new();
 
-        fetch_aggregated_withdrawal_events(&backend, ADDRESS, 10, 25, &budget, &mut transactions)
-            .await
-            .unwrap();
+        fetch_aggregated_withdrawal_events(
+            &backend,
+            ADDRESS,
+            10,
+            Some(25),
+            &budget,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
 
         assert!(transactions.is_empty());
     }
@@ -819,7 +903,7 @@ mod tests {
             &backend,
             ADDRESS,
             10,
-            25,
+            Some(25),
             &budget,
             &mut transactions,
         )
@@ -833,6 +917,70 @@ mod tests {
         assert!(transactions.is_empty());
     }
 
+    #[tokio::test]
+    async fn withdrawal_events_first_page_cost_uses_to_block_number() {
+        // Range is [0, 1024] → 1025 blocks → 2 chunks of 1024 → cost = 20.
+        // The first-page flag is independent: it controls only the BlockId
+        // passed to the RPC (snapshot's pinned block_id vs. concrete number).
+        let backend = MockEventBackend::empty();
+        let budget = IoBudget::new(COST_EVENTS_CHUNK * 2);
+        let mut transactions = HashMap::new();
+
+        fetch_aggregated_withdrawal_events(
+            &backend,
+            ADDRESS,
+            0,
+            Some(1024),
+            &budget,
+            &mut transactions,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(budget.remaining(), 0);
+
+        // One less and the call must fail with a legitimate (small) `needed`.
+        let tight_budget = IoBudget::new(COST_EVENTS_CHUNK * 2 - 1);
+        let error = fetch_aggregated_withdrawal_events(
+            &backend,
+            ADDRESS,
+            0,
+            Some(1024),
+            &tight_budget,
+            &mut HashMap::new(),
+        )
+        .await
+        .unwrap_err();
+        match error {
+            DiscoveryError::InsufficientBudget { needed, available } => {
+                assert_eq!(needed, COST_EVENTS_CHUNK * 2);
+                assert_eq!(available, COST_EVENTS_CHUNK * 2 - 1);
+            }
+            other => panic!("expected InsufficientBudget, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_transactions_skips_notes_above_cursor_upper_bound() {
+        // Regression: stale/malicious cursor with begin_block_number below the
+        // scanner's first emitted note block used to trigger a u64 underflow
+        // in the withdrawal-event cost calc, producing `needed ≈ 1.8e17`.
+        // Now such notes are skipped silently.
+        let (backend, mut cursor) = FixtureBuilder::new()
+            .note(0, 100, TX_HASH_1)
+            .deposit(50, 100, TX_HASH_1)
+            .build(Some(0));
+        cursor.begin_block_number = Some(10); // below the note's block (100)
+
+        let budget = IoBudget::new(1_000);
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &budget)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty(), "note above upper bound must be skipped");
+        assert!(cursor.history_complete);
+    }
+
     // -- fetch_transactions tests --
 
     #[tokio::test]
@@ -843,7 +991,7 @@ mod tests {
         };
         let mut cursor = HistoryCursor {
             subchannels: vec![],
-            begin_block_number: 100,
+            begin_block_number: Some(100),
             history_complete: false,
         };
 
@@ -984,13 +1132,13 @@ mod tests {
     #[tokio::test]
     async fn cursor_state_after_full_scan() {
         let (backend, mut cursor) = FixtureBuilder::new().note(0, 10, TX_HASH_1).build(Some(0));
-        assert_eq!(cursor.begin_block_number, 100);
+        assert_eq!(cursor.begin_block_number, Some(100));
 
         fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
             .await
             .unwrap();
 
-        assert_eq!(cursor.begin_block_number, 9);
+        assert_eq!(cursor.begin_block_number, Some(9));
         assert!(cursor.history_complete);
     }
 

--- a/crates/discovery-core/src/history/types.rs
+++ b/crates/discovery-core/src/history/types.rs
@@ -77,9 +77,10 @@ pub struct HistorySubchannel {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HistoryCursor {
     pub subchannels: Vec<HistorySubchannel>,
-    /// Inclusive upper bound for event queries — the block where backward scanning begins.
-    /// Typically set to the latest confirmed block when the scan starts.
-    pub begin_block_number: u64,
+    /// Inclusive upper bound for event queries (block number). `None` on the
+    /// first page — the caller provides the upper bound separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub begin_block_number: Option<u64>,
     /// `true` = all subchannels exhausted, no more history.
     /// `false` = stopped due to budget or max_transactions limit.
     pub history_complete: bool,

--- a/crates/discovery-core/src/privacy_pool/events.rs
+++ b/crates/discovery-core/src/privacy_pool/events.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use starknet_core::types::BlockId;
 use starknet_core::utils::starknet_keccak;
 use starknet_types_core::felt::Felt;
 
@@ -95,33 +96,33 @@ pub enum PrivacyPoolEventContent {
 #[async_trait]
 pub trait IEvents: Send + Sync {
     /// Fetches all privacy pool events in a single block.
-    ///
-    /// Parses all known event types (Deposit, Withdrawal, EncNoteCreated, OpenNoteDeposited).
-    /// Unknown selectors are silently skipped. Malformed known events return an error.
-    async fn get_block_events(
-        &self,
-        block_number: u64,
-    ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+    async fn get_block_events(&self, block: BlockId)
+        -> Result<Vec<PrivacyPoolEvent>, StorageError>;
 
-    /// Fetches `Withdrawal` events for the given address within a block range (inclusive).
-    ///
-    /// The address matches the recipient (key position 1 in `Withdrawal`).
+    /// Fetches `Withdrawal` events for the given address within a block range.
     async fn get_withdrawal_events(
         &self,
         address: Felt,
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
 
-    /// Fetches `ViewingKeySet` events for the given user within a block range (inclusive).
-    ///
-    /// The address matches the user (key position 1 in `ViewingKeySet`).
+    /// Fetches `ViewingKeySet` events for the given user within a block range.
     async fn get_viewing_key_set_events(
         &self,
         user_address: Felt,
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError>;
+
+    /// Returns the `BlockId` this view is pinned to (number, hash, or tag).
+    fn block_id(&self) -> BlockId;
+
+    /// Returns the concrete block number this view is pinned to.
+    ///
+    /// Resolved once at snapshot creation and stable thereafter. Used as an
+    /// upper-bound estimator for event-range cost accounting.
+    fn block_number(&self) -> u64;
 }
 
 /// Reason a raw event could not be converted to a typed event.
@@ -221,7 +222,7 @@ fn parse_events(raw_events: Vec<EmittedEvent>) -> Result<Vec<PrivacyPoolEvent>, 
 impl<T: RawEventAccess> IEvents for T {
     async fn get_block_events(
         &self,
-        block_number: u64,
+        block: BlockId,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
         let selectors = vec![
             *DEPOSIT_SELECTOR,
@@ -229,17 +230,15 @@ impl<T: RawEventAccess> IEvents for T {
             *ENC_NOTE_CREATED_SELECTOR,
             *OPEN_NOTE_DEPOSITED_SELECTOR,
         ];
-        let raw_events = self
-            .get_events(&[selectors], block_number, block_number)
-            .await?;
+        let raw_events = self.get_events(&[selectors], block, block).await?;
         parse_events(raw_events)
     }
 
     async fn get_withdrawal_events(
         &self,
         address: Felt,
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
         let raw_events = self
             .get_events(
@@ -254,8 +253,8 @@ impl<T: RawEventAccess> IEvents for T {
     async fn get_viewing_key_set_events(
         &self,
         user_address: Felt,
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<PrivacyPoolEvent>, StorageError> {
         let raw_events = self
             .get_events(
@@ -265,6 +264,14 @@ impl<T: RawEventAccess> IEvents for T {
             )
             .await?;
         parse_events(raw_events)
+    }
+
+    fn block_id(&self) -> BlockId {
+        RawEventAccess::block_id(self)
+    }
+
+    fn block_number(&self) -> u64 {
+        RawEventAccess::block_number(self)
     }
 }
 
@@ -327,7 +334,7 @@ mod tests {
             ),
         ]);
 
-        let events = backend.get_block_events(10).await.unwrap();
+        let events = backend.get_block_events(BlockId::Number(10)).await.unwrap();
         assert_eq!(events.len(), 3);
         assert!(matches!(
             events[0].content,
@@ -346,7 +353,7 @@ mod tests {
     #[tokio::test]
     async fn get_block_events_skips_keyless_events() {
         let backend = MockEventBackend::new(vec![mock_event(10, TX_HASH, vec![], vec![Felt::ONE])]);
-        let events = backend.get_block_events(10).await.unwrap();
+        let events = backend.get_block_events(BlockId::Number(10)).await.unwrap();
         assert!(events.is_empty());
     }
 
@@ -367,7 +374,7 @@ mod tests {
             ),
         ]);
 
-        let events = backend.get_block_events(10).await.unwrap();
+        let events = backend.get_block_events(BlockId::Number(10)).await.unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].block_number, 10);
     }
@@ -381,7 +388,7 @@ mod tests {
             vec![Felt::from(100u64)],
         )]);
 
-        let events = backend.get_block_events(10).await.unwrap();
+        let events = backend.get_block_events(BlockId::Number(10)).await.unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].block_number, 10);
         assert_eq!(events[0].transaction_hash, TX_HASH);
@@ -404,7 +411,7 @@ mod tests {
             vec![Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(75u64)],
         )]);
 
-        let events = backend.get_block_events(20).await.unwrap();
+        let events = backend.get_block_events(BlockId::Number(20)).await.unwrap();
         assert_eq!(events.len(), 1);
         let PrivacyPoolEventContent::Withdrawal(withdrawal) = &events[0].content else {
             panic!("expected Withdrawal");
@@ -433,7 +440,10 @@ mod tests {
             ),
         ]);
 
-        let events = backend.get_withdrawal_events(alice, 0, 100).await.unwrap();
+        let events = backend
+            .get_withdrawal_events(alice, BlockId::Number(0), BlockId::Number(100))
+            .await
+            .unwrap();
         assert_eq!(events.len(), 1);
         let PrivacyPoolEventContent::Withdrawal(withdrawal) = &events[0].content else {
             panic!("expected Withdrawal");
@@ -459,7 +469,10 @@ mod tests {
             ),
         ]);
 
-        let events = backend.get_withdrawal_events(USER, 0, 100).await.unwrap();
+        let events = backend
+            .get_withdrawal_events(USER, BlockId::Number(0), BlockId::Number(100))
+            .await
+            .unwrap();
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0].content,
@@ -484,7 +497,10 @@ mod tests {
             ),
         ]);
 
-        let events = backend.get_withdrawal_events(USER, 15, 100).await.unwrap();
+        let events = backend
+            .get_withdrawal_events(USER, BlockId::Number(15), BlockId::Number(100))
+            .await
+            .unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].block_number, 20);
     }
@@ -498,7 +514,7 @@ mod tests {
             vec![Felt::from(100u64)],
         )]);
 
-        let result = backend.get_block_events(10).await;
+        let result = backend.get_block_events(BlockId::Number(10)).await;
         assert!(result.is_err());
     }
 
@@ -512,7 +528,7 @@ mod tests {
             vec![Felt::ZERO, Felt::ZERO], // only 2 data elements, need 4
         )]);
 
-        let result = backend.get_block_events(20).await;
+        let result = backend.get_block_events(BlockId::Number(20)).await;
         assert!(result.is_err());
     }
 }

--- a/crates/discovery-core/src/storage_backend.rs
+++ b/crates/discovery-core/src/storage_backend.rs
@@ -54,8 +54,14 @@ pub trait StorageBackend: Send + Sync {
     type Snapshot: StorageSnapshot;
 
     /// Creates a snapshot at the specified block for the given contract.
-    /// If `block_id` is `None`, uses the latest block.
-    async fn snapshot(&self, contract_address: Felt, block_id: Option<BlockId>) -> Self::Snapshot;
+    /// If `block_id` is `None`, uses the latest block. Returns an error when
+    /// the block id cannot be resolved to a concrete number (e.g. RPC failure
+    /// when resolving `Tag(PreConfirmed)`).
+    async fn snapshot(
+        &self,
+        contract_address: Felt,
+        block_id: Option<BlockId>,
+    ) -> Result<Self::Snapshot, StorageError>;
 }
 
 /// Consistent view of storage at a specific block.

--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -33,7 +33,6 @@ request_timeout = 30        # seconds
 max_idle_per_host = 10
 max_batch_size = 256        # max storage slots per JSON-RPC batch request
 event_page_size = 1024      # max events per starknet_getEvents page (spec max: 1024)
-max_event_block_range = 0   # max block range for get_events queries; 0 = unlimited
 
 [indexer]
 ws_url = "ws://127.0.0.1:5050/ws"

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -90,7 +90,8 @@ where
     let snapshot = state
         .backend
         .snapshot(base.contract_address, Some(block_ref))
-        .await;
+        .await
+        .map_err(crate::api::types::storage_error_to_response)?;
 
     validate_viewing_key(
         &base.viewing_key,
@@ -268,7 +269,8 @@ where
     let snapshot = state
         .backend
         .snapshot(request.contract_address, Some(block_ref))
-        .await;
+        .await
+        .map_err(crate::api::types::storage_error_to_response)?;
 
     validate_viewing_key(
         &request.viewing_key,
@@ -339,27 +341,16 @@ where
     let snapshot = state
         .backend
         .snapshot(request.contract_address, Some(block_ref))
-        .await;
+        .await
+        .map_err(crate::api::types::storage_error_to_response)?;
 
     let mut cursor = request.cursor;
-    if cursor.begin_block_number == 0 {
-        let head = state.backend.get_head().await.ok_or_else(|| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                ApiErrorResponse::new(
-                    error_codes::SERVICE_UNAVAILABLE,
-                    "No indexed head available yet",
-                ),
-            )
-        })?;
-        cursor.begin_block_number = head.block_number;
-    }
 
     debug!(
         user = %format!("{:#x}", request.user_address),
         block = ?block_ref,
         num_subchannels = cursor.subchannels.len(),
-        begin_block = cursor.begin_block_number,
+        begin_block_number = ?cursor.begin_block_number,
         "history request"
     );
 

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -15,7 +15,7 @@ use discovery_core::sync::incoming_state::IncomingSubchannel;
 use discovery_core::sync::outgoing_state::OutgoingSubchannel;
 use serde::{Deserialize, Serialize};
 use starknet_core::types::{BlockId, Felt};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::block_id_serde;
 use crate::chain_state::ChainHead;
@@ -70,31 +70,34 @@ impl ApiErrorResponse {
     }
 }
 
+/// Maps [`discovery_core::storage_backend::StorageError`] (e.g. from
+/// `StorageBackend::snapshot`) to an HTTP status + API error response.
+pub fn storage_error_to_response(
+    error: discovery_core::storage_backend::StorageError,
+) -> (StatusCode, ApiErrorResponse) {
+    use discovery_core::storage_backend::StorageError;
+    match error {
+        StorageError::ContractNotFound => (
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(
+                error_codes::CONTRACT_NOT_FOUND,
+                "Contract not found at the configured address",
+            ),
+        ),
+        other => {
+            debug!("Storage error: {}", other);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiErrorResponse::new(error_codes::STORAGE_ERROR, "Storage backend error"),
+            )
+        }
+    }
+}
+
 /// Maps [`DiscoveryError`] to an HTTP status + API error response.
 pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErrorResponse) {
     match error {
-        DiscoveryError::Storage(storage_err) => {
-            use discovery_core::storage_backend::StorageError;
-            if matches!(storage_err, StorageError::ContractNotFound) {
-                warn!("Contract not found during discovery");
-                (
-                    StatusCode::BAD_REQUEST,
-                    ApiErrorResponse::new(
-                        error_codes::CONTRACT_NOT_FOUND,
-                        "Contract not found at the configured address",
-                    ),
-                )
-            } else {
-                warn!("Storage error during discovery: {}", storage_err);
-                (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    ApiErrorResponse::new(
-                        error_codes::RPC_UNAVAILABLE,
-                        "Upstream RPC is unavailable",
-                    ),
-                )
-            }
-        }
+        DiscoveryError::Storage(storage_err) => storage_error_to_response(storage_err),
         DiscoveryError::Decryption { index, source } => {
             warn!("Decryption failed at channel index {}: {}", index, source);
             (
@@ -118,6 +121,13 @@ pub fn discovery_error_to_response(error: DiscoveryError) -> (StatusCode, ApiErr
                 "Insufficient I/O budget: needed {}, available {}",
                 needed, available
             );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
+            )
+        }
+        DiscoveryError::CostOverflow(cost) => {
+            warn!("I/O cost overflow: {} exceeds usize", cost);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ApiErrorResponse::new(error_codes::INTERNAL_ERROR, "Internal discovery error"),
@@ -355,6 +365,7 @@ pub mod error_codes {
     pub const SERVICE_UNAVAILABLE: &str = "SERVICE_UNAVAILABLE";
     pub const CONTRACT_NOT_FOUND: &str = "CONTRACT_NOT_FOUND";
     pub const RPC_UNAVAILABLE: &str = "RPC_UNAVAILABLE";
+    pub const STORAGE_ERROR: &str = "STORAGE_ERROR";
     pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
     pub const OHTTP_DECAPSULATION_FAILED: &str = "OHTTP_DECAPSULATION_FAILED";
     pub const OHTTP_INVALID_FORMAT: &str = "OHTTP_INVALID_FORMAT";

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -7,7 +7,7 @@ use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::history::types::HistoryCursor;
 use discovery_core::storage_backend::{StorageError, StorageSnapshot};
 use starknet_core::types::{BlockId, Felt};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::api::types::{error_codes, ApiErrorResponse};
 use crate::chain_state::{ChainState, ChainStateError};
@@ -216,13 +216,10 @@ pub async fn validate_viewing_key<S: StorageSnapshot>(
                     ),
                 ),
                 other => {
-                    warn!("Storage error fetching public key: {}", other);
+                    debug!("Storage error fetching public key: {}", other);
                     (
                         StatusCode::SERVICE_UNAVAILABLE,
-                        ApiErrorResponse::new(
-                            error_codes::RPC_UNAVAILABLE,
-                            "Upstream RPC is unavailable",
-                        ),
+                        ApiErrorResponse::new(error_codes::STORAGE_ERROR, "Storage backend error"),
                     )
                 }
             })?;
@@ -492,7 +489,7 @@ mod tests {
             .collect();
         let cursor = HistoryCursor {
             subchannels,
-            begin_block_number: 100,
+            begin_block_number: Some(100),
             history_complete: false,
         };
 
@@ -525,7 +522,7 @@ mod tests {
         let subchannels: Vec<_> = (0..5).map(|_| dummy_history_subchannel()).collect();
         let cursor = HistoryCursor {
             subchannels,
-            begin_block_number: 100,
+            begin_block_number: Some(100),
             history_complete: false,
         };
 

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -48,10 +48,6 @@ pub struct RpcConfig {
     /// Maximum number of events per `starknet_getEvents` page.
     /// The RPC spec allows up to 1024.
     pub event_page_size: usize,
-    /// Maximum allowed block range for a single `get_events` query.
-    /// Requests spanning more than this many blocks are rejected with an error.
-    /// `0` means unlimited.
-    pub max_event_block_range: u64,
 }
 
 impl Default for RpcConfig {
@@ -64,7 +60,6 @@ impl Default for RpcConfig {
             max_idle_per_host: 10,
             max_batch_size: 256,
             event_page_size: 1024,
-            max_event_block_range: 0,
         }
     }
 }

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -53,9 +53,6 @@ struct RpcBackendInner {
     head: RwLock<Option<ChainHead>>,
     max_batch_size: usize,
     event_page_size: usize,
-    /// Maximum allowed block range for a single `get_events` query.
-    /// `0` means unlimited.
-    max_event_block_range: u64,
 }
 
 /// RPC-based storage backend that reads from a StarkNet node via JSON-RPC.
@@ -90,7 +87,6 @@ impl RpcBackend {
                 head: RwLock::new(None),
                 max_batch_size: config.max_batch_size,
                 event_page_size: config.event_page_size,
-                max_event_block_range: config.max_event_block_range,
             }),
         })
     }
@@ -100,13 +96,43 @@ impl RpcBackend {
 impl StorageBackend for RpcBackend {
     type Snapshot = RpcSnapshot;
 
-    async fn snapshot(&self, contract_address: Felt, block_id: Option<BlockId>) -> Self::Snapshot {
+    async fn snapshot(
+        &self,
+        contract_address: Felt,
+        block_id: Option<BlockId>,
+    ) -> Result<Self::Snapshot, StorageError> {
         let block_id = block_id.unwrap_or(BlockId::Tag(BlockTag::Latest));
-        RpcSnapshot {
+        let block_number = self.resolve_block_number(block_id).await?;
+        Ok(RpcSnapshot {
             backend: self.clone(),
             contract_address,
             block_id,
+            block_number,
+        })
+    }
+}
+
+impl RpcBackend {
+    /// Resolves a `BlockId` to a concrete block number for snapshot pinning.
+    ///
+    /// `Number(n)` returns `n` directly; every other variant (`Tag(_)` or
+    /// `Hash(_)`) is resolved authoritatively via `get_block_with_tx_hashes`,
+    /// which returns either a `Block` or `PreConfirmedBlock` variant — both
+    /// carry `block_number`. RPC errors propagate.
+    async fn resolve_block_number(&self, block_id: BlockId) -> Result<u64, StorageError> {
+        if let BlockId::Number(n) = block_id {
+            return Ok(n);
         }
+        let block = self
+            .inner
+            .provider
+            .get_block_with_tx_hashes(block_id)
+            .await
+            .map_err(|e| RpcBackendError::Request(e.to_string()))?;
+        Ok(match block {
+            MaybePreConfirmedBlockWithTxHashes::Block(b) => b.block_number,
+            MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(b) => b.block_number,
+        })
     }
 }
 
@@ -116,6 +142,7 @@ pub struct RpcSnapshot {
     backend: RpcBackend,
     contract_address: Felt,
     block_id: BlockId,
+    block_number: u64,
 }
 
 impl RpcSnapshot {
@@ -239,19 +266,14 @@ impl RawEventAccess for RpcSnapshot {
     async fn get_events(
         &self,
         keys: &[Vec<Felt>],
-        from_block: u64,
-        to_block: u64,
+        from_block: BlockId,
+        to_block: BlockId,
     ) -> Result<Vec<EmittedEvent>, StorageError> {
-        let max_range = self.backend.inner.max_event_block_range;
-        if max_range > 0 {
-            let range = to_block.saturating_sub(from_block).saturating_add(1);
-            if range > max_range {
-                return Err(RpcBackendError::Request(format!(
-                    "event query block range {range} exceeds maximum {max_range}"
-                ))
-                .into());
-            }
-        }
+        // TODO: history queries spanning a large block range bottleneck here
+        // on an unbounded `starknet_getEvents` scan against the node. Pre-index
+        // privacy-pool events (at minimum withdrawals, which drive the history
+        // feed) locally so history can be served from our own store instead of
+        // re-querying the RPC on every request.
 
         // Strip trailing empty key vecs — they mean "wildcard" in our trait but
         // some RPC implementations (e.g. devnet) treat them as "match nothing".
@@ -264,8 +286,8 @@ impl RawEventAccess for RpcSnapshot {
         };
 
         let filter = EventFilter {
-            from_block: Some(BlockId::Number(from_block)),
-            to_block: Some(BlockId::Number(to_block)),
+            from_block: Some(from_block),
+            to_block: Some(to_block),
             address: Some(AddressFilter::Single(self.contract_address)),
             keys: if trimmed_keys.is_empty() {
                 None
@@ -299,7 +321,31 @@ impl RawEventAccess for RpcSnapshot {
             }
         }
 
+        patch_pre_confirmed_block_number(self.block_number, &mut all_events);
+
         Ok(all_events)
+    }
+
+    fn block_id(&self) -> BlockId {
+        self.block_id
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block_number
+    }
+}
+
+/// TODO: Pathfinder workaround — pre-confirmed events are returned with
+/// `block_number: None`. Fill the gap using the snapshot's resolved block
+/// number (which is `cached_head + 1` when the snapshot is pinned to
+/// `Tag(PreConfirmed)`). Remove once
+/// <https://github.com/equilibriumco/pathfinder/pull/3348> is included in a
+/// Pathfinder release and rolled out across RPC providers.
+fn patch_pre_confirmed_block_number(snapshot_block_number: u64, events: &mut [EmittedEvent]) {
+    for event in events.iter_mut() {
+        if event.block_number.is_none() {
+            event.block_number = Some(snapshot_block_number);
+        }
     }
 }
 

--- a/crates/discovery-service/tests/test_api.rs
+++ b/crates/discovery-service/tests/test_api.rs
@@ -505,7 +505,7 @@ async fn test_history_basic() {
         block_ref: Some(sync_response.block_ref),
         cursor: HistoryCursor {
             subchannels: history_subchannels,
-            begin_block_number: 0,
+            begin_block_number: None,
             history_complete: false,
         },
     };

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -36,7 +36,10 @@ async fn test_public_key_lookup() {
     };
     let backend = RpcBackend::new(rpc_config).unwrap();
 
-    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+    let snapshot = backend
+        .snapshot(metadata.contract_address, None)
+        .await
+        .unwrap();
 
     // Alice should have a registered public key
     let alice_pubkey = snapshot
@@ -66,12 +69,18 @@ async fn test_block_events() {
     })
     .unwrap();
     let head_block = backend.get_head().await.unwrap().block_number;
-    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+    let snapshot = backend
+        .snapshot(metadata.contract_address, None)
+        .await
+        .unwrap();
 
     // Collect all events across all blocks in the devnet fixture.
     let mut all_events = Vec::new();
     for block_number in 0..=head_block {
-        let events = snapshot.get_block_events(block_number).await.unwrap();
+        let events = snapshot
+            .get_block_events(starknet_core::types::BlockId::Number(block_number))
+            .await
+            .unwrap();
         all_events.extend(events);
     }
 
@@ -111,10 +120,17 @@ async fn test_withdrawal_events() {
     })
     .unwrap();
     let head_block = backend.get_head().await.unwrap().block_number;
-    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+    let snapshot = backend
+        .snapshot(metadata.contract_address, None)
+        .await
+        .unwrap();
 
     let withdrawals = snapshot
-        .get_withdrawal_events(metadata.bob_address, 0, head_block)
+        .get_withdrawal_events(
+            metadata.bob_address,
+            starknet_core::types::BlockId::Number(0),
+            starknet_core::types::BlockId::Number(head_block),
+        )
         .await
         .unwrap();
 
@@ -137,11 +153,18 @@ async fn test_withdrawal_events_empty_for_non_recipient() {
     })
     .unwrap();
     let head_block = backend.get_head().await.unwrap().block_number;
-    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+    let snapshot = backend
+        .snapshot(metadata.contract_address, None)
+        .await
+        .unwrap();
 
     // Alice is not a withdrawal recipient in the devnet scenario
     let withdrawals = snapshot
-        .get_withdrawal_events(metadata.alice_address, 0, head_block)
+        .get_withdrawal_events(
+            metadata.alice_address,
+            starknet_core::types::BlockId::Number(0),
+            starknet_core::types::BlockId::Number(head_block),
+        )
         .await
         .unwrap();
 
@@ -157,7 +180,10 @@ async fn test_read_slots_with_block() {
         ..Default::default()
     };
     let backend = RpcBackend::new(rpc_config).unwrap();
-    let snapshot = backend.snapshot(metadata.contract_address, None).await;
+    let snapshot = backend
+        .snapshot(metadata.contract_address, None)
+        .await
+        .unwrap();
 
     // Query a slot known to be written during fixture generation (Alice's public key)
     let alice_pubkey_slot = storage_slots::public_key(metadata.alice_address);

--- a/deploy/discovery-service/config.example.toml
+++ b/deploy/discovery-service/config.example.toml
@@ -14,7 +14,6 @@ request_timeout = 30
 max_idle_per_host = 10
 max_batch_size = 256
 event_page_size = 1024
-max_event_block_range = 0
 
 [indexer]
 ws_url = "ws://127.0.0.1:5050/ws"

--- a/e2e/tests/devnet/history.test.ts
+++ b/e2e/tests/devnet/history.test.ts
@@ -4,6 +4,7 @@ import {
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import { type HistoryTransaction } from "@starkware-libs/starknet-privacy-sdk";
+import type { BlockIdentifier } from "starknet";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
 
 describe("E2E History", () => {
@@ -137,7 +138,7 @@ describe("E2E History", () => {
     // Fetch one transaction at a time
     const allTransactions: HistoryTransaction[] = [];
     let historyCursor: undefined | typeof firstPage.cursor = undefined;
-    let blockRef: string | undefined;
+    let blockIdentifier: BlockIdentifier | undefined;
 
     const firstPage = await indexerDiscovery.fetchHistory(
       aliceAddress,
@@ -147,7 +148,7 @@ describe("E2E History", () => {
     );
     allTransactions.push(...firstPage.transactions);
     historyCursor = firstPage.cursor;
-    blockRef = firstPage.blockRef;
+    blockIdentifier = firstPage.blockRef;
 
     // Continue fetching until complete
     while (!historyCursor.historyComplete) {
@@ -155,11 +156,11 @@ describe("E2E History", () => {
         aliceAddress,
         notesCursor,
         channelCursor,
-        { maxTransactions: 1, historyCursor, blockRef },
+        { maxTransactions: 1, historyCursor, blockIdentifier },
       );
       allTransactions.push(...page.transactions);
       historyCursor = page.cursor;
-      blockRef = page.blockRef;
+      blockIdentifier = page.blockRef;
     }
 
     // Should have fetched multiple pages (scenario has at least 1 tx)

--- a/e2e/tests/integration/privacy-starknet-integration.test.ts
+++ b/e2e/tests/integration/privacy-starknet-integration.test.ts
@@ -349,7 +349,7 @@ describe("Privacy StarkNet integration", () => {
     allTransactions.push(...firstPage.transactions);
 
     let historyCursor = firstPage.cursor;
-    let blockRef: string | undefined = firstPage.blockRef;
+    let blockIdentifier = firstPage.blockRef;
     const MAX_PAGES = 5;
     let pageCount = 1;
 
@@ -358,11 +358,11 @@ describe("Privacy StarkNet integration", () => {
         aliceAddress,
         notesCursor,
         channelCursor,
-        { maxTransactions: 1, historyCursor, blockRef },
+        { maxTransactions: 1, historyCursor, blockIdentifier },
       );
       allTransactions.push(...page.transactions);
       historyCursor = page.cursor;
-      blockRef = page.blockRef;
+      blockIdentifier = page.blockRef;
       pageCount++;
     }
 
@@ -377,5 +377,32 @@ describe("Privacy StarkNet integration", () => {
           deposit.amount === 100n && deposit.token === BigInt(TOKEN),
       ),
     ).toBeDefined();
+  }, 300_000);
+
+  it("history works with pre_confirmed block ref", async () => {
+    const aliceAddress = BigInt(alice.address);
+    const aliceViewingKey = BigInt(alice.viewingKey);
+
+    const notesResult = await discovery.discoverNotes(
+      aliceAddress,
+      aliceViewingKey,
+    );
+    const { channels } = await discovery.discoverChannels(
+      aliceAddress,
+      aliceViewingKey,
+      "all",
+    );
+
+    const page = await discovery.fetchHistory(
+      aliceAddress,
+      notesResult.cursor,
+      { channels },
+      { maxTransactions: 5, blockIdentifier: "pre_confirmed" },
+    );
+
+    expect(page.blockRef).toBeDefined();
+    // Fresh pool may have no transactions — just verify the call succeeds
+    // with a pre_confirmed tag (no 503 or deserialization errors).
+    expect(page.transactions).toBeDefined();
   }, 300_000);
 });

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -8,8 +8,9 @@
 - `ProofInvocation` type now imports `INVOKE_TXN_V3` from `@starknet-io/starknet-types-0101` (was `@starknet-io/starknet-types-010`)
 - Removed `@starknet-io/starknet-types-09` direct dependency (now resolved transitively via starknet)
 - **Node.js >= 24** now required (due to `ohttp-ts` dependency using WebCrypto APIs)
-- `fetchHistory` `blockRef` option changed from `string` to `BlockIdentifier`
+- `fetchHistory` option renamed from `blockRef` to `blockIdentifier` (type: `BlockIdentifier`)
 - `HistoryPage.blockRef` changed from `string` to `BlockIdentifier`
+- `HistoryCursor.beginBlockNumber` is now optional (`undefined` on first page; server resolves from `block_ref`)
 
 ### Changed
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -390,11 +390,13 @@ import { classifyTransaction } from "@starkware-libs/starknet-privacy-sdk";
 const { notes, cursor: notesCursor } = await transfers.discoverNotes();
 const { channels } = await transfers.discoverChannels("all");
 
+// First page — blockIdentifier pins both storage reads and the event scan upper bound.
+// Use "pre_confirmed" to include events from pre-confirmed blocks.
 const page = await discovery.fetchHistory(
   userAddress,
   notesCursor,
   { channels },
-  { maxTransactions: 10 }
+  { maxTransactions: 10, blockIdentifier: "latest" }
 );
 
 for (const tx of page.transactions) {
@@ -417,7 +419,7 @@ if (!page.cursor.historyComplete) {
     userAddress,
     notesCursor,
     { channels },
-    { maxTransactions: 10, historyCursor: page.cursor, blockRef: page.blockRef }
+    { maxTransactions: 10, historyCursor: page.cursor, blockIdentifier: page.blockRef }
   );
 }
 ```

--- a/sdk/src/internal/history.ts
+++ b/sdk/src/internal/history.ts
@@ -17,7 +17,7 @@ export type HistorySubchannel = {
 
 export type HistoryCursor = {
   subchannels: HistorySubchannel[];
-  beginBlockNumber: number;
+  beginBlockNumber?: number;
   historyComplete: boolean;
 };
 
@@ -79,7 +79,7 @@ type ApiHistorySubchannel = {
 
 type ApiHistoryCursor = {
   subchannels: ApiHistorySubchannel[];
-  begin_block_number: number;
+  begin_block_number?: number;
   history_complete: boolean;
 };
 
@@ -169,7 +169,7 @@ export function buildHistoryCursor(
     }
   }
 
-  return { subchannels, beginBlockNumber: 0, historyComplete: false };
+  return { subchannels, historyComplete: false };
 }
 
 /** Converts SDK HistoryCursor → API wire format. */

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -371,7 +371,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     options?: {
       maxTransactions?: number;
       lastKnownBlock?: string;
-      blockRef?: BlockIdentifier;
+      blockIdentifier?: BlockIdentifier;
       /** Pass the cursor from a previous HistoryPage to continue pagination. */
       historyCursor?: HistoryCursor;
     }
@@ -384,8 +384,8 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       max_transactions: options?.maxTransactions ?? 50,
       cursor: historyCursorToApi(cursor),
     };
-    if (options?.blockRef !== undefined) {
-      body.block_ref = options.blockRef;
+    if (options?.blockIdentifier !== undefined) {
+      body.block_ref = options.blockIdentifier;
     } else if (options?.lastKnownBlock) {
       body.last_known_block = options.lastKnownBlock;
     }


### PR DESCRIPTION
## Summary

- Add `block_ref` parameter (block hash, number, or tag) to all discovery API endpoints, enabling clients to pin storage reads to a specific chain state
- Explicit block identifiers pass through to the RPC node as-is; when omitted, resolves to the current head hash for pagination consistency
- Custom flat wire format via `block_id_serde` — backwards compatible with existing clients that send hex strings
- Wire `provingBlockId` from `ExecuteOptions` through the compiler to discovery, so proving and discovery use the same block state
- Support `pre_confirmed` tag in history: event range bounds upgraded from `u64` to `Option<BlockId>`, mirroring the Starknet RPC `starknet_getEvents` filter

## Motivation

Clients need to pin discovery reads to specific blocks for two reasons:
1. **Proving at historical state** — discovery must see the same contract state the prover will verify against
2. **Pre-confirmed reads** — `pre_confirmed` blocks are tag-addressable only on Starknet nodes; resolving the tag to a block number breaks because pre-confirmed blocks live in memory only

## Wire format

Flat values, backwards compatible with the old hex-string-only format:
- `"0xabcdef..."` — block hash (hex string)
- `12345` — block number (integer)
- `"latest"` / `"pre_confirmed"` / `"l1_accepted"` — block tag (string)

## Event range bounds

`RawEventAccess::get_events` and `IEvents` methods now accept `Option<BlockId>` for `from_block`/`to_block`, mirroring the Starknet RPC `starknet_getEvents` filter. This allows passing tags like `pre_confirmed` as the event scan upper bound.

`HistoryCursor.begin_block_number` is now `Option<u64>` — `None` on the first page. The server uses `block_ref` as the initial upper bound for event queries, so passing `block_ref: "pre_confirmed"` includes events from pre-confirmed blocks.

## Consistency guarantees

| Type | Consistency | Reorg detection |
|------|------------|-----------------|
| Block hash | Full — identical state across all paginated requests | Yes |
| Block number | Stable height, may reference different branch after reorg | No |
| Block tag | Best-effort — underlying block may change between requests | No |

## Test plan

- [x] `cargo fmt --check -p discovery-core -p discovery-service`
- [x] `cargo clippy -p discovery-core -p discovery-service --all-targets`
- [x] `cargo test -p discovery-core` (152 tests)
- [x] `cargo test -p discovery-service` (66 tests)
- [x] `cd sdk && npm run lint` (prettier, eslint, tsc)
- [x] `cd sdk && npm test` (208 tests)
- [x] `cd e2e && npm test -- devnet` (16 tests)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/707)
<!-- Reviewable:end -->
