### PR TITLE
feat(sdk): ephemeral-account deposit via SNIP-9 outside execution

### DIFF
--- a/e2e/tests/devnet/vesu-lending.test.ts
+++ b/e2e/tests/devnet/vesu-lending.test.ts
@@ -85,7 +85,7 @@ describe("Vesu lending on devnet", () => {
       .transfer({
         recipient: de.alice.address,
         amount: Open,
-        depositor: helperAddress,
+        depositor: anonymizerAddress,
       })
       .done()
       .invoke((args) => {
@@ -132,7 +132,7 @@ describe("Vesu lending on devnet", () => {
       .transfer({
         recipient: de.alice.address,
         amount: Open,
-        depositor: helperAddress,
+        depositor: anonymizerAddress,
       })
       .done()
       .invoke((args) => {

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added
+
+- `createEphemeralDeposit` on `PrivateTransfersInterface` and standalone
+  `calculateEphemeralAddress`: orchestrate a single-tx deposit from an
+  ephemeral SNIP-9 account into the caller's own channel. The caller provides
+  a future account address (deterministically derived from a class hash +
+  constructor calldata), optionally instructions to deploy it via UDC, and a
+  `Pick<SignerInterface, "signMessage">` that owns the ephemeral key. The SDK
+  returns the calls needed to (1) create an open note, (2) optionally deploy
+  the ephemeral account via UDC, and (3) finalize the deposit via SNIP-9
+  `execute_from_outside_v2`. The ephemeral account class must implement
+  SNIP-9 outside execution (OpenZeppelin `AccountComponent` ships it).
+- `openNoteIds` on `ProofInvocationResult` / `ExecuteResult`: the ids of any
+  open notes created by the compiled actions, in input order.
+
+### Changed
+
+- `Devnet.executeOutside` (in `@starkware-libs/starknet-privacy-sdk/testing`)
+  now also accepts `{ calls: Call[]; proof: Proof }` for multi-call flows
+  such as `createEphemeralDeposit`. The existing single-call `CallAndProof`
+  overload is unchanged.
+
 ### Breaking
 
 - Renamed `MockSwapHelper` to `MockSwapAnonymizer` in `@starkware-libs/starknet-privacy-sdk/testing` (and its `browser` re-export). Update imports accordingly.

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,3 +37,4 @@ export type {
   HistoryAction,
   SwapLeg,
 } from "./internal/action-classifier.js";
+export { calculateEphemeralAddress } from "./internal/ephemeral-deposit.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -6,6 +6,7 @@ import type {
   BlockNumber,
   Call,
   CallDetails,
+  SignerInterface,
   constants,
 } from "starknet";
 import { ec } from "starknet";
@@ -314,12 +315,16 @@ export type ExecuteResult = {
   registry: PrivateRegistry;
 
   warnings: Warning[];
+  /** Ids of open notes created by `createNotes` actions, in input order. */
+  openNoteIds: readonly NoteId[];
 };
 
 export type ProofInvocationResult = {
   invocation: ProofInvocation;
   registry: PrivateRegistry;
   warnings: Warning[];
+  /** Ids of open notes created by `createNotes` actions, in input order. */
+  openNoteIds: readonly NoteId[];
 };
 
 /**
@@ -455,7 +460,87 @@ export interface PrivateTransfersInterface {
 
   /** Create a builder for batching multiple operations */
   build(options?: ExecuteOptions): PrivateTransfersBuilder;
+
+  /**
+   * Build the calls needed to deposit funds held by an ephemeral SNIP-9 account
+   * `ephemeralAddress` into a fresh open note in the caller's own channel.
+   *
+   * The returned `calls` array packages, in order:
+   *   1. `pool.apply_actions(...)` that creates the open note (depositor = `ephemeralAddress`).
+   *   2. (optional) `UDC.deployContract(...)` if `params.deploy` is provided.
+   *   3. `ephemeralAddress.execute_from_outside_v2(payload, sig)` whose inner calls are
+   *      `[token.approve(pool, amount), pool.deposit_to_open_note(noteId, token, amount)]`.
+   *
+   * Submit the whole array as one Starknet multicall from any wallet, wiring the
+   * usual `proof_facts = proof.proofFacts` on the apply_actions sub-call.
+   *
+   * The ephemeral account class **must** implement SNIP-9 `execute_from_outside_v2`
+   * (OpenZeppelin `AccountComponent` ships it).
+   */
+  createEphemeralDeposit(
+    params: EphemeralDepositParams,
+    options?: ExecuteOptions
+  ): Promise<EphemeralDepositResult>;
 }
+
+/**
+ * Inputs for `PrivateTransfersInterface.createEphemeralDeposit`.
+ */
+export type EphemeralDepositParams = {
+  /** The address of the ephemeral account that holds the funds to deposit. */
+  ephemeralAddress: StarknetAddress;
+  /** ERC-20 to deposit. */
+  token: StarknetAddress;
+  /** Amount to deposit (and to approve, since open notes are single-fill). */
+  amount: Amount;
+  /** Signs the SNIP-9 OutsideExecution typed data with the ephemeral private key. */
+  signer: Pick<SignerInterface, "signMessage">;
+  /**
+   * If provided, prepend a UDC `deployContract` call to deploy the ephemeral
+   * account in the same tx. The SDK derives the address from these fields and
+   * throws if it does not match `ephemeralAddress`.
+   */
+  deploy?: {
+    classHash: BigNumberish;
+    constructorCalldata: BigNumberish[];
+    /** Defaults to 0. */
+    salt?: BigNumberish;
+    /** Defaults to false. */
+    unique?: boolean;
+    /** Required iff `unique === true`. */
+    deployerAddress?: BigNumberish;
+  };
+  /**
+   * Optional SNIP-9 OutsideExecution knobs. Defaults to a random nonce, no
+   * expiry, and `ANY_CALLER`.
+   */
+  outsideExecution?: {
+    nonce?: BigNumberish;
+    executeAfter?: BigNumberish;
+    executeBefore?: BigNumberish;
+    caller?: StarknetAddress;
+  };
+};
+
+/**
+ * Result of `PrivateTransfersInterface.createEphemeralDeposit`.
+ */
+export type EphemeralDepositResult = {
+  ephemeralAddress: StarknetAddress;
+  /** The id of the created open note. */
+  noteId: NoteId;
+  /** Proof for the apply_actions call. Must be wired into the tx envelope. */
+  proof: Proof;
+  /**
+   * 2 or 3 calls in canonical order:
+   *   [0]    pool.apply_actions(...)             — submit with proof_facts = proof
+   *   [1]?   UDC.deployContract(...)             — only if `params.deploy`
+   *   [last] ephemeralAddress.execute_from_outside_v2(payload, sig)
+   */
+  calls: Call[];
+  registry: PrivateRegistry;
+  warnings: Warning[];
+};
 
 // ============ Builder Types ============
 

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -10,6 +10,8 @@ import type {
   Actions,
   Channel,
   DiscoveryProviderInterface,
+  EphemeralDepositParams,
+  EphemeralDepositResult,
   ExecuteOptions,
   ExecuteResult,
   Note,
@@ -124,4 +126,12 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
     invocation: ProofInvocationResult,
     provingBlockId?: ProvingBlockId
   ): Promise<ExecuteResult>;
+
+  /**
+   * Build the calls for an ephemeral-account deposit. See `PrivateTransfersInterface.createEphemeralDeposit`.
+   */
+  abstract createEphemeralDeposit(
+    params: EphemeralDepositParams,
+    options?: ExecuteOptions
+  ): Promise<EphemeralDepositResult>;
 }

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -45,6 +45,8 @@ export type CompileResult = {
   clientActions: ClientAction[];
   registry: PrivateRegistry;
   warnings: Warning[];
+  /** Ids of open notes created by `createNotes` actions, in input order. */
+  openNoteIds: bigint[];
 };
 
 type ClientActions = {
@@ -128,7 +130,12 @@ export class ActionCompiler {
     const pool = this.createPool(toBigInt(this.userViewingKey), registry, channels, total);
 
     // Phase 3: Transform Actions to ClientAction[]
-    const clientActions = this.transformToClientActions(actions, pool, recipientsNeeded, options);
+    const { clientActions, openNoteIds } = this.transformToClientActions(
+      actions,
+      pool,
+      recipientsNeeded,
+      options
+    );
 
     debugLog("compiler", "compile", "post transformToClientActions", clientActions);
 
@@ -136,6 +143,7 @@ export class ActionCompiler {
       clientActions,
       registry: pool.updateRegistry(registry),
       warnings: this.checkWarnings(clientActions),
+      openNoteIds,
     };
   }
 
@@ -224,7 +232,7 @@ export class ActionCompiler {
     pool: PoolSimulator,
     recipientsNeeded: AddressMap<boolean>,
     options?: ExecuteOptions
-  ): ClientAction[] {
+  ): { clientActions: ClientAction[]; openNoteIds: bigint[] } {
     const clientActions: ClientActions = {
       setViewingKey: undefined,
       openChannels: [],
@@ -445,19 +453,22 @@ export class ActionCompiler {
 
     // surpluses were handled in resolveNotes
 
+    // Compute open note ids for each CreateOpenNote (used by InvokeExternal below
+    // and surfaced on CompileResult for downstream callers like createEphemeralDeposit).
+    const openNotes = clientActions.createNotes.flatMap((note) => {
+      if (note.type !== "CreateOpenNote") return [];
+      const channelKey = pool.getChannel(note.input.recipient_addr)?.key;
+      assert(channelKey, () => `Missing channel key for open note recipient`);
+      return [
+        {
+          noteId: compute_note_id(channelKey, note.input.token, note.input.index),
+          token: note.input.token,
+        },
+      ];
+    });
+
     // 8. InvokeExternal
     if (actions.invoke) {
-      const openNotes = clientActions.createNotes.flatMap((note) => {
-        if (note.type !== "CreateOpenNote") return [];
-        const channelKey = pool.getChannel(note.input.recipient_addr)?.key;
-        assert(channelKey, () => `Missing channel key for open note recipient`);
-        return [
-          {
-            noteId: compute_note_id(channelKey, note.input.token, note.input.index),
-            token: note.input.token,
-          },
-        ];
-      });
       const withdrawals = clientActions.withdraws.map((withdraw) => ({
         recipient: withdraw.input.to_addr,
         token: withdraw.input.token,
@@ -481,9 +492,12 @@ export class ActionCompiler {
       clientActions.invoke = execute(input);
     }
 
-    return Object.values(clientActions)
-      .filter((action) => action !== undefined)
-      .flat();
+    return {
+      clientActions: Object.values(clientActions)
+        .filter((action) => action !== undefined)
+        .flat(),
+      openNoteIds: openNotes.map((n) => n.noteId),
+    };
   }
 
   /**

--- a/sdk/src/internal/ephemeral-deposit.ts
+++ b/sdk/src/internal/ephemeral-deposit.ts
@@ -1,0 +1,201 @@
+/**
+ * Ephemeral-account deposit flow (SNIP-9).
+ *
+ * Builds the calls needed to deposit funds held by a fresh ephemeral SNIP-9
+ * account `A` into an open note in the caller's own channel. Submitted as a
+ * single multicall by any wallet:
+ *   1. pool.apply_actions(...)                    — open note with depositor = A
+ *   2. (optional) UDC.deployContract(...)         — deploys A if needed
+ *   3. A.execute_from_outside_v2(payload, sig)    — inner calls run with caller = A
+ *      where the inner calls are
+ *        [erc20.approve(pool, amount), pool.deposit_to_open_note(noteId, token, amount)]
+ *
+ * The signature over the SNIP-9 OutsideExecution typed data is produced by a
+ * caller-supplied `signer` (any object satisfying `Pick<SignerInterface,
+ * "signMessage">`). The SDK does not touch the ephemeral private key.
+ */
+
+import {
+  CallData,
+  constants,
+  hash,
+  outsideExecution as snip9,
+  OutsideExecutionVersion,
+  uint256,
+  type BigNumberish,
+  type Call,
+  type OutsideExecutionOptions,
+  type OutsideTransaction,
+} from "starknet";
+
+import { Open } from "../interfaces.js";
+import type {
+  EphemeralDepositParams,
+  EphemeralDepositResult,
+  ExecuteOptions,
+  PrivateTransfersInterface,
+  StarknetAddress,
+} from "../interfaces.js";
+import { generateRandom } from "../utils/crypto.js";
+import { toBigInt, toHex } from "../utils/convert.js";
+import { PrivacyPoolABI } from "./abi.js";
+
+const ANY_CALLER = constants.OutsideExecutionCallerAny;
+const UDC_ADDRESS = constants.LegacyUDC.ADDRESS;
+const UDC_ENTRYPOINT = constants.LegacyUDC.ENTRYPOINT;
+const MAX_U64 = 2n ** 64n - 1n;
+
+/**
+ * Compute the deterministic Starknet address of a UDC-deployed contract.
+ *
+ * Mirrors what the on-chain UDC computes when called with the same arguments.
+ * Convenience wrapper around `hash.calculateContractAddressFromHash`; callers
+ * can derive the same address using starknet.js primitives directly.
+ *
+ * - `unique = false`: address = `calculateContractAddressFromHash(salt, classHash, constructorCalldata, 0)`.
+ * - `unique = true`:  address = `calculateContractAddressFromHash(pedersen(deployerAddress, salt), classHash, constructorCalldata, UDC_ADDRESS)`.
+ */
+export function calculateEphemeralAddress(params: {
+  classHash: BigNumberish;
+  constructorCalldata: BigNumberish[];
+  salt?: BigNumberish;
+  unique?: boolean;
+  deployerAddress?: BigNumberish;
+}): StarknetAddress {
+  const salt = params.salt ?? 0n;
+  if (params.unique) {
+    if (params.deployerAddress === undefined) {
+      throw new Error("calculateEphemeralAddress: deployerAddress is required when unique=true");
+    }
+    const mixedSalt = hash.computePedersenHash(toHex(params.deployerAddress), toHex(salt));
+    return hash.calculateContractAddressFromHash(
+      mixedSalt,
+      params.classHash,
+      params.constructorCalldata,
+      UDC_ADDRESS
+    );
+  }
+  return hash.calculateContractAddressFromHash(
+    salt,
+    params.classHash,
+    params.constructorCalldata,
+    0
+  );
+}
+
+/**
+ * See `PrivateTransfersInterface.createEphemeralDeposit`.
+ *
+ * `poolAddress` and `chainId` are supplied by the wrapping `PrivateTransfers`
+ * (which knows them from its construction params); accepted here so the helper
+ * stays usable standalone.
+ */
+export async function createEphemeralDeposit(
+  transfers: PrivateTransfersInterface,
+  poolAddress: StarknetAddress,
+  chainId: constants.StarknetChainId,
+  params: EphemeralDepositParams,
+  options?: ExecuteOptions
+): Promise<EphemeralDepositResult> {
+  // 1. Verify the derived address when `deploy` is provided, to catch caller mistakes.
+  if (params.deploy) {
+    const derived = calculateEphemeralAddress(params.deploy);
+    if (toBigInt(derived) !== toBigInt(params.ephemeralAddress)) {
+      throw new Error(
+        `createEphemeralDeposit: ephemeralAddress ${toHex(params.ephemeralAddress)} does not match address derived from \`deploy\` (${toHex(derived)})`
+      );
+    }
+  }
+
+  // 2. Compile + prove the open-note creation via the builder.
+  const executed = await transfers
+    .build(options)
+    .with(params.token)
+    .transfer({
+      recipient: transfers.user,
+      amount: Open,
+      depositor: params.ephemeralAddress,
+    })
+    .execute();
+  if (executed.openNoteIds.length !== 1) {
+    throw new Error(
+      `createEphemeralDeposit: expected 1 open note, got ${executed.openNoteIds.length}`
+    );
+  }
+  const noteId = executed.openNoteIds[0];
+
+  // 4. Inner calls that A will execute via outside execution.
+  const approveCall: Call = {
+    contractAddress: toHex(params.token),
+    entrypoint: "approve",
+    calldata: CallData.compile([toHex(poolAddress), uint256.bnToUint256(params.amount)]),
+  };
+  const depositCall: Call = {
+    contractAddress: toHex(poolAddress),
+    entrypoint: "deposit_to_open_note",
+    calldata: new CallData(PrivacyPoolABI).compile("deposit_to_open_note", [
+      noteId,
+      params.token,
+      params.amount,
+    ]),
+  };
+  const innerCalls: Call[] = [approveCall, depositCall];
+
+  // 5. Sign the SNIP-9 OutsideExecution typed data with the ephemeral key.
+  const callOptions: OutsideExecutionOptions = {
+    caller: params.outsideExecution?.caller ? toHex(params.outsideExecution.caller) : ANY_CALLER,
+    execute_after: params.outsideExecution?.executeAfter ?? 0n,
+    execute_before: params.outsideExecution?.executeBefore ?? MAX_U64,
+  };
+  const nonce = params.outsideExecution?.nonce ?? generateRandom();
+  const typedData = snip9.getTypedData(
+    chainId,
+    callOptions,
+    nonce,
+    innerCalls,
+    OutsideExecutionVersion.V2
+  );
+  const ephemeralAddressHex = toHex(params.ephemeralAddress);
+  const signature = await params.signer.signMessage(typedData, ephemeralAddressHex);
+
+  // 6. Build the outer call to A.execute_from_outside_v2.
+  const outsideTransaction: OutsideTransaction = {
+    outsideExecution: {
+      caller: callOptions.caller,
+      nonce,
+      execute_after: callOptions.execute_after,
+      execute_before: callOptions.execute_before,
+      calls: innerCalls.map((call) => snip9.getOutsideCall(call)),
+    },
+    signature,
+    signerAddress: ephemeralAddressHex,
+    version: OutsideExecutionVersion.V2,
+  };
+  const [executeFromOutsideCall] = snip9.buildExecuteFromOutsideCall(outsideTransaction);
+
+  // 7. Optional UDC deploy call.
+  const calls: Call[] = [executed.callAndProof.call];
+  if (params.deploy) {
+    const { classHash, constructorCalldata, salt, unique, deployerAddress } = params.deploy;
+    if (unique && deployerAddress === undefined) {
+      throw new Error(
+        "createEphemeralDeposit: deployerAddress is required when deploy.unique=true"
+      );
+    }
+    calls.push({
+      contractAddress: UDC_ADDRESS,
+      entrypoint: UDC_ENTRYPOINT,
+      calldata: CallData.compile([classHash, salt ?? 0n, unique ? 1n : 0n, constructorCalldata]),
+    });
+  }
+  calls.push(executeFromOutsideCall);
+
+  return {
+    ephemeralAddress: params.ephemeralAddress,
+    noteId,
+    proof: executed.callAndProof.proof,
+    calls,
+    registry: executed.registry,
+    warnings: executed.warnings,
+  };
+}

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -4,6 +4,8 @@
 
 import type {
   Actions,
+  EphemeralDepositParams,
+  EphemeralDepositResult,
   ExecuteOptions,
   ExecuteResult,
   ProofProviderInterface,
@@ -17,6 +19,7 @@ import type { Account, TypedContractV2 } from "starknet";
 import { ActionCompiler } from "./compiler.js";
 import { PrivacyPoolABI } from "./abi.js";
 import { AbstractPrivateTransfers } from "./abstract-private-transfers.js";
+import { createEphemeralDeposit as createEphemeralDepositImpl } from "./ephemeral-deposit.js";
 import { debugLog } from "../utils/logging.js";
 import type { ProofInvocationFactoryInterface } from "./proof-invocation-factory.js";
 import { toBigInt, toHex } from "../utils/convert.js";
@@ -62,7 +65,10 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     );
 
     // Compile actions
-    const { clientActions, registry, warnings } = await compiler.compile(actions, options);
+    const { clientActions, registry, warnings, openNoteIds } = await compiler.compile(
+      actions,
+      options
+    );
 
     // Create invocation for proving
     const details = await this.params.provingProvider.getDefaultDetails();
@@ -73,7 +79,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       details
     );
 
-    return { invocation, registry, warnings };
+    return { invocation, registry, warnings, openNoteIds };
   }
 
   invalidateProofNonceCache(): void {
@@ -81,7 +87,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
   }
 
   async executeWithInvocation(
-    { invocation, registry, warnings }: ProofInvocationResult,
+    { invocation, registry, warnings, openNoteIds }: ProofInvocationResult,
     provingBlockId?: ProvingBlockId
   ): Promise<ExecuteResult> {
     const proof = await this.params.provingProvider.prove(invocation, provingBlockId);
@@ -106,6 +112,21 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       },
       registry,
       warnings,
+      openNoteIds,
     };
+  }
+
+  async createEphemeralDeposit(
+    params: EphemeralDepositParams,
+    options?: ExecuteOptions
+  ): Promise<EphemeralDepositResult> {
+    const { chainId } = await this.params.provingProvider.getDefaultDetails();
+    return createEphemeralDepositImpl(
+      this,
+      this.params.poolContractAddress,
+      chainId,
+      params,
+      options
+    );
   }
 }

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -19,10 +19,11 @@ import {
   RpcProvider,
   UniversalDetails,
   waitForTransactionOptions,
+  type Call,
   type GetTransactionReceiptResponse,
 } from "starknet";
 import { TracingRpcProvider } from "./tracing-provider.js";
-import type { CallAndProof, PrivateTransfersInterface } from "../interfaces.js";
+import type { CallAndProof, Proof, PrivateTransfersInterface } from "../interfaces.js";
 import { createPrivateTransfers } from "../factory.js";
 import { CallMockProofProvider } from "./mock-proving.js";
 import {
@@ -361,14 +362,25 @@ export class Devnet {
   }
 
   /**
-   * Execute a call via outside execution using the admin account.
-   * The admin creates the outside transaction and executes it.
+   * Execute a call (or multi-call) via outside execution using the admin
+   * account. The admin creates the outside transaction and executes it.
    * This simulates a paymaster flow.
+   *
+   * Accepts either:
+   * - the legacy `CallAndProof` shape (single inner call), as produced by
+   *   `transfers.execute()`; or
+   * - `{ calls: Call[]; proof: Proof }` for multi-call flows such as
+   *   `transfers.createEphemeralDeposit()`.
    */
-  async executeOutside(callAndProof: CallAndProof): Promise<GetTransactionReceiptResponse> {
+  async executeOutside(
+    input: CallAndProof | { calls: Call[]; proof: Proof }
+  ): Promise<GetTransactionReceiptResponse> {
     if (!this.setup) {
       throw new Error("Devnet not initialized");
     }
+
+    const calls = "call" in input ? input.call : input.calls;
+    const proof = input.proof;
 
     const now_seconds = Math.floor(Date.now() / 1000);
     const callOptions: OutsideExecutionOptions = {
@@ -391,13 +403,13 @@ export class Devnet {
 
     const outsideTransaction = await this.setup.admin.getOutsideTransaction(
       callOptions,
-      callAndProof.call,
+      calls,
       OutsideExecutionVersion.V2
     );
 
     const response = await this.setup.admin.executeFromOutside(outsideTransaction, {
-      proofFacts: callAndProof.proof.proofFacts,
-      proof: callAndProof.proof.data,
+      proofFacts: proof.proofFacts,
+      proof: proof.data,
     });
     const receipt = await this.provider!.waitForTransaction(response.transaction_hash);
     if (!receipt.isSuccess()) {

--- a/sdk/tests/ephemeral-deposit.devnet.test.ts
+++ b/sdk/tests/ephemeral-deposit.devnet.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Devnet integration tests for the ephemeral-account deposit flow (SNIP-9).
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { Signer } from "starknet";
+import { Devnet, createDevnetTestEnv, type DevnetTestEnv } from "../src/testing/index.js";
+import { calculateEphemeralAddress } from "../src/internal/ephemeral-deposit.js";
+
+// Standard OpenZeppelin Account class, pre-declared on the devnet image. OZ
+// `AccountComponent` ships SNIP-9 `execute_from_outside_v2`.
+const OZ_ACCOUNT_CLASS_HASH = "0x5b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564";
+
+describe("Ephemeral-account deposit (SNIP-9) on devnet", () => {
+  let devnet: Devnet;
+  let env: DevnetTestEnv;
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await createDevnetTestEnv(devnet);
+  });
+
+  afterAll(async () => {
+    await devnet?.cleanup();
+  });
+
+  it("fresh ephemeral account: fund A, single tx (deploy + outside-exec) lands funds in Alice's note", async () => {
+    const { env: de, transfers } = env;
+    const amount = 100n;
+
+    // Register Alice and set up her STRK self-channel.
+    const setup = await transfers.alice
+      .build({ autoSetup: true })
+      .register()
+      .with(de.strk, (t) => t.setup(de.alice.address))
+      .execute();
+    await devnet.executeOutside(setup.callAndProof);
+
+    // Pick a fresh ephemeral keypair and derive its address.
+    const ephemeralPrivateKey = "0x0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ephemeralSigner = new Signer(ephemeralPrivateKey);
+    const ephemeralPublicKey = await ephemeralSigner.getPubKey();
+    const ephemeralAddress = calculateEphemeralAddress({
+      classHash: OZ_ACCOUNT_CLASS_HASH,
+      constructorCalldata: [ephemeralPublicKey],
+      salt: ephemeralPublicKey,
+    });
+
+    // External "depositor" funds the ephemeral address (out-of-scope step, simulated
+    // here with an admin STRK transfer).
+    await de.admin.execute({
+      contractAddress: de.strk,
+      entrypoint: "transfer",
+      calldata: [ephemeralAddress, amount, 0n],
+    });
+
+    // Alice builds the deposit bundle.
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: de.strk,
+        amount,
+        signer: ephemeralSigner,
+        deploy: {
+          classHash: OZ_ACCOUNT_CLASS_HASH,
+          constructorCalldata: [ephemeralPublicKey],
+          salt: ephemeralPublicKey,
+        },
+      },
+      { autoDiscover: { channels: "refresh", notes: "refresh" } }
+    );
+
+    expect(result.calls).toHaveLength(3);
+
+    // Submit via admin's SNIP-9 outside execution (paymaster pattern). Alice's
+    // account never appears as the on-chain tx sender.
+    const receipt = await devnet.executeOutside({
+      calls: result.calls,
+      proof: result.proof,
+    });
+    expect(receipt.isSuccess()).toBe(true);
+
+    // Alice should now discover a STRK note for `amount`.
+    const { notes } = await transfers.alice.discoverNotes();
+    const strkNotes = notes.get(BigInt(de.strk)) ?? [];
+    const filled = strkNotes.find((n) => n.amount === amount);
+    expect(filled).toBeDefined();
+  });
+
+  it("tampered signature: outside-execution validation rejects the tx", async () => {
+    const { env: de, transfers } = env;
+    const amount = 100n;
+
+    const ephemeralPrivateKey = "0x0fedcba9876543210fedcba9876543210fedcba987654321";
+    const ephemeralSigner = new Signer(ephemeralPrivateKey);
+    const ephemeralPublicKey = await ephemeralSigner.getPubKey();
+    const ephemeralAddress = calculateEphemeralAddress({
+      classHash: OZ_ACCOUNT_CLASS_HASH,
+      constructorCalldata: [ephemeralPublicKey],
+      salt: ephemeralPublicKey,
+    });
+
+    await de.admin.execute({
+      contractAddress: de.strk,
+      entrypoint: "transfer",
+      calldata: [ephemeralAddress, amount, 0n],
+    });
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: de.strk,
+        amount,
+        signer: ephemeralSigner,
+        deploy: {
+          classHash: OZ_ACCOUNT_CLASS_HASH,
+          constructorCalldata: [ephemeralPublicKey],
+          salt: ephemeralPublicKey,
+        },
+      },
+      { autoDiscover: { channels: "refresh", notes: "refresh" } }
+    );
+
+    // Corrupt the signature on the outer (last) call. The signature pair
+    // [r, s] is the tail of the calldata; replace with clearly invalid values.
+    const calldata = result.calls[result.calls.length - 1].calldata as string[];
+    calldata[calldata.length - 2] = "0x1";
+    calldata[calldata.length - 1] = "0x1";
+
+    await expect(
+      devnet.executeOutside({ calls: result.calls, proof: result.proof })
+    ).rejects.toThrow();
+  });
+});

--- a/sdk/tests/internal/ephemeral-deposit.test.ts
+++ b/sdk/tests/internal/ephemeral-deposit.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for the ephemeral-account deposit flow (SNIP-9 outside execution).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CallData,
+  Signer,
+  constants,
+  hash,
+  num,
+  outsideExecution as snip9,
+  OutsideExecutionVersion,
+  shortString,
+  uint256,
+  type Call,
+  type Signature,
+  type TypedData,
+} from "starknet";
+
+import { calculateEphemeralAddress } from "../../src/internal/ephemeral-deposit.js";
+import {
+  AUTO_DISCOVERY_ONLY,
+  createTestEnv,
+  MockTestEnv,
+  POOL_ADDRESS,
+} from "../helpers/test-fixtures.js";
+import { toBigInt, toHex } from "../../src/utils/index.js";
+
+const OZ_ACCOUNT_CLASS_HASH = "0x540d7f5ec7ecf317e68d48564934cb99259781b1ee3cedbbc37ec5337f8e688";
+
+// Encoded constant SNIP-9 "ANY_CALLER" value from starknet.js constants module.
+const ANY_CALLER = constants.OutsideExecutionCallerAny;
+
+function chainIdSepoliaHex(): string {
+  // Same encoding rules as starknet.js getTypedData uses for the domain.
+  return shortString.encodeShortString("SN_SEPOLIA");
+}
+
+describe("calculateEphemeralAddress", () => {
+  const classHash = OZ_ACCOUNT_CLASS_HASH;
+  const publicKey = 0x1234abcd1234abcd1234abcd1234abcdn;
+
+  it("unique=false: address matches calculateContractAddressFromHash with deployer=0", () => {
+    const expected = hash.calculateContractAddressFromHash(7n, classHash, [publicKey], 0);
+    const actual = calculateEphemeralAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+      salt: 7n,
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("unique=true: address matches calculateContractAddressFromHash with pedersen(deployer, salt) and deployer=UDC", () => {
+    const deployer = 0xdeadbeefn;
+    const salt = 0x1234n;
+    const mixedSalt = hash.computePedersenHash(toHex(deployer), toHex(salt));
+    const expected = hash.calculateContractAddressFromHash(
+      mixedSalt,
+      classHash,
+      [publicKey],
+      constants.LegacyUDC.ADDRESS
+    );
+    const actual = calculateEphemeralAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+      salt,
+      unique: true,
+      deployerAddress: deployer,
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("salt defaults to 0", () => {
+    const expected = hash.calculateContractAddressFromHash(0n, classHash, [publicKey], 0);
+    const actual = calculateEphemeralAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("unique=true without deployerAddress throws", () => {
+    expect(() =>
+      calculateEphemeralAddress({
+        classHash,
+        constructorCalldata: [publicKey],
+        unique: true,
+      })
+    ).toThrow(/deployerAddress is required/);
+  });
+});
+
+describe("createEphemeralDeposit", () => {
+  let testEnv: MockTestEnv;
+
+  beforeEach(() => {
+    testEnv = createTestEnv();
+  });
+
+  // Bootstrap: each test needs Alice registered + self-channel + ace-subchannel before
+  // we can create an open note with depositor = A.
+  async function bootstrapAlice() {
+    const { mocknet, env, transfers } = testEnv;
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(
+      await transfers.alice
+        .build({ autoSetup: true })
+        .setup(env.alice.address)
+        .with(env.ace, (t) => t.setup(env.alice.address))
+        .execute()
+    );
+  }
+
+  // Pick a fresh keypair for each call so test isolation is clean.
+  function makeEphemeralSigner() {
+    const privateKey = "0x0123456789abcdef0123456789abcdef0123456789abcdef"; // < curve order
+    const signer = new Signer(privateKey);
+    return { signer, privateKey };
+  }
+
+  it("no `deploy`: returns 2 calls (apply_actions, execute_from_outside_v2)", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    // A is opaque to the SDK; we just need a stable felt for the depositor.
+    const ephemeralAddress = `0x${"a".repeat(63)}1`;
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer,
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(result.calls).toHaveLength(2);
+    expect(result.calls[0].entrypoint).toBe("apply_actions");
+    expect(toBigInt(result.calls[0].contractAddress)).toBe(toBigInt(POOL_ADDRESS));
+    expect(result.calls[1].entrypoint).toBe("execute_from_outside_v2");
+    expect(toBigInt(result.calls[1].contractAddress)).toBe(toBigInt(ephemeralAddress));
+    expect(result.noteId).toBeTypeOf("bigint");
+    expect(result.proof).toBeDefined();
+  });
+
+  it("with `deploy`: returns 3 calls and middle call is UDC.deployContract", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const classHash = OZ_ACCOUNT_CLASS_HASH;
+    const constructorCalldata = [123n];
+    const salt = 7n;
+    const ephemeralAddress = calculateEphemeralAddress({
+      classHash,
+      constructorCalldata,
+      salt,
+    });
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer,
+        deploy: { classHash, constructorCalldata, salt },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(result.calls).toHaveLength(3);
+    expect(result.calls[0].entrypoint).toBe("apply_actions");
+    expect(result.calls[1].entrypoint).toBe(constants.LegacyUDC.ENTRYPOINT);
+    expect(toBigInt(result.calls[1].contractAddress)).toBe(toBigInt(constants.LegacyUDC.ADDRESS));
+    expect(result.calls[2].entrypoint).toBe("execute_from_outside_v2");
+    expect(toBigInt(result.calls[2].contractAddress)).toBe(toBigInt(ephemeralAddress));
+  });
+
+  it("UDC deploy calldata matches [classHash, salt, unique?, constructorCalldata]", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const classHash = OZ_ACCOUNT_CLASS_HASH;
+    const constructorCalldata = [123n, 456n];
+    const salt = 42n;
+    const ephemeralAddress = calculateEphemeralAddress({
+      classHash,
+      constructorCalldata,
+      salt,
+    });
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 50n,
+        signer,
+        deploy: { classHash, constructorCalldata, salt },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    const expected = CallData.compile([classHash, salt, 0n, constructorCalldata]);
+    expect(result.calls[1].calldata).toEqual(expected);
+  });
+
+  it("`deploy` with mismatching ephemeralAddress throws", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const classHash = OZ_ACCOUNT_CLASS_HASH;
+
+    await expect(
+      transfers.alice.createEphemeralDeposit(
+        {
+          ephemeralAddress: "0xdeadbeef", // arbitrary mismatch
+          token: env.ace,
+          amount: 100n,
+          signer,
+          deploy: { classHash, constructorCalldata: [123n], salt: 7n },
+        },
+        AUTO_DISCOVERY_ONLY
+      )
+    ).rejects.toThrow(/does not match address derived from `deploy`/);
+  });
+
+  it("signs the SNIP-9 typed data with the ephemeral key and returns the same hash as starknet.js", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const ephemeralAddress = `0x${"a".repeat(63)}1`;
+
+    // Capture the typedData the SDK passes to signMessage.
+    let observedTypedData: TypedData | undefined;
+    let observedAccountAddress: string | undefined;
+    const spySigner = {
+      signMessage: vi.fn(
+        async (typedData: TypedData, accountAddress: string): Promise<Signature> => {
+          observedTypedData = typedData;
+          observedAccountAddress = accountAddress;
+          return signer.signMessage(typedData, accountAddress);
+        }
+      ),
+    };
+    const nonce = 0x99n; // fix for reproducibility
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spySigner,
+        outsideExecution: { nonce },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(spySigner.signMessage).toHaveBeenCalledTimes(1);
+    expect(toBigInt(observedAccountAddress!)).toBe(toBigInt(ephemeralAddress));
+
+    // Reconstruct the typed data manually and compare hashes.
+    const tokenHex = toHex(env.ace);
+    const approveCall: Call = {
+      contractAddress: tokenHex,
+      entrypoint: "approve",
+      calldata: CallData.compile([toHex(POOL_ADDRESS), uint256.bnToUint256(100n)]),
+    };
+    const depositCall: Call = {
+      contractAddress: toHex(POOL_ADDRESS),
+      entrypoint: "deposit_to_open_note",
+      calldata: CallData.compile([result.noteId, env.ace, 100n]),
+    };
+    const expectedTypedData = snip9.getTypedData(
+      chainIdSepoliaHex() as constants.StarknetChainId,
+      { caller: ANY_CALLER, execute_after: 0n, execute_before: 2n ** 64n - 1n },
+      nonce,
+      [approveCall, depositCall],
+      OutsideExecutionVersion.V2
+    );
+    expect(observedTypedData).toEqual(expectedTypedData);
+  });
+
+  it("outsideExecution.caller defaults to ANY_CALLER; override propagates", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const ephemeralAddress = "0x1234567890abcdef1234567890abcdef1234567890abcdef1";
+    const restrictedCaller = "0x5555555555555555555555555555555555555555555555552";
+
+    let firstCallTypedData: TypedData | undefined;
+    let secondCallTypedData: TypedData | undefined;
+    const spy = (capture: (td: TypedData) => void) => ({
+      signMessage: async (typedData: TypedData, accountAddress: string): Promise<Signature> => {
+        capture(typedData);
+        return signer.signMessage(typedData, accountAddress);
+      },
+    });
+
+    await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spy((td) => (firstCallTypedData = td)),
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+    await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spy((td) => (secondCallTypedData = td)),
+        outsideExecution: { caller: restrictedCaller },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    const callerOf = (td: TypedData | undefined) =>
+      toBigInt((td!.message as Record<string, string>).Caller);
+    expect(callerOf(firstCallTypedData)).toBe(toBigInt(ANY_CALLER));
+    expect(callerOf(secondCallTypedData)).toBe(toBigInt(restrictedCaller));
+  });
+
+  it("reuses the openNoteId from executeWithInvocation in the inner deposit call", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const ephemeralAddress = `0x${"a".repeat(63)}1`;
+
+    const result = await transfers.alice.createEphemeralDeposit(
+      {
+        ephemeralAddress,
+        token: env.ace,
+        amount: 100n,
+        signer,
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    // The outer calldata to execute_from_outside_v2 carries the inner deposit_to_open_note
+    // call. The selector and the noteId felt must both appear in it.
+    const depositSelector = hash.getSelectorFromName("deposit_to_open_note");
+    const outer = result.calls[result.calls.length - 1].calldata as string[];
+    expect(outer.some((c) => num.toBigInt(c) === num.toBigInt(depositSelector))).toBe(true);
+    expect(outer.some((c) => num.toBigInt(c) === toBigInt(result.noteId))).toBe(true);
+  });
+});

--- a/sdk/tests/internal/invoke-external.test.ts
+++ b/sdk/tests/internal/invoke-external.test.ts
@@ -52,9 +52,9 @@ describe("InvokeExternal (at most one invoke per tx)", () => {
         .withdraw({ recipient: anonymizer.address, amount: 10n })
         .surplusTo(env.alice.address, false)
         .with(env.bee)
-        .transfer({ recipient: env.alice.address, amount: Open, depositor: helper.address })
+        .transfer({ recipient: env.alice.address, amount: Open, depositor: anonymizer.address })
         .with(env.bee)
-        .transfer({ recipient: env.alice.address, amount: Open, depositor: helper.address })
+        .transfer({ recipient: env.alice.address, amount: Open, depositor: anonymizer.address })
         .done()
         .invoke(({ openNotes, withdrawals }) => {
           expect(openNotes.length).toBe(2);
@@ -123,7 +123,7 @@ describe("InvokeExternal (at most one invoke per tx)", () => {
         .withdraw({ recipient: anonymizer.address, amount: swapAmount })
         .surplusTo(env.alice.address, false)
         .with(env.bee)
-        .transfer({ recipient: env.alice.address, amount: Open, depositor: helper.address })
+        .transfer({ recipient: env.alice.address, amount: Open, depositor: anonymizer.address })
         .done()
         .with(env.bee, (t) => t.withdraw({ recipient: env.alice.address, amount: feeAmount }))
         .invoke(({ openNotes }) => {
@@ -191,7 +191,7 @@ describe("InvokeExternal (at most one invoke per tx)", () => {
         .withdraw({ recipient: anonymizer.address, amount: 10n })
         .surplusTo(env.alice.address, false)
         .with(env.bee)
-        .transfer({ recipient: env.alice.address, amount: Open, depositor: helper.address })
+        .transfer({ recipient: env.alice.address, amount: Open, depositor: anonymizer.address })
         .done()
         .invoke(({ openNotes, withdrawals }) => {
           expect(openNotes.length).toBe(1);


### PR DESCRIPTION
Add createEphemeralDeposit and calculateEphemeralAddress to
PrivateTransfersInterface. Given an externally-funded ephemeral SNIP-9
account A, the SDK builds a single multicall — apply_actions creates the
open note (depositor = A), an optional UDC.deployContract deploys A, and
A.execute_from_outside_v2 wraps [approve(pool, amount),
pool.deposit_to_open_note(...)] signed off-chain by the ephemeral key.
Inside outside execution the inner calls run with caller = A, so the
existing pool entry point's `caller == depositor` check passes without
any Cairo changes. The account class must implement SNIP-9 v2 (OZ
AccountComponent does).

Also surfaces `openNoteIds` on ProofInvocationResult/ExecuteResult so the
new flow (and any future consumer) can recover the generated note id
without duplicating the compiler's bookkeeping.

Devnet.executeOutside now also accepts { calls: Call[]; proof: Proof }
for multi-call flows; the existing CallAndProof overload is unchanged.

Drive-by: fix `helper` -> `anonymizer` rename misses in two tests
(invoke-external.test.ts, vesu-lending.test.ts) that #740 missed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/745)
<!-- Reviewable:end -->
