### PR TITLE
feat(proof-interceptor): build_info gauge and redacted startup banner

### DIFF
--- a/proof-interceptor/src/build_info.ts
+++ b/proof-interceptor/src/build_info.ts
@@ -1,0 +1,39 @@
+// src/build_info.ts
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageMetadata {
+  version: string;
+}
+
+/**
+ * Resolves the service version by reading `package.json` adjacent to the
+ * compiled `dist/` (or `src/` under vitest). Returns `"unknown"` if the file
+ * can't be read or parsed — version info is observability metadata, never a
+ * load-bearing field.
+ */
+function loadServiceVersion(): string {
+  try {
+    const moduleDir = dirname(fileURLToPath(import.meta.url));
+    const packageJsonPath = resolve(moduleDir, "..", "package.json");
+    const text = readFileSync(packageJsonPath, "utf-8");
+    const parsed = JSON.parse(text) as PackageMetadata;
+    if (typeof parsed.version === "string" && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  } catch {
+    // fall through to "unknown"
+  }
+  return "unknown";
+}
+
+export const SERVICE_VERSION = loadServiceVersion();
+
+/**
+ * Git commit SHA the binary was built from. Surfaced via the `GIT_SHA`
+ * environment variable, set by the Docker build (`docker build --build-arg
+ * GIT_SHA=$(git rev-parse HEAD)`) or by the CI pipeline. Defaults to
+ * `"unknown"` so the metric remains queryable on local dev runs.
+ */
+export const GIT_SHA = process.env.GIT_SHA ?? "unknown";

--- a/proof-interceptor/src/config.ts
+++ b/proof-interceptor/src/config.ts
@@ -65,6 +65,30 @@ export function requiredEnv(name: string): string {
   return value;
 }
 
+/**
+ * Returns a copy of `config` suitable for logging at startup. Strips fields
+ * that could leak credentials — currently `screening.partnerSecret`. The
+ * presence of the secret is preserved as a marker so misconfiguration (e.g.
+ * empty secret in production) is still observable from logs.
+ */
+export function redactConfig(config: Config): Record<string, unknown> {
+  const { screening, tls, ...rest } = config;
+  const redacted: Record<string, unknown> = { ...rest };
+  if (screening) {
+    const { partnerSecret, ...screeningRest } = screening;
+    redacted.screening = {
+      ...screeningRest,
+      partnerSecret: partnerSecret.length > 0 ? "[REDACTED]" : "[EMPTY]",
+    };
+  }
+  if (tls) {
+    // Paths are not secrets but the contents are; surface only the on/off bit
+    // so startup logs stay narrow.
+    redacted.tls = { enabled: true };
+  }
+  return redacted;
+}
+
 function parseIntEnv(name: string, defaultValue: number): number {
   const raw = process.env[name];
   if (raw == null) return defaultValue;

--- a/proof-interceptor/src/index.ts
+++ b/proof-interceptor/src/index.ts
@@ -1,12 +1,29 @@
 // src/index.ts
-import { loadConfig } from "./config.js";
+import { loadConfig, redactConfig } from "./config.js";
 import { createHandler } from "./proxy.js";
 import { startServer } from "./server.js";
 import { setupGracefulShutdown } from "./shutdown.js";
 import { ScreeningInterceptor } from "./screening-interceptor.js";
+import { GIT_SHA, SERVICE_VERSION } from "./build_info.js";
+// Importing `metrics` for its side effect: registering the build_info gauge so
+// it appears in /metrics output before the first scrape.
+import "./metrics.js";
 import type { TransactionInterceptor } from "./interceptor.js";
 
 const config = loadConfig();
+
+// Startup banner — version + git SHA + redacted config (no secrets) so a
+// running pod can be tied back to a deploy from logs alone. See `build_info.ts`
+// for how GIT_SHA is supplied to the binary.
+console.log(
+  JSON.stringify({
+    level: "info",
+    event: "startup",
+    version: SERVICE_VERSION,
+    git_sha: GIT_SHA,
+    config: redactConfig(config),
+  })
+);
 
 const interceptors: TransactionInterceptor[] = [];
 if (config.screening) {

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -6,10 +6,24 @@ import {
   Gauge,
   collectDefaultMetrics,
 } from "prom-client";
+import { GIT_SHA, SERVICE_VERSION } from "./build_info.js";
 
 export const registry = new Registry();
 
 collectDefaultMetrics({ register: registry });
+
+/**
+ * Constant gauge that exposes build identity. Always 1 — the value carries no
+ * information; the `version` and `git_sha` labels are what dashboards join
+ * against to correlate behaviour with deploys.
+ */
+export const buildInfo = new Gauge({
+  name: "proof_interceptor_build_info",
+  help: "Build identity (version, git SHA). Value is always 1.",
+  labelNames: ["version", "git_sha"] as const,
+  registers: [registry],
+});
+buildInfo.labels(SERVICE_VERSION, GIT_SHA).set(1);
 
 export const rpcRequestsTotal = new Counter({
   name: "proof_interceptor_rpc_requests_total",

--- a/proof-interceptor/tests/build_info.test.ts
+++ b/proof-interceptor/tests/build_info.test.ts
@@ -1,0 +1,26 @@
+// tests/build_info.test.ts
+import { describe, it, expect } from "vitest";
+import { SERVICE_VERSION, GIT_SHA } from "../src/build_info.js";
+import { registry } from "../src/metrics.js";
+
+describe("build info", () => {
+  it("loads a non-empty service version from package.json", () => {
+    expect(typeof SERVICE_VERSION).toBe("string");
+    expect(SERVICE_VERSION.length).toBeGreaterThan(0);
+    expect(SERVICE_VERSION).not.toBe("unknown");
+  });
+
+  it("falls back to 'unknown' for git SHA when env var is unset", () => {
+    expect(typeof GIT_SHA).toBe("string");
+    expect(GIT_SHA.length).toBeGreaterThan(0);
+  });
+
+  it("exposes build_info gauge in the Prometheus registry", async () => {
+    const text = await registry.metrics();
+    expect(text).toContain("proof_interceptor_build_info");
+    const re = new RegExp(
+      `proof_interceptor_build_info\\{[^}]*version="${SERVICE_VERSION}"[^}]*git_sha="${GIT_SHA}"[^}]*\\}\\s+1`
+    );
+    expect(text).toMatch(re);
+  });
+});

--- a/proof-interceptor/tests/config.test.ts
+++ b/proof-interceptor/tests/config.test.ts
@@ -1,6 +1,6 @@
 // tests/config.test.ts
 import { describe, it, expect, beforeEach } from "vitest";
-import { loadConfig } from "../src/config.js";
+import { loadConfig, redactConfig, type Config } from "../src/config.js";
 
 describe("loadConfig", () => {
   const originalEnv = process.env;
@@ -139,5 +139,72 @@ describe("loadConfig", () => {
     delete process.env.SCREENING_POOL_ADDRESS;
 
     expect(() => loadConfig()).toThrow("SCREENING_POOL_ADDRESS");
+  });
+});
+
+describe("redactConfig", () => {
+  const baseConfig: Config = {
+    host: "0.0.0.0",
+    port: 8080,
+    maxBodyBytes: 5 * 1024 * 1024,
+  };
+
+  it("returns plain config untouched when no screening or TLS is set", () => {
+    expect(redactConfig(baseConfig)).toEqual(baseConfig);
+  });
+
+  it("masks partnerSecret but preserves other screening fields", () => {
+    const config: Config = {
+      ...baseConfig,
+      screening: {
+        ellipticProxyUrl: "http://elliptic-proxy:3000",
+        partnerName: "test-partner",
+        partnerSecret: "supersecret",
+        timeoutMs: 1000,
+        failOpen: false,
+        maxRetries: 0,
+        totalTimeoutMs: 5000,
+        poolAddress: "0xabc",
+        blockNonPoolTx: true,
+      },
+    };
+    const redacted = redactConfig(config);
+    const screening = (redacted.screening ?? {}) as Record<string, unknown>;
+    expect(screening.partnerSecret).toBe("[REDACTED]");
+    expect(screening.partnerName).toBe("test-partner");
+    expect(screening.ellipticProxyUrl).toBe("http://elliptic-proxy:3000");
+    expect(JSON.stringify(redacted)).not.toContain("supersecret");
+  });
+
+  it("marks an empty partnerSecret as [EMPTY] so misconfiguration stays visible", () => {
+    const config: Config = {
+      ...baseConfig,
+      screening: {
+        ellipticProxyUrl: "http://elliptic-proxy:3000",
+        partnerName: "test-partner",
+        partnerSecret: "",
+        timeoutMs: 1000,
+        failOpen: false,
+        maxRetries: 0,
+        totalTimeoutMs: 5000,
+        poolAddress: "0xabc",
+        blockNonPoolTx: false,
+      },
+    };
+    const redacted = redactConfig(config);
+    expect((redacted.screening as Record<string, unknown>).partnerSecret).toBe(
+      "[EMPTY]"
+    );
+  });
+
+  it("collapses TLS to {enabled: true} so cert/key paths don't appear", () => {
+    const config: Config = {
+      ...baseConfig,
+      tls: { certPath: "/etc/cert.pem", keyPath: "/etc/key.pem" },
+    };
+    const redacted = redactConfig(config);
+    expect(redacted.tls).toEqual({ enabled: true });
+    expect(JSON.stringify(redacted)).not.toContain("/etc/cert.pem");
+    expect(JSON.stringify(redacted)).not.toContain("/etc/key.pem");
   });
 });


### PR DESCRIPTION
## Summary
- New \`proof_interceptor_build_info{version, git_sha}\` gauge for grouping metric changes by deploy. Version read from package.json; git_sha from \`GIT_SHA\` env var (Docker build arg / CI).
- Startup banner logs version + git SHA + the loaded configuration. \`redactConfig\` masks \`screening.partnerSecret\` (\`[REDACTED]\` when present, \`[EMPTY]\` when missing so misconfig is still visible) and collapses TLS paths to \`{enabled: true}\`. No secret values reach the log sink.

Follows #750 and #751 in the proof-interceptor observability series.

## Test plan
- [x] New test asserting \`partnerSecret\` is masked and never appears in the redacted JSON
- [x] New test verifying \`build_info\` gauge appears in /metrics with the right labels
- [x] \`npm test\` — 112 tests pass
- [x] \`npm run lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/752)
<!-- Reviewable:end -->
