### PR TITLE
fix(sdk): support OHTTP on React Native

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.14.2-rc.5",
       "license": "ISC",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@panva/hpke-noble": "^1.1.0",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
         "ohttp-ts": "^0.3.0",
         "starknet": "^10.0.0-beta.6",
@@ -787,6 +790,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
@@ -802,13 +817,90 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/hashes": {
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.6.1.tgz",
+      "integrity": "sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "~2.2.0",
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@panva/hpke-noble": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@panva/hpke-noble/-/hpke-noble-1.1.0.tgz",
+      "integrity": "sha512-1awnSeLKWEgCBGjuuFhKk6+AxxHzQGfeM0wP0LHtNQPWssXfTTdZvjXD5ruqguf+eNeLfTrMuC+89TNbEDGxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^2.0.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      },
+      "peerDependencies": {
+        "hpke": "^1.0.0"
+      }
+    },
+    "node_modules/@panva/hpke-noble/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1258,6 +1350,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1335,6 +1439,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1384,6 +1489,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -1600,6 +1706,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.0.17.tgz",
       "integrity": "sha512-cgf2JZk2fv5or3efmOrRJe1V9Md89BPgz4ntzbf84yAb+z2hW6niaGFinl9aFzPZ1q3TGfWZQWZ9gXTFThs2Qw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.17",
         "@vitest/utils": "4.0.17",
@@ -1622,6 +1729,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.0.17.tgz",
       "integrity": "sha512-CE9nlzslHX6Qz//MVrjpulTC9IgtXTbJ+q7Rx1HD+IeSOWv4NHIRNHPA6dB4x01d9paEqt+TvoqZfmgq40DxEQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -1845,6 +1953,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2550,6 +2659,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3238,6 +3348,7 @@
       "resolved": "https://registry.npmjs.org/hpke/-/hpke-1.0.6.tgz",
       "integrity": "sha512-2T/TYYmlFRPWaBv6lTA/jGp/Y70aupUjDpvEn15z5iB0WiJLW4MyDsuUBXoCrCTW02xy4r8AiuuuAKNfD6ahsg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3743,6 +3854,18 @@
         }
       }
     },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3792,6 +3915,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4244,6 +4368,18 @@
         "decompress-targz": "^4.1.1"
       }
     },
+    "node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -4470,6 +4606,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4550,6 +4687,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4625,6 +4763,7 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -4865,6 +5004,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -70,6 +70,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
+    "@panva/hpke-noble": "^1.1.0",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
     "ohttp-ts": "^0.3.0",
     "starknet": "^10.0.0-beta.6",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -17,6 +17,7 @@ export { IndexerDiscoveryProvider } from "./internal/indexer-discovery.js";
 export type { DiscoveryHealthResponse } from "./internal/indexer-discovery.js";
 export { OhttpClient } from "./internal/ohttp-client.js";
 export type { OhttpOption } from "./internal/ohttp-client.js";
+export { installOhttpWebCryptoFallback } from "./internal/ohttp-webcrypto-fallback.js";
 export { buildHistoryCursor } from "./internal/history.js";
 export { classifyTransaction } from "./internal/action-classifier.js";
 export type { ClassifyOptions } from "./internal/action-classifier.js";

--- a/sdk/src/internal/ohttp-client.ts
+++ b/sdk/src/internal/ohttp-client.ts
@@ -6,7 +6,8 @@
  */
 
 import { OHTTPClient, KeyConfig } from "ohttp-ts";
-import { CipherSuite, KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM } from "hpke";
+import { CipherSuite } from "hpke";
+import { AEAD_AES_128_GCM, KDF_HKDF_SHA256, KEM_DHKEM_X25519_HKDF_SHA256 } from "@panva/hpke-noble";
 import { ReorgError } from "./errors.js";
 
 /** HTTP 409 — the discovery service returns this exclusively for block reorgs (BLOCK_REORGED). */

