### PR TITLE
fix(sdk): decouple OHTTP inner request URL from gatewayUrl prefix

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `INDEX_NOT_SEQUENTIAL` error when the paymaster fee token equals the swap output token (`toToken`) in a private swap. The compiler was emitting `CreateEncNote` at index N+1 before `CreateOpenNote` at index N for the same token. Note-creation actions are now accumulated in a single list in processing order instead of separate enc/open arrays.
+- `OhttpClient` now builds the inner OHTTP request URL with a synthetic origin (`https://ohttp-target.invalid`) instead of `${gatewayUrl}${path}`. Previously, when `gatewayUrl` included a reverse-proxy path prefix (e.g. `https://api.example.com/discovery`), that prefix leaked into the encrypted inner request path and produced a 404 inside the OHTTP envelope (`OHTTP inner response /v1/sync/outgoing_state failed (404)`). The OHTTP gateway routes by path only, so the synthetic origin is inert; only the per-call `path` argument is used for routing.
 
 ## 0.14.2-RC.3
 

--- a/sdk/src/internal/ohttp-client.ts
+++ b/sdk/src/internal/ohttp-client.ts
@@ -12,6 +12,15 @@ import { ReorgError } from "./errors.js";
 /** HTTP 409 — the discovery service returns this exclusively for block reorgs (BLOCK_REORGED). */
 const REORG_STATUS = 409;
 
+// Synthetic origin for the inner OHTTP Request URL. The OHTTP gateway routes
+// the decapsulated request by path only (axum does not match on Host), so the
+// scheme/authority on the inner Request are inert. Using a fixed reserved-TLD
+// origin (RFC 6761 `.invalid`) decouples the inner request path from whatever
+// outer URL the SDK was configured with — without this, a `gatewayUrl` that
+// includes a reverse-proxy path prefix (e.g. `/discovery`) leaks into the
+// inner path and produces a 404 when the gateway server tries to route it.
+const INNER_REQUEST_ORIGIN = "https://ohttp-target.invalid";
+
 /** Configuration for enabling OHTTP. `true` uses defaults; an object allows custom relay/key config. */
 export type OhttpOption = boolean | { relayUrl?: string; publicKeyConfig?: Uint8Array };
 
