### PR TITLE
feat(proof-interceptor): log uncaught errors and shutdown lifecycle

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -129,8 +129,17 @@ Prometheus counters/histograms exported on `/metrics` (defined in `src/metrics.t
 - `proof_interceptor_screening_duration_seconds{result}` — Elliptic round-trip latency.
 - `proof_interceptor_interceptor_verdicts_total{interceptor,verdict}` — per-interceptor verdicts.
 - `proof_interceptor_rpc_requests_total{action,method}` and `proof_interceptor_errors_total{type}` — request and error counters.
+- `proof_interceptor_process_crashes_total{source}` — `uncaught_exception` / `unhandled_rejection`. Non-zero means the process died and was restarted.
 
 Plus default Node.js process metrics from `prom-client`.
+
+## Process lifecycle
+
+An uncaught exception or unhandled rejection is logged as JSON with its stack trace,
+counted in `proof_interceptor_process_crashes_total`, and then the process exits `1`
+rather than dying silently. `SIGTERM`/`SIGINT` close the listener and log
+`shutdown_started` then `shutdown_complete` (or `shutdown_error`); repeated signals
+while a shutdown is already running are logged and ignored.
 
 ## Verifying a deployment
 

--- a/proof-interceptor/src/index.ts
+++ b/proof-interceptor/src/index.ts
@@ -3,8 +3,11 @@ import { loadConfig } from "./config.js";
 import { createHandler } from "./proxy.js";
 import { startServer } from "./server.js";
 import { setupGracefulShutdown } from "./shutdown.js";
+import { installProcessCrashHandlers } from "./process.js";
 import { ScreeningInterceptor } from "./screening-interceptor.js";
 import type { TransactionInterceptor } from "./interceptor.js";
+
+installProcessCrashHandlers();
 
 const config = loadConfig();
 

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -80,3 +80,10 @@ export const inFlightRequests = new Gauge({
   help: "Currently processing requests",
   registers: [registry],
 });
+
+export const processCrashesTotal = new Counter({
+  name: "proof_interceptor_process_crashes_total",
+  help: "Total uncaught errors at the process level by source",
+  labelNames: ["source"] as const,
+  registers: [registry],
+});

--- a/proof-interceptor/src/process.ts
+++ b/proof-interceptor/src/process.ts
@@ -1,0 +1,39 @@
+// src/process.ts
+import { processCrashesTotal } from "./metrics.js";
+
+/**
+ * Installs handlers for `uncaughtException` and `unhandledRejection`. Each
+ * handler logs the failure (with stack trace when available), increments
+ * `processCrashesTotal` labelled by `source`, and exits the process with code 1.
+ *
+ * Without these handlers, an uncaught throw or unhandled promise rejection
+ * tears the process down with no log line — observability requirements call
+ * for a breadcrumb before exit so operators can correlate the restart with the
+ * cause.
+ */
+export function installProcessCrashHandlers(): void {
+  process.on("uncaughtException", (error) => {
+    processCrashesTotal.inc({ source: "uncaught_exception" });
+    console.error(
+      JSON.stringify({
+        event: "uncaught_exception",
+        message: error.message,
+        stack: error.stack,
+      })
+    );
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    processCrashesTotal.inc({ source: "unhandled_rejection" });
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    console.error(
+      JSON.stringify({
+        event: "unhandled_rejection",
+        message: error.message,
+        stack: error.stack,
+      })
+    );
+    process.exit(1);
+  });
+}

--- a/proof-interceptor/src/shutdown.ts
+++ b/proof-interceptor/src/shutdown.ts
@@ -1,15 +1,48 @@
 // src/shutdown.ts
 import type { Server } from "node:http";
 
+const SHUTDOWN_SIGNALS = ["SIGTERM", "SIGINT"] as const;
+type ShutdownSignal = (typeof SHUTDOWN_SIGNALS)[number];
+
+/**
+ * Wires SIGTERM/SIGINT to a graceful close of `server`. Emits structured logs
+ * on signal receipt and after `server.close` finishes so deployments and
+ * restarts are visible in logs (rather than disappearing into silence).
+ * Repeated signals while shutdown is already in flight are ignored.
+ */
 export function setupGracefulShutdown(server: Server): void {
-  const shutdown = () => {
-    console.log("Shutting down...");
-    server.close(() => {
-      console.log("Server closed");
+  let shuttingDown = false;
+
+  const shutdown = (signal: ShutdownSignal) => {
+    if (shuttingDown) {
+      console.log(
+        JSON.stringify({
+          event: "shutdown_signal_ignored",
+          signal,
+          reason: "shutdown already in progress",
+        })
+      );
+      return;
+    }
+    shuttingDown = true;
+
+    console.log(JSON.stringify({ event: "shutdown_started", signal }));
+    server.close((error) => {
+      if (error) {
+        console.error(
+          JSON.stringify({
+            event: "shutdown_error",
+            message: error.message,
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify({ event: "shutdown_complete" }));
       process.exit(0);
     });
   };
 
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
+  for (const signal of SHUTDOWN_SIGNALS) {
+    process.on(signal, () => shutdown(signal));
+  }
 }

--- a/proof-interceptor/tests/process.test.ts
+++ b/proof-interceptor/tests/process.test.ts
@@ -1,0 +1,75 @@
+// tests/process.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { installProcessCrashHandlers } from "../src/process.js";
+import { processCrashesTotal } from "../src/metrics.js";
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+async function crashCounterValue(source: string): Promise<number> {
+  const data = await processCrashesTotal.get();
+  const sample = data.values.find((entry) => entry.labels.source === source);
+  return sample?.value ?? 0;
+}
+
+beforeEach(() => {
+  exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  process.removeAllListeners("uncaughtException");
+  process.removeAllListeners("unhandledRejection");
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+  errorSpy.mockRestore();
+  process.removeAllListeners("uncaughtException");
+  process.removeAllListeners("unhandledRejection");
+});
+
+describe("installProcessCrashHandlers", () => {
+  it("logs and exits on uncaughtException, incrementing the counter", async () => {
+    const before = await crashCounterValue("uncaught_exception");
+    installProcessCrashHandlers();
+
+    process.emit("uncaughtException", new Error("boom"));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const after = await crashCounterValue("uncaught_exception");
+    expect(after).toBe(before + 1);
+
+    const logged = errorSpy.mock.calls.find((call) =>
+      String(call[0]).includes("uncaught_exception")
+    );
+    expect(logged).toBeDefined();
+    const parsed = JSON.parse(String(logged![0])) as Record<string, unknown>;
+    expect(parsed.event).toBe("uncaught_exception");
+    expect(parsed.message).toBe("boom");
+    expect(typeof parsed.stack).toBe("string");
+  });
+
+  it("logs and exits on unhandledRejection with Error reason", async () => {
+    const before = await crashCounterValue("unhandled_rejection");
+    installProcessCrashHandlers();
+
+    process.emit("unhandledRejection", new Error("nope"), Promise.resolve());
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const after = await crashCounterValue("unhandled_rejection");
+    expect(after).toBe(before + 1);
+  });
+
+  it("normalizes non-Error rejection reasons into an Error", async () => {
+    installProcessCrashHandlers();
+
+    process.emit("unhandledRejection", "string reason", Promise.resolve());
+
+    const logged = errorSpy.mock.calls.find((call) =>
+      String(call[0]).includes("unhandled_rejection")
+    );
+    expect(logged).toBeDefined();
+    const parsed = JSON.parse(String(logged![0])) as Record<string, unknown>;
+    expect(parsed.message).toBe("string reason");
+  });
+});

--- a/proof-interceptor/tests/shutdown.test.ts
+++ b/proof-interceptor/tests/shutdown.test.ts
@@ -1,0 +1,91 @@
+// tests/shutdown.test.ts
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { setupGracefulShutdown } from "../src/shutdown.js";
+
+let server: Server;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  exitSpy.mockRestore();
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+  process.removeAllListeners("SIGTERM");
+  process.removeAllListeners("SIGINT");
+  if (server && server.listening) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+function startServerOnEphemeralPort(): Promise<Server> {
+  server = createServer();
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve(server))
+  );
+}
+
+function findJsonLog(
+  spy: ReturnType<typeof vi.spyOn>,
+  event: string
+): Record<string, unknown> | undefined {
+  for (const call of spy.mock.calls) {
+    const arg = call[0];
+    if (typeof arg !== "string") continue;
+    try {
+      const parsed = JSON.parse(arg) as Record<string, unknown>;
+      if (parsed.event === event) return parsed;
+    } catch {
+      // skip non-JSON lines
+    }
+  }
+  return undefined;
+}
+
+describe("setupGracefulShutdown", () => {
+  it("logs shutdown_started and shutdown_complete on SIGTERM", async () => {
+    await startServerOnEphemeralPort();
+    setupGracefulShutdown(server);
+
+    process.emit("SIGTERM");
+
+    // Wait until exit was called (server.close finished)
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalled();
+    });
+
+    const started = findJsonLog(logSpy, "shutdown_started");
+    const complete = findJsonLog(logSpy, "shutdown_complete");
+    expect(started).toEqual({ event: "shutdown_started", signal: "SIGTERM" });
+    expect(complete).toEqual({ event: "shutdown_complete" });
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("ignores a second signal while shutdown is in flight", async () => {
+    await startServerOnEphemeralPort();
+    setupGracefulShutdown(server);
+
+    process.emit("SIGTERM");
+    process.emit("SIGINT");
+
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalled();
+    });
+
+    const ignored = findJsonLog(logSpy, "shutdown_signal_ignored");
+    expect(ignored).toEqual({
+      event: "shutdown_signal_ignored",
+      signal: "SIGINT",
+      reason: "shutdown already in progress",
+    });
+  });
+});


### PR DESCRIPTION
feat(proof-interceptor): log uncaught errors and shutdown lifecycle

Top-level process failures previously exited with no log line, leaving
operators with a silent restart. Install handlers for `uncaughtException`
and `unhandledRejection` that emit structured logs, increment
`proof_interceptor_process_crashes_total{source}`, and exit cleanly with
code 1. Graceful shutdown now logs `shutdown_started`, `shutdown_complete`
(or `shutdown_error`), and ignores repeated signals while shutdown is in
flight so deployments and restarts are visible.

Co-Authored-By: Claude Opus 4.7 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" alt="Reviewable">](https://reviewable.io/reviews/starkware-libs/starknet-privacy/762)

<!-- Reviewable:end -->