### PR TITLE
docs: bump compatibility matrix tags to PRIVACY-0.14.2-RC.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Component | Docs | Tag |
 |-----------|------|-------------|
-| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.4`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover?tag=PRIVACY-0.14.2-RC.4) |
-| Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service) |
+| Transaction Prover | [README](https://github.com/starkware-libs/sequencer/tree/avi/privacy/configmap-docs/crates/starknet_transaction_prover) | [`ghcr.io/starkware-libs/starknet-privacy/transaction-prover:PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/sequencer/pkgs/container/starknet-privacy%2Ftransaction-prover?tag=PRIVACY-0.14.2-RC.5) |
+| Discovery Service | [README](deploy/discovery-service/README.md) | [`ghcr.io/starkware-libs/starknet-privacy/discovery-service:PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/starknet-privacy/pkgs/container/starknet-privacy%2Fdiscovery-service) |
 | Pathfinder* | [docs](https://eqlabs.github.io/pathfinder/getting-started/running-pathfinder) | [`eqlabs/pathfinder:v0.22.3`](https://hub.docker.com/layers/eqlabs/pathfinder/v0.22.3/images/sha256-e3ae2c2895d18dd17a3bb64c3582c6758e4701a248dff9f957b69f1ad63be7f7) |
-| SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) |
+| SDK | [README](sdk/README.md) | [`PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.5) |
 
 \* For the transaction prover to work correctly with Pathfinder, set `PATHFINDER_STORAGE_STATE_TRIES=10000`.
 
@@ -54,9 +54,9 @@ All components in a row are tested together. Use matching revisions when deployi
 
 | Contract | Docs | Tag | Class Hash |
 |----------|------|-----|------------|
-| Privacy Pool | [README](packages/privacy/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x30b8c540cf04d8ef0f4db2a9098d9cc0e35e83af1cb3325f5a4f40144b4b30b` |
-| Ekubo Helper | [README](packages/ekubo_swap_helper/README.md) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x61047c201f235d66cab8a0c4768ea0ca9f900c64b478a90531fb2fb30e061dc` |
-| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) | [`PRIVACY-0.14.2-RC.3`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.3) | `0x2fec72887f6431e4a66090bec49ecf8bde30cf39a7045e4ed6ce57447704b24` |
+| Privacy Pool | [README](packages/privacy/README.md) | [`PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.5) | `0x30b8c540cf04d8ef0f4db2a9098d9cc0e35e83af1cb3325f5a4f40144b4b30b` |
+| Ekubo Helper | [README](packages/ekubo_swap_helper/README.md) | [`PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.5) | `0x61047c201f235d66cab8a0c4768ea0ca9f900c64b478a90531fb2fb30e061dc` |
+| Vesu Helper | [README](https://github.com/starkware-libs/starknet-privacy/tree/main/packages/vesu_lending_helper) | [`PRIVACY-0.14.2-RC.5`](https://github.com/starkware-libs/starknet-privacy/tree/PRIVACY-0.14.2-RC.5) | `0x2fec72887f6431e4a66090bec49ecf8bde30cf39a7045e4ed6ce57447704b24` |
 
 ## Repository map
 


### PR DESCRIPTION
## Summary
- Bumps the compatibility-matrix tags in the top-level `README.md` to `PRIVACY-0.14.2-RC.5` in preparation for cutting the next RC.
- All listed components are aligned on `PRIVACY-0.14.2-RC.5`:
  - Transaction Prover (image tag): `RC.4` → `RC.5`
  - Discovery Service (image tag): `RC.3` → `RC.5`
  - SDK (git tag): `RC.3` → `RC.5`
  - Privacy Pool, Ekubo Helper, Vesu Helper (git tag): `RC.3` → `RC.5`
- **Class hashes preserved**: contract source hasn't changed since RC.3, so the deterministic class hashes remain valid.
- **Tag not created in this PR.** The actual `PRIVACY-0.14.2-RC.5` git tag will be cut separately after merge.

## Test plan
- [x] Diff inspected — only README rows in the compatibility matrix and contracts table changed (6 line changes, all RC.3/RC.4 → RC.5).
- [ ] Confirm that no other doc references the previous tag (sole match outside README is `sdk/CHANGELOG.md`'s historical note about the `PRIVACY-0.14.2-RC.2` starknet.js fork — historical, intentionally unchanged).
- [ ] Verify final tag name with the release driver before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/737)
<!-- Reviewable:end -->
