### PR TITLE
feat(elliptic-proxy): add mock-screener mode for non-mainnet deployments

### DIFF
--- a/elliptic-proxy/src/config.ts
+++ b/elliptic-proxy/src/config.ts
@@ -12,6 +12,18 @@ export interface Config {
   configCacheTtlSeconds: number;
   blockedCacheTtlSeconds: number;
   partners: Record<string, string>; // partner name -> HMAC secret
+  // When true, the proxy never calls Elliptic. Use on non-mainnet
+  // deployments where Elliptic has no data coverage, or as a kill
+  // switch. Off by default. Operator-curated lists below still apply.
+  skipElliptic?: boolean;
+  // Lowercase hex addresses to always treat as blocked, regardless of
+  // Elliptic's verdict (or in lieu of it when skipElliptic is set).
+  // Supplemental deny list for operator policy.
+  additionalBlockedAddresses?: string[];
+  // Lowercase hex addresses to always treat as allowed, regardless of
+  // Elliptic's verdict and regardless of additionalBlockedAddresses.
+  // Operator override for addresses we believe were wrongly flagged.
+  blockOverrideAddresses?: string[];
 }
 
 type SecretFetcher = () => Promise<string>;
@@ -100,6 +112,14 @@ function validateConfig(raw: unknown): Config {
     }
   }
 
+  let skipElliptic: boolean | undefined;
+  if (root.skipElliptic !== undefined) {
+    if (typeof root.skipElliptic !== "boolean") {
+      throw new Error("config: skipElliptic must be a boolean");
+    }
+    skipElliptic = root.skipElliptic;
+  }
+
   return {
     elliptic: {
       url: requireString(elliptic, "url"),
@@ -115,5 +135,26 @@ function validateConfig(raw: unknown): Config {
       "blockedCacheTtlSeconds"
     ),
     partners: root.partners as Record<string, string>,
+    skipElliptic,
+    additionalBlockedAddresses: parseLowercaseHexList(
+      root,
+      "additionalBlockedAddresses"
+    ),
+    blockOverrideAddresses: parseLowercaseHexList(
+      root,
+      "blockOverrideAddresses"
+    ),
   };
+}
+
+function parseLowercaseHexList(
+  object: Record<string, unknown>,
+  key: string
+): string[] | undefined {
+  const value = object[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || !value.every((a) => typeof a === "string")) {
+    throw new Error(`config: ${key} must be string[]`);
+  }
+  return (value as string[]).map((a) => a.toLowerCase());
 }

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -128,6 +128,47 @@ export function createHandler(
     }
     address = address.toLowerCase();
 
+    // Operator overrides take precedence over Elliptic and the cache.
+    // blockOverrideAddresses wins over additionalBlockedAddresses so an
+    // explicit allow can rescue a globally-denied address.
+    if (config.blockOverrideAddresses?.includes(address)) {
+      sendResponse(
+        200,
+        JSON.stringify({ blocked: false, source: "allowlist" }),
+        {
+          partner: partnerName,
+          result: "allowed",
+          source: "allowlist",
+        }
+      );
+      return;
+    }
+
+    if (config.additionalBlockedAddresses?.includes(address)) {
+      sendResponse(
+        200,
+        JSON.stringify({ blocked: true, source: "blocklist" }),
+        {
+          partner: partnerName,
+          result: "blocked",
+          source: "blocklist",
+        }
+      );
+      return;
+    }
+
+    // skipElliptic short-circuits the live screening path. Useful on
+    // non-mainnet deployments where Elliptic has no Starknet coverage,
+    // or as a kill switch. Operator lists above still apply.
+    if (config.skipElliptic) {
+      sendResponse(200, JSON.stringify({ blocked: false, source: "skip" }), {
+        partner: partnerName,
+        result: "allowed",
+        source: "skip",
+      });
+      return;
+    }
+
     // Check cache first — blocked addresses skip the Elliptic call
     if (blockedCache.isBlocked(address)) {
       sendResponse(200, JSON.stringify({ blocked: true }), {

--- a/elliptic-proxy/tests/config.test.ts
+++ b/elliptic-proxy/tests/config.test.ts
@@ -107,4 +107,64 @@ describe("ConfigLoader", () => {
       "partners.bad-partner must be a non-empty string"
     );
   });
+
+  it("leaves operator-policy fields unset by default", async () => {
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(VALID_CONFIG));
+    const loader = new ConfigLoader(fetcher);
+    const config = await loader.get();
+    expect(config.skipElliptic).toBeUndefined();
+    expect(config.additionalBlockedAddresses).toBeUndefined();
+    expect(config.blockOverrideAddresses).toBeUndefined();
+  });
+
+  it("accepts skipElliptic with operator-curated lists, lowercasing addresses", async () => {
+    const config = {
+      ...VALID_CONFIG,
+      skipElliptic: true,
+      additionalBlockedAddresses: ["0xABCDEF", "0xdeadbeef"],
+      blockOverrideAddresses: ["0xCAFE"],
+    };
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(config));
+    const loader = new ConfigLoader(fetcher);
+    const loaded = await loader.get();
+    expect(loaded.skipElliptic).toBe(true);
+    expect(loaded.additionalBlockedAddresses).toEqual([
+      "0xabcdef",
+      "0xdeadbeef",
+    ]);
+    expect(loaded.blockOverrideAddresses).toEqual(["0xcafe"]);
+  });
+
+  it("throws when skipElliptic is not a boolean", async () => {
+    const invalidConfig = { ...VALID_CONFIG, skipElliptic: "yes" };
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(invalidConfig));
+    const loader = new ConfigLoader(fetcher);
+    await expect(loader.get()).rejects.toThrow(
+      "skipElliptic must be a boolean"
+    );
+  });
+
+  it("throws when additionalBlockedAddresses is not a string array", async () => {
+    const invalidConfig = {
+      ...VALID_CONFIG,
+      additionalBlockedAddresses: ["0xabc", 123],
+    };
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(invalidConfig));
+    const loader = new ConfigLoader(fetcher);
+    await expect(loader.get()).rejects.toThrow(
+      "additionalBlockedAddresses must be string[]"
+    );
+  });
+
+  it("throws when blockOverrideAddresses is not a string array", async () => {
+    const invalidConfig = {
+      ...VALID_CONFIG,
+      blockOverrideAddresses: "not-an-array",
+    };
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(invalidConfig));
+    const loader = new ConfigLoader(fetcher);
+    await expect(loader.get()).rejects.toThrow(
+      "blockOverrideAddresses must be string[]"
+    );
+  });
 });

