### PR TITLE
fix(sdk): use account reference in ProofUser instead of extracted signer

### DIFF
--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -67,7 +67,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     // Create invocation for proving
     const details = await this.params.provingProvider.getDefaultDetails();
     const invocation = await this.params.proofInvocationFactory.create(
-      { address: this.params.account.address, signer: this.params.account.signer, viewingKey },
+      { account: this.params.account, viewingKey },
       this.params.poolContractAddress,
       clientActions,
       details

--- a/sdk/src/internal/proof-invocation-factory.ts
+++ b/sdk/src/internal/proof-invocation-factory.ts
@@ -6,12 +6,7 @@
  * - Mock implementation: passes through client actions directly
  */
 
-import type {
-  BigNumberish,
-  CallResult,
-  SignerInterface,
-  V3InvocationsSignerDetails,
-} from "starknet";
+import type { Account, BigNumberish, CallResult, V3InvocationsSignerDetails } from "starknet";
 import type { constants } from "starknet";
 import { CallData, ETransactionVersion, hash, stark } from "starknet";
 
@@ -62,8 +57,7 @@ export function getDefaultProofDetails(
  * Minimal user info needed for creating a proof invocation.
  */
 export interface ProofUser {
-  address: BigNumberish;
-  signer: SignerInterface;
+  account: Account;
   viewingKey: BigNumberish;
 }
 
@@ -126,7 +120,7 @@ export class ProofInvocationFactory implements ProofInvocationFactoryInterface {
   ): Promise<ProofInvocation> {
     const cairoActions = serializeClientActions(clientActions);
     const callDataCompiler = new CallData(PrivacyPoolABI);
-    const userAddress = toBigInt(user.address);
+    const userAddress = toBigInt(user.account.address);
     const poolAddressHex = toHex(poolAddress);
 
     const executeViewCalldata = callDataCompiler.compile("compile_actions", [
@@ -145,7 +139,7 @@ export class ProofInvocationFactory implements ProofInvocationFactoryInterface {
     // signTransaction internally calls getExecuteCalldata which wraps the call
     // into Array<Call> format — the same layout as compiledCalldata. So we pass
     // the inner executeViewCalldata here, not the already-wrapped compiledCalldata.
-    const signature = await user.signer.signTransaction(
+    const signature = await user.account.signer.signTransaction(
       [
         {
           contractAddress: poolAddressHex,

--- a/sdk/src/testing/mock-proof-invocation-factory.ts
+++ b/sdk/src/testing/mock-proof-invocation-factory.ts
@@ -70,7 +70,7 @@ export class MockProofInvocationFactory implements ProofInvocationFactoryInterfa
       type: "INVOKE",
       sender_address: poolAddressHex,
       calldata: [
-        toHex(user.address),
+        toHex(user.account.address),
         toHex(user.viewingKey),
         JSON.stringify(clientActions, jsonReplacer),
       ],


### PR DESCRIPTION
Replace
   `address + signer` fields in `ProofUser` with a single `account: Account` reference. The factory now    
  reads `account.signer` at signing time rather than from a pinned extracted reference, so custom Account 
  subclasses (Braavos, ArgentX, hardware wallets) that override the signer property are respected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/727)
<!-- Reviewable:end -->
