### PR TITLE
chore: bump scarb and snforge, update readmes

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -11,11 +11,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       - name: Check formatting
         run: |

--- a/.github/workflows/e2e-devnet.yaml
+++ b/.github/workflows/e2e-devnet.yaml
@@ -42,7 +42,7 @@ jobs:
       # Scarb (for Cairo contract build)
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       # Devnet binary
       - name: Install starknet-devnet
@@ -52,10 +52,10 @@ jobs:
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       # Build Cairo contracts (both profiles: release for e2e harness, dev for SDK devnet helper)
-      # All workspace packages + ekubo-contracts + test-token use Scarb 2.17.0-rc.4
+      # All workspace packages + ekubo-contracts + test-token use Scarb 2.17.0
       - name: Build contracts
         run: |
           scarb --profile release build -p privacy

--- a/.github/workflows/e2e-integration.yaml
+++ b/.github/workflows/e2e-integration.yaml
@@ -22,11 +22,11 @@ jobs:
       # Scarb (for Cairo contract build)
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       # Build Cairo contracts (release for class hash + artifacts)
       - name: Build contracts

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -69,18 +69,18 @@ jobs:
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
       - name: Install starknet-foundry via asdf
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         uses: asdf-vm/actions/install@v3
         with:
           asdf_branch: v0.14.1
           tool_versions: |
-            starknet-foundry nightly-2026-02-20
+            starknet-foundry 0.59.0
       - name: Generate Cairo reference data
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,18 +11,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       - name: Install starknet-foundry via asdf
         uses: asdf-vm/actions/install@v3
         with:
           asdf_branch: v0.14.1
           tool_versions: |
-            starknet-foundry nightly-2026-02-20
+            starknet-foundry 0.59.0
 
       - name: Run tests
         run: scarb test -w

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -51,18 +51,18 @@ jobs:
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       - name: Install starknet-foundry via asdf
         uses: asdf-vm/actions/install@v3
         with:
           asdf_branch: v0.14.1
           tool_versions: |
-            starknet-foundry nightly-2026-02-20
+            starknet-foundry 0.59.0
 
       - name: Regenerate Cairo contract artifacts
         run: npm run generate
@@ -94,11 +94,11 @@ jobs:
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.17.0-rc.4"
+          scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
         with:
-          universal-sierra-compiler-version: "v2.8.0-rc.0"
+          universal-sierra-compiler-version: "v2.8.0"
 
       - name: Install starknet-devnet
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
-github:software-mansion-labs/starknet-foundry-nightlies[exe=snforge] starknet-foundry nightly-2026-02-20
-scarb 2.17.0-rc.4
-starknet-foundry nightly-2026-02-20
+scarb 2.17.0
+starknet-foundry 0.59.0

--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Component | Docs | Tag |
 |-----------|------|-------------|
