### PR TITLE
chore(elliptic-proxy): build dist via gcp-build hook on deploy

### DIFF
--- a/elliptic-proxy/package.json
+++ b/elliptic-proxy/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "gcp-build": "tsc",
     "start": "functions-framework --target=ellipticProxy --source=dist/",
     "dev": "tsc --watch",
     "test": "vitest run",


### PR DESCRIPTION
Cloud Buildpacks runs the `gcp-build` npm script on every deploy but
does not auto-run `build`. Without either a `gcp-build` hook or a
shipped `dist/`, redeploys silently kept serving the cached
pre-build artifact while the revision number bumped — a stale-deploy
trap we hit during this work.

Add the hook so the buildpack always recompiles from the uploaded
source. `dist/` stays in `.gcloudignore` (the local change that
included it is reverted): deploys are now source-only, deterministic,
and don't require operators to remember a manual `npm run build`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/724)
<!-- Reviewable:end -->
