### PR TITLE
feat(discovery-service): disable edge case withdrawal events range scan by default

### DIFF
--- a/crates/discovery-core/src/history/transactions.rs
+++ b/crates/discovery-core/src/history/transactions.rs
@@ -24,7 +24,9 @@ use crate::privacy_pool::views::IViews;
 /// Each loop iteration:
 /// 1. Drain the next block of notes via [`BufferedNoteScanner::next_block`].
 /// 2. Fetch block events and group into transactions via [`fetch_aggregated_block_events`].
-/// 3. Fetch withdrawal events for the gap range via [`fetch_aggregated_withdrawal_events`].
+/// 3. If `scan_full_withdrawals` is on, fetch standalone withdrawal events for
+///    the gap range via [`fetch_aggregated_withdrawal_events`] — catches a full
+///    withdrawal that leaves no change note.
 ///
 /// Budget is consumed incrementally; exits early if insufficient.
 /// Returns transactions sorted by `block_number` descending.
@@ -33,12 +35,14 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
     user_address: Felt,
     cursor: &mut HistoryCursor,
     max_transactions: usize,
+    scan_full_withdrawals: bool,
     budget: &IoBudget,
 ) -> Result<Vec<HistoryTransaction>, DiscoveryError> {
     debug!(
         num_subchannels = cursor.subchannels.len(),
         begin_block_number = ?cursor.begin_block_number,
         snapshot_block_id = ?backend.block_id(),
+        scan_full_withdrawals,
         budget_remaining = budget.remaining(),
         max_transactions,
         "history: starting fetch_transactions"
@@ -61,6 +65,7 @@ pub async fn fetch_transactions<B: IViews + IEvents>(
             user_address,
             &mut note_scanner,
             cursor,
+            scan_full_withdrawals,
             budget,
             &mut transactions,
         )
@@ -133,6 +138,7 @@ async fn process_next_block<B: IViews + IEvents>(
     user_address: Felt,
     note_scanner: &mut BufferedNoteScanner,
     cursor: &mut HistoryCursor,
+    scan_full_withdrawals: bool,
     budget: &IoBudget,
     transactions: &mut HashMap<Felt, HistoryTransaction>,
 ) -> Result<Option<u64>, DiscoveryError> {
@@ -178,15 +184,17 @@ async fn process_next_block<B: IViews + IEvents>(
     )
     .await?;
 
-    fetch_aggregated_withdrawal_events(
-        backend,
-        user_address,
-        block_number + 1,
-        cursor.begin_block_number,
-        budget,
-        transactions,
-    )
-    .await?;
+    if scan_full_withdrawals {
+        fetch_aggregated_withdrawal_events(
+            backend,
+            user_address,
+            block_number + 1,
+            cursor.begin_block_number,
+            budget,
+            transactions,
+        )
+        .await?;
+    }
 
     Ok(Some(block_number))
 }
@@ -973,7 +981,7 @@ mod tests {
         cursor.begin_block_number = Some(10); // below the note's block (100)
 
         let budget = IoBudget::new(1_000);
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &budget)
+        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, true, &budget)
             .await
             .unwrap();
 
@@ -995,9 +1003,16 @@ mod tests {
             history_complete: false,
         };
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert!(result.is_empty());
         assert!(cursor.history_complete);
@@ -1010,9 +1025,16 @@ mod tests {
             .deposit(100, 10, TX_HASH_1)
             .build(Some(0));
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].block_number, 10);
@@ -1030,9 +1052,16 @@ mod tests {
             .withdrawal(50, 20, TX_HASH_2)
             .build(Some(1));
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].block_number, 20);
@@ -1047,7 +1076,7 @@ mod tests {
     async fn zero_budget_returns_insufficient_budget_error() {
         let (backend, mut cursor) = FixtureBuilder::new().note(0, 10, TX_HASH_1).build(Some(0));
 
-        let error = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(0))
+        let error = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, true, &IoBudget::new(0))
             .await
             .unwrap_err();
 
@@ -1072,6 +1101,7 @@ mod tests {
             ADDRESS,
             &mut cursor,
             10,
+            true,
             &IoBudget::new(one_block_budget),
         )
         .await
