### PR TITLE
feat(discovery): surface note creation block to clients

### DIFF
--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 
+use starknet_core::types::StorageResult;
 use starknet_types_core::felt::Felt;
 
 use crate::discovery::cursor::SubchannelCursor;
@@ -38,7 +39,8 @@ pub fn boundary_budget(max_note_log_index: u32) -> usize {
 /// fully or makes no progress (budget too small).
 ///
 /// Returns `(probe_cache, has_more)`:
-/// - `probe_cache`: index → (note_id, packed_amount) from probe hits (for incoming scan).
+/// - `probe_cache`: index → (note_id, storage_result) from probe hits (for incoming scan).
+///   The `StorageResult` carries both the packed value and the slot's last-update block.
 /// - `has_more`: `true` if budget was insufficient and another call is needed.
 ///
 /// On success, sets `cursor.total_n_notes`. Callers read the result via
@@ -50,7 +52,7 @@ pub async fn find_last_note_index<S: IViews>(
     cursor: &mut SubchannelCursor,
     max_note_log_index: u32,
     budget: &IoBudget,
-) -> Result<(HashMap<u64, (Felt, Felt)>, bool), DiscoveryError> {
+) -> Result<(HashMap<u64, (Felt, StorageResult)>, bool), DiscoveryError> {
     if cursor.total_n_notes.is_some() {
         return Ok((HashMap::new(), false));
     }
@@ -107,16 +109,16 @@ async fn bisect_boundary<S: IViews>(
     token: Felt,
     mut lower_bound: u64,
     mut upper_bound: u64,
-    cache: &mut HashMap<u64, (Felt, Felt)>,
+    cache: &mut HashMap<u64, (Felt, StorageResult)>,
 ) -> Result<(u64, usize), DiscoveryError> {
     let mut step_count = 0;
     while lower_bound + 1 < upper_bound {
         let mid = lower_bound + (upper_bound - lower_bound) / 2;
         let note_id = compute_note_id(channel_key, token, mid);
         step_count += 1;
-        let packed = pool.get_note(note_id).await?;
-        if packed != Felt::ZERO {
-            cache.insert(mid, (note_id, packed));
+        let result = pool.get_note_with_block(note_id).await?;
+        if result.value != Felt::ZERO {
+            cache.insert(mid, (note_id, result));
             lower_bound = mid;
         } else {
             upper_bound = mid;
@@ -147,7 +149,7 @@ async fn exponential_probe<S: IViews>(
     token: Felt,
     start_index: u64,
     max_note_log_index: u32,
-    cache: &mut HashMap<u64, (Felt, Felt)>,
+    cache: &mut HashMap<u64, (Felt, StorageResult)>,
 ) -> Result<Option<(u64, u64)>, DiscoveryError> {
     // Offsets: [0, 1, 3, 7, 15, ..., 2^k - 1] where k = max_note_log_index.
     let offsets: Vec<u64> = (0..=max_note_log_index)
@@ -158,14 +160,14 @@ async fn exponential_probe<S: IViews>(
         .iter()
         .map(|&off| compute_note_id(channel_key, token, start_index + off))
         .collect();
-    let results = pool.get_notes_batch(&note_ids).await?;
+    let results = pool.get_notes_batch_with_block(&note_ids).await?;
 
     let mut lower_bound: Option<u64> = None;
 
-    for (i, &packed) in results.iter().enumerate() {
+    for (i, result) in results.into_iter().enumerate() {
         let idx = start_index + offsets[i];
-        if packed != Felt::ZERO {
-            cache.insert(idx, (note_ids[i], packed));
+        if result.value != Felt::ZERO {
+            cache.insert(idx, (note_ids[i], result));
             lower_bound = Some(idx);
         } else {
             return Ok(lower_bound.map(|lower_bound| (lower_bound, idx)));

--- a/crates/discovery-core/src/discovery/mod.rs
+++ b/crates/discovery-core/src/discovery/mod.rs
@@ -23,13 +23,13 @@ pub const COST_CHANNEL_INFO: usize = 3;
 /// Cost for `get_subchannel_info` (2 storage slot reads).
 pub const COST_SUBCHANNEL_INFO: usize = 2;
 
-/// Cost for `get_note` + `nullifier_exists` (2 storage slot reads).
+/// Cost for `get_note_with_block` + `nullifier_exists` (2 storage slot reads).
 pub const COST_NOTE: usize = 2;
 
 /// Cost for outgoing channel info (3 storage slot reads: salt + enc_recipient_addr + public_key).
 pub const COST_OUTGOING_CHANNEL_INFO: usize = 3;
 
-/// Cost for a single note existence probe (1 `get_note` read, no nullifier check).
+/// Cost for a single note existence probe (1 `get_note_with_block` read, no nullifier check).
 pub const COST_NOTE_PROBING: usize = 1;
 
 /// Cost for a single `get_public_key` (1 storage slot read).

--- a/crates/discovery-core/src/discovery/notes.rs
+++ b/crates/discovery-core/src/discovery/notes.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use starknet_core::types::StorageResult;
 use starknet_types_core::felt::Felt;
 
 use tracing::{debug, trace};
@@ -51,6 +52,10 @@ pub struct DecryptedNote {
     /// The salt used for encryption.
     #[serde(with = "u128_as_string")]
     pub salt: u128,
+    /// Block in which the note was created (the slot's `last_update_block`).
+    /// Note slots are write-once, so this is also the creation block. Clients
+    /// use it to enforce the 10-block maturity rule before spending.
+    pub block_number: u64,
 }
 
 impl DecryptedNote {
@@ -165,7 +170,7 @@ async fn discover_notes<S: IViews>(
     end_index: u64,
     private_key: &SecretFelt,
     budget: &IoBudget,
-    probe_cache: &HashMap<u64, (Felt, Felt)>,
+    probe_cache: &HashMap<u64, (Felt, StorageResult)>,
 ) -> Result<NotesDiscoveryResult, DiscoveryError> {
     let num_remaining_notes = usize::try_from((end_index + 1).saturating_sub(start_index))
         .map_err(|_| DiscoveryError::InvalidCursor("note range too large".into()))?;
@@ -213,7 +218,7 @@ async fn process_note_batch<S: IViews>(
     token: Felt,
     indices: std::ops::Range<u64>,
     private_key: &SecretFelt,
-    probe_cache: &HashMap<u64, (Felt, Felt)>,
+    probe_cache: &HashMap<u64, (Felt, StorageResult)>,
 ) -> Result<(Vec<DecryptedNote>, usize), DiscoveryError> {
     // Batch-check nullifiers.
     let nullifiers: Vec<_> = indices
@@ -222,9 +227,9 @@ async fn process_note_batch<S: IViews>(
         .collect();
     let spent_flags = pool.nullifier_exists_batch(&nullifiers).await?;
 
-    // Classify: spent → skip, unspent+cached → insert with amount,
+    // Classify: spent → skip, unspent+cached → insert with stored result,
     // unspent+uncached → collect for batch fetch.
-    let mut unspent_notes: HashMap<u64, (Felt, Felt)> = HashMap::new();
+    let mut unspent_notes: HashMap<u64, (Felt, StorageResult)> = HashMap::new();
     let mut indices_to_fetch: Vec<u64> = Vec::new();
     let mut num_skipped = 0;
 
@@ -233,7 +238,7 @@ async fn process_note_batch<S: IViews>(
             num_skipped += 1;
             continue;
         }
-        if let Some(&cached_note) = probe_cache.get(&idx) {
+        if let Some(cached_note) = probe_cache.get(&idx).cloned() {
             num_skipped += 1;
             unspent_notes.insert(idx, cached_note);
         } else {
@@ -241,27 +246,34 @@ async fn process_note_batch<S: IViews>(
         }
     }
 
-    // Fetch amounts for uncached unspent notes, merge into map.
+    // Fetch storage results (value + creation block) for uncached unspent notes.
     if !indices_to_fetch.is_empty() {
         let note_ids: Vec<_> = indices_to_fetch
             .iter()
             .map(|&index| compute_note_id(channel_key, token, index))
             .collect();
-        let packed_values = pool.get_notes_batch(&note_ids).await?;
-        for (index, (note_id, packed)) in indices_to_fetch
+        let storage_results = pool.get_notes_batch_with_block(&note_ids).await?;
+        for (index, (note_id, result)) in indices_to_fetch
             .iter()
-            .zip(note_ids.into_iter().zip(packed_values))
+            .zip(note_ids.into_iter().zip(storage_results))
         {
-            unspent_notes.insert(*index, (note_id, packed));
+            unspent_notes.insert(*index, (note_id, result));
         }
     }
 
     // Decrypt in index order by iterating the original batch range.
     let notes = indices
         .filter_map(|idx| {
-            unspent_notes
-                .remove(&idx)
-                .map(|(note_id, packed)| decrypt_note(channel_key, token, idx, note_id, packed))
+            unspent_notes.remove(&idx).map(|(note_id, result)| {
+                decrypt_note(
+                    channel_key,
+                    token,
+                    idx,
+                    note_id,
+                    result.value,
+                    result.last_update_block,
+                )
+            })
         })
         .collect();
 
@@ -278,9 +290,10 @@ fn decrypt_note(
     index: u64,
     note_id: Felt,
     packed: Felt,
+    block_number: u64,
 ) -> DecryptedNote {
     let (amount, salt) = decrypt_packed_value(packed, channel_key, token, index);
-    trace!(index, amount, salt, "unspent note found");
+    trace!(index, amount, salt, block_number, "unspent note found");
     DecryptedNote {
         sender_addr: Felt::ZERO, // set by the sync orchestrator after discovery
         token: Felt::ZERO,       // set by the sync orchestrator after discovery
@@ -288,6 +301,7 @@ fn decrypt_note(
         note_id,
         amount,
         salt,
+        block_number,
     }
 }
 
@@ -720,19 +734,21 @@ mod tests {
         let token = Felt::from_hex_unchecked("0x67890");
         let index = 0u64;
         let note_id = Felt::from(42u64);
+        let block_number = 1234u64;
 
         let amount: u128 = 50_000_000_000_000_000_000;
         // Pack: salt=1 in upper 128 bits, plaintext amount in lower 128 bits
         let packed = Felt::from(OPEN_NOTE_SALT) * Felt::from(1u128 << 64) * Felt::from(1u128 << 64)
             + Felt::from(amount);
 
-        let note = decrypt_note(&channel_key, token, index, note_id, packed);
+        let note = decrypt_note(&channel_key, token, index, note_id, packed, block_number);
 
         assert!(note.is_open(), "salt==1 note should be open");
         assert_eq!(note.amount, amount, "open note amount should be plaintext");
         assert_eq!(note.salt, OPEN_NOTE_SALT);
         assert_eq!(note.index, index);
         assert_eq!(note.note_id, note_id);
+        assert_eq!(note.block_number, block_number);
     }
 
     #[test]
@@ -741,6 +757,7 @@ mod tests {
         let token = Felt::from_hex_unchecked("0x67890");
         let index = 0u64;
         let note_id = Felt::from(42u64);
+        let block_number = 9999u64;
 
         // Salt >= 2 means encrypted note
         let salt: u128 = 2;
@@ -748,9 +765,44 @@ mod tests {
         let packed = Felt::from(salt) * Felt::from(1u128 << 64) * Felt::from(1u128 << 64)
             + Felt::from(enc_amount);
 
-        let note = decrypt_note(&channel_key, token, index, note_id, packed);
+        let note = decrypt_note(&channel_key, token, index, note_id, packed, block_number);
 
         assert!(!note.is_open(), "salt>=2 note should not be open");
         assert_eq!(note.salt, salt);
+        assert_eq!(note.block_number, block_number);
+    }
+
+    #[tokio::test]
+    async fn test_discover_notes_propagates_block_number() {
+        // Insert two open notes at distinct blocks; verify each DecryptedNote
+        // carries the slot's last_update_block as block_number.
+        use crate::privacy_pool::decryption::OPEN_NOTE_SALT;
+        use crate::privacy_pool::storage_slots;
+
+        let channel_key = SecretFelt::new(Felt::from_hex_unchecked("0x12345"));
+        let token = Felt::from_hex_unchecked("0x67890");
+        let zero_key = SecretFelt::new(Felt::ZERO);
+
+        // Open notes (salt=1) so decryption returns the plaintext amount.
+        let pack = |amount: u128| {
+            Felt::from(OPEN_NOTE_SALT) * Felt::from(1u128 << 64) * Felt::from(1u128 << 64)
+                + Felt::from(amount)
+        };
+
+        let mut backend = MockBackend::empty();
+        let note_id_0 = compute_note_id(&channel_key, token, 0);
+        let note_id_1 = compute_note_id(&channel_key, token, 1);
+        backend.insert_with_block(storage_slots::notes(note_id_0), pack(100), 42);
+        backend.insert_with_block(storage_slots::notes(note_id_1), pack(200), 77);
+
+        let budget = IoBudget::new(200);
+        let (notes, cursor) =
+            discover_with_fresh_cursor(&backend, &channel_key, token, &zero_key, &budget).await;
+
+        assert!(cursor.note_discovery_complete);
+        assert_eq!(notes.len(), 2);
+        let by_index: HashMap<u64, &DecryptedNote> = notes.iter().map(|n| (n.index, n)).collect();
+        assert_eq!(by_index[&0].block_number, 42);
+        assert_eq!(by_index[&1].block_number, 77);
     }
 }

--- a/crates/discovery-core/src/privacy_pool/views.rs
+++ b/crates/discovery-core/src/privacy_pool/views.rs
@@ -49,14 +49,13 @@ pub trait IViews: Send + Sync {
         outgoing_channel_id: Felt,
     ) -> Result<EncOutgoingChannelInfo, StorageError>;
 
-    /// Returns the note value for the given note ID.
-    async fn get_note(&self, note_id: Felt) -> Result<Felt, StorageError> {
-        self.get_notes_batch(&[note_id]).await.map(|notes| {
-            notes
-                .first()
-                .copied()
-                .ok_or(StorageError::SlotCountMismatch)
-        })?
+    /// Returns the note value with its last-update block number for the given note ID.
+    async fn get_note_with_block(&self, note_id: Felt) -> Result<StorageResult, StorageError> {
+        self.get_notes_batch_with_block(&[note_id])
+            .await?
+            .into_iter()
+            .next()
+            .ok_or(StorageError::SlotCountMismatch)
     }
 
     /// Checks if a nullifier exists.
@@ -93,11 +92,6 @@ pub trait IViews: Send + Sync {
         start_index: u64,
         count: usize,
     ) -> Result<Vec<EncChannelInfo>, StorageError>;
-
-    /// Batch-reads packed note values for the given note IDs.
-    ///
-    /// Returns a `Vec<Felt>` matching the input length. Zero = note doesn't exist.
-    async fn get_notes_batch(&self, note_ids: &[Felt]) -> Result<Vec<Felt>, StorageError>;
 
     /// Batch-reads public keys for the given addresses.
     ///
@@ -220,21 +214,6 @@ impl<T: RawStorageAccess> IViews for T {
             });
         }
         Ok(result)
-    }
-
-    #[tracing::instrument(
-        name = "get_notes_batch",
-        level = "debug",
-        skip(self, note_ids),
-        fields(count = note_ids.len())
-    )]
-    async fn get_notes_batch(&self, note_ids: &[Felt]) -> Result<Vec<Felt>, StorageError> {
-        let slots: Vec<_> = note_ids
-            .iter()
-            .map(|&nid| storage_slots::notes(nid))
-            .collect();
-        let values = self.read_slots(slots).await?;
-        Ok(values)
     }
 
     #[tracing::instrument(

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -107,7 +107,7 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
     { "sender_addr": "0x...", "token": "0x..." }
   ],
   "notes": [
-    { "sender_addr": "0x...", "token": "0x...", "index": 1, "note_id": "0x...", "amount": "1000", "salt": "12345" }
+    { "sender_addr": "0x...", "token": "0x...", "index": 1, "note_id": "0x...", "amount": "1000", "salt": "12345", "block_number": 12345 }
   ],
   "cursor": {
     "channel_discovery_complete": false,
@@ -146,6 +146,8 @@ A unified endpoint that discovers channels, subchannels, and notes in one call w
 3. **Store for next session**: If the final `block_ref` is a block hash, save it as your `last_known_block` for reorg detection. Block number or tag refs cannot be used for reorg detection.
 
 **Note filtering:** For each decrypted note, the service derives the nullifier and checks if it exists in contract state. Only unspent notes (those whose nullifier does not exist) are included in the response.
+
+**Note `block_number`:** The slot's `last_update_block` from the storage RPC (`get_storage_at` with the `IncludeLastUpdateBlock` flag). Note slots are write-once, so this equals the block in which the note was created. Clients use it to enforce the 10-block maturity rule before spending.
 
 ## 6.6 Outgoing Channel Sync Endpoint
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - `fee` action type in `classifyTransaction` for withdrawals to fee recipients (e.g. paymaster forwarder), distinct from regular withdrawals
 - `ClassifyOptions.feeRecipients` parameter on `classifyTransaction` to identify fee recipient addresses
+- `Note.created` is now populated by `IndexerDiscoveryProvider` from the discovery service's per-note `block_number` (slot's `last_update_block`), enabling clients to enforce the 10-block maturity rule before spending
 
 ### Changed
 

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -65,6 +65,7 @@ type ApiIncomingNoteInfo = {
   note_id: string;
   amount: string;
   salt: string;
+  block_number: number;
 };
 
 type ApiOutgoingChannel = {
@@ -648,6 +649,7 @@ export function convertIncomingNotes(
     result.get(token)!.push({
       id: n.note_id,
       amount: BigInt(n.amount),
+      created: n.block_number,
       witness: new Witness(channelKey, n.index, BigInt(n.salt)),
       sender,
       open: n.salt === "1",


### PR DESCRIPTION
# feat(discovery): surface note creation block to clients

## Why

Notes in the privacy pool aren't immediately spendable: clients must wait for the **10-block maturity rule** before referencing a note in a withdrawal, or the contract rejects the call. Today the SDK has no way to know how mature a note is — `discovery-core` reads note slots via `getStorageAt` returning only the slot value, throwing away the per-slot block metadata the RPC could have included for free.

The result is that the SDK can't gate spend attempts on maturity. It either:
- over-rejects (waits longer than necessary, e.g. blocking on the chain head before trying), or
- under-rejects (sends the call and gets a contract-side rejection that the user has to interpret).

The `Note.created?: BlockNumber` field already exists on the SDK's `Note` type as a stub — it's just never populated because the wire format doesn't carry the data.

## What

Switch the notes-discovery storage reads from value-only to value-plus-block, plumb the block number through `DecryptedNote`, and populate `Note.created` in the SDK.

The Starknet RPC supports an `IncludeLastUpdateBlock` flag on `getStorageAt` that piggybacks the slot's last-update block onto the same call (no extra round-trip, no extra cost). Note slots are write-once in the privacy-pool design, so `last_update_block` of a note slot equals the block in which the note was created.

The infra to fetch this metadata already exists in the trait (`IViews::get_notes_batch_with_block`) and is already used by the history flow — the notes-discovery flow just hadn't adopted it yet.

## Changes

**`discovery-core`**
- `DecryptedNote` gains `block_number: u64`.
- `process_note_batch`, `exponential_probe`, and `bisect_boundary` switch to the `_with_block` storage variants. The probe cache now stores `(note_id, packed, last_update_block)` so cached probe-hits flow through to the linear scan without re-fetching.
- New `IViews::get_note_with_block` default method (single-note variant for the bisect path).
- Removed now-unused `IViews::get_note` and `IViews::get_notes_batch` — sole callers were the three sites being switched.
- `COST_NOTE` and `COST_NOTE_PROBING` doc-comments updated to reference the new method names. Numeric cost is unchanged: `IncludeLastUpdateBlock` rides on the same `getStorageAt` call.

**`discovery-service`**
- No code change. `IncomingSyncResponse.notes` directly serializes `DecryptedNote`, so the new field auto-propagates onto the wire as `"block_number": <u64>`.
- Spec `06-api-design.md`: updated the JSON example for the notes response and added a paragraph explaining the field's source (slot's `last_update_block` via the `IncludeLastUpdateBlock` flag) and purpose (10-block maturity gate).

**SDK**
- `ApiIncomingNoteInfo` gains `block_number: number`.
- `convertIncomingNotes` populates `Note.created` from it.
- `CHANGELOG.md` entry under `## Unreleased` → `### Added`.

## Tests

- Updated existing `test_decrypt_note_*` to pass and assert `block_number`.
- New `test_discover_notes_propagates_block_number`: inserts two open notes at distinct blocks via `MockBackend::insert_with_block`, runs `discover_notes_paginated`, asserts each `DecryptedNote.block_number` matches the inserted block.
- All existing notes / last-note-index tests continue to pass after the cache type change.

## Notes

- The change keeps the wire format additive — older SDK clients ignore the new `block_number` field and continue to function. New SDK code that reads `Note.created` requires the updated discovery-service.
- `block_number = 0` is a possible-but-degenerate value (e.g. notes against a `MockBackend` that wasn't given a block via `insert_with_block`). On real chain data it will always be the genuine creation block. Consumers of `Note.created` should treat `0` as "unknown" if they want to be defensive against pre-deployment fixture data, but this isn't a concern for the indexer flow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/713)
<!-- Reviewable:end -->
