### PR TITLE
fix(discovery-service): bump tower_ohttp to drop OHTTP_KEY from error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2039,7 +2039,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2298,7 +2298,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2366,7 +2366,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2893,7 +2893,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3213,7 +3213,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower_ohttp"
 version = "0.18.0-rc.1"
-source = "git+https://github.com/starkware-libs/sequencer.git?rev=f2d0af15734d97dbd29e59942da637d8daa48305#f2d0af15734d97dbd29e59942da637d8daa48305"
+source = "git+https://github.com/starkware-libs/sequencer.git?rev=3eb55733b7a3a5aa00a22618fc619272a17e7943#3eb55733b7a3a5aa00a22618fc619272a17e7943"
 dependencies = [
  "bhttp",
  "bytes",
@@ -3586,7 +3586,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -50,7 +50,7 @@ backoff = { version = "0.4", features = ["tokio"] }
 starknet-crypto = { package = "starknet-rust-crypto", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 
 # OHTTP (RFC 9458)
-tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "f2d0af15734d97dbd29e59942da637d8daa48305" }
+tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "3eb55733b7a3a5aa00a22618fc619272a17e7943" }
 
 # Cache
 moka = { version = "0.12", features = ["sync"] }
@@ -67,7 +67,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 anyhow = "1.0"
-tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "f2d0af15734d97dbd29e59942da637d8daa48305", features = ["testing"] }
+tower_ohttp = { git = "https://github.com/starkware-libs/sequencer.git", rev = "3eb55733b7a3a5aa00a22618fc619272a17e7943", features = ["testing"] }
 expect-test = "1.5"
 flate2 = "1.0"
 libc = "0.2"


### PR DESCRIPTION
## Summary
- Previously pinned rev `f2d0af1` (a feature-branch commit on `m-kus/tx-prover-ohttp`) was the unsquashed version of the original `tower_ohttp` add. In that revision, `OhttpGateway::from_hex_key` formatted the raw `OHTTP_KEY` value into an `InvalidKey` error on hex-decode failure (`format!("invalid hex: {hex_key}")`).
- `main.rs:78` prints that error to stderr on startup, so a malformed `OHTTP_KEY` env var would leak the (almost-correct) private key material to logs.
- Bump to the tip of `main-v0.14.2` (`3eb55733b7a3a5aa00a22618fc619272a17e7943`), which replaces the message with a static `"hex decode failed (expected 64 hex characters)"`.
- No API change: `OhttpGateway::from_env` / `from_hex_key` / `from_ikm` signatures are identical for callers.

## Test plan
- [x] `cargo build -p discovery-service`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p discovery-service --all-targets -- -D warnings` (0 warnings)
- [x] `cargo test -p discovery-service --lib` (46/46 pass, including `api::ohttp_layer_tests::ohttp_round_trip_through_axum_router`)
- [ ] Integration tests requiring `starknet-devnet` — not run locally (devnet not on PATH); CI will exercise these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/736)
<!-- Reviewable:end -->
