### PR TITLE
feat(proof-interceptor): screening availability metric and per-interceptor errors

### DIFF
--- a/proof-interceptor/src/interceptor.ts
+++ b/proof-interceptor/src/interceptor.ts
@@ -3,6 +3,7 @@ import type { ProveTxnV3 } from "./types.js";
 import {
   interceptorVerdicts,
   interceptorDuration,
+  interceptorErrors,
   errorsTotal,
 } from "./metrics.js";
 
@@ -31,8 +32,15 @@ export async function runInterceptors(
       verdict = await interceptor.intercept(transaction);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(JSON.stringify({ error: "interceptor_error", message }));
+      console.error(
+        JSON.stringify({
+          error: "interceptor_error",
+          interceptor: interceptor.name,
+          message,
+        })
+      );
       errorsTotal.inc({ type: "interceptor_error" });
+      interceptorErrors.inc({ interceptor: interceptor.name });
       verdict = { action: "block", reason: message };
     }
     const durationSeconds = (Date.now() - startTime) / 1000;

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -27,8 +27,40 @@ export const interceptorVerdicts = new Counter({
 
 export const screeningResults = new Counter({
   name: "proof_interceptor_screening_results_total",
-  help: "Total screening outcomes",
+  help: "Total screening verdicts (allowed/blocked/unavailable)",
   labelNames: ["result"] as const,
+  registers: [registry],
+});
+
+/**
+ * Upstream screening-service availability, split by outcome of each call.
+ * Separate from `screeningResults` (which tracks verdicts) — this metric is
+ * the input dashboards use to track elliptic-proxy availability without
+ * conflating fail-open allowed verdicts with successful screening.
+ *
+ * Label values:
+ * - `success` — elliptic-proxy returned 2xx
+ * - `timeout` — request exceeded per-call timeout (AbortSignal.timeout)
+ * - `http_error` — elliptic-proxy returned non-2xx
+ * - `network_error` — TCP / DNS / TLS failure before any HTTP response
+ */
+export const screeningAvailability = new Counter({
+  name: "proof_interceptor_screening_availability_total",
+  help: "Upstream screening-service call outcomes",
+  labelNames: ["outcome"] as const,
+  registers: [registry],
+});
+
+/**
+ * Per-interceptor error counter, so a failure can be attributed to a
+ * specific interceptor (currently only `screening`, but designed to scale)
+ * rather than the single global `errors_total{type="interceptor_error"}`
+ * bucket. Increments on any thrown error inside `interceptor.intercept(...)`.
+ */
+export const interceptorErrors = new Counter({
+  name: "proof_interceptor_interceptor_errors_total",
+  help: "Per-interceptor errors raised during transaction screening",
+  labelNames: ["interceptor"] as const,
   registers: [registry],
 });
 

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -5,10 +5,33 @@ import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import type { TransactionInterceptor, Verdict } from "./interceptor.js";
 import type { ProveTxnV3 } from "./types.js";
 import {
+  screeningAvailability,
   screeningResults,
   screeningRetries,
   screeningDuration,
 } from "./metrics.js";
+
+/**
+ * Categorizes a failure of `callEllipticProxy` for the
+ * `proof_interceptor_screening_availability_total{outcome}` metric.
+ */
+export type ScreeningErrorCategory = "timeout" | "http_error" | "network_error";
+
+/**
+ * Error thrown by `callEllipticProxy` that carries the category the metric
+ * should be labelled with. Keeps categorization at the throw site (where the
+ * cause is unambiguous) so the metric increment can be a simple lookup at
+ * the catch site.
+ */
+class ScreeningError extends Error {
+  constructor(
+    readonly category: ScreeningErrorCategory,
+    message: string
+  ) {
+    super(message);
+    this.name = "ScreeningError";
+  }
+}
 
 export interface ScreeningConfig {
   ellipticProxyUrl: string;
@@ -151,17 +174,15 @@ export class ScreeningInterceptor implements TransactionInterceptor {
 
     for (const address of addresses) {
       const result = await this.screenAddress(address);
+      // Reason strings are forwarded to the caller as JSON-RPC error `data`,
+      // so they must NOT reveal the depositor address (extracted from the
+      // private-pool calldata). Use opaque codes — server-side logs are the
+      // place to learn which address triggered which outcome.
       if (result === "blocked") {
-        return {
-          action: "block",
-          reason: `address screening: ${address} blocked`,
-        };
+        return { action: "block", reason: "address_blocked" };
       }
       if (result === "unavailable") {
-        return {
-          action: "block",
-          reason: `screening unavailable for ${address}`,
-        };
+        return { action: "block", reason: "screening_unavailable" };
       }
     }
 
@@ -194,6 +215,7 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         const screeningLatencyMs = Date.now() - callStart;
         screeningResults.inc({ result });
         screeningDuration.observe({ result }, screeningLatencyMs / 1000);
+        screeningAvailability.inc({ outcome: "success" });
         console.log(
           JSON.stringify({
             screening: "complete",
@@ -205,6 +227,9 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         return result;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
+        const outcome: ScreeningErrorCategory =
+          error instanceof ScreeningError ? error.category : "network_error";
+        screeningAvailability.inc({ outcome });
       }
     }
 
@@ -238,20 +263,43 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       body
     );
 
-    const response = await fetch(this.config.ellipticProxyUrl + path, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-access-key": this.config.partnerName,
-        "x-access-sign": signature,
-        "x-access-timestamp": timestamp,
-      },
-      body,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    let response;
+    try {
+      response = await fetch(this.config.ellipticProxyUrl + path, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-access-key": this.config.partnerName,
+          "x-access-sign": signature,
+          "x-access-timestamp": timestamp,
+        },
+        body,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      // `AbortSignal.timeout` raises `TimeoutError` (Node >=22) — older runtimes
+      // and some test shims raise `AbortError`. Accept both. Any other thrown
+      // error from `fetch` (TypeError "fetch failed", DNS / TCP / TLS issues)
+      // is categorized as a network error.
+      const name = (error as { name?: string }).name;
+      if (name === "TimeoutError" || name === "AbortError") {
+        throw new ScreeningError(
+          "timeout",
+          `elliptic-proxy timed out after ${timeoutMs}ms`
+        );
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ScreeningError(
+        "network_error",
+        `elliptic-proxy network error: ${message}`
+      );
+    }
 
     if (!response.ok) {
-      throw new Error(`elliptic-proxy returned ${response.status}`);
+      throw new ScreeningError(
+        "http_error",
+        `elliptic-proxy returned ${response.status}`
+      );
     }
 
     const result: unknown = await response.json();

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -206,6 +206,9 @@ describe("e2e: proof-interceptor → elliptic-proxy → mock Elliptic API", () =
 
     expect(body.error.code).toBe(10000);
     expect(body.error.message).toBe("Transaction rejected");
-    expect(body.error.data).toContain("0xbad0");
+    // The depositor address must NOT appear in the JSON-RPC error data — it
+    // is read from private-pool calldata and would leak to the caller.
+    expect(body.error.data).toBe("address_blocked");
+    expect(body.error.data).not.toContain("0xbad0");
   }, 15000);
 });

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -457,7 +457,11 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("0xaaa111");
+      // Reason must be an opaque code — the depositor address (taken from
+      // private-pool calldata) is forwarded to the caller as JSON-RPC error
+      // `data` and would otherwise leak.
+      expect(verdict.reason).toBe("address_blocked");
+      expect(verdict.reason).not.toContain("0xaaa111");
     }
 
     const logCall = logSpy.mock.calls.find((call) => {
@@ -516,7 +520,7 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("screening unavailable");
+      expect(verdict.reason).toBe("screening_unavailable");
     }
 
     const errorCall = errorSpy.mock.calls.find((call) => {
@@ -553,7 +557,7 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("screening unavailable");
+      expect(verdict.reason).toBe("screening_unavailable");
     }
     spy.mockRestore();
   });

--- a/proof-interceptor/tests/screening-outcomes.test.ts
+++ b/proof-interceptor/tests/screening-outcomes.test.ts
@@ -1,0 +1,239 @@
+// tests/screening-outcomes.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import { ScreeningInterceptor } from "../src/screening-interceptor.js";
+import { screeningAvailability, interceptorErrors } from "../src/metrics.js";
+import { runInterceptors } from "../src/interceptor.js";
+
+// Match the test calldata layout used by the existing screening tests so the
+// ABI decoder sees a real Deposit action and the screening request actually
+// goes out — without that, the metric we care about never increments.
+const POOL_ADDR = "0xpool";
+const USER_ADDR = "0xaaa111";
+const PRIVATE_KEY = "0xbbb222";
+const TOKEN = "0xdead";
+const AMOUNT = "0x64";
+
+interface ProveTxn {
+  type: "INVOKE";
+  version: "0x3";
+  sender_address: string;
+  calldata: string[];
+  signature: string[];
+  nonce: string;
+  resource_bounds: Record<string, unknown>;
+  tip: string;
+  paymaster_data: string[];
+  account_deployment_data: string[];
+  nonce_data_availability_mode: string;
+  fee_data_availability_mode: string;
+}
+
+function sampleTransaction(): ProveTxn {
+  return {
+    type: "INVOKE",
+    version: "0x3",
+    sender_address: "0xcontract",
+    calldata: [
+      "0x1", // 1 call
+      POOL_ADDR,
+      "0xselector",
+      "0x6", // inner calldata length
+      USER_ADDR,
+      PRIVATE_KEY,
+      "0x1", // 1 action
+      "0x5", // Deposit variant
+      TOKEN,
+      AMOUNT,
+    ],
+    signature: ["0x1"],
+    nonce: "0x0",
+    resource_bounds: {},
+    tip: "0x0",
+    paymaster_data: [],
+    account_deployment_data: [],
+    nonce_data_availability_mode: "L1",
+    fee_data_availability_mode: "L1",
+  };
+}
+
+interface AvailabilityOutcomes {
+  success: number;
+  timeout: number;
+  http_error: number;
+  network_error: number;
+}
+
+async function getAvailability(): Promise<AvailabilityOutcomes> {
+  const data = await screeningAvailability.get();
+  const out: AvailabilityOutcomes = {
+    success: 0,
+    timeout: 0,
+    http_error: 0,
+    network_error: 0,
+  };
+  for (const sample of data.values) {
+    const outcome = sample.labels.outcome as keyof AvailabilityOutcomes;
+    if (outcome in out) out[outcome] = sample.value;
+  }
+  return out;
+}
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+  }
+});
+
+function makeConfig(
+  overrides: Partial<ConstructorParameters<typeof ScreeningInterceptor>[0]> = {}
+): ConstructorParameters<typeof ScreeningInterceptor>[0] {
+  return {
+    ellipticProxyUrl: "http://127.0.0.1:1",
+    partnerName: "test-partner",
+    partnerSecret: Buffer.from("secret").toString("base64"),
+    timeoutMs: 200,
+    failOpen: false,
+    maxRetries: 0,
+    totalTimeoutMs: 1000,
+    poolAddress: POOL_ADDR,
+    blockNonPoolTx: false,
+    ...overrides,
+  };
+}
+
+function startScreeningServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse
+  ) => void
+): Promise<string> {
+  return new Promise((resolve) => {
+    server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server!.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+// Suppress noisy stderr from the interceptor's failure log.
+function suppressErrorLogs() {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+describe("screening availability metric", () => {
+  it("labels HTTP 5xx as http_error", async () => {
+    const url = await startScreeningServer((_req, res) => {
+      res.writeHead(503);
+      res.end();
+    });
+
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({ ellipticProxyUrl: url })
+    );
+    const errSpy = suppressErrorLogs();
+    const before = await getAvailability();
+
+    await interceptor.intercept(sampleTransaction());
+
+    const after = await getAvailability();
+    expect(after.http_error - before.http_error).toBe(1);
+    expect(after.timeout - before.timeout).toBe(0);
+    expect(after.network_error - before.network_error).toBe(0);
+    errSpy.mockRestore();
+  });
+
+  it("labels a connection refused as network_error", async () => {
+    // Port 1 is reserved/refused on all platforms.
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({ ellipticProxyUrl: "http://127.0.0.1:1" })
+    );
+    const errSpy = suppressErrorLogs();
+    const before = await getAvailability();
+
+    await interceptor.intercept(sampleTransaction());
+
+    const after = await getAvailability();
+    expect(after.network_error - before.network_error).toBe(1);
+    expect(after.success - before.success).toBe(0);
+    errSpy.mockRestore();
+  });
+
+  it("labels success when elliptic-proxy returns 2xx", async () => {
+    const url = await startScreeningServer((req, res) => {
+      // Echo a minimal payload so the interceptor can parse it.
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ blocked: false }));
+      });
+    });
+
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({ ellipticProxyUrl: url })
+    );
+    const before = await getAvailability();
+
+    await interceptor.intercept(sampleTransaction());
+
+    const after = await getAvailability();
+    expect(after.success - before.success).toBe(1);
+  });
+
+  it("labels per-call timeout as timeout", async () => {
+    const url = await startScreeningServer(() => {
+      // never respond — let the client-side AbortSignal fire.
+    });
+
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({
+        ellipticProxyUrl: url,
+        timeoutMs: 50,
+        totalTimeoutMs: 200,
+      })
+    );
+    const errSpy = suppressErrorLogs();
+    const before = await getAvailability();
+
+    await interceptor.intercept(sampleTransaction());
+
+    const after = await getAvailability();
+    expect(after.timeout - before.timeout).toBeGreaterThanOrEqual(1);
+    errSpy.mockRestore();
+  });
+});
+
+describe("interceptor_errors_total per-interceptor counter", () => {
+  it("attributes a thrown error to the failing interceptor's name", async () => {
+    const before =
+      (await interceptorErrors.get()).values.find(
+        (entry) => entry.labels.interceptor === "thrower"
+      )?.value ?? 0;
+
+    const errSpy = suppressErrorLogs();
+    await runInterceptors(
+      [
+        {
+          name: "thrower",
+          intercept: async () => {
+            throw new Error("blow up");
+          },
+        },
+      ],
+      sampleTransaction()
+    );
+    errSpy.mockRestore();
+
+    const after =
+      (await interceptorErrors.get()).values.find(
+        (entry) => entry.labels.interceptor === "thrower"
+      )?.value ?? 0;
+    expect(after - before).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- New \`proof_interceptor_screening_availability_total{outcome}\` counter — \`success | timeout | http_error | network_error\`. Distinct from the verdict metric (\`screening_results_total\`) so a fail-open \"allowed\" verdict no longer masks an elliptic-proxy outage.
- New \`proof_interceptor_interceptor_errors_total{interceptor}\` so failures attribute to a specific interceptor instead of one global bucket.
- Errors raised by \`callEllipticProxy\` are typed via \`ScreeningError\` carrying the category — categorization happens at the throw site, not the catch site.

**Security fix bundled in**: the screening interceptor previously returned reasons like \`\"address screening: \${address} blocked\"\` and \`\"screening unavailable for \${address}\"\`. These reasons are forwarded to the JSON-RPC caller as \`error.data\`, which leaked the depositor address (read from privacy-pool calldata). Replaced with opaque codes \`address_blocked\` and \`screening_unavailable\`. The e2e test now asserts the address does NOT appear in the response payload.

## Test plan
- [x] New \`screening-outcomes.test.ts\`: success / timeout / http_error / network_error labels, per-interceptor error counter
- [x] Updated e2e test asserts \`body.error.data\` is the opaque code and does NOT contain the depositor address
- [x] \`npm test\` — 110 tests pass
- [x] \`npm run lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/753)
<!-- Reviewable:end -->
