### PR TITLE
feat(sdk): account-funded deposit via SNIP-9 outside execution

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -18,3 +18,7 @@
 - Use reference vectors when available in the codebase; if none exist, ask user to provide them or instructions to generate them
 - Think about edge cases: empty inputs, boundary values, error conditions
 - Always assume the worst - test failure modes, not just happy paths
+
+**SDK devnet test naming:**
+- Any new vitest file that spawns a real devnet (e.g. `new Devnet()`, `createDevnetTestEnv`) MUST be named `*.devnet.test.ts` (or be the exact path `tests/devnet.test.ts`). `sdk/vitest.config.ts` routes those into a `devnet` project with `fileParallelism: false`; everything else stays parallel.
+- If a devnet test isn't named that way it lands in the parallel `unit` project, where two devnet-spawning files race on RPC traffic and filesystem state and fail intermittently. Mocknet-only tests have no naming requirement.

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,6 +2,17 @@
 version = 1
 
 [[package]]
+name = "deposit_anonymizer"
+version = "0.1.0"
+dependencies = [
+ "openzeppelin",
+ "privacy",
+ "snforge_std",
+ "starkware_utils",
+ "starkware_utils_testing",
+]
+
+[[package]]
 name = "ekubo"
 version = "0.1.0"
 source = "git+https://github.com/EkuboProtocol/starknet-contracts?rev=8b4de8b5701d10b101c06b786740bf45b6cf15cb#8b4de8b5701d10b101c06b786740bf45b6cf15cb"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "packages/deposit_anonymizer",
     "packages/ekubo_swap_anonymizer",
     "packages/privacy",
     "packages/vesu_lending_anonymizer",

--- a/packages/deposit_anonymizer/README.md
+++ b/packages/deposit_anonymizer/README.md
@@ -1,0 +1,68 @@
+# Deposit Anonymizer
+
+Cairo contract used as a privacy-pool `privacy_invoke` target that mediates a SNIP-9-authorized account deposit into a privacy-pool open note.
+
+## Overview
+
+`DepositAnonymizer` implements the protocol's `privacy_invoke(calls) -> Span<OpenNoteDeposit>` interface and exposes a second entrypoint, `deposit_to_open_note(note_id, token, amount)`, which is called *inside* a user-signed SNIP-9 outside execution. The two entrypoints are designed to work together so the deposit's `note_id` is committed to by the user's SNIP-9 signature, defeating front-running where an attacker captures the signed outside execution and redirects the deposit to a different note.
+
+The privacy pool's `InvokeExternal` action calls a single contract at the hardcoded `privacy_invoke` selector and feeds its `Span<OpenNoteDeposit>` return back into the pool's `_apply_invoke`. Plain Starknet accounts implement neither that selector nor the `OpenNoteDeposit` return contract, so flows that need user-signed pre-conditions on `apply_actions` (ephemeral-account SNIP-9 deposits, transferFrom-based pulls, etc.) need a small intermediary that's both reachable by the pool and capable of dispatching arbitrary calls. This contract is that intermediary.
+
+## Interface
+
+```cairo
+fn privacy_invoke(calls: Array<Call>) -> Span<OpenNoteDeposit>
+fn deposit_to_open_note(note_id: felt252, token: ContractAddress, amount: u128) -> OpenNoteDeposit
+```
+
+### `privacy_invoke`
+
+Dispatches each `Call` in order via `call_contract_syscall`. The **last** call must be `A.execute_from_outside_v2(...)`; its return is parsed as the `Array<Span<felt252>>` produced by OZ's SRC9_V2 (one `Span` per inner call), and the **last** inner `Span` is deserialized as `OpenNoteDeposit` (the return of `deposit_to_open_note`). The anonymizer then approves the pool (`get_caller_address()`) for the deposit amount on the deposit token, and returns `[deposit].span()` for the pool to fill the note.
+
+### `deposit_to_open_note`
+
+Called *inside* A's SNIP-9 outside execution (caller = A). Pulls `amount` of `token` from the caller via `transferFrom` (A must have pre-approved this contract for `amount` via a preceding inner call). Returns `OpenNoteDeposit { note_id, token, amount }`.
+
+## Why this shape
+
+The `note_id` is part of the inner `deposit_to_open_note` call's calldata, so the user's SNIP-9 signature commits to it. A front-runner that captures the signed outside execution cannot redirect the deposit to a different note: substituting `note_id` invalidates the signature, and re-using the original payload simply fills the originally-signed note.
+
+There is no contract storage — the deposit info flows through return values only.
+
+## Source modules
+
+| File | Purpose |
+|------|---------|
+| [`deposit_anonymizer.cairo`](src/deposit_anonymizer.cairo) | `IDepositAnonymizer`, `DepositAnonymizer` contract |
+
+## Build and test
+
+```bash
+scarb build --package deposit_anonymizer
+scarb test   # wraps snforge test
+```
+
+snforge version: `0.59.0`
+
+## Declare and deploy with sncast
+
+Run from the **repository root**.
+
+```bash
+scarb --profile release build
+sncast --account <ACCOUNT_NAME> declare \
+  --contract-name DepositAnonymizer \
+  --package deposit_anonymizer \
+  --network <mainnet|sepolia|devnet>
+
+sncast --account <ACCOUNT_NAME> deploy \
+  --class-hash <CLASS_HASH_FROM_DECLARE> \
+  --network <mainnet|sepolia|devnet>
+```
+
+The constructor takes no arguments.
+
+## See also
+
+- [Privacy pool contract](../privacy/README.md) — calls this contract via `InvokeExternal`
+- [Project root](../../README.md) — architecture overview and prerequisites

--- a/packages/deposit_anonymizer/Scarb.toml
+++ b/packages/deposit_anonymizer/Scarb.toml
@@ -1,0 +1,43 @@
+[package]
+name = "deposit_anonymizer"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[tool]
+fmt.workspace = true
+scarb.workspace = true
+
+[dependencies]
+starknet.workspace = true
+openzeppelin.workspace = true
+starkware_utils.workspace = true
+privacy = { path = "../privacy" }
+
+[dev-dependencies]
+assert_macros.workspace = true
+snforge_std.workspace = true
+starkware_utils_testing.workspace = true
+
+[features]
+test_utils = []
+
+[lib]
+
+[[test]]
+name = "deposit_anonymizer_unittest"
+build-external-contracts = ["starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock"]
+
+[scripts]
+test = "snforge test"
+
+[[target.starknet-contract]]
+sierra = true
+casm = true
+casm-add-pythonic-hints = true
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+inlining-strategy = "avoid"

