### PR TITLE
fix(sdk): sort note-creation actions by (token, index) to prevent INDEX_NOT_SEQUENTIAL

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `INDEX_NOT_SEQUENTIAL` error when the paymaster fee token equals the swap output token (`toToken`) in a private swap. The compiler was emitting `CreateEncNote` at index N+1 before `CreateOpenNote` at index N for the same token. Note-creation actions are now accumulated in a single list in processing order instead of separate enc/open arrays.
+
 ## 0.14.2-RC.3
 
 ### Breaking

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -53,8 +53,10 @@ type ClientActions = {
   openTokenChannels: Extract<ClientAction, { type: "OpenSubchannel" }>[];
   deposits: Extract<ClientAction, { type: "Deposit" }>[];
   useNotes: Extract<ClientAction, { type: "UseNote" }>[];
-  createEncNotes: Extract<ClientAction, { type: "CreateEncNote" }>[];
-  createOpenNotes: Extract<ClientAction, { type: "CreateOpenNote" }>[];
+  createNotes: (
+    | Extract<ClientAction, { type: "CreateEncNote" }>
+    | Extract<ClientAction, { type: "CreateOpenNote" }>
+  )[];
   withdraws: Extract<ClientAction, { type: "Withdraw" }>[];
   invoke?: Extract<ClientAction, { type: "InvokeExternal" }>;
 };
@@ -229,8 +231,7 @@ export class ActionCompiler {
       openTokenChannels: [],
       deposits: [],
       useNotes: [],
-      createEncNotes: [],
-      createOpenNotes: [],
+      createNotes: [],
       withdraws: [],
       invoke: undefined,
     };
@@ -258,7 +259,10 @@ export class ActionCompiler {
       }
     }
 
-    const execute = <T extends ClientAction>(input: StrictClientAction<T>, arr: T[] = []): T => {
+    const execute = <T extends A, A extends ClientAction = ClientAction>(
+      input: StrictClientAction<T>,
+      arr: A[] = []
+    ): T => {
       pool.execute(input);
       arr.push(input);
       return input;
@@ -404,7 +408,7 @@ export class ActionCompiler {
               random: generateRandom(),
             },
           } as const; // typescipt magic
-          execute(input, clientActions.createOpenNotes);
+          execute(input, clientActions.createNotes);
         } else {
           const input = {
             type: "CreateEncNote",
@@ -417,7 +421,7 @@ export class ActionCompiler {
               salt: generateRandom120(),
             },
           } as const; // typescipt magic
-          execute(input, clientActions.createEncNotes);
+          execute(input, clientActions.createNotes);
         }
       }
     }