-| Sequencer | | [`APOLLO-0.14.2-RC.6`](https://github.com/starkware-libs/sequencer/releases/tag/APOLLO-0.14.2-RC.6) |
-| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover/743671200?tag=PRIVACY-0.14.2-RC.3) |
-| Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.2`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service) |
-| Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.1`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.1/images/sha256-ff7e7b1b2121c1abc754701f6acd24587da21b26c010061633ebc1f270f08aa7) |
-| SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.2`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.2) |
+| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.4`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover?tag=PRIVACY-0.14.2-RC.4) |
+| Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service) |
+| Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.3`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.3/images/sha256-e3ae2c2895d18dd17a3bb64c3582c6758e4701a248dff9f957b69f1ad63be7f7) |
+| SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) |
 
 \* For the transaction prover to work correctly with Pathfinder, set `PATHFINDER_STORAGE_STATE_TRIES=10000`.
 
@@ -55,9 +54,9 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Contract | Docs | Tag | Class Hash |
 |----------|------|-----|------------|
-| Privacy Pool | [README](packages/privacy/README.md) | [`PRIVACY-0.14.2-RC.2`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.2) | `0x715b22abfb60815623f4127ba64bd2f93613d8a5c1e519841eaab444659d2af` |
-| Ekubo Helper | | | |
-| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) | [`PRIVACY-0.14.2-RC.2`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.2) | |
+| Privacy Pool | [README](packages/privacy/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x30b8c540cf04d8ef0f4db2a9098d9cc0e35e83af1cb3325f5a4f40144b4b30b` |
+| Ekubo Helper | [README](packages/ekubo_swap_helper/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x61047c201f235d66cab8a0c4768ea0ca9f900c64b478a90531fb2fb30e061dc` |
+| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x2fec72887f6431e4a66090bec49ecf8bde30cf39a7045e4ed6ce57447704b24` |
 
 ## Repository map
 

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -171,15 +171,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.55.0+nightly-2026-02-03"
-source = "registry+https://scarbs.dev/"
-checksum = "sha256:b046fee1fe2e0d4463eadea6dcd04175649c92754302f2f06c23fef581fe8f29"
+version = "0.59.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:871fba677c03b66a1bf40815dac0ab1b385eb1b9be6e6c3cf2ad9788eeb2b6bb"
 
 [[package]]
 name = "snforge_std"
-version = "0.55.0+nightly-2026-02-03"
-source = "registry+https://scarbs.dev/"
-checksum = "sha256:3e5efb24f7d8b28713eee6d9e0f3476fb2aba2e19ffde21a109f72cc751afff6"
+version = "0.59.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:3620924fa08bd2d740b2b5b01ef86c8dab3d4b9c2206387c8dbdc8d2ec15133e"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,9 +11,9 @@ edition = "2024_07"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-starknet = "2.17.0-rc.4"
-snforge_std = { version = "0.55.0+nightly-2026-02-20", registry = "https://scarbs.dev/" }
-assert_macros = "2.17.0-rc.4"
+starknet = "2.17.0"
+snforge_std = "0.59.0"
+assert_macros = "2.17.0"
 # TODO: once openzeppelin upgrades to Cairo >=2.17, remove all SCARB_IGNORE_CAIRO_VERSION
 # flags from CI workflows and sdk/package.json scripts
 openzeppelin = "3.0.0"
@@ -26,6 +26,12 @@ sort-module-level-items = true
 
 [workspace.tool.scarb]
 allow-prebuilt-plugins = ["snforge_std"]
+
+# Redirect transitive `starkware_utils_testing` requests for snforge_std (pinned to
+# scarbs.dev) to the stable 0.59.0 release on scarbs.xyz, so we don't end up with
+# two snforge_scarb_plugin copies from incompatible registries.
+[patch."https://scarbs.dev/"]
+snforge_std = "0.59.0"
 
 [scripts]
 test = "SNFORGE_BACKTRACE=1 snforge test"

--- a/e2e/contracts/ekubo/Scarb.toml
+++ b/e2e/contracts/ekubo/Scarb.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024_07"
 
 [dependencies]
-starknet = "2.17.0-rc.4"
+starknet = "2.17.0"
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts", rev = "8b4de8b5701d10b101c06b786740bf45b6cf15cb" }
 
 [[target.starknet-contract]]

--- a/e2e/contracts/test-token/Scarb.toml
+++ b/e2e/contracts/test-token/Scarb.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024_07"
 
 [dependencies]
-starknet = "2.17.0-rc.4"
+starknet = "2.17.0"
 openzeppelin_token = "3.0.0"
 
 [[target.starknet-contract]]

--- a/e2e/scripts/README.md
+++ b/e2e/scripts/README.md
@@ -14,7 +14,7 @@ cd e2e/contracts/vesu      && scarb build  # Vesu Pool, PoolFactory, VToken, Ora
 scarb build                                 # Privacy pool + VesuLendingHelper + EkuboSwapHelper (from repo root)
 ```
 
-Note: `contracts/vesu/` requires Scarb 2.11.4 (pinned in its `.tool-versions`). The repo root, `contracts/test-token/`, and `contracts/ekubo/` use Scarb 2.17.0-rc.4.
+Note: `contracts/vesu/` requires Scarb 2.11.4 (pinned in its `.tool-versions`). The repo root, `contracts/test-token/`, and `contracts/ekubo/` use Scarb 2.17.0.
 
 ### Ekubo deployment
 

--- a/packages/ekubo_swap_helper/README.md
+++ b/packages/ekubo_swap_helper/README.md
@@ -1,0 +1,93 @@
+# Ekubo Swap Helper
+
+Cairo smart contract for privacy-preserving single-hop swaps on the [Ekubo](https://ekubo.org) AMM.
+
+## Overview
+
+`EkuboSwapHelper` is an invoke helper contract called by the privacy pool contract via the `privacy_invoke` selector. It executes a single-hop Ekubo swap on behalf of the privacy contract and returns a span of `OpenNoteDeposit` values for the privacy contract to apply.
+
+Full-swap-only: the helper asserts no input tokens remain on the router after the swap (`sqrt_ratio_limit = 0`), so partial fills revert.
+
+## Interface
+
+### IEkuboSwapHelper
+
+```
+fn privacy_invoke(
+    router_addr: ContractAddress,
+    token_amount: TokenAmount,
+    pool_key: PoolKey,
+    minimum_received: u256,
+    skip_ahead: u128,
+    note_id: felt252,
+) -> Span<OpenNoteDeposit>
+```
+
+| Parameter          | Description                                                                                         |
+|--------------------|-----------------------------------------------------------------------------------------------------|
+| `router_addr`      | Ekubo Router contract address                                                                       |
+| `token_amount`     | Input token + amount (Ekubo `TokenAmount`; amount must be positive)                                 |
+| `pool_key`         | Ekubo pool key (`token0`, `token1`, `fee`, `tick_spacing`, `extension`). Output token is the other. |
+| `minimum_received` | Slippage protection — minimum output amount passed to `clear_minimum`                               |
+| `skip_ahead`       | Ekubo route optimization parameter                                                                  |
+| `note_id`          | Open note identifier to deposit the output into                                                     |
+
+Returns a single-element `Span<OpenNoteDeposit>` containing `(note_id, out_token, out_amount)`.
+
+## Errors
+
+| Constant                  | Condition                                                                  |
+|---------------------------|----------------------------------------------------------------------------|
+| `ZERO_ROUTER`             | `router_addr` is zero                                                      |
+| `ZERO_IN_TOKEN`           | `token_amount.token` is zero                                               |
+| `NEGATIVE_AMOUNT`         | `token_amount.amount` is negative                                          |
+| `ZERO_IN_AMOUNT`          | `token_amount.amount` is zero                                              |
+| `TOKEN_MISMATCH_POOL_KEY` | `token_amount.token` is neither `pool_key.token0` nor `pool_key.token1`    |
+| `IN_TOKEN_NOT_CLEARED`    | Input-token balance on the router is non-zero after the swap (partial fill)|
+| `RECEIVED_AMOUNT_OVERFLOW`| Received output amount overflows `u128`                                    |
+| `ZERO_OUT_AMOUNT`         | Swap produced zero output tokens                                           |
+
+## Source modules
+
+| File                                                            | Purpose                                                           |
+|-----------------------------------------------------------------|-------------------------------------------------------------------|
+| [`ekubo_swap_helper.cairo`](src/ekubo_swap_helper.cairo)        | `IEkuboSwapHelper`, `errors`, `EkuboSwapHelper` contract          |
+
+## Build and test
+
+```bash
+scarb build --package ekubo_swap_helper
+scarb test   # wraps snforge test
+```
+
+## Declare and deploy with sncast
+
+[sncast](https://foundry-rs.github.io/starknet-foundry/) (Starknet Foundry) can declare and deploy the contract. Run from the **repository root** (the workspace has multiple packages) and use an [account](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account.html) configured in `snfoundry.toml` or via `--account` / `--url`.
+
+**1. Declare the contract**
+
+```bash
+scarb --profile release build
+sncast --account <ACCOUNT_NAME> declare \
+  --contract-name EkuboSwapHelper \
+  --package ekubo_swap_helper \
+  --network <mainnet|sepolia|devnet>
+```
+
+If you use a custom RPC instead of a preset network, use `--url <RPC_URL>` instead of `--network`. The command prints the **class hash**; use it for deploy.
+
+**2. Deploy the contract**
+
+The constructor takes no arguments.
+
+```bash
+sncast --account <ACCOUNT_NAME> deploy \
+  --class-hash <CLASS_HASH_FROM_DECLARE> \
+  --network <mainnet|sepolia|devnet>
+```
+
+## See also
+
+- [Privacy pool contract](../privacy/README.md) — calls this contract via `InvokeExternal`
+- [Vesu Lending Helper](../vesu_lending_helper/README.md) — sibling helper for lending operations
+- [Project root](../../README.md) — architecture overview and prerequisites

--- a/packages/privacy/README.md
+++ b/packages/privacy/README.md
@@ -110,7 +110,7 @@ scarb build
 scarb test   # wraps snforge test
 ```
 
-snforge version: `0.55.0+nightly-2026-02-20`
+snforge version: `0.59.0`
 
 Reference data generation: [`tests/generate_reference_data.cairo`](src/tests/generate_reference_data.cairo)
 

--- a/packages/vesu_lending_helper/README.md
+++ b/packages/vesu_lending_helper/README.md
@@ -73,7 +73,7 @@ scarb build --package vesu_lending_helper
 scarb test   # wraps snforge test
 ```
 
-snforge version: `0.55.0+nightly-2026-02-20`
+snforge version: `0.59.0`
 
 ## Declare and deploy with sncast
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.14.2-RC.3
+
 ### Breaking
 
 - Switch `starknet` dependency from custom fork (`starkware-libs/starknet.js#PRIVACY-0.14.2-RC.2`) to official `starknet@10.0.0-beta.6`
@@ -11,12 +13,6 @@
 - `fetchHistory` option renamed from `blockRef` to `blockIdentifier` (type: `BlockIdentifier`)
 - `HistoryPage.blockRef` changed from `string` to `BlockIdentifier`
 - `HistoryCursor.beginBlockNumber` is now optional (`undefined` on first page; server resolves from `block_ref`)
-
-### Changed
-
-- `block_ref` in API models now accepts block hash (hex string), block number (integer), or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Wire format is backwards compatible — block hashes remain plain hex strings.
-- `discoverNotes` and `discoverChannels` accept optional `blockIdentifier` param to pin discovery reads to a specific block
-- Compiler passes `ExecuteOptions.provingBlockId` to discovery as `blockIdentifier`, ensuring discovery and proving use the same block state
 
 ### Added
 
@@ -31,15 +27,15 @@
   - Same relay/key-pinning options as `IndexerDiscoveryProvider`
   - Also available via `ProofProviderConfig.ohttp` in `createPrivateTransfers()` factory
 - Export `OhttpOption` type for reuse in consumer code
-
-### Added
-
 - `fee` action type in `classifyTransaction` for withdrawals to fee recipients (e.g. paymaster forwarder), distinct from regular withdrawals
 - `ClassifyOptions.feeRecipients` parameter on `classifyTransaction` to identify fee recipient addresses
 - `Note.created` is now populated by `IndexerDiscoveryProvider` from the discovery service's per-note `block_number` (slot's `last_update_block`), enabling clients to enforce the 10-block maturity rule before spending
 
 ### Changed
 
