### PR TITLE
chore(proof-interceptor): add Dockerfile for sidecar image

### DIFF
--- a/proof-interceptor/Dockerfile
+++ b/proof-interceptor/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage build for the proof-interceptor sidecar.
+#
+# Build context MUST be the workspace root (`starknet-privacy/`) because
+# proof-interceptor depends on the local SDK via `"file:../sdk"` in its
+# package.json. Build with:
+#
+#   docker build -f proof-interceptor/Dockerfile -t proof-interceptor:<tag> .
+#
+# The runtime stage is `node:22-slim` and runs as the unprivileged `node`
+# user on port 8080. /health responds 200 OK; use it for liveness +
+# readiness probes (see the deployment guide).
+
+# ---- build stage ----------------------------------------------------------
+FROM node:22-slim AS build
+WORKDIR /app
+
+# Build the local SDK first so its compiled `dist/` is available when
+# proof-interceptor's `npm ci` resolves `file:../sdk`.
+COPY sdk/ ./sdk/
+RUN cd sdk \
+ && npm ci \
+ && npm run build
+
+# Build proof-interceptor against the just-built SDK.
+COPY proof-interceptor/ ./proof-interceptor/
+RUN cd proof-interceptor \
+ && npm ci \
+ && npm run build
+
+# Drop devDependencies once compilation is done; the runtime stage only
+# needs the production deps.
+RUN cd proof-interceptor \
+ && npm prune --omit=dev
+
+# ---- runtime stage --------------------------------------------------------
+FROM node:22-slim
+WORKDIR /app/proof-interceptor
+
+# The SDK is a file: dependency, so the runtime needs both directories
+# present at the path npm resolved during install.
+COPY --from=build /app/sdk /app/sdk
+COPY --from=build /app/proof-interceptor /app/proof-interceptor
+
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+USER node
+
+CMD ["node", "dist/index.js"]

--- a/proof-interceptor/Dockerfile.dockerignore
+++ b/proof-interceptor/Dockerfile.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context lean. BuildKit (default in modern Docker) looks
+# for <dockerfile>.dockerignore first, falling back to .dockerignore at
+# the context root. Only patterns that match files actually copied in
+# the Dockerfile matter; the rest are harmless.
+
+# never copied
+**/.git
+**/.gitignore
+**/node_modules
+**/dist
+**/.cache
+**/coverage
+**/*.log
+
+# vscode/jetbrains noise
+**/.vscode
+**/.idea
+
+# things outside the two directories the Dockerfile copies
+crates
+target
+e2e
+demo
+elliptic-proxy
+docs
+deploy
+scripts
+lean
+.claude
+**/*.md
+**/Cargo.lock
+**/Cargo.toml
+**/Scarb.lock
+**/Scarb.toml
+**/conftest.py
+**/py_requirements.txt


### PR DESCRIPTION
Materializes the inline heredoc Dockerfile from the deployment guide
into a checked-in artifact. Multi-stage Node.js 22-slim build; runs as
the unprivileged `node` user on port 8080.

Build context must be the workspace root so `file:../sdk` resolves
correctly:

    docker build -f proof-interceptor/Dockerfile \
                 -t proof-interceptor:<tag> .

Differences from the heredoc variant in the deployment guide:

  - `npm prune --omit=dev` after compilation drops typescript, vite,
    vitest, eslint, prettier, etc. from the runtime `node_modules/`.
    Cuts the runtime image by ~80–120 MB.
  - `ENV NODE_ENV=production` and `ENV PORT=8080` are set so a plain
    `docker run` produces sane defaults; k8s overrides PORT via env in
    the deployment manifest either way.
  - Co-located `Dockerfile.dockerignore` keeps `target/`, every
    `node_modules/`, `crates/`, etc. out of the build context — local
    `docker build` no longer ships hundreds of MB to the daemon on each
    iteration. The final image is unchanged either way.
  - Header comment self-documents the build-context expectation so a
    reader who finds the file in isolation doesn't have to dig the
    deployment guide.

No HEALTHCHECK directive — k8s liveness/readiness probes (configured
in the deployment manifest, not the image) are the source of truth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/725)
<!-- Reviewable:end -->
