### PR TITLE
feat(elliptic-proxy): tag verdict source on responses

### DIFF
--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -171,9 +171,10 @@ export function createHandler(
 
     // Check cache first — blocked addresses skip the Elliptic call
     if (blockedCache.isBlocked(address)) {
-      sendResponse(200, JSON.stringify({ blocked: true }), {
+      sendResponse(200, JSON.stringify({ blocked: true, source: "cache" }), {
         partner: partnerName,
         result: "cached",
+        source: "cache",
         cached: true,
         cacheSize: blockedCache.size,
       });
@@ -245,17 +246,22 @@ export function createHandler(
       blockedCache.markBlocked(address);
     }
 
-    sendResponse(200, JSON.stringify({ blocked: scoringResult.blocked }), {
-      partner: partnerName,
-      ellipticStatus: result.status,
-      ellipticLatencyMs: result.durationMs,
-      result: blocked ? "blocked" : "allowed",
-      scoringReason: scoringResult.reason,
-      triggeringRuleIds:
-        scoringResult.triggeringRuleIds.length > 0
-          ? scoringResult.triggeringRuleIds
-          : undefined,
-      cacheSize: blockedCache.size,
-    });
+    sendResponse(
+      200,
+      JSON.stringify({ blocked: scoringResult.blocked, source: "elliptic" }),
+      {
+        partner: partnerName,
+        ellipticStatus: result.status,
+        ellipticLatencyMs: result.durationMs,
+        result: blocked ? "blocked" : "allowed",
+        source: "elliptic",
+        scoringReason: scoringResult.reason,
+        triggeringRuleIds:
+          scoringResult.triggeringRuleIds.length > 0
+            ? scoringResult.triggeringRuleIds
+            : undefined,
+        cacheSize: blockedCache.size,
+      }
+    );
   };
 }

--- a/elliptic-proxy/tests/handler.test.ts
+++ b/elliptic-proxy/tests/handler.test.ts
@@ -295,7 +295,7 @@ describe("createHandler", () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ blocked: true });
+    expect(JSON.parse(res.body)).toEqual({ blocked: true, source: "elliptic" });
     expect(mockForward).toHaveBeenCalledWith(
       expect.objectContaining({ address: "0xabc123" })
     );
@@ -332,7 +332,10 @@ describe("createHandler", () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ blocked: false });
+    expect(JSON.parse(res.body)).toEqual({
+      blocked: false,
+      source: "elliptic",
+    });
 
     const logCall = logSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
@@ -413,7 +416,10 @@ describe("createHandler", () => {
     const res1 = makeResponse();
     await handler(makeRequest({}, "0xcacbed"), res1);
     expect(res1.statusCode).toBe(200);
-    expect(JSON.parse(res1.body)).toEqual({ blocked: true });
+    expect(JSON.parse(res1.body)).toEqual({
+      blocked: true,
+      source: "elliptic",
+    });
     expect(mockForward).toHaveBeenCalledTimes(1);
 
     // Second request: same address should return cached result
@@ -422,7 +428,7 @@ describe("createHandler", () => {
     const res2 = makeResponse();
     await handler(makeRequest({}, "0xcacbed"), res2);
     expect(res2.statusCode).toBe(200);
-    expect(JSON.parse(res2.body)).toEqual({ blocked: true });
+    expect(JSON.parse(res2.body)).toEqual({ blocked: true, source: "cache" });
     expect(mockForward).not.toHaveBeenCalled();
 
     const cachedLog = logSpy.mock.calls.find((call) => {
@@ -463,7 +469,10 @@ describe("createHandler", () => {
     const res2 = makeResponse();
     await handler(makeRequest({}, "0xd0e5cafe"), res2);
     expect(res2.statusCode).toBe(200);
-    expect(JSON.parse(res2.body)).toEqual({ blocked: false });
+    expect(JSON.parse(res2.body)).toEqual({
+      blocked: false,
+      source: "elliptic",
+    });
     // If the address had been erroneously cached as blocked on the 500,
     // this second request would return { blocked: true } from cache.
     spy.mockRestore();
@@ -498,7 +507,10 @@ describe("createHandler", () => {
     const res2 = makeResponse();
     await handler(makeRequest({}, "0xbadcafe"), res2);
     expect(res2.statusCode).toBe(200);
-    expect(JSON.parse(res2.body)).toEqual({ blocked: false });
+    expect(JSON.parse(res2.body)).toEqual({
+      blocked: false,
+      source: "elliptic",
+    });
     spy.mockRestore();
   });
 
@@ -517,8 +529,12 @@ describe("createHandler", () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ blocked: false });
+    expect(JSON.parse(res.body)).toEqual({
+      blocked: false,
+      source: "elliptic",
+    });
   });
+
   describe("operator policy lists", () => {
     function makePolicyConfig(overrides: Partial<Config> = {}): Config {
       return { ...makeConfig(), ...overrides };

--- a/elliptic-proxy/tests/integration.test.ts
+++ b/elliptic-proxy/tests/integration.test.ts
@@ -79,7 +79,10 @@ describe("integration: full request flow", () => {
     await handler(req, res as unknown as Parameters<typeof handler>[1]);
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ blocked: false });
+    expect(JSON.parse(res.body)).toEqual({
+      blocked: false,
+      source: "elliptic",
+    });
     expect(mockForward).toHaveBeenCalledWith(
       expect.objectContaining({ address: "0xabc123" })
     );


### PR DESCRIPTION
Sidecar logs and downstream callers couldn't tell a real Elliptic
verdict apart from a cache hit (or, with mock-screener mode, a fixture
hit). They all looked like {blocked: bool}.

Add a `source` field to every success-path response:
  • `elliptic` — verdict scored from a live Elliptic call.
  • `cache`    — verdict from the in-memory blocked-address cache.
  • `mock`     — verdict from mock-screener-mode fixture lookup
                  (added in the previous commit).

Field appears in both the response body and the structured log line, so
operators can grep for `"source": "…"` to attribute verdicts at a
glance. Backward-compatible — existing callers that ignore extra
properties continue to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/722)
<!-- Reviewable:end -->