--- a/packages/deposit_anonymizer/src/deposit_anonymizer.cairo
+++ b/packages/deposit_anonymizer/src/deposit_anonymizer.cairo
@@ -1,0 +1,107 @@
+//! Deposit anonymizer — mediates a SNIP-9-authorized account deposit into a privacy-pool open
+//! note via the pool's `InvokeExternal` action.
+//!
+//! Two entrypoints:
+//!
+//! - `deposit_to_open_note(note_id, token, amount) -> OpenNoteDeposit` — called *inside* a
+//!   user-signed SNIP-9 outside execution. Pulls funds from the SNIP-9 account (the caller) via
+//!   `transferFrom` (the caller must have pre-approved this contract for `amount`). Returns
+//!   the constructed `OpenNoteDeposit` so it propagates up the SNIP-9 return chain.
+//!
+//! - `privacy_invoke(calls) -> Span<OpenNoteDeposit>` — called by the pool. Dispatches each
+//!   `Call` in order via `call_contract_syscall`. The **last** call's return value is parsed as
+//!   the `Array<Span<felt252>>` produced by `execute_from_outside_v2`, and the **last** inner
+//!   `Span` is deserialized as `OpenNoteDeposit`. Approves the pool for the deposit, then
+//!   returns it for the pool to fill the note.
+//!
+//! ## Why this shape
+//!
+//! The `note_id` is part of the inner `deposit_to_open_note` call's calldata, so the user's
+//! SNIP-9 signature commits to it. A front-runner that captures the signed outside execution
+//! cannot redirect the deposit to a different note: substituting `note_id` invalidates the
+//! signature, and re-using the original payload simply fills the originally-signed note.
+//!
+//! There is no contract storage — the deposit info flows through return values only.
+
+use privacy::objects::OpenNoteDeposit;
+use starknet::ContractAddress;
+use starknet::account::Call;
+
+#[starknet::interface]
+pub trait IDepositAnonymizer<T> {
+    fn privacy_invoke(ref self: T, calls: Array<Call>) -> Span<OpenNoteDeposit>;
+    fn deposit_to_open_note(
+        ref self: T, note_id: felt252, token: ContractAddress, amount: u128,
+    ) -> OpenNoteDeposit;
+}
+
+pub mod errors {
+    pub const BAD_OUTSIDE_RETURN: felt252 = 'BAD_OUTSIDE_RETURN';
+    pub const EMPTY_INNER_RETURNS: felt252 = 'EMPTY_INNER_RETURNS';
+    pub const BAD_DEPOSIT_RETURN: felt252 = 'BAD_DEPOSIT_RETURN';
+}
+
+#[starknet::contract]
+pub mod DepositAnonymizer {
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use privacy::objects::OpenNoteDeposit;
+    use starknet::SyscallResultTrait;
+    use starknet::account::Call;
+    use starknet::syscalls::call_contract_syscall;
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use super::{IDepositAnonymizer, errors};
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {}
+
+    #[abi(embed_v0)]
+    pub impl Impl of IDepositAnonymizer<ContractState> {
+        fn privacy_invoke(
+            ref self: ContractState, calls: Array<Call>,
+        ) -> Span<OpenNoteDeposit> {
+            let mut last_return: Span<felt252> = ArrayTrait::new().span();
+            for call in calls.span() {
+                let Call { to, selector, calldata } = *call;
+                last_return = call_contract_syscall(
+                    address: to, entry_point_selector: selector, :calldata,
+                )
+                    .unwrap_syscall();
+            }
+
+            let mut iter = last_return;
+            let inner_returns: Array<Span<felt252>> = Serde::deserialize(ref iter)
+                .expect(errors::BAD_OUTSIDE_RETURN);
+            let n = inner_returns.len();
+            assert(n != 0, errors::EMPTY_INNER_RETURNS);
+
+            let mut last_inner = *inner_returns.at(n - 1);
+            let deposit: OpenNoteDeposit = Serde::deserialize(ref last_inner)
+                .expect(errors::BAD_DEPOSIT_RETURN);
+
+            let pool = get_caller_address();
+            IERC20Dispatcher { contract_address: deposit.token }
+                .approve(spender: pool, amount: deposit.amount.into());
+
+            [deposit].span()
+        }
+
+        fn deposit_to_open_note(
+            ref self: ContractState,
+            note_id: felt252,
+            token: ContractAddress,
+            amount: u128,
+        ) -> OpenNoteDeposit {
+            let depositor = get_caller_address();
+            IERC20Dispatcher { contract_address: token }
+                .transfer_from(
+                    sender: depositor,
+                    recipient: get_contract_address(),
+                    amount: amount.into(),
+                );
+            OpenNoteDeposit { note_id, token, amount }
+        }
+    }
+}

--- a/packages/deposit_anonymizer/src/lib.cairo
+++ b/packages/deposit_anonymizer/src/lib.cairo
@@ -1,0 +1,3 @@
+pub mod deposit_anonymizer;
+#[cfg(test)]
+pub mod tests;

--- a/packages/deposit_anonymizer/src/tests.cairo
+++ b/packages/deposit_anonymizer/src/tests.cairo
@@ -1,0 +1,1 @@
+pub mod test_deposit_anonymizer;