+- `block_ref` in API models now accepts block hash (hex string), block number (integer), or tag (`"latest"`, `"pre_confirmed"`, `"l1_accepted"`). Wire format is backwards compatible — block hashes remain plain hex strings.
+- `discoverNotes` and `discoverChannels` accept optional `blockIdentifier` param to pin discovery reads to a specific block
+- Compiler passes `ExecuteOptions.provingBlockId` to discovery as `blockIdentifier`, ensuring discovery and proving use the same block state
 - Switch devnet testing from `ProvingServiceProofProvider` to `CallMockProofProvider` with `--proof-mode none` (proofFacts validated, proof ignored)
 - Run channel and note discovery concurrently during transaction compilation to reduce latency
 - `ProofInvocationFactory` builds `INVOKE_TXN_V3` manually instead of using `RpcChannel.prototype.buildTransaction()` (removed in v10)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -65,6 +65,138 @@ const transfers = createPrivateTransfers({
 });
 ```
 
+## Typical workflows
+
+This section describes the recommended integration patterns. Each subsection gives one opinionated recipe — stick to it unless you have a specific reason to deviate.
+
+### State management: go stateless
+
+Do not persist `PrivateRegistry` between sessions. Rely on the default full-refresh discovery on every `execute()` call:
+
+```typescript
+const result = await transfers
+  .build({
+    autoDiscover: { notes: "refresh", channels: "refresh" },
+    autoSelectNotes: "naive",
+  })
+  .with(STRK)
+  .transfer({ recipient: bob, amount: 50n })
+  .surplusTo(self)
+  .execute();
+```
+
+No local state means no cursor drift, no reorg reconciliation, and no stale-channel bugs.
+
+By default `execute()` mutates the `registry` argument in place. If you want to hand the SDK a registry you intend to reuse elsewhere, pass `registryConst: true` — the call then returns a new registry object and leaves the input untouched. Either way, treat the registry as ephemeral within a session and rebuild it from `discoverNotes` / `discoverChannels` at the start of the next session.
+
+**When to graduate.** Discovery becomes the UX bottleneck only past several thousand notes per account. At that point switch to incremental discovery by storing the `cursor` from the previous `discoverNotes` / `discoverChannels` response and passing it back on the next call (see [Discover notes](#discover-notes)). Incremental adds complexity — don't do it prematurely.
+
+### Speculative balances and history (`pre_confirmed`)
+
+For balance displays, history UI, and other read-only views where latency matters, pass `blockIdentifier: "pre_confirmed"` to `discoverNotes`, `discoverChannels`, and `fetchHistory`:
+
+```typescript
+const { notes } = await transfers.discoverNotes({
+  blockIdentifier: "pre_confirmed",
+});
+```
+
+`pre_confirmed` reads the node's speculative next-block state, so newly accepted transactions show up immediately rather than after `ACCEPTED_ON_L2`.
+
+**Precondition — the wallet must already handle reorgs on transparent balances.** If it does, `pre_confirmed` is a free latency win for private state too. If it doesn't, stay on `"latest"` until the wallet's reorg story is solid. Never prove against `pre_confirmed` — the prover requires finalized state (see next subsection).
+
+Caveats:
+
+- Speculative state may be reverted if the pre-confirmed block doesn't finalize.
+- Paginated discovery may see the underlying block advance between pages — fine for displaying a balance, not for building a transaction (use a block hash for that).
+- Pre-confirmed data can point at a branch that never gets finalized.
+
+**Alternative for a just-submitted tx: optimistic registry.** Every `execute()` returns a registry reflecting the compiled actions (the same mutated object by default; a new object if `registryConst: true` was passed). If the tx succeeds, use that registry directly and skip a discovery round-trip; replace it with fresh discovery before building the next tx.
+
+```typescript
+const result = await transfers.build(/* ... */).execute();
+const receipt = await provider.waitForTransaction(txHash);
+if (receipt.isSuccess()) {
+  // Use result.registry directly — no need to re-discover
+}
+```
+
+### Sequencing private transactions
+
+Two constraints govern when you can prove the next private transaction:
+
+1. **The prover reads finalized state, not `pre_confirmed`.** Your previous private tx's block must be finalized before you can prove the next one.
+2. **The sequencer accepts proofs whose `base_block` is at least 10 blocks older than the submission block.** The proving block must sit within the acceptance window when the transaction arrives.
+
+**Recipe:**
+
+1. After each accepted private tx, record `lastTxBlockNumber = receipt.block_number`.
+2. Before starting the next private tx, poll until `latestBlock - lastTxBlockNumber ≥ 10`.
+3. Prove at `latestBlock - 10` (or a couple of blocks earlier, see comment) and submit.
+4. Hide the wait behind a spinner — from the user's perspective the transaction just takes a bit longer.
+
+```typescript
+// Wait until the last tx block is finalized and old enough for the sequencer.
+// getBlockNumber() returns the latest finalized block, so this loop covers
+// both constraints: finalization and sequencer acceptance depth.
+let latestBlock = await provider.getBlockNumber();
+while (lastTxBlockNumber >= latestBlock - 10) {
+  await sleep(blockTime);
+  latestBlock = await provider.getBlockNumber();
+}
+
+// Prove at latest - 10 so the sequencer accepts it even after proving delay.
+// Optimization: use 8–9 instead of 10 — proving takes ~4s, which is less than
+// 1–2 block times, so the proof will still be within the window on arrival.
+const provingBlock = latestBlock - 10;
+const result = await transfers
+  .build({
+    autoDiscover: { notes: "refresh", channels: "refresh" },
+    autoSelectNotes: "naive",
+    provingBlockId: { block_number: provingBlock },
+  })
+  .with(STRK)
+  .transfer({ recipient: bob, amount: 50n })
+  .surplusTo(myAddress)
+  .execute();
+
+// Update tracking after the tx is accepted
+const receipt = await provider.waitForTransaction(txHash);
+lastTxBlockNumber = receipt.block_number;
+```
+
+The compiler forwards `provingBlockId` to discovery calls, ensuring the prover and discovery see the same contract state.
+
+### Sequencing after transparent state changes
+
+The same 10-block rule applies to **transparent** (non-private) transactions whose effects the pool will later need to prove against. Treat the receipt block of such a transaction exactly like `lastTxBlockNumber` in the previous recipe.
+
+Two concrete cases:
+
+- **Freshly deployed account → register.** You cannot call `register()` immediately after the account's deploy-account transaction. The prover must read the account's on-chain viewing-key slot at its base block; that slot only exists once the deploy is finalized. Wait ~10 blocks after the deploy receipt before registering.
+- **Freshly topped-up account → deposit.** You cannot `deposit()` tokens into the pool in the same block (or within ~10 blocks) of the ERC-20 transfer that funded the account. The prover reads the depositor's token balance at its base block; if the transfer hasn't propagated to that base block, the proof is invalid or the deposit fails on-chain due to insufficient balance.
+
+```typescript
+// After topping up the account with tokens, wait before depositing into the pool.
+const topupReceipt = await provider.waitForTransaction(topupTxHash);
+const topupBlock = topupReceipt.block_number;
+
+let latestBlock = await provider.getBlockNumber();
+while (topupBlock >= latestBlock - 10) {
+  await sleep(blockTime);
+  latestBlock = await provider.getBlockNumber();
+}
+
+// Safe to deposit now.
+const result = await transfers
+  .build({ autoDiscover: { notes: "refresh", channels: "refresh" } })
+  .with(STRK, (t) => t.deposit({ amount: 100n }))
+  .surplusTo(self)
+  .execute();
+```
+
+Rule of thumb: any on-chain state that the pool proof reads — account viewing key, depositor token balance, nullifier set — must have been written at least 10 blocks before the proof's base block.
+
 ## Configuration
 
 ### `createPrivateTransfers(params)`
@@ -423,6 +555,16 @@ if (!page.cursor.historyComplete) {
   );
 }
 ```