@@ -1100,6 +1130,7 @@ mod tests {
             ADDRESS,
             &mut cursor,
             10,
+            true,
             &IoBudget::new(one_block_budget),
         )
         .await
@@ -1119,9 +1150,16 @@ mod tests {
             .deposit_from(OTHER_ADDRESS, 200, 10, TX_HASH_1)
             .build(Some(0));
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].deposits.len(), 1);
@@ -1134,9 +1172,16 @@ mod tests {
         let (backend, mut cursor) = FixtureBuilder::new().note(0, 10, TX_HASH_1).build(Some(0));
         assert_eq!(cursor.begin_block_number, Some(100));
 
-        fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(cursor.begin_block_number, Some(9));
         assert!(cursor.history_complete);
@@ -1153,9 +1198,16 @@ mod tests {
             .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
             .build(Some(0));
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 2);
         assert!(cursor.history_complete);
@@ -1184,6 +1236,7 @@ mod tests {
             ADDRESS,
             &mut cursor,
             10,
+            true,
             &IoBudget::new(one_block_budget),
         )
         .await
@@ -1201,18 +1254,32 @@ mod tests {
             .build(Some(0));
 
         // First page: max_transactions=1, note tx fills the page.
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 1, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            1,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 1);
         assert!(result[0].registered_pubkey.is_none());
         assert!(!cursor.history_complete);
 
         // Second page: scanner is already exhausted, only registration returned.
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 1, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            1,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].registered_pubkey, Some(PUBKEY));
@@ -1227,9 +1294,16 @@ mod tests {
             .pubkey(ADDRESS, PUBKEY, 5, TX_HASH_REG)
             .build(Some(1));
 
-        let result = fetch_transactions(&backend, ADDRESS, &mut cursor, 10, &IoBudget::new(1000))
-            .await
-            .unwrap();
+        let result = fetch_transactions(
+            &backend,
+            ADDRESS,
+            &mut cursor,
+            10,
+            true,
+            &IoBudget::new(1000),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].block_number, 20);

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -349,6 +349,7 @@ Retrieves paginated transaction history by scanning backward through note subcha
 
 - `max_history_subchannels` (default: 256): Maximum number of subchannels in a history cursor.
 - `max_history_transactions` (default: 100): Maximum allowed `max_transactions` value.
+- `history_scan_full_withdrawals` (default: `false`): Opt-in to a range `starknet_getEvents` scan of withdrawal events across block gaps between note blocks. This catches the edge case of a *full* withdrawal that leaves no change note. Off by default because common flows already cover this: partial withdrawals and paymaster flows create a change note (picked up via the in-block event path), and a fully transparent withdrawal is visible directly at the recipient account. Range scans dominate history cost, so operators should enable this only when the service must return fully-withdrawn transactions for users who do not run a wallet.
 
 **Error responses:**
 

--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -58,6 +58,7 @@ level = "info"
 max_cursor_channels = 256
 max_cursor_subchannels_per_channel = 64
 max_outgoing_recipients = 64
+history_scan_full_withdrawals = false  # opt-in gap-range withdrawal scan (see §06 history)
 server_budget = 10000
 max_request_body_bytes = 102400
 ```

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -360,6 +360,7 @@ where
         request.user_address,
         &mut cursor,
         request.max_transactions as usize,
+        state.validation_limits.history_scan_full_withdrawals,
         &budget,
     )
     .await

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -152,6 +152,13 @@ pub struct ValidationLimits {
     pub max_history_subchannels: usize,
     /// Maximum number of transactions per history request.
     pub max_history_transactions: usize,
+    /// Opt-in to a range scan of withdrawal events in the gaps between note
+    /// blocks. Catches a *full* withdrawal — one that leaves no change note —
+    /// which is rare. Common flows (partial withdrawal, paymaster change note,
+    /// transparent withdrawals already visible at the wallet) don't need it.
+    /// Off by default because the range `starknet_getEvents` dominates
+    /// history cost.
+    pub history_scan_full_withdrawals: bool,
     /// Server-controlled I/O budget per request.
     pub server_budget: usize,
     /// Maximum request body size in bytes.
@@ -167,6 +174,7 @@ impl Default for ValidationLimits {
             max_outgoing_recipients: 64,
             max_history_subchannels: 256,
             max_history_transactions: 100,
+            history_scan_full_withdrawals: false,
             server_budget: 10_000,
             max_request_body_bytes: 102_400,
             public_key_cache_capacity: 10_000,

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `block_ref` in API models now accepts block hash (hex string), block number (integer), or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Wire format is backwards compatible — block hashes remain plain hex strings.
 - `discoverNotes` and `discoverChannels` accept optional `blockIdentifier` param to pin discovery reads to a specific block
 - Compiler passes `ExecuteOptions.provingBlockId` to discovery as `blockIdentifier`, ensuring discovery and proving use the same block state
+- `fetchHistory` no longer returns full withdrawals that leave no change note unless the indexer is deployed with `limits.history_scan_full_withdrawals = true`. Documented as an edge case in the README; the previous always-on gap-range scan dominated history cost for a rare flow.
 
 ### Added
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -424,6 +424,19 @@ if (!page.cursor.historyComplete) {
 }
 ```
 