--- a/elliptic-proxy/tests/handler.test.ts
+++ b/elliptic-proxy/tests/handler.test.ts
@@ -519,4 +519,156 @@ describe("createHandler", () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ blocked: false });
   });
+  describe("operator policy lists", () => {
+    function makePolicyConfig(overrides: Partial<Config> = {}): Config {
+      return { ...makeConfig(), ...overrides };
+    }
+
+    it("blocks via additionalBlockedAddresses without calling Elliptic", async () => {
+      const configLoader = {
+        get: vi
+          .fn()
+          .mockResolvedValue(
+            makePolicyConfig({ additionalBlockedAddresses: ["0xdeadbeef"] })
+          ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xdeadbeef");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: true,
+        source: "blocklist",
+      });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("allows via blockOverrideAddresses without calling Elliptic", async () => {
+      const configLoader = {
+        get: vi
+          .fn()
+          .mockResolvedValue(
+            makePolicyConfig({ blockOverrideAddresses: ["0xcafe"] })
+          ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xCAFE");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: false,
+        source: "allowlist",
+      });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("allowlist wins over blocklist when both list the same address", async () => {
+      const configLoader = {
+        get: vi.fn().mockResolvedValue(
+          makePolicyConfig({
+            additionalBlockedAddresses: ["0xdeadbeef"],
+            blockOverrideAddresses: ["0xdeadbeef"],
+          })
+        ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xdeadbeef");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: false,
+        source: "allowlist",
+      });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("skipElliptic returns allowed without calling Elliptic when no list matches", async () => {
+      const configLoader = {
+        get: vi
+          .fn()
+          .mockResolvedValue(makePolicyConfig({ skipElliptic: true })),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xf00d");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ blocked: false, source: "skip" });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("blocklist still applies under skipElliptic", async () => {
+      const configLoader = {
+        get: vi.fn().mockResolvedValue(
+          makePolicyConfig({
+            skipElliptic: true,
+            additionalBlockedAddresses: ["0xdeadbeef"],
+          })
+        ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xdeadbeef");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: true,
+        source: "blocklist",
+      });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("blocklist overrides Elliptic on a clean live response", async () => {
+      mockForward.mockResolvedValue({
+        status: 200,
+        durationMs: 5,
+        body: JSON.stringify({
+          process_status: "complete",
+          evaluation_detail: { source: [], destination: [] },
+        }),
+      });
+      const configLoader = {
+        get: vi
+          .fn()
+          .mockResolvedValue(
+            makePolicyConfig({ additionalBlockedAddresses: ["0xabc123"] })
+          ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest();
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: true,
+        source: "blocklist",
+      });
+      expect(mockForward).not.toHaveBeenCalled();
+    });
+
+    it("matches policy lists case-insensitively (handler lowercases the address)", async () => {
+      const configLoader = {
+        get: vi
+          .fn()
+          .mockResolvedValue(
+            makePolicyConfig({ additionalBlockedAddresses: ["0xabcdef"] })
+          ),
+      };
+      const handler = createHandler(configLoader, mockForward);
+      const req = makeRequest({}, "0xABCDEF");
+      const res = makeResponse();
+      await handler(req, res);
+
+      expect(JSON.parse(res.body)).toEqual({
+        blocked: true,
+        source: "blocklist",
+      });
+    });
+  });
 });


### PR DESCRIPTION
Elliptic doesn't index testnets (general AML-provider rule) and currently
has no Starknet coverage at all. Calling Elliptic from a Sepolia
deployment is wasted: legitimate addresses come back as 404
NotInBlockchain and there's no real-world sanctions data to match.

Add a deployment-config flag `mockScreener` plus an optional
`mockBlockedAddresses` fixture list. When mockScreener is true, the
handler short-circuits before any Elliptic call and returns a
deterministic verdict: blocked iff the (lowercased) address is in the
fixture list. Mainnet deployments leave mockScreener unset and use the
live Elliptic path unchanged.

Lets us exercise the full sidecar→proxy→prover blocked path on testnet
with arbitrary Starknet-shape vectors, decoupling testnet test fidelity
from Elliptic's coverage decisions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/721)
<!-- Reviewable:end -->