--- a/sdk/src/internal/ohttp-webcrypto-fallback.ts
+++ b/sdk/src/internal/ohttp-webcrypto-fallback.ts
@@ -1,0 +1,181 @@
+import { gcm } from "@noble/ciphers/aes.js";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha256, sha384, sha512 } from "@noble/hashes/sha2.js";
+
+/**
+ * Installs a narrow React Native fallback for the WebCrypto operations that
+ * ohttp-ts currently performs internally while decrypting OHTTP responses.
+ *
+ * The patch is deliberately conservative: native WebCrypto is always tried
+ * first, and noble is used only when the runtime throws for raw HMAC/AES-GCM
+ * key import. This keeps browsers and Node on their native implementations
+ * while allowing React Native's partial SubtleCrypto implementation to work.
+ *
+ * TODO: Remove this once ohttp-ts accepts injectable HKDF/AEAD primitives.
+ */
+let didInstall = false;
+
+export function installOhttpWebCryptoFallback(): void {
+  if (didInstall) return;
+
+  const subtle = globalThis.crypto?.subtle;
+  if (typeof subtle?.importKey !== "function") return;
+
+  didInstall = true;
+  installFallback(subtle);
+}
+
+type FallbackCryptoKey = object;
+
+type NobleHash = Parameters<typeof hmac>[0];
+
+type HmacFallbackKeyStore = WeakMap<FallbackCryptoKey, { keyData: Uint8Array; hash: NobleHash }>;
+
+type AesFallbackKeyStore = WeakMap<FallbackCryptoKey, { keyData: Uint8Array }>;
+
+function installFallback(subtle: SubtleCrypto): void {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const patchedSubtle = subtle as any;
+  const originalImportKey = patchedSubtle.importKey.bind(patchedSubtle);
+  const originalSign = patchedSubtle.sign?.bind(patchedSubtle);
+  const originalEncrypt = patchedSubtle.encrypt?.bind(patchedSubtle);
+  const originalDecrypt = patchedSubtle.decrypt?.bind(patchedSubtle);
+
+  const hmacKeys: HmacFallbackKeyStore = new WeakMap();
+  const aesKeys: AesFallbackKeyStore = new WeakMap();
+
+  patchedSubtle.importKey = async function patchedImportKey(
+    format: string,
+    keyData: BufferSource,
+    algorithm: AlgorithmIdentifier | HmacImportParams | AesKeyAlgorithm,
+    extractable: boolean,
+    keyUsages: KeyUsage[]
+  ): Promise<CryptoKey | FallbackCryptoKey> {
+    const algName = getAlgorithmName(algorithm);
+    const rawKey = toUint8Array(keyData);
+
+    const importArgs = [format, keyData, algorithm, extractable, keyUsages] as const;
+    if (format === "raw" && algName === "HMAC") {
+      return importHmacKeyWithFallback(originalImportKey, hmacKeys, rawKey, algorithm, importArgs);
+    }
+    if (format === "raw" && algName === "AES-GCM") {
+      return importAesKeyWithFallback(originalImportKey, aesKeys, rawKey, importArgs);
+    }
+    return originalImportKey(format, keyData, algorithm, extractable, keyUsages);
+  };
+
+  patchedSubtle.sign = async function patchedSign(
+    algorithm: AlgorithmIdentifier,
+    key: CryptoKey | FallbackCryptoKey,
+    data: BufferSource
+  ): Promise<ArrayBuffer> {
+    const fallbackKey = hmacKeys.get(key);
+    if (fallbackKey) {
+      return copyArrayBuffer(hmac(fallbackKey.hash, fallbackKey.keyData, toUint8Array(data)));
+    }
+    return originalSign(algorithm, key, data);
+  };
+
+  patchedSubtle.encrypt = async function patchedEncrypt(
+    algorithm: AesGcmParams,
+    key: CryptoKey | FallbackCryptoKey,
+    data: BufferSource
+  ): Promise<ArrayBuffer> {
+    const fallbackKey = aesKeys.get(key);
+    if (fallbackKey) {
+      return copyArrayBuffer(
+        openAesGcm(fallbackKey.keyData, algorithm).encrypt(toUint8Array(data))
+      );
+    }
+    return originalEncrypt(algorithm, key, data);
+  };
+
+  patchedSubtle.decrypt = async function patchedDecrypt(
+    algorithm: AesGcmParams,
+    key: CryptoKey | FallbackCryptoKey,
+    data: BufferSource
+  ): Promise<ArrayBuffer> {
+    const fallbackKey = aesKeys.get(key);
+    if (fallbackKey) {
+      return copyArrayBuffer(
+        openAesGcm(fallbackKey.keyData, algorithm).decrypt(toUint8Array(data))
+      );
+    }
+    return originalDecrypt(algorithm, key, data);
+  };
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+async function importHmacKeyWithFallback(
+  originalImportKey: (...args: readonly unknown[]) => Promise<CryptoKey>,
+  store: HmacFallbackKeyStore,
+  keyData: Uint8Array,
+  algorithm: AlgorithmIdentifier | HmacImportParams | AesKeyAlgorithm,
+  args: readonly unknown[]
+): Promise<CryptoKey | FallbackCryptoKey> {
+  try {
+    return await originalImportKey(...args);
+  } catch (error) {
+    const hash = getHmacHash(algorithm);
+    if (!hash) throw error;
+    const fallbackKey: FallbackCryptoKey = {};
+    store.set(fallbackKey, { keyData, hash });
+    return fallbackKey;
+  }
+}
+
+async function importAesKeyWithFallback(
+  originalImportKey: (...args: readonly unknown[]) => Promise<CryptoKey>,
+  store: AesFallbackKeyStore,
+  keyData: Uint8Array,
+  args: readonly unknown[]
+): Promise<CryptoKey | FallbackCryptoKey> {
+  try {
+    return await originalImportKey(...args);
+  } catch {
+    const fallbackKey: FallbackCryptoKey = {};
+    store.set(fallbackKey, { keyData });
+    return fallbackKey;
+  }
+}
+
+function getAlgorithmName(algorithm: AlgorithmIdentifier | { name?: string }): string {
+  const name = typeof algorithm === "string" ? algorithm : algorithm.name;
+  return (name ?? "").toUpperCase();
+}
+
+function getHmacHash(
+  algorithm: AlgorithmIdentifier | HmacImportParams | AesKeyAlgorithm
+): NobleHash | undefined {
+  if (typeof algorithm === "string") return undefined;
+  if (!("hash" in algorithm)) return undefined;
+  const hashName = typeof algorithm.hash === "string" ? algorithm.hash : algorithm.hash?.name;
+  switch ((hashName ?? "").toUpperCase().replace("_", "-")) {
+    case "SHA-256":
+      return sha256;
+    case "SHA-384":
+      return sha384;
+    case "SHA-512":
+      return sha512;
+    default:
+      return undefined;
+  }
+}
+
+function openAesGcm(keyData: Uint8Array, algorithm: AesGcmParams) {
+  const iv = toUint8Array(algorithm.iv);
+  const aad = algorithm.additionalData ? toUint8Array(algorithm.additionalData) : undefined;
+  return gcm(keyData, iv, aad);
+}
+
+function toUint8Array(data: BufferSource): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+function copyArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}