@@ -26,11 +35,18 @@ export class OhttpClient {
   private readonly pinnedKeyConfig: Uint8Array | undefined;
 
   /**
-   * @param gatewayUrl - Discovery service base URL (used for `/ohttp-keys` and as default target).
-   *   Must be HTTPS in production — without it (or a pinned `publicKeyConfig`), an active
-   *   network attacker can replace the OHTTP key config.
-   * @param options.relayUrl - Optional OHTTP relay URL. When set, encapsulated requests are sent here instead of the gateway.
-   * @param options.publicKeyConfig - Optional pinned key config bytes (`application/ohttp-keys` format). When set, `/ohttp-keys` is never fetched.
+   * @param gatewayUrl - URL where the OHTTP gateway accepts encapsulated requests
+   *   and serves `/ohttp-keys`. May include a reverse-proxy path prefix (e.g.
+   *   `https://api.example.com/discovery`); the prefix is preserved on outer
+   *   requests but stripped from the inner OHTTP request path (which always
+   *   uses just the supplied per-call `path`).
+   *   Must be HTTPS in production — without it (or a pinned `publicKeyConfig`),
+   *   an active network attacker can replace the OHTTP key config.
+   * @param options.relayUrl - Optional OHTTP relay URL. When set, encapsulated
+   *   requests are sent here instead of the gateway. `/ohttp-keys` is still
+   *   fetched from `gatewayUrl`.
+   * @param options.publicKeyConfig - Optional pinned key config bytes
+   *   (`application/ohttp-keys` format). When set, `/ohttp-keys` is never fetched.
    */
   constructor(
     private readonly gatewayUrl: string,
@@ -48,7 +64,7 @@ export class OhttpClient {
    * Send an OHTTP-encapsulated GET request and return the decrypted JSON response.
    */
   async get<T>(path: string): Promise<T> {
-    return this.send<T>(path, new Request(`${this.gatewayUrl}${path}`, { method: "GET" }));
+    return this.send<T>(path, new Request(`${INNER_REQUEST_ORIGIN}${path}`, { method: "GET" }));
   }
 
   /**
@@ -57,7 +73,7 @@ export class OhttpClient {
   async post<T>(path: string, body: unknown): Promise<T> {
     return this.send<T>(
       path,
-      new Request(`${this.gatewayUrl}${path}`, {
+      new Request(`${INNER_REQUEST_ORIGIN}${path}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/sdk/tests/internal/ohttp-client.test.ts
+++ b/sdk/tests/internal/ohttp-client.test.ts
@@ -5,6 +5,11 @@ import { OhttpClient } from "../../src/internal/ohttp-client.js";
 // Module-level factory for customizing decapsulateResponse per test.
 let decapsulateResponseFactory: () => Promise<unknown>;
 
+// Module-level capture of the inner Request objects passed to encapsulateRequest,
+// so tests can assert on what URL/method/path the SDK serialized into the
+// encrypted envelope (this is what the gateway's router will route on).
+let capturedInnerRequests: Request[] = [];
+
 function defaultDecapsulateResponse(): Promise<unknown> {
   return Promise.resolve({
     status: 200,
@@ -18,16 +23,19 @@ function defaultDecapsulateResponse(): Promise<unknown> {
 // We provide minimal stubs so ensureClient() and encapsulateRequest() succeed.
 vi.mock("ohttp-ts", () => {
   class MockOHTTPClient {
-    encapsulateRequest = vi.fn().mockImplementation(async () => ({
-      init: {
-        method: "POST",
-        headers: { "Content-Type": "message/ohttp-req" },
-        body: new Uint8Array(),
-      },
-      context: {
-        decapsulateResponse: vi.fn().mockImplementation(() => decapsulateResponseFactory()),
-      },
-    }));
+    encapsulateRequest = vi.fn().mockImplementation(async (request: Request) => {
+      capturedInnerRequests.push(request);
+      return {
+        init: {
+          method: "POST",
+          headers: { "Content-Type": "message/ohttp-req" },
+          body: new Uint8Array(),
+        },
+        context: {
+          decapsulateResponse: vi.fn().mockImplementation(() => decapsulateResponseFactory()),
+        },
+      };
+    });
   }
   return {
     OHTTPClient: MockOHTTPClient,
@@ -50,6 +58,7 @@ describe("OhttpClient", () => {
   beforeEach(() => {
     originalFetch = globalThis.fetch;
     decapsulateResponseFactory = defaultDecapsulateResponse;
+    capturedInnerRequests = [];
   });
 
   afterEach(() => {
@@ -106,6 +115,81 @@ describe("OhttpClient", () => {
 
       expect(fetchMock.mock.calls[0][0]).toBe("https://relay.example.com/ohttp-relay");
       expect(fetchMock.mock.calls[1][0]).toBe("https://relay.example.com/ohttp-relay");
+    });
+  });
+
+  describe("inner request URL", () => {
+    function mockFetch() {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => "message/ohttp-res" },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+      globalThis.fetch = fetchMock;
+      return fetchMock;
+    }
+
+    it("encapsulates POST inner request with the supplied path, ignoring gatewayUrl prefix", async () => {
+      mockFetch();
+      const client = new OhttpClient("https://api.example.com/discovery", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      await client.post("/v1/sync/outgoing_state", { key: "abc" });
+
+      expect(capturedInnerRequests).toHaveLength(1);
+      const innerUrl = new URL(capturedInnerRequests[0].url);
+      expect(innerUrl.pathname).toBe("/v1/sync/outgoing_state");
+      expect(innerUrl.host).not.toBe("api.example.com");
+      expect(capturedInnerRequests[0].method).toBe("POST");
+    });
+
+    it("encapsulates GET inner request with the supplied path, ignoring gatewayUrl prefix", async () => {
+      mockFetch();
+      const client = new OhttpClient("https://api.example.com/discovery", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      await client.get("/health");
+
+      expect(capturedInnerRequests).toHaveLength(1);
+      const innerUrl = new URL(capturedInnerRequests[0].url);
+      expect(innerUrl.pathname).toBe("/health");
+      expect(innerUrl.host).not.toBe("api.example.com");
+      expect(capturedInnerRequests[0].method).toBe("GET");
+    });
+
+    it("inner path is identical regardless of gatewayUrl prefix depth", async () => {
+      mockFetch();
+      const noPrefix = new OhttpClient("https://api.example.com", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+      const onePrefix = new OhttpClient("https://api.example.com/discovery", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+      const deepPrefix = new OhttpClient("https://api.example.com/a/b/c", {
+        publicKeyConfig: new Uint8Array([1]),
+      });
+
+      await noPrefix.post("/v1/history", {});
+      await onePrefix.post("/v1/history", {});
+      await deepPrefix.post("/v1/history", {});
+
+      const paths = capturedInnerRequests.map((request) => new URL(request.url).pathname);
+      expect(paths).toEqual(["/v1/history", "/v1/history", "/v1/history"]);
+    });
+
+    it("relayUrl does not affect inner request path", async () => {
+      mockFetch();
+      const client = new OhttpClient("https://api.example.com/discovery", {
+        publicKeyConfig: new Uint8Array([1]),
+        relayUrl: "https://relay.example.com/forward",
+      });
+
+      await client.post("/v1/sync/outgoing_state", {});
+
+      expect(new URL(capturedInnerRequests[0].url).pathname).toBe("/v1/sync/outgoing_state");
     });
   });
 


### PR DESCRIPTION
## Summary

Re-land of #734 from an internal branch so CI can run. The original fork is no longer accessible (`headRepository: null`), so GitHub Actions never queued workflow runs and follow-up commits aren't possible on the original PR. Cherry-picked unchanged — credit to @hwildwood / @herbieporter.

### Original change

- The SDK was building the inner OHTTP request URL as `${gatewayUrl}${path}`, which leaked any reverse-proxy path prefix (e.g. `/api/discovery`) into the encrypted inner path. The OHTTP gateway then 404'd inside the envelope: `OHTTP inner response /v1/sync/outgoing_state failed (404)`.
- Fix: build the inner Request with a synthetic reserved-TLD origin (`https://ohttp-target.invalid`, RFC 6761). The OHTTP gateway routes by path only, so the inner scheme/authority are inert. The encapsulated path is now always exactly the per-call `path`, independent of `gatewayUrl`.
- Lets users go back to a single URL: `new IndexerDiscoveryProvider("https://api.example.com/discovery", contract, { ohttp: true })` — no `relayUrl` workaround needed.

## Test plan

- [x] `sdk/tests/internal/ohttp-client.test.ts` — 12/12 pass (4 new tests covering inner-URL construction across no/single/deep prefix and with `relayUrl` set)
- [x] `npm run lint` (prettier + eslint + tsc) — clean
- [ ] E2E (`cd e2e && npm test`) — devnet tests don't exercise OHTTP, so no expected impact; deferred to reviewers

Closes #734.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/735)
<!-- Reviewable:end -->