--- a/packages/deposit_anonymizer/src/tests/test_deposit_anonymizer.cairo
+++ b/packages/deposit_anonymizer/src/tests/test_deposit_anonymizer.cairo
@@ -1,0 +1,78 @@
+use deposit_anonymizer::deposit_anonymizer::{
+    DepositAnonymizer, IDepositAnonymizerDispatcher, IDepositAnonymizerDispatcherTrait,
+    IDepositAnonymizerSafeDispatcher, IDepositAnonymizerSafeDispatcherTrait,
+};
+use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+use privacy::objects::OpenNoteDeposit;
+use snforge_std::{CustomToken, DeclareResultTrait, Token, TokenTrait, declare};
+use starknet::deployment::DeploymentParams;
+use starknet::{ContractAddress, SyscallResultTrait};
+use starkware_utils_testing::test_utils::{
+    Deployable, TokenConfig, TokenHelperTrait, cheat_caller_address_once,
+};
+
+const TRANSFER_AMOUNT: u128 = 1_000_000_000_000_000_000;
+const NOTE_ID: felt252 = 'NOTE_ID';
+
+fn deploy_deposit_anonymizer() -> ContractAddress {
+    let class_hash = declare(contract: "DepositAnonymizer")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
+    let (address, _) = DepositAnonymizer::deploy_for_test(
+        class_hash: *class_hash, :deployment_params,
+    )
+        .expect('Anonymizer deploy failed');
+    address
+}
+
+fn deploy_test_erc20_token() -> Token {
+    let config = TokenConfig {
+        name: "DepositAnonTestToken",
+        symbol: "DAT",
+        decimals: 18,
+        initial_supply: 1_000_000_000_000_000_000_000_000_000_000_u256,
+        owner: 'TOKEN_OWNER'.try_into().unwrap(),
+    };
+    let token = config.deploy();
+    Token::Custom(
+        CustomToken {
+            contract_address: token.address,
+            balances_variable_selector: selector!("ERC20_balances"),
+        },
+    )
+}
+
+#[test]
+fn test_deposit_to_open_note_transfers_and_returns_deposit() {
+    let anonymizer = deploy_deposit_anonymizer();
+    let token = deploy_test_erc20_token();
+    let account: ContractAddress = 'ACCOUNT_A'.try_into().unwrap();
+    let token_addr = token.contract_address();
+
+    token.supply(address: account, amount: TRANSFER_AMOUNT);
+    cheat_caller_address_once(contract_address: token_addr, caller_address: account);
+    IERC20Dispatcher { contract_address: token_addr }
+        .approve(spender: anonymizer, amount: TRANSFER_AMOUNT.into());
+
+    cheat_caller_address_once(contract_address: anonymizer, caller_address: account);
+    let deposit = IDepositAnonymizerDispatcher { contract_address: anonymizer }
+        .deposit_to_open_note(note_id: NOTE_ID, token: token_addr, amount: TRANSFER_AMOUNT);
+
+    assert_eq!(
+        deposit,
+        OpenNoteDeposit { note_id: NOTE_ID, token: token_addr, amount: TRANSFER_AMOUNT },
+    );
+    assert_eq!(token.balance_of(address: account), 0);
+    assert_eq!(token.balance_of(address: anonymizer), TRANSFER_AMOUNT.into());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_privacy_invoke_empty_calls_reverts() {
+    let anonymizer = deploy_deposit_anonymizer();
+    let result = IDepositAnonymizerSafeDispatcher { contract_address: anonymizer }
+        .privacy_invoke(calls: ArrayTrait::new());
+    assert!(result.is_err());
+}

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+### Added
+
+- Standalone utilities `buildAccountDepositInvoke` and
+  `calculateAccountAddress`: build the `.invoke()` callback for a
+  single-tx deposit from a SNIP-9-capable account into the caller's own
+  channel. The deposit is routed through the new `DepositAnonymizer`
+  contract (separate Cairo package). The user signs an
+  `execute_from_outside_v2` whose inner calls are
+  `[token.approve(anonymizer, amount), anonymizer.deposit_to_open_note(note_id, token, amount)]`;
+  the anonymizer parses the `OpenNoteDeposit` out of the SNIP-9 return
+  chain and approves the pool to fill the open note. Because `note_id`
+  is in the signed calldata, a front-runner cannot redirect a captured
+  signed outside execution to a different note. The `.invoke()`
+  callback is now invoked asynchronously by the compiler, so signing
+  can happen after the open-note id is minted. The account class must
+  implement SNIP-9 outside execution (OpenZeppelin `AccountComponent`
+  ships it).
+- `Devnet.executeOutside` (in `@starkware-libs/starknet-privacy-sdk/testing`)
+  now also accepts `{ calls: Call[]; proof: Proof }` for multi-call flows.
+  The existing single-call `CallAndProof` overload is unchanged.
+
 ### Breaking
 
 - Renamed `MockSwapHelper` to `MockSwapAnonymizer` in `@starkware-libs/starknet-privacy-sdk/testing` (and its `browser` re-export). Update imports accordingly.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -33,6 +33,14 @@ npm run test      # run all tests
 npm run test:fast # run tests excluding devnet
 ```
 
+### Test file naming
+
+Tests that spawn a real devnet (`new Devnet()` / `createDevnetTestEnv`) **must** be named
+`*.devnet.test.ts` (or be the exact file `tests/devnet.test.ts`). `vitest.config.ts` routes
+them to a separate project that disables file-level parallelism; otherwise concurrent devnet
+spawns collide on RPC traffic and filesystem state. Tests using the in-memory mocknet need no
+special naming.
+
 ## Installation
 
 From a tagged release (GitHub npm registry):

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,3 +37,8 @@ export type {
   HistoryAction,
   SwapLeg,
 } from "./internal/action-classifier.js";
+export { calculateAccountAddress, buildAccountDepositInvoke } from "./internal/account-deposit.js";
+export type {
+  AccountDepositParams,
+  AccountDepositInvokeParams,
+} from "./internal/account-deposit.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -206,7 +206,7 @@ export type InvokeCalldataBuilderArgs = {
 };
 
 export type InvokeAction = {
-  callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails;
+  callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails | Promise<CallDetails>;
 };
 
 /** Actions - context comes from registry */
@@ -600,7 +600,9 @@ export interface PrivateTransfersBuilder {
   setup(recipient: StarknetAddress): this;
 
   /** Add a call to `privacy_invoke` entrypoint that will run on starknet after the private operations are executed */
-  invoke(callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails): this;
+  invoke(
+    callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails | Promise<CallDetails>
+  ): this;
 
   /**
    * Set the default recipient for any surplus across all tokens.

--- a/sdk/src/internal/account-deposit.ts
+++ b/sdk/src/internal/account-deposit.ts
@@ -1,0 +1,296 @@
+/**
+ * Account-funded deposit helper — utilities to build the `.invoke()` callback for depositing
+ * funds held by a SNIP-9–capable account into a fresh open note in the caller's own channel,
+ * routed through the `DepositAnonymizer`. See `buildAccountDepositInvoke` for details.
+ */
+
+import {
+  CallData,
+  constants,
+  hash,
+  outsideExecution as snip9,
+  OutsideExecutionVersion,
+  uint256,
+  type BigNumberish,
+  type Call,
+  type CallDetails,
+  type OutsideExecutionOptions,
+  type OutsideTransaction,
+  type SignerInterface,
+} from "starknet";
+
+import type { InvokeCalldataBuilderArgs, StarknetAddress } from "../interfaces.js";
+import { generateRandom } from "../utils/crypto.js";
+import { toBigInt, toHex } from "../utils/convert.js";
+
+const UDC_ADDRESS = constants.LegacyUDC.ADDRESS;
+const UDC_ENTRYPOINT = constants.LegacyUDC.ENTRYPOINT;
+const MAX_U64 = 2n ** 64n - 1n;
+
+/**
+ * Compute the deterministic Starknet address of a UDC-deployed contract.
+ *
+ * Convenience wrapper around `hash.calculateContractAddressFromHash` mirroring what the on-chain
+ * UDC computes. Callers can derive the same address with starknet.js primitives directly.
+ *
+ * - `unique = false`: `calculateContractAddressFromHash(salt, classHash, constructorCalldata, 0)`.
+ * - `unique = true`:  `calculateContractAddressFromHash(pedersen(deployerAddress, salt), classHash, constructorCalldata, UDC_ADDRESS)`.
+ */
+export function calculateAccountAddress(params: {
+  classHash: BigNumberish;
+  constructorCalldata: BigNumberish[];
+  salt?: BigNumberish;
+  unique?: boolean;
+  deployerAddress?: BigNumberish;
+}): StarknetAddress {
+  const salt = params.salt ?? 0n;
+  if (params.unique) {
+    if (params.deployerAddress === undefined) {
+      throw new Error("calculateAccountAddress: deployerAddress is required when unique=true");
+    }
+    const mixedSalt = hash.computePedersenHash(toHex(params.deployerAddress), toHex(salt));
+    return hash.calculateContractAddressFromHash(
+      mixedSalt,
+      params.classHash,
+      params.constructorCalldata,
+      UDC_ADDRESS
+    );
+  }
+  return hash.calculateContractAddressFromHash(
+    salt,
+    params.classHash,
+    params.constructorCalldata,
+    0
+  );
+}
+
+/** Inputs for `buildAccountDepositInvoke`. */
+export type AccountDepositParams = {
+  /** Address of the deployed `DepositAnonymizer` contract for this pool. */
+  depositAnonymizerAddress: StarknetAddress;
+  /** Chain id used in the SNIP-9 typed-data domain. */
+  chainId: constants.StarknetChainId;
+  /** The SNIP-9-capable account holding the funds. */
+  accountAddress: StarknetAddress;
+  /** ERC-20 to deposit. */
+  token: StarknetAddress;
+  /** Amount to deposit. */
+  amount: bigint;
+  /** Signs the SNIP-9 OutsideExecution typed data with the account's private key. */
+  signer: Pick<SignerInterface, "signMessage">;
+  /**
+   * If provided, fold a UDC `deployContract` call into the anonymizer's calls array. The SDK
+   * derives the address from these fields and throws if it does not match `accountAddress`.
+   * Useful when `accountAddress` is a fresh ephemeral account that has not been deployed yet.
+   */
+  deploy?: {
+    classHash: BigNumberish;
+    constructorCalldata: BigNumberish[];
+    /** Defaults to 0. */
+    salt?: BigNumberish;
+    /** Defaults to false. */
+    unique?: boolean;
+    /** Required iff `unique === true`. */
+    deployerAddress?: BigNumberish;
+  };
+  /**
+   * Optional SNIP-9 OutsideExecution knobs. Defaults to a random nonce, no expiry, and the
+   * `DepositAnonymizer` address as `caller`. The anonymizer is the only contract that invokes
+   * `execute_from_outside_v2` here, so that's the tightest valid binding.
+   */
+  outsideExecution?: {
+    nonce?: BigNumberish;
+    executeAfter?: BigNumberish;
+    executeBefore?: BigNumberish;
+    /** Defaults to the `DepositAnonymizer` address. Pass `ANY_CALLER` to widen. */
+    caller?: StarknetAddress;
+  };
+};
+
+/** Inputs for `buildAccountDepositInvoke` — same fields as `AccountDepositParams`. */
+export type AccountDepositInvokeParams = AccountDepositParams;
+
+/**
+ * Build the `.invoke()` callback for an account-funded deposit.
+ *
+ * Wire-up with the builder:
+ *
+ * ```ts
+ * const cb = buildAccountDepositInvoke({ ... });
+ * await transfers.build()
+ *   .with(token, t => t.transfer({ recipient: transfers.user, amount: Open }))
+ *   .invoke(cb)
+ *   .execute();
+ * ```
+ *
+ * Signing the SNIP-9 typed data happens **inside** the returned async callback, after the open
+ * note id has been minted upstream. This binds the user's signature to `note_id`, which closes a
+ * front-running hole where an attacker could otherwise capture the signed outside execution and
+ * re-route the deposit into a different note.
+ *
+ * ## Flow
+ *
+ * On submission, `pool.apply_actions(...)` runs the pool's `InvokeExternal` action, which calls
+ * `DepositAnonymizer.privacy_invoke(calls)`. The anonymizer dispatches:
+ *
+ *   1. (optional) `UDC.deployContract(...)` deploys `A` if `params.deploy` is set.
+ *   2. `A.execute_from_outside_v2(payload, sig)` — `A`'s two signed inner calls run as `A`:
+ *        a. `token.approve(anonymizer, amount)` — authorizes the anonymizer to pull funds.
+ *        b. `anonymizer.deposit_to_open_note(note_id, token, amount)` — pulls funds from `A` via
+ *           `transferFrom` and returns an `OpenNoteDeposit`.
+ *
+ * The anonymizer parses that `OpenNoteDeposit` out of the SNIP-9 return chain, approves the pool
+ * to pull the deposit amount, and returns `[OpenNoteDeposit { note_id, token, amount }]`. The
+ * pool's `_apply_invoke` then performs `transferFrom(anonymizer, pool, amount)` to fill the open
+ * note.
+ *
+ * Because `note_id` is part of the *inner* `deposit_to_open_note` calldata, the user's SNIP-9
+ * signature commits to it — a front-runner cannot swap it out without invalidating the signature.
+ *
+ * ```mermaid
+ * sequenceDiagram
+ *     actor Submitter
+ *     participant Pool as Privacy Pool
+ *     participant Anon as DepositAnonymizer
+ *     participant UDC
+ *     participant A as Account A (SNIP-9)
+ *     participant ERC20
+ *
+ *     Submitter->>Pool: apply_actions(server_actions, proof)
+ *     Note over Pool: CreateOpenNote (note_id)
+ *     Pool->>Anon: privacy_invoke(calls)
+ *
+ *     opt params.deploy
+ *         Anon->>UDC: deployContract(...)
+ *         UDC->>A: deploys
+ *     end
+ *
+ *     Anon->>A: execute_from_outside_v2(payload, signature)
+ *     A->>ERC20: approve(Anon, amount)
+ *     A->>Anon: deposit_to_open_note(note_id, token, amount)
+ *     Anon->>ERC20: transferFrom(A, Anon, amount)
+ *
+ *     Anon->>ERC20: approve(Pool, amount)
+ *     Anon-->>Pool: [OpenNoteDeposit { note_id, token, amount }]
+ *
+ *     Note over Pool: _apply_invoke loops deposits
+ *     Pool->>ERC20: transferFrom(Anon, Pool, amount)
+ *     Note over Pool: open note filled
+ * ```
+ */
+export function buildAccountDepositInvoke(
+  params: AccountDepositInvokeParams
+): (args: InvokeCalldataBuilderArgs) => Promise<CallDetails> {
+  if (params.deploy) {
+    const derived = calculateAccountAddress(params.deploy);
+    if (toBigInt(derived) !== toBigInt(params.accountAddress)) {
+      throw new Error(
+        `buildAccountDepositInvoke: accountAddress ${toHex(params.accountAddress)} does not match address derived from \`deploy\` (${toHex(derived)})`
+      );
+    }
+    if (params.deploy.unique && params.deploy.deployerAddress === undefined) {
+      throw new Error(
+        "buildAccountDepositInvoke: deployerAddress is required when deploy.unique=true"
+      );
+    }
+  }
+
+  const anonymizerHex = toHex(params.depositAnonymizerAddress);
+  const accountAddressHex = toHex(params.accountAddress);
+  const tokenHex = toHex(params.token);
+  const tokenBigInt = toBigInt(params.token);
+
+  return async ({ openNotes }: InvokeCalldataBuilderArgs): Promise<CallDetails> => {
+    const openNoteForToken = openNotes.find((note) => note.token === tokenBigInt);
+    if (!openNoteForToken) {
+      throw new Error(
+        `buildAccountDepositInvoke: no open note found for token ${tokenHex}; ` +
+          `add a CreateOpenNote action for that token before .invoke()`
+      );
+    }
+    const noteIdHex = toHex(openNoteForToken.noteId);
+
+    // A's signed inner calls: approve the anonymizer, then call `deposit_to_open_note`, which
+    // pulls funds via `transferFrom` and returns an `OpenNoteDeposit` propagated up the SNIP-9
+    // return chain.
+    const approveInner: Call = {
+      contractAddress: tokenHex,
+      entrypoint: "approve",
+      calldata: CallData.compile([anonymizerHex, uint256.bnToUint256(params.amount)]),
+    };
+    const depositInner: Call = {
+      contractAddress: anonymizerHex,
+      entrypoint: "deposit_to_open_note",
+      calldata: CallData.compile([noteIdHex, tokenHex, params.amount]),
+    };
+    const innerCalls: Call[] = [approveInner, depositInner];
+
+    const callerHex = params.outsideExecution?.caller
+      ? toHex(params.outsideExecution.caller)
+      : anonymizerHex;
+    const callOptions: OutsideExecutionOptions = {
+      caller: callerHex,
+      execute_after: params.outsideExecution?.executeAfter ?? 0n,
+      execute_before: params.outsideExecution?.executeBefore ?? MAX_U64,
+    };
+    const nonce = params.outsideExecution?.nonce ?? generateRandom();
+    const typedData = snip9.getTypedData(
+      params.chainId,
+      callOptions,
+      nonce,
+      innerCalls,
+      OutsideExecutionVersion.V2
+    );
+    const signature = await params.signer.signMessage(typedData, accountAddressHex);
+
+    const outsideTransaction: OutsideTransaction = {
+      outsideExecution: {
+        caller: callOptions.caller,
+        nonce,
+        execute_after: callOptions.execute_after,
+        execute_before: callOptions.execute_before,
+        calls: innerCalls.map((call) => snip9.getOutsideCall(call)),
+      },
+      signature,
+      signerAddress: accountAddressHex,
+      version: OutsideExecutionVersion.V2,
+    };
+    const [executeFromOutsideCall] = snip9.buildExecuteFromOutsideCall(outsideTransaction);
+
+    // privacy_invoke calls array: [optional UDC.deploy, A.execute_from_outside_v2]. The
+    // anonymizer parses the deposit out of the SNIP-9 return chain and approves the pool itself,
+    // so we no longer push a standalone `token.approve(pool, ...)` call here.
+    const calls: Call[] = [];
+    if (params.deploy) {
+      const { classHash, constructorCalldata, salt, unique } = params.deploy;
+      calls.push({
+        contractAddress: UDC_ADDRESS,
+        entrypoint: UDC_ENTRYPOINT,
+        calldata: CallData.compile([classHash, salt ?? 0n, unique ? 1n : 0n, constructorCalldata]),
+      });
+    }
+    calls.push(executeFromOutsideCall);
+
+    return {
+      contractAddress: anonymizerHex,
+      calldata: serializePrivacyInvokeCalldata(calls),
+    };
+  };
+}
+
+/**
+ * Serialize `(calls: Array<Call>)` as Cairo wire calldata for
+ * `DepositAnonymizer.privacy_invoke`. Each `Call` is `(to, selector, len_inner, ...inner)`. The
+ * outer array is length-prefixed.
+ */
+function serializePrivacyInvokeCalldata(calls: Call[]): BigNumberish[] {
+  const out: BigNumberish[] = [calls.length];
+  for (const call of calls) {
+    const inner = CallData.compile(call.calldata ?? []);
+    out.push(toHex(call.contractAddress));
+    out.push(hash.getSelectorFromName(call.entrypoint));
+    out.push(inner.length);
+    out.push(...inner);
+  }
+  return out;
+}

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -180,7 +180,9 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
     return this;
   }
 
