### PR TITLE
ci(proof-interceptor): add Dockerfile and GHCR multi-arch publish

### DIFF
--- a/.github/workflows/proof-interceptor-docker.yaml
+++ b/.github/workflows/proof-interceptor-docker.yaml
@@ -1,0 +1,101 @@
+name: Proof Interceptor Docker
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches: [main]
+    tags: ['*']
+    paths:
+      - 'proof-interceptor/**'
+      - 'sdk/**'
+      - 'deploy/proof-interceptor/**'
+      - '.github/workflows/proof-interceptor-docker.yaml'
+  pull_request:
+    paths:
+      - 'proof-interceptor/**'
+      - 'sdk/**'
+      - 'deploy/proof-interceptor/**'
+      - '.github/workflows/proof-interceptor-docker.yaml'
+
+jobs:
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/proof-interceptor
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+      - uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: .
+          file: deploy/proof-interceptor/Dockerfile
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=ghcr.io/${{ github.repository }}/proof-interceptor",push-by-digest=true,name-canonical=true,push=true
+      - run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/proof-interceptor
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+      - run: |
+          cd /tmp/digests
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}')
+          sources=$(printf 'ghcr.io/${{ github.repository }}/proof-interceptor@sha256:%s ' *)
+          docker buildx imagetools create $tags $sources
+        shell: bash

--- a/deploy/proof-interceptor/Dockerfile
+++ b/deploy/proof-interceptor/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage build for the proof-interceptor sidecar.
+#
+# Build context MUST be the workspace root (`starknet-privacy/`) because
+# proof-interceptor depends on the local SDK via `"file:../sdk"` in its
+# package.json. Build with:
+#
+#   docker build -f deploy/proof-interceptor/Dockerfile -t proof-interceptor:<tag> .
+#
+# The runtime stage is `node:22-slim` and runs as the unprivileged `node`
+# user on port 8080. /health responds 200 OK; use it for liveness +
+# readiness probes (see the deployment guide).
+
+# ---- build stage ----------------------------------------------------------
+FROM node:22-slim AS build
+WORKDIR /app
+
+# Build the local SDK first so its compiled `dist/` is available when
+# proof-interceptor's `npm ci` resolves `file:../sdk`.
+COPY sdk/ ./sdk/
+RUN cd sdk \
+ && npm ci \
+ && npm run build
+
+# Build proof-interceptor against the just-built SDK.
+COPY proof-interceptor/ ./proof-interceptor/
+RUN cd proof-interceptor \
+ && npm ci \
+ && npm run build
+
+# Drop devDependencies once compilation is done; the runtime stage only
+# needs the production deps.
+RUN cd proof-interceptor \
+ && npm prune --omit=dev
+
+# ---- runtime stage --------------------------------------------------------
+FROM node:22-slim
+WORKDIR /app/proof-interceptor
+
+# The SDK is a file: dependency, so the runtime needs both directories
+# present at the path npm resolved during install.
+COPY --from=build /app/sdk /app/sdk
+COPY --from=build /app/proof-interceptor /app/proof-interceptor
+
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+USER node
+
+CMD ["node", "dist/index.js"]

--- a/deploy/proof-interceptor/Dockerfile.dockerignore
+++ b/deploy/proof-interceptor/Dockerfile.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context lean. BuildKit (default in modern Docker) looks
+# for <dockerfile>.dockerignore first, falling back to .dockerignore at
+# the context root. Only patterns that match files actually copied in
+# the Dockerfile matter; the rest are harmless.
+
+# never copied
+**/.git
+**/.gitignore
+**/node_modules
+**/dist
+**/.cache
+**/coverage
+**/*.log
+
+# vscode/jetbrains noise
+**/.vscode
+**/.idea
+
+# things outside the two directories the Dockerfile copies
+crates
+target
+e2e
+demo
+elliptic-proxy
+docs
+deploy
+scripts
+lean
+.claude
+**/*.md
+**/Cargo.lock
+**/Cargo.toml
+**/Scarb.lock
+**/Scarb.toml
+**/conftest.py
+**/py_requirements.txt


### PR DESCRIPTION
Adds deploy/proof-interceptor/Dockerfile{,.dockerignore} and a
workflow mirroring discovery-service-docker.yaml — multi-arch
buildx, push-by-digest, manifest merge — publishing to
ghcr.io/<owner>/<repo>/proof-interceptor on PRs, main, and tags.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/728)
<!-- Reviewable:end -->
