### PR TITLE
fix(sdk): paginate total-only outgoing discovery

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed `INDEX_NOT_SEQUENTIAL` error when the paymaster fee token equals the swap output token (`toToken`) in a private swap. The compiler was emitting `CreateEncNote` at index N+1 before `CreateOpenNote` at index N for the same token. Note-creation actions are now accumulated in a single list in processing order instead of separate enc/open arrays.
 - `OhttpClient` now builds the inner OHTTP request URL with a synthetic origin (`https://ohttp-target.invalid`) instead of `${gatewayUrl}${path}`. Previously, when `gatewayUrl` included a reverse-proxy path prefix (e.g. `https://api.example.com/discovery`), that prefix leaked into the encrypted inner request path and produced a 404 inside the OHTTP envelope (`OHTTP inner response /v1/sync/outgoing_state failed (404)`). The OHTTP gateway routes by path only, so the synthetic origin is inert; only the per-call `path` argument is used for routing.
+- `IndexerDiscoveryProvider.discoverChannels(..., "total-only")` now paginates `/v1/sync/outgoing_state` until the discovery service reports `total_n_channels`, instead of assuming the count is present on the first page.
 
 ## 0.14.2-RC.3
 

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -225,21 +225,35 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     total?: number;
   }> {
     if (recipients === "total-only") {
-      // For total-only, do a minimal outgoing sync to get the total channel count
-      const body: Record<string, unknown> = {
-        contract_address: toHex(this.contractAddress),
-        sender_address: toHex(address),
-        viewing_key: toHex(viewingKey),
-        cursor: { channel_discovery_complete: false },
-      };
-      if (params?.blockIdentifier !== undefined) {
-        body.block_ref = params.blockIdentifier;
+      // For total-only, follow outgoing-channel pagination until the service
+      // reaches the sentinel and reports the count. Drop per-channel cursors
+      // between calls: the compiler only needs the channel total here, not
+      // subchannel/note state.
+      let apiCursor: ApiDiscoveryCursor = { channel_discovery_complete: false };
+      let blockRef: BlockIdentifier | undefined;
+      while (true) {
+        const body: Record<string, unknown> = {
+          contract_address: toHex(this.contractAddress),
+          sender_address: toHex(address),
+          viewing_key: toHex(viewingKey),
+          cursor: apiCursor,
+        };
+        if (blockRef) {
+          body.block_ref = blockRef;
+        } else if (params?.blockIdentifier !== undefined) {
+          body.block_ref = params.blockIdentifier;
+        }
+
+        const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
+        blockRef = resp.block_ref;
+
+        const total = totalChannelsFromCursor(resp.cursor);
+        if (total !== undefined) {
+          return { timestamp: blockRef, total };
+        }
+
+        apiCursor = totalOnlyCursor(resp.cursor);
       }
-      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
-      return {
-        timestamp: resp.block_ref,
-        total: resp.cursor.total_n_channels!,
-      };
     }
 
     const cursorMap = params?.cursor?.channels;
@@ -436,6 +450,20 @@ function isApiCursorComplete(cursor: ApiDiscoveryCursor): boolean {
       ch.subchannel_discovery_complete &&
       (!ch.subchannels || Object.values(ch.subchannels).every((sc) => !!sc.note_discovery_complete))
   );
+}
+
+function totalChannelsFromCursor(cursor: ApiDiscoveryCursor): number | undefined {
+  if (cursor.total_n_channels !== undefined) return cursor.total_n_channels;
+  if (cursor.channel_discovery_complete) return (cursor.last_channel_index ?? -1) + 1;
+  return undefined;
+}
+
+function totalOnlyCursor(cursor: ApiDiscoveryCursor): ApiDiscoveryCursor {
+  return {
+    channel_discovery_complete: cursor.channel_discovery_complete,
+    last_channel_index: cursor.last_channel_index,
+    total_n_channels: cursor.total_n_channels,
+  };
 }
 
 /** Builds `Record<string, ApiSubchannelCursor>` from token→noteIndex pairs, optionally filtered. */

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -375,6 +375,64 @@ describe("IndexerDiscoveryProvider", () => {
       expect(result.channels).toBeUndefined();
     });
 
+    it("paginates 'total-only' until total_n_channels is returned", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson(
+        {
+          body: outgoingSyncResponse({
+            cursor: {
+              channel_discovery_complete: false,
+              last_channel_index: 255,
+              channels: {
+                [RECIPIENT_ADDR]: {
+                  channel_key: CHANNEL_KEY_1,
+                  subchannel_discovery_complete: false,
+                  subchannels: {},
+                },
+              },
+            },
+          }),
+        },
+        {
+          body: outgoingSyncResponse({
+            cursor: {
+              channel_discovery_complete: true,
+              last_channel_index: 258,
+              total_n_channels: 259,
+            },
+          }),
+        }
+      );
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ timestamp: BLOCK_REF, total: 259 });
+
+      const secondCallBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(secondCallBody.block_ref).toBe(BLOCK_REF);
+      expect(secondCallBody.cursor).toEqual({
+        channel_discovery_complete: false,
+        last_channel_index: 255,
+      });
+    });
+
+    it("derives 'total-only' count from a completed cursor when total_n_channels is absent", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          cursor: {
+            channel_discovery_complete: true,
+            last_channel_index: 6,
+          },
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+
+      expect(result).toEqual({ timestamp: BLOCK_REF, total: 7 });
+    });
+
     it("prefers real channels over precomputed channels for the same recipient", async () => {
       const provider = createProvider();
       const PRECOMPUTED_KEY = "0xdd1";


### PR DESCRIPTION
## Summary

Fixes the SDK `IndexerDiscoveryProvider.discoverChannels(..., "total-only")` path so it paginates `/v1/sync/outgoing_state` until the discovery service reports `total_n_channels`.

The live discovery service only sets `cursor.total_n_channels` after outgoing channel discovery reaches the sentinel. The previous SDK path made one request and returned `resp.cursor.total_n_channels!`, which can be `undefined` for senders with more than one discovery page. Callers that use the result to pick the next outgoing channel index can then fall back to index `0` and collide with existing privacy-pool storage.

## Changes

- Loop `total-only` outgoing discovery across pages until the top-level channel total is known.
- Preserve `block_ref` across pagination requests.
- Drop per-channel subcursor state between `total-only` calls, because the compiler only needs the top-level channel count and should not spend discovery budget on subchannels/notes for this path.
- Add unit tests for multi-page `total-only` discovery and completed-cursor fallback.
- Add a changelog entry.

## Validation

- `npm run build`
- `npm run lint`
- `npx vitest run --coverage.enabled=false tests/internal/indexer-discovery.test.ts`
- `npm run test:fast -- --coverage.enabled=false`

Note: `npm test -- tests/internal/indexer-discovery.test.ts` passes the selected test file but exits non-zero because the repo's global coverage thresholds are enforced against only that one file. The same focused run with coverage disabled is listed above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/748)
<!-- Reviewable:end -->