-  invoke(callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails): this {
+  invoke(
+    callBuilder: (args: InvokeCalldataBuilderArgs) => CallDetails | Promise<CallDetails>
+  ): this {
     if (this.invokeExternal !== undefined) {
       throw new Error("At most one .invoke() per transaction; already set.");
     }

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -128,7 +128,12 @@ export class ActionCompiler {
     const pool = this.createPool(toBigInt(this.userViewingKey), registry, channels, total);
 
     // Phase 3: Transform Actions to ClientAction[]
-    const clientActions = this.transformToClientActions(actions, pool, recipientsNeeded, options);
+    const { clientActions } = await this.transformToClientActions(
+      actions,
+      pool,
+      recipientsNeeded,
+      options
+    );
 
     debugLog("compiler", "compile", "post transformToClientActions", clientActions);
 
@@ -219,12 +224,12 @@ export class ActionCompiler {
   /**
    * Transform high-level Actions to low-level ClientAction[] using registry context.
    */
-  private transformToClientActions(
+  private async transformToClientActions(
     actions: Actions,
     pool: PoolSimulator,
     recipientsNeeded: AddressMap<boolean>,
     options?: ExecuteOptions
-  ): ClientAction[] {
+  ): Promise<{ clientActions: ClientAction[] }> {
     const clientActions: ClientActions = {
       setViewingKey: undefined,
       openChannels: [],
@@ -444,7 +449,8 @@ export class ActionCompiler {
 
     // surpluses were handled in resolveNotes
 
-    // 8. InvokeExternal
+    // 8. InvokeExternal — pass the open notes created above so the invoke callback can
+    // reference their ids.
     if (actions.invoke) {
       const openNotes = clientActions.createNotes.flatMap((note) => {
         if (note.type !== "CreateOpenNote") return [];
@@ -463,7 +469,7 @@ export class ActionCompiler {
         amount: withdraw.input.amount,
       }));
 
-      const call = actions.invoke.callBuilder({
+      const call = await actions.invoke.callBuilder({
         openNotes,
         withdrawals,
         poolAddress: this.poolAddress,
@@ -480,9 +486,11 @@ export class ActionCompiler {
       clientActions.invoke = execute(input);
     }
 
-    return Object.values(clientActions)
-      .filter((action) => action !== undefined)
-      .flat();
+    return {
+      clientActions: Object.values(clientActions)
+        .filter((action) => action !== undefined)
+        .flat(),
+    };
   }
 
   /**

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -38,16 +38,6 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     super(params.account.address, params.viewingKeyProvider, params.discoveryProvider);
   }
 
-  private async getCompiler(): Promise<ActionCompiler> {
-    const viewingKey = await this.params.viewingKeyProvider.getViewingKey();
-    return new ActionCompiler(
-      this.user,
-      viewingKey,
-      this.params.discoveryProvider,
-      toBigInt(this.params.poolContractAddress)
-    );
-  }
-
   async createProofInvocation(
     actions: Actions,
     options?: Omit<ExecuteOptions, "provingBlockId">

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -19,10 +19,11 @@ import {
   RpcProvider,
   UniversalDetails,
   waitForTransactionOptions,
+  type Call,
   type GetTransactionReceiptResponse,
 } from "starknet";
 import { TracingRpcProvider } from "./tracing-provider.js";
-import type { CallAndProof, PrivateTransfersInterface } from "../interfaces.js";
+import type { CallAndProof, Proof, PrivateTransfersInterface } from "../interfaces.js";
 import { createPrivateTransfers } from "../factory.js";
 import { CallMockProofProvider } from "./mock-proving.js";
 import {
@@ -50,6 +51,14 @@ const CONTRACT_CLASS_PATH = join(
 const COMPILED_CONTRACT_PATH = join(
   __dirname,
   "../../../target/dev/privacy_Privacy.compiled_contract_class.json"
+);
+const DEPOSIT_ANONYMIZER_CONTRACT_CLASS_PATH = join(
+  __dirname,
+  "../../../target/dev/deposit_anonymizer_DepositAnonymizer.contract_class.json"
+);
+const DEPOSIT_ANONYMIZER_COMPILED_CONTRACT_PATH = join(
+  __dirname,
+  "../../../target/dev/deposit_anonymizer_DepositAnonymizer.compiled_contract_class.json"
 );
 
 // Resource bounds for devnet transactions
@@ -83,6 +92,8 @@ export interface DevnetEnvironment {
   strk: string;
   eth: string;
   privacy: PrivacyPoolContract;
+  /** Deployed `DepositAnonymizer` address; required for account-deposit flows. */
+  depositAnonymizer: string;
   provider: RpcProvider;
 }
 
@@ -229,6 +240,22 @@ export class Devnet {
     // Deploy the privacy pool contract
     const privacy = await this.deployPrivacyContract(admin, contractClass, compiledContract);
 
+    // Deploy the deposit anonymizer (used by buildAccountDepositInvoke to mediate SNIP-9
+    // outside-execution deposits into open notes).
+    const depositAnonymizerContractClass = JSON.parse(
+      readFileSync(DEPOSIT_ANONYMIZER_CONTRACT_CLASS_PATH, "utf8")
+    );
+    const depositAnonymizerCompiledContract = JSON.parse(
+      readFileSync(DEPOSIT_ANONYMIZER_COMPILED_CONTRACT_PATH, "utf8")
+    );
+    const depositAnonymizer = await this.deployNoArgContract(
+      admin,
+      depositAnonymizerContractClass,
+      depositAnonymizerCompiledContract,
+      "0x1" // salt
+    );
+    debugLog("devnet", "setup", "DepositAnonymizer at:", depositAnonymizer);
+
     // Pad devnet with empty blocks so block numbers exceed the blockifier's
     // STORED_BLOCK_HASH_BUFFER (10), required for proof_facts validation.
     for (let blockIndex = 0; blockIndex < 10; blockIndex++) {
@@ -247,6 +274,7 @@ export class Devnet {
       strk,
       eth,
       privacy,
+      depositAnonymizer,
       provider: this.provider,
     };
 
@@ -313,6 +341,29 @@ export class Devnet {
   }
 
   /**
+   * Declare and deploy a contract that takes no constructor arguments. Returns the deployed
+   * contract address. Used for utility contracts like the ephemeral-deposit anonymizer.
+   */
+  private async deployNoArgContract(
+    deployer: Account,
+    contractClass: CompiledContract,
+    compiledContract: CairoAssembly,
+    salt: string
+  ): Promise<string> {
+    const declareResponse = await deployer.declare({
+      contract: contractClass,
+      casm: compiledContract,
+      compiledClassHash: hash.computeCompiledClassHash(compiledContract),
+    });
+    const classHash = declareResponse.class_hash;
+    const deployResponse = await deployer.deployContract(
+      { classHash, constructorCalldata: [], salt },
+      { retryInterval: 100 }
+    );
+    return deployResponse.contract_address;
+  }
+
+  /**
    * Deploy the privacy pool contract
    */
   private async deployPrivacyContract(
@@ -361,14 +412,25 @@ export class Devnet {
   }
 
   /**
-   * Execute a call via outside execution using the admin account.
-   * The admin creates the outside transaction and executes it.
+   * Execute a call (or multi-call) via outside execution using the admin
+   * account. The admin creates the outside transaction and executes it.
    * This simulates a paymaster flow.
+   *
+   * Accepts either:
+   * - the legacy `CallAndProof` shape (single inner call), as produced by
+   *   `transfers.execute()`; or
+   * - `{ calls: Call[]; proof: Proof }` for multi-call flows such as
+   *   `transfers.createEphemeralDeposit()`.
    */
-  async executeOutside(callAndProof: CallAndProof): Promise<GetTransactionReceiptResponse> {
+  async executeOutside(
+    input: CallAndProof | { calls: Call[]; proof: Proof }
+  ): Promise<GetTransactionReceiptResponse> {
     if (!this.setup) {
       throw new Error("Devnet not initialized");
     }
+
+    const calls = "call" in input ? input.call : input.calls;
+    const proof = input.proof;
 
     const now_seconds = Math.floor(Date.now() / 1000);
     const callOptions: OutsideExecutionOptions = {
@@ -391,13 +453,13 @@ export class Devnet {
 
     const outsideTransaction = await this.setup.admin.getOutsideTransaction(
       callOptions,
-      callAndProof.call,
+      calls,
       OutsideExecutionVersion.V2
     );
 
     const response = await this.setup.admin.executeFromOutside(outsideTransaction, {
-      proofFacts: callAndProof.proof.proofFacts,
-      proof: callAndProof.proof.data,
+      proofFacts: proof.proofFacts,
+      proof: proof.data,
     });
     const receipt = await this.provider!.waitForTransaction(response.transaction_hash);
     if (!receipt.isSuccess()) {

--- a/sdk/tests/account-deposit.devnet.test.ts
+++ b/sdk/tests/account-deposit.devnet.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Devnet integration tests for `buildAccountDepositInvoke` — SNIP-9 outside execution dispatched
+ * via the `DepositAnonymizer`.
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { Signer, constants, type Signature, type TypedData } from "starknet";
+import { Devnet, createDevnetTestEnv, type DevnetTestEnv } from "../src/testing/index.js";
+import {
+  buildAccountDepositInvoke,
+  calculateAccountAddress,
+  type AccountDepositParams,
+} from "../src/internal/account-deposit.js";
+import { Open, type ExecuteOptions, type ExecuteResult } from "../src/interfaces.js";
+import type { PrivateTransfersInterface } from "../src/interfaces.js";
+
+async function depositViaBuilder(
+  transfers: PrivateTransfersInterface,
+  params: AccountDepositParams,
+  options?: ExecuteOptions
+): Promise<ExecuteResult> {
+  const cb = buildAccountDepositInvoke(params);
+  return transfers
+    .build(options)
+    .with(params.token, (t) => t.transfer({ recipient: transfers.user, amount: Open }))
+    .invoke(cb)
+    .execute();
+}
+
+// Standard OpenZeppelin Account class, pre-declared on the devnet image. OZ
+// `AccountComponent` ships SNIP-9 `execute_from_outside_v2`.
+const OZ_ACCOUNT_CLASS_HASH = "0x5b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564";
+
+describe("Account-funded deposit (SNIP-9) on devnet", () => {
+  let devnet: Devnet;
+  let env: DevnetTestEnv;
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await createDevnetTestEnv(devnet);
+  });
+
+  afterAll(async () => {
+    await devnet?.cleanup();
+  });
+
+  it("fresh ephemeral account: fund A, single tx (deploy + apply_actions) lands funds in Alice's note", async () => {
+    const { env: de, transfers } = env;
+    const amount = 100n;
+
+    // Register Alice and set up her STRK self-channel.
+    const setup = await transfers.alice
+      .build({ autoSetup: true })
+      .register()
+      .with(de.strk, (t) => t.setup(de.alice.address))
+      .execute();
+    await devnet.executeOutside(setup.callAndProof);
+
+    // Pick a fresh ephemeral keypair and derive its address.
+    const ephemeralPrivateKey = "0x0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ephemeralSigner = new Signer(ephemeralPrivateKey);
+    const ephemeralPublicKey = await ephemeralSigner.getPubKey();
+    const accountAddress = calculateAccountAddress({
+      classHash: OZ_ACCOUNT_CLASS_HASH,
+      constructorCalldata: [ephemeralPublicKey],
+      salt: ephemeralPublicKey,
+    });
+
+    // External funder transfers STRK to the future account address (out-of-scope; simulated by
+    // the admin account here).
+    await de.admin.execute({
+      contractAddress: de.strk,
+      entrypoint: "transfer",
+      calldata: [accountAddress, amount, 0n],
+    });
+
+    const result = await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: de.depositAnonymizer,
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: de.strk,
+        amount,
+        signer: ephemeralSigner,
+        deploy: {
+          classHash: OZ_ACCOUNT_CLASS_HASH,
+          constructorCalldata: [ephemeralPublicKey],
+          salt: ephemeralPublicKey,
+        },
+      },
+      { autoDiscover: { channels: "refresh", notes: "refresh" } }
+    );
+
+    // Single outer call: apply_actions. UDC deploy and A.execute_from_outside_v2 are dispatched
+    // by the DepositAnonymizer inside the InvokeExternal action.
+    expect(result.callAndProof.call.entrypoint).toBe("apply_actions");
+
+    // Submit via admin's SNIP-9 outside execution (paymaster pattern). Alice's account never
+    // appears as the on-chain tx sender.
+    const receipt = await devnet.executeOutside({
+      calls: [result.callAndProof.call],
+      proof: result.callAndProof.proof,
+    });
+    expect(receipt.isSuccess()).toBe(true);
+
+    // Alice should now discover a STRK note for `amount`.
+    const { notes } = await transfers.alice.discoverNotes();
+    const strkNotes = notes.get(BigInt(de.strk)) ?? [];
+    const filled = strkNotes.find((n) => n.amount === amount);
+    expect(filled).toBeDefined();
+  });
+
+  it("tampered signature: outside-execution validation rejects the tx", async () => {
+    const { env: de, transfers } = env;
+    const amount = 100n;
+
+    const ephemeralPrivateKey = "0x0fedcba9876543210fedcba9876543210fedcba987654321";
+    const ephemeralSigner = new Signer(ephemeralPrivateKey);
+    const ephemeralPublicKey = await ephemeralSigner.getPubKey();
+    const accountAddress = calculateAccountAddress({
+      classHash: OZ_ACCOUNT_CLASS_HASH,
+      constructorCalldata: [ephemeralPublicKey],
+      salt: ephemeralPublicKey,
+    });
+
+    await de.admin.execute({
+      contractAddress: de.strk,
+      entrypoint: "transfer",
+      calldata: [accountAddress, amount, 0n],
+    });
+
+    // A signer that returns a clearly invalid (r, s). The on-chain SNIP-9 verifier in the OZ
+    // account rejects when the anonymizer forwards.
+    const badSigner = {
+      signMessage: async (_typedData: TypedData, _accountAddress: string): Promise<Signature> => [
+        "0x1",
+        "0x1",
+      ],
+    };
+
+    const result = await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: de.depositAnonymizer,
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: de.strk,
+        amount,
+        signer: badSigner,
+        deploy: {
+          classHash: OZ_ACCOUNT_CLASS_HASH,
+          constructorCalldata: [ephemeralPublicKey],
+          salt: ephemeralPublicKey,
+        },
+      },
+      { autoDiscover: { channels: "refresh", notes: "refresh" } }
+    );
+
+    await expect(
+      devnet.executeOutside({
+        calls: [result.callAndProof.call],
+        proof: result.callAndProof.proof,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/sdk/tests/helpers/test-fixtures.ts
+++ b/sdk/tests/helpers/test-fixtures.ts
@@ -10,6 +10,8 @@ import {
 } from "../../src/interfaces.js";
 
 export const POOL_ADDRESS = 0x1n;
+/** Used by `account-deposit.test.ts` to stand in for a deployed `DepositAnonymizer`. */
+export const DEPOSIT_ANONYMIZER_ADDRESS = 0xa1n;
 
 // Default options presets - for operations AFTER registration and setup are done
 export const AUTO_ALL: ExecuteOptions = {

--- a/sdk/tests/internal/account-deposit.test.ts
+++ b/sdk/tests/internal/account-deposit.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for `buildAccountDepositInvoke` — SNIP-9 outside execution dispatched via
+ * `DepositAnonymizer`.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Signer, constants, hash, shortString, type Signature, type TypedData } from "starknet";
+
+import {
+  buildAccountDepositInvoke,
+  calculateAccountAddress,
+  type AccountDepositParams,
+} from "../../src/internal/account-deposit.js";
+import { Open, type ExecuteOptions, type ExecuteResult } from "../../src/interfaces.js";
+import type { PrivateTransfersInterface } from "../../src/interfaces.js";
+import {
+  AUTO_DISCOVERY_ONLY,
+  DEPOSIT_ANONYMIZER_ADDRESS,
+  createTestEnv,
+  MockTestEnv,
+} from "../helpers/test-fixtures.js";
+import { toBigInt, toHex } from "../../src/utils/index.js";
+
+/**
+ * Test helper that wires `buildAccountDepositInvoke` into the builder, mirroring the example
+ * in its JSDoc. Returns the `ExecuteResult` so tests can assert on the assembled call.
+ */
+async function depositViaBuilder(
+  transfers: PrivateTransfersInterface,
+  params: AccountDepositParams,
+  options?: ExecuteOptions
+): Promise<ExecuteResult> {
+  const cb = buildAccountDepositInvoke(params);
+  return transfers
+    .build(options)
+    .with(params.token, (t) => t.transfer({ recipient: transfers.user, amount: Open }))
+    .invoke(cb)
+    .execute();
+}
+
+const OZ_ACCOUNT_CLASS_HASH = "0x540d7f5ec7ecf317e68d48564934cb99259781b1ee3cedbbc37ec5337f8e688";
+
+function chainIdSepoliaHex(): string {
+  return shortString.encodeShortString("SN_SEPOLIA");
+}
+
+describe("calculateAccountAddress", () => {
+  const classHash = OZ_ACCOUNT_CLASS_HASH;
+  const publicKey = 0x1234abcd1234abcd1234abcd1234abcdn;
+
+  it("unique=false: address matches calculateContractAddressFromHash with deployer=0", () => {
+    const expected = hash.calculateContractAddressFromHash(7n, classHash, [publicKey], 0);
+    const actual = calculateAccountAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+      salt: 7n,
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("unique=true: address matches calculateContractAddressFromHash with pedersen(deployer, salt) and deployer=UDC", () => {
+    const deployer = 0xdeadbeefn;
+    const salt = 0x1234n;
+    const mixedSalt = hash.computePedersenHash(toHex(deployer), toHex(salt));
+    const expected = hash.calculateContractAddressFromHash(
+      mixedSalt,
+      classHash,
+      [publicKey],
+      constants.LegacyUDC.ADDRESS
+    );
+    const actual = calculateAccountAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+      salt,
+      unique: true,
+      deployerAddress: deployer,
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("salt defaults to 0", () => {
+    const expected = hash.calculateContractAddressFromHash(0n, classHash, [publicKey], 0);
+    const actual = calculateAccountAddress({
+      classHash,
+      constructorCalldata: [publicKey],
+    });
+    expect(toBigInt(actual)).toBe(toBigInt(expected));
+  });
+
+  it("unique=true without deployerAddress throws", () => {
+    expect(() =>
+      calculateAccountAddress({
+        classHash,
+        constructorCalldata: [publicKey],
+        unique: true,
+      })
+    ).toThrow(/deployerAddress is required/);
+  });
+});
+
+describe("buildAccountDepositInvoke (via builder)", () => {
+  let testEnv: MockTestEnv;
+
+  beforeEach(() => {
+    testEnv = createTestEnv();
+  });
+
+  async function bootstrapAlice() {
+    const { mocknet, env, transfers } = testEnv;
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(
+      await transfers.alice
+        .build({ autoSetup: true })
+        .setup(env.alice.address)
+        .with(env.ace, (t) => t.setup(env.alice.address))
+        .execute()
+    );
+  }
+
+  function makeEphemeralSigner() {
+    const privateKey = "0x0123456789abcdef0123456789abcdef0123456789abcdef";
+    return { signer: new Signer(privateKey), privateKey };
+  }
+
+  it("returns a single apply_actions call (no deploy)", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const accountAddress = `0x${"a".repeat(63)}1`;
+
+    const result = await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer,
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(result.callAndProof.call.entrypoint).toBe("apply_actions");
+
+    expect(result.callAndProof.proof).toBeDefined();
+  });
+
+  it("with `deploy`: still a single apply_actions call (UDC deploy is folded into the anonymizer's calls)", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const classHash = OZ_ACCOUNT_CLASS_HASH;
+    const constructorCalldata = [123n];
+    const salt = 7n;
+    const accountAddress = calculateAccountAddress({
+      classHash,
+      constructorCalldata,
+      salt,
+    });
+
+    const result = await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer,
+        deploy: { classHash, constructorCalldata, salt },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(result.callAndProof.call.entrypoint).toBe("apply_actions");
+  });
+
+  it("`deploy` with mismatching accountAddress throws", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const classHash = OZ_ACCOUNT_CLASS_HASH;
+
+    await expect(
+      depositViaBuilder(
+        transfers.alice,
+        {
+          depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+          chainId: constants.StarknetChainId.SN_SEPOLIA,
+          accountAddress: "0xdeadbeef",
+          token: env.ace,
+          amount: 100n,
+          signer,
+          deploy: { classHash, constructorCalldata: [123n], salt: 7n },
+        },
+        AUTO_DISCOVERY_ONLY
+      )
+    ).rejects.toThrow(/does not match address derived from `deploy`/);
+  });
+
+  it("signs SNIP-9 typed data with the account key, version = V2, chainId = sepolia", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const accountAddress = `0x${"a".repeat(63)}1`;
+
+    let observedTypedData: TypedData | undefined;
+    let observedAccountAddress: string | undefined;
+    const spySigner = {
+      signMessage: vi.fn(async (typedData: TypedData, accountAddr: string): Promise<Signature> => {
+        observedTypedData = typedData;
+        observedAccountAddress = accountAddr;
+        return signer.signMessage(typedData, accountAddr);
+      }),
+    };
+
+    await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spySigner,
+        outsideExecution: { nonce: 0x99n },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    expect(spySigner.signMessage).toHaveBeenCalledTimes(1);
+    expect(toBigInt(observedAccountAddress!)).toBe(toBigInt(accountAddress));
+    expect(observedTypedData!.domain.name).toBe("Account.execute_from_outside");
+    expect(observedTypedData!.domain.version).toBe("2");
+    expect(observedTypedData!.domain.chainId).toBe(chainIdSepoliaHex());
+  });
+
+  it("inner signed calls are [token.approve(anonymizer, amount), anonymizer.deposit_to_open_note(...)]", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const accountAddress = `0x${"a".repeat(63)}1`;
+
+    let observedTypedData: TypedData | undefined;
+    const spySigner = {
+      signMessage: async (typedData: TypedData, accountAddr: string): Promise<Signature> => {
+        observedTypedData = typedData;
+        return signer.signMessage(typedData, accountAddr);
+      },
+    };
+    await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spySigner,
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    const message = observedTypedData!.message as Record<string, unknown>;
+    const calls = message.Calls as { To: string; Selector: string }[];
+    expect(calls).toHaveLength(2);
+
+    expect(toBigInt(calls[0].To)).toBe(toBigInt(env.ace));
+    expect(toBigInt(calls[0].Selector)).toBe(toBigInt(hash.getSelectorFromName("approve")));
+
+    expect(toBigInt(calls[1].To)).toBe(toBigInt(DEPOSIT_ANONYMIZER_ADDRESS));
+    expect(toBigInt(calls[1].Selector)).toBe(
+      toBigInt(hash.getSelectorFromName("deposit_to_open_note"))
+    );
+  });
+
+  it("outsideExecution.caller defaults to the anonymizer; override propagates", async () => {
+    const { env, transfers } = testEnv;
+    await bootstrapAlice();
+    const { signer } = makeEphemeralSigner();
+    const accountAddress = "0x1234567890abcdef1234567890abcdef1234567890abcdef1";
+    const widerCaller = constants.OutsideExecutionCallerAny;
+
+    let firstCallTypedData: TypedData | undefined;
+    let secondCallTypedData: TypedData | undefined;
+    const spy = (capture: (td: TypedData) => void) => ({
+      signMessage: async (typedData: TypedData, accountAddr: string): Promise<Signature> => {
+        capture(typedData);
+        return signer.signMessage(typedData, accountAddr);
+      },
+    });
+
+    await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spy((td) => (firstCallTypedData = td)),
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+    await depositViaBuilder(
+      transfers.alice,
+      {
+        depositAnonymizerAddress: toHex(DEPOSIT_ANONYMIZER_ADDRESS),
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        accountAddress,
+        token: env.ace,
+        amount: 100n,
+        signer: spy((td) => (secondCallTypedData = td)),
+        outsideExecution: { caller: widerCaller },
+      },
+      AUTO_DISCOVERY_ONLY
+    );
+
+    const callerOf = (td: TypedData | undefined) =>
+      toBigInt((td!.message as Record<string, string>).Caller);
+    expect(callerOf(firstCallTypedData)).toBe(toBigInt(DEPOSIT_ANONYMIZER_ADDRESS));
+    expect(callerOf(secondCallTypedData)).toBe(toBigInt(widerCaller));
+  });
+});

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["tests/**/*.test.ts"],
     reporters: ["default"], // shows failures with context; use "verbose" to see all tests
     outputFile: undefined,
     hideSkippedTests: true,
@@ -13,6 +12,28 @@ export default defineConfig({
     hookTimeout: 30000, // for beforeAll/afterAll hooks
     teardownTimeout: 5000, // max time for cleanup
     pool: "forks", // isolate tests in separate processes (can be killed)
+    // Tests that spawn a real devnet (any `tests/**/*.devnet.test.ts` and the catch-all
+    // `tests/devnet.test.ts`) collide if run as parallel forks — each fork wants its own
+    // devnet, and the resulting RPC traffic + filesystem state races. Carve them into their
+    // own project with `fileParallelism: false`; everything else stays parallel.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          include: ["tests/**/*.test.ts"],
+          exclude: ["tests/devnet.test.ts", "tests/**/*.devnet.test.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "devnet",
+          include: ["tests/devnet.test.ts", "tests/**/*.devnet.test.ts"],
+          fileParallelism: false,
+        },
+      },
+    ],
     coverage: {
       enabled: true,
       provider: "v8",


### PR DESCRIPTION
Add `buildAccountDepositInvoke` and `calculateEphemeralAddress` utilities
that build the `.invoke()` callback for depositing funds held by a
SNIP-9-capable account `A` into a fresh open note in the caller's own
channel. No changes to `PrivateTransfersInterface`.

The flow is one outer call (`pool.apply_actions`). Inside it, the pool's
`InvokeExternal` action calls a new generic `CallAnonymizer` contract,
which syscalls a user-supplied `Array<Call>` and returns a user-supplied
`Array<OpenNoteDeposit>`. For the ephemeral-account flow the helper
supplies:

  calls    = [UDC.deployContract(...)?,
              A.execute_from_outside_v2(payload, sig),
              token.approve(pool, amount)]
  deposits = [{ note_id, token, amount }]

A's signed inner call is `[token.transfer(anonymizer, amount)]`, so
signing happens before compilation and the open-note id only enters the
`deposits` array (not the SNIP-9 typed-data hash). The anonymizer holds
the funds transiently; the pool then `transferFrom`s anonymizer to fill
the note. The user's account never appears as the on-chain tx sender —
any wallet (incl. a paymaster) can submit the assembled call.

The `CallAnonymizer` contract is intentionally minimal: it implements no
deposit logic of its own, doesn't know about SNIP-9, and is reusable for
any `apply_actions`-time pre-condition flow. A source comment flags an
open question on whether to add a per-token balance-delta check. The
helper's JSDoc includes a mermaid sequence diagram of the full flow and
a note that the funds-transit step through the anonymizer would not be
required if the pool supported unfilled open notes.

Devnet:
- `Devnet.initialize` deploys the `CallAnonymizer` artifact and exposes
  its address as `callAnonymizer` on `DevnetEnvironment`.
- `Devnet.executeOutside` accepts `{ calls: Call[]; proof: Proof }` for
  multi-call flows; the single-call `CallAndProof` overload is unchanged.

Vitest:
- `vitest.config.ts` splits tests into a parallel `unit` project and a
  serial `devnet` project (matched on `tests/devnet.test.ts` and
  `tests/**/*.devnet.test.ts`). Devnet-spawning files collide on RPC
  state under parallel forks; the convention is documented in
  `sdk/README.md` and the agent rules in `.claude/rules/testing.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/747)
<!-- Reviewable:end -->
