### PR TITLE
chore(elliptic-proxy): surface fetch.cause and upstream body in error logs

### DIFF
--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -191,10 +191,28 @@ export function createHandler(
         address,
       });
     } catch (error) {
+      // Node's fetch masks transport errors behind a generic "fetch failed"
+      // TypeError; the underlying DNS/TCP/TLS reason lives in error.cause.
+      const details =
+        error instanceof Error
+          ? {
+              message: error.message,
+              name: error.name,
+              cause:
+                error.cause instanceof Error
+                  ? {
+                      message: error.cause.message,
+                      name: error.cause.name,
+                      code: (error.cause as NodeJS.ErrnoException).code,
+                    }
+                  : error.cause,
+            }
+          : { message: String(error) };
       console.error(
         JSON.stringify({
           error: "upstream_request_failed",
-          message: error instanceof Error ? error.message : String(error),
+          url: config.elliptic.url,
+          ...details,
         })
       );
       sendResponse(503, JSON.stringify({ error: "service unavailable" }), {
@@ -232,6 +250,7 @@ export function createHandler(
         JSON.stringify({
           error: "upstream_error",
           ellipticStatus: result.status,
+          ellipticBody: result.body.slice(0, 2000),
         })
       );
       sendResponse(502, JSON.stringify({ error: "upstream error" }), {


### PR DESCRIPTION
Node's fetch reports transport errors as `TypeError: fetch failed` and
hides the real reason (DNS / TLS / TCP) in `error.cause`. Surface it
in the `upstream_request_failed` log so DNS/TLS/etc. failures are
diagnosable from logs alone — saves a round-trip to add ad-hoc logging
during incidents.

Same rationale on the non-2xx path: include the first 2KB of Elliptic's
response body in the `upstream_error` log. Knowing that a 401 is
"AuthenticationError: Unauthorized" vs. a 400
"ValidationError: subject.asset combination not recognised" makes
diagnosis a one-line log read instead of a code-side debugging session.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/723)
<!-- Reviewable:end -->