+**Completeness caveats.** The history feed is anchored on the user's notes — each page scans backward one note block at a time and attaches the events that sit in that block. A few transaction shapes fall outside this anchor:
+
+- **Full withdrawals with no change note** — e.g. spending all inputs into a single `withdraw` call with no `transfer` or `surplusTo` remainder. The transaction produces no new note for the user, so it is invisible unless the indexer is run with `limits.history_scan_full_withdrawals = true` (off by default — the range `starknet_getEvents` scan dominates per-request cost). The withdrawal itself is a transparent on-chain transfer to the recipient, so the recipient's wallet still shows it via ordinary account activity.
+- **Deposits inside a bundled multi-user transaction** — when another user's deposit shares a transaction with your notes (atypical), it is filtered out of your history by `user_address` to avoid double-counting balances. Your own deposits in the same transaction still appear.
+- **Notes above the cursor's upper bound** — if the client-provided cursor or `blockIdentifier` disagrees with the actual block of a discovered note (stale cursor, malicious input, or chain drift), those notes are skipped silently and the scanner advances.
+
+**Withdrawal attribution caveat.** On-chain `Withdrawal` events expose only the recipient address; the initiating `user_addr` is encrypted. The service cannot filter in-block withdrawals by initiator, so:
+
+- A withdrawal that shares a transaction with your notes is attached to that transaction in your history, even if a different user initiated it (e.g. A withdraws to B while B has notes in the same tx).
+- In multi-user batched transactions, unrelated withdrawals may be attached to any user with matched notes in the batch.
+
+Gap-range withdrawals (when enabled via `history_scan_full_withdrawals`) are keyed on the user's own address at the RPC filter level, so the attribution caveat above does **not** apply to them.
+
 ## Execute result
 
 Every `execute()` call returns:


### PR DESCRIPTION
### TL;DR

Adds a `history_scan_full_withdrawals` operator flag (default: `false`) that gates the gap-range withdrawal event scan in transaction history fetching.

### What changed?

`fetch_transactions` and `process_next_block` now accept a `scan_full_withdrawals: bool` parameter. When `false`, the call to `fetch_aggregated_withdrawal_events` is skipped entirely. The flag is surfaced as `history_scan_full_withdrawals` in `ValidationLimits`, defaulting to `false`, and is passed through from the API handler using the service's configured limits. The API design spec and configuration reference have been updated to document the new option.

### How to test?

All existing tests pass `true` for `scan_full_withdrawals`, preserving prior behaviour. To verify the off path, configure a service instance with `history_scan_full_withdrawals = false` and confirm that a full withdrawal (one that leaves no change note) does not appear in the returned history, while partial withdrawals and paymaster flows continue to appear correctly.

### Why make this change?

The gap-range `starknet_getEvents` scan is the dominant cost driver in history requests. The scan is only necessary to catch the edge case of a full withdrawal that leaves no change note — partial withdrawals and paymaster flows produce a change note that is already picked up via the in-block event path, and fully transparent withdrawals are visible directly at the recipient account. Making this scan opt-in lets operators avoid the cost by default and enable it only when the service must surface fully-withdrawn transactions for users who do not run a wallet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/711)
<!-- Reviewable:end -->