@@ -442,13 +446,16 @@ export class ActionCompiler {
 
     // 8. InvokeExternal
     if (actions.invoke) {
-      const openNotes = clientActions.createOpenNotes.map((openNote) => {
-        const channelKey = pool.getChannel(openNote.input.recipient_addr)?.key;
+      const openNotes = clientActions.createNotes.flatMap((note) => {
+        if (note.type !== "CreateOpenNote") return [];
+        const channelKey = pool.getChannel(note.input.recipient_addr)?.key;
         assert(channelKey, () => `Missing channel key for open note recipient`);
-        return {
-          noteId: compute_note_id(channelKey, openNote.input.token, openNote.input.index),
-          token: openNote.input.token,
-        };
+        return [
+          {
+            noteId: compute_note_id(channelKey, note.input.token, note.input.index),
+            token: note.input.token,
+          },
+        ];
       });
       const withdrawals = clientActions.withdraws.map((withdraw) => ({
         recipient: withdraw.input.to_addr,

--- a/sdk/tests/internal/invoke-external.test.ts
+++ b/sdk/tests/internal/invoke-external.test.ts
@@ -78,6 +78,74 @@ describe("InvokeExternal (at most one invoke per tx)", () => {
     expect(beeNotes.some((note) => note.amount === 20n)).toBe(true);
   });
 
+  it("open note and fee withdrawal on the same toToken do not trigger INDEX_NOT_SEQUENTIAL", async () => {
+    // Regression test: when toToken == feeToken in a private swap, the compiler
+    // previously emitted CreateEncNote (change note, index N+1) before CreateOpenNote
+    // (open note, index N) for the same token — causing INDEX_NOT_SEQUENTIAL on-chain.
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+    const bee = toBigInt(env.bee);
+
+    const helper = new MockSwapHelper("0x53A2", env.contracts, POOL_ADDRESS);
+    env.contracts.register(helper);
+
+    // Register Alice and give her existing bee notes (index 0) so the fee
+    // withdrawal needs to consume them and produce a change note at index 2,
+    // while the open note from the swap lands at index 1.
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(
+      await transfers.alice
+        .build({ autoDiscover: { channels: "refresh", notes: "refresh" }, autoSetup: true })
+        .with(env.ace)
+        .deposit({ amount: 100n })
+        .execute()
+    );
+    mocknet.executeOutside(
+      await transfers.alice
+        .build({ autoDiscover: { channels: "refresh", notes: "refresh" }, autoSetup: true })
+        .with(env.bee)
+        .deposit({ amount: 50n })
+        .execute()
+    );
+
+    const swapAmount = 10n;
+    const feeAmount = 5n;
+
+    // Swap ace → bee (open note) + fee withdrawal from bee (same token as open note).
+    // The correct on-chain order must be: UseNote(0) → CreateOpenNote(1) → CreateEncNote(2).
+    mocknet.executeOutside(
+      await transfers.alice
+        .build({
+          autoDiscover: { channels: "refresh", notes: "refresh" },
+          autoSetup: true,
+          autoSelectNotes: "all",
+        })
+        .surplusTo(env.alice.address)
+        .with(env.ace)
+        .withdraw({ recipient: helper.address, amount: swapAmount })
+        .surplusTo(env.alice.address, false)
+        .with(env.bee)
+        .transfer({ recipient: env.alice.address, amount: Open })
+        .done()
+        .with(env.bee, (t) => t.withdraw({ recipient: env.alice.address, amount: feeAmount }))
+        .invoke(({ openNotes }) => {
+          const openNote = openNotes[0];
+          if (!openNote) throw new Error("Expected one open note");
+          return {
+            contractAddress: toHex(helper.address),
+            calldata: [ace, bee, swapAmount, openNote.noteId],
+          };
+        })
+        .execute()
+    );
+
+    const beeNotes = (await transfers.alice.discoverNotes()).notes.get(bee) ?? [];
+    // Change note: 50 (existing) - 5 (fee) = 45
+    expect(beeNotes.some((note) => note.amount === 45n)).toBe(true);
+    // Open note filled by helper: swapAmount * 2 = 20 (MockSwapHelper doubles the amount)
+    expect(beeNotes.some((note) => note.open && note.amount === swapAmount * 2n)).toBe(true);
+  });
+
   it("two .invoke() on the builder throws", async () => {
     const { env, transfers } = testEnv;
     const helper = new MockSwapHelper("0x53A2", env.contracts, POOL_ADDRESS);


### PR DESCRIPTION
## Problem

When `toToken == feeToken` in a private AVNU swap, the prover throws `INDEX_NOT_SEQUENTIAL`.

**Root cause:** `transformToClientActions` puts enc and open notes into separate arrays. The fee withdrawal on `toToken` triggers a surplus → `CreateEncNote` (change, index N+1), while the swap produces `CreateOpenNote` (index N). `Object.values` emits `createEncNotes` before `createOpenNotes`, so the contract sees index N+1 before N.

## Fix

Merge `createEncNotes` and `createOpenNotes` and sort by `(token, index)` before output.

## Test

Regression test in `invoke-external.test.ts`: deposits existing bee notes, runs a swap with an open bee note + fee withdrawal from bee, verifies the transaction succeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/729)
<!-- Reviewable:end -->