--- a/sdk/tests/internal/ohttp-client.test.ts
+++ b/sdk/tests/internal/ohttp-client.test.ts
@@ -65,7 +65,7 @@ describe("OhttpClient", () => {
     globalThis.fetch = originalFetch;
   });
 
-  describe("outer URL construction (Finding 3)", () => {
+  describe("OHTTP URL construction", () => {
     function mockFetch() {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,

--- a/sdk/tests/internal/ohttp-noble-interop.test.ts
+++ b/sdk/tests/internal/ohttp-noble-interop.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { CipherSuite } from "hpke";
+import { KeyConfig, OHTTPClient, OHTTPServer } from "ohttp-ts";
+import { AEAD_AES_128_GCM, KDF_HKDF_SHA256, KEM_DHKEM_X25519_HKDF_SHA256 } from "@panva/hpke-noble";
+
+const suite = new CipherSuite(KEM_DHKEM_X25519_HKDF_SHA256, KDF_HKDF_SHA256, AEAD_AES_128_GCM);
+
+const supportedAlgorithms = [{ kdfId: 0x0001, aeadId: 0x0001 }];
+
+async function createClientAndServer() {
+  const serverKey = await KeyConfig.derive(
+    suite,
+    new Uint8Array(32).fill(7),
+    1,
+    supportedAlgorithms
+  );
+  const rawKeyConfig = KeyConfig.serializeMultiple([serverKey]);
+  const [clientKey] = KeyConfig.parseMultiple(rawKeyConfig);
+
+  return {
+    client: new OHTTPClient(suite, clientKey),
+    server: new OHTTPServer([serverKey]),
+  };
+}
+
+describe("OHTTP noble interop", () => {
+  it("roundtrips an HTTP request and response with noble-backed X25519/HKDF/AES", async () => {
+    const { client, server } = await createClientAndServer();
+    const request = new Request("https://gateway.example/v1/sync/outgoing_state", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+
+    const { init, context } = await client.encapsulateRequest(request);
+    const outerRequest = new Request("https://relay.example/ohttp", init);
+    const { request: innerRequest, context: serverContext } =
+      await server.decapsulateRequest(outerRequest);
+
+    expect(innerRequest.method).toBe("POST");
+    expect(new URL(innerRequest.url).pathname).toBe("/v1/sync/outgoing_state");
+    expect(await innerRequest.json()).toEqual({ hello: "world" });
+
+    const outerResponse = await serverContext.encapsulateResponse(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const innerResponse = await context.decapsulateResponse(outerResponse);
+
+    expect(innerResponse.status).toBe(200);
+    expect(await innerResponse.json()).toEqual({ ok: true });
+  });
+
+  it("decapsulates a response reconstructed from copied ArrayBuffer bytes", async () => {
+    const { client, server } = await createClientAndServer();
+    const request = new Request("https://gateway.example/health", { method: "GET" });
+
+    const { init, context } = await client.encapsulateRequest(request);
+    const outerRequest = new Request("https://relay.example/ohttp", init);
+    const { context: serverContext } = await server.decapsulateRequest(outerRequest);
+
+    const outerResponse = await serverContext.encapsulateResponse(
+      new Response(JSON.stringify({ status: "OK" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const copiedBytes = new Uint8Array(await outerResponse.arrayBuffer()).slice();
+    const reconstructedResponse = new Response(copiedBytes, {
+      status: 200,
+      headers: { "content-type": "message/ohttp-res" },
+    });
+
+    const innerResponse = await context.decapsulateResponse(reconstructedResponse);
+
+    expect(innerResponse.status).toBe(200);
+    expect(await innerResponse.json()).toEqual({ status: "OK" });
+  });
+});

--- a/sdk/tests/internal/ohttp-webcrypto-fallback.test.ts
+++ b/sdk/tests/internal/ohttp-webcrypto-fallback.test.ts
@@ -1,0 +1,99 @@
+import { gcm } from "@noble/ciphers/aes.js";
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha384 } from "@noble/hashes/sha2.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalCrypto = globalThis.crypto;
+
+describe("installOhttpWebCryptoFallback", () => {
+  afterEach(() => {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: originalCrypto,
+    });
+    vi.resetModules();
+  });
+
+  it("can be retried when crypto.subtle becomes available later", async () => {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: undefined,
+    });
+    const { installOhttpWebCryptoFallback } =
+      await import("../../src/internal/ohttp-webcrypto-fallback.js");
+
+    installOhttpWebCryptoFallback();
+
+    const subtle = createThrowingSubtle();
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { subtle },
+    });
+
+    installOhttpWebCryptoFallback();
+
+    const keyData = new Uint8Array([1, 2, 3, 4]);
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      keyData,
+      { name: "HMAC", hash: "SHA-384" },
+      false,
+      ["sign"]
+    );
+    const data = new Uint8Array([5, 6, 7, 8]);
+    const signature = new Uint8Array(await globalThis.crypto.subtle.sign("HMAC", key, data));
+
+    expect(signature).toEqual(hmac(sha384, keyData, data));
+  });
+
+  it("falls back for AES-GCM encrypt and decrypt", async () => {
+    const subtle = createThrowingSubtle();
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { subtle },
+    });
+    const { installOhttpWebCryptoFallback } =
+      await import("../../src/internal/ohttp-webcrypto-fallback.js");
+
+    installOhttpWebCryptoFallback();
+
+    const keyData = new Uint8Array(16).fill(7);
+    const iv = new Uint8Array(12).fill(3);
+    const aad = new Uint8Array([1, 2, 3]);
+    const plaintext = new Uint8Array([4, 5, 6]);
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      keyData,
+      { name: "AES-GCM" },
+      false,
+      ["encrypt", "decrypt"]
+    );
+
+    const ciphertext = new Uint8Array(
+      await globalThis.crypto.subtle.encrypt(
+        { name: "AES-GCM", iv, additionalData: aad },
+        key,
+        plaintext
+      )
+    );
+    expect(ciphertext).toEqual(gcm(keyData, iv, aad).encrypt(plaintext));
+
+    const decrypted = new Uint8Array(
+      await globalThis.crypto.subtle.decrypt(
+        { name: "AES-GCM", iv, additionalData: aad },
+        key,
+        ciphertext
+      )
+    );
+    expect(decrypted).toEqual(plaintext);
+  });
+});
+
+function createThrowingSubtle(): SubtleCrypto {
+  return {
+    importKey: vi.fn().mockRejectedValue(new Error("native importKey unavailable")),
+    sign: vi.fn().mockRejectedValue(new Error("native sign unavailable")),
+    encrypt: vi.fn().mockRejectedValue(new Error("native encrypt unavailable")),
+    decrypt: vi.fn().mockRejectedValue(new Error("native decrypt unavailable")),
+  } as unknown as SubtleCrypto;
+}


### PR DESCRIPTION
## Summary
- switch SDK OHTTP HPKE suite to noble-backed X25519/HKDF/AES-GCM primitives
- add a React Native-compatible SubtleCrypto fallback for ohttp-ts internal HMAC and AES-GCM operations
- add noble OHTTP interop coverage for request/response roundtrips and copied response buffers

## Context
React Native's crypto.subtle implementation does not support the HMAC/AES-GCM importKey paths used internally by ohttp-ts while decapsulating OHTTP responses. This caused mobile OHTTP response decryption to fail even though request encapsulation worked.

This keeps the existing synthetic inner request origin behavior from main, so gateway path prefixes are not leaked into encrypted inner requests.

## Validation
- npm run build
- npm run lint
- npm run test:fast -- --coverage.enabled=false
- live OHTTP route sanity check returns expected API 400 for dummy viewing key instead of transport/decryption failure

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/759)
<!-- Reviewable:end -->