+
+**Completeness caveats.** The history feed is anchored on the user's notes — each page scans backward one note block at a time and attaches the events that sit in that block. A few transaction shapes fall outside this anchor:
+
+- **Bundled multi-user deposits** — when another user's deposit shares a transaction with your notes (atypical), it is filtered out of your history by `user_address` to avoid double-counting balances. Your own deposits in the same transaction still appear.
+- **Notes above the cursor / `blockIdentifier` upper bound** — if the client-provided cursor or `blockIdentifier` disagrees with the actual block of a discovered note (stale cursor, malicious input, or chain drift), those notes are skipped silently and the scanner advances.
+
+**Withdrawal attribution caveat.** On-chain `Withdrawal` events expose only the recipient address; the initiating `user_addr` is encrypted. The service cannot filter in-block withdrawals by initiator, so:
+
+- A withdrawal that shares a transaction with your notes is attached to that transaction in your history, even if a different user initiated it (e.g. A withdraws to B while B has notes in the same tx).
+- In multi-user batched transactions, unrelated withdrawals may be attached to any user with matched notes in the batch.
 
 ## Execute result
 


### PR DESCRIPTION
Upgrades toolchain dependencies from release candidates to stable releases and bumps component versions in the compatibility table.

**Toolchain upgrades**
- Scarb `2.17.0-rc.4` → `2.17.0`
- Universal Sierra Compiler `v2.8.0-rc.0` → `v2.8.0`
- starknet-foundry `nightly-2026-02-20` → `0.59.0`
- `snforge_std` / `snforge_scarb_plugin` `0.55.0+nightly-2026-02-03` → `0.59.0`, migrated from `scarbs.dev` to `scarbs.xyz` registry
- Adds a `[patch."https://scarbs.dev/"]` entry to redirect transitive `snforge_std` requests from the old registry to the stable `0.59.0` release, preventing duplicate plugin copies

**Compatibility table (README)**
- Transaction Prover: `PRIVACY-0.14.2-RC.3` → `PRIVACY-0.14.2-RC.4`
- Discovery Service: `PRIVACY-0.14.2-RC.2` → `PRIVACY-0.14.2-RC.4`
- SDK: `PRIVACY-0.14.2-RC.2` → `PRIVACY-0.14.2-RC.4`
- Privacy Pool class hash updated; Ekubo Helper and Vesu Helper class hashes updated and tagged at `PRIVACY-0.14.2-RC.4`

**Documentation**
- Adds `packages/ekubo_swap_helper/README.md` covering the contract interface, error catalogue, build/test instructions, and declare/deploy steps
- Expands `sdk/README.md` with a "Typical workflows" section covering stateless state management, `pre_confirmed` speculative balances, private transaction sequencing (the 10-block proving window), sequencing after transparent state changes, and history completeness/withdrawal attribution caveats
- Fixes `sdk/CHANGELOG.md` section ordering for `0.14.2-RC.3`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/712)
<!-- Reviewable:end -->