### PR TITLE
feat(proof-interceptor): structured logger with sanitized request-id

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -78,6 +78,10 @@ Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. O
 | `/health`  | GET    | Liveness/readiness. Returns `200 {"status":"ok"}`.                                                                    |
 | `/metrics` | GET    | Prometheus metrics.                                                                                                   |
 
+Every response carries an `x-request-id` header. An inbound `x-request-id` is reused when it
+is printable ASCII with no whitespace and at most 128 characters; anything else is replaced by
+a fresh UUID, so a caller cannot inject header bytes or bloat the log line. See [Logging](#logging).
+
 ### Request
 
 The body mirrors `starknet_proveTransaction` exactly (object or positional params). The screened shape is a single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` with `calldata = [call_count=1, contract_address=pool, selector, inner_len, user_addr, user_private_key, ...action_span]`. The action span is decoded against `PrivacyPoolABI`; only the Deposit variant triggers a screen. See `src/rpc.ts` for envelope validation and the calldata-layout comments above `isSinglePoolCall` in `src/screening-interceptor.ts` for the field-by-field breakdown.
@@ -132,6 +136,19 @@ Prometheus counters/histograms exported on `/metrics` (defined in `src/metrics.t
 - `proof_interceptor_process_crashes_total{source}` — `uncaught_exception` / `unhandled_rejection`. Non-zero means the process died and was restarted.
 
 Plus default Node.js process metrics from `prom-client`.
+
+## Logging
+
+Every log line is a single JSON object on stdout (stderr for `error`), carrying `level` and an
+`event` name. Inside a request, `request_id` is attached automatically — the id is held in an
+`AsyncLocalStorage` scope, so downstream lines (`screening_complete`, `screening_failed`,
+`interceptor_error`) correlate to the originating call without being threaded through.
+
+Each request produces exactly one `event="request"` line with `method`, `url`, `status`,
+`latencyMs`, and the RPC outcome. Errors are logged where they happen rather than only where
+they are mapped to a response.
+
+Request bodies are never logged: `user_addr` and pool calldata are private user data.
 
 ## Process lifecycle
 

--- a/proof-interceptor/src/interceptor.ts
+++ b/proof-interceptor/src/interceptor.ts
@@ -1,5 +1,6 @@
 // src/interceptor.ts
 import type { ProveTxnV3 } from "./types.js";
+import { logger } from "./logger.js";
 import {
   interceptorVerdicts,
   interceptorDuration,
@@ -43,7 +44,11 @@ export async function runInterceptors(
       verdict = await interceptor.intercept(transaction);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(JSON.stringify({ error: "interceptor_error", message }));
+      logger.error({
+        event: "interceptor_error",
+        interceptor: interceptor.name,
+        message,
+      });
       errorsTotal.inc({ type: "interceptor_error" });
       verdict = { action: "block", reason: message };
     }

--- a/proof-interceptor/src/logger.ts
+++ b/proof-interceptor/src/logger.ts
@@ -1,0 +1,50 @@
+// src/logger.ts
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Per-request context propagated via Node's `AsyncLocalStorage`. Anything
+ * logged inside a `withRequestId(...)` scope automatically picks up the
+ * request id, so downstream error logs (interceptors, screening, etc.) link
+ * back to the originating HTTP request without explicit threading.
+ */
+interface LogContext {
+  requestId: string;
+}
+
+const context = new AsyncLocalStorage<LogContext>();
+
+export function withRequestId<T>(
+  requestId: string,
+  fn: () => T | Promise<T>
+): T | Promise<T> {
+  return context.run({ requestId }, fn);
+}
+
+export function currentRequestId(): string | undefined {
+  return context.getStore()?.requestId;
+}
+
+type LogLevel = "info" | "warn" | "error";
+
+function emit(level: LogLevel, fields: Record<string, unknown>): void {
+  const requestId = context.getStore()?.requestId;
+  const payload: Record<string, unknown> = {
+    level,
+    ...(requestId !== undefined ? { request_id: requestId } : {}),
+    ...fields,
+  };
+  const sink = level === "error" ? console.error : console.log;
+  sink(JSON.stringify(payload));
+}
+
+export const logger = {
+  info(fields: Record<string, unknown>): void {
+    emit("info", fields);
+  },
+  warn(fields: Record<string, unknown>): void {
+    emit("warn", fields);
+  },
+  error(fields: Record<string, unknown>): void {
+    emit("error", fields);
+  },
+};

--- a/proof-interceptor/src/proxy.ts
+++ b/proof-interceptor/src/proxy.ts
@@ -1,9 +1,11 @@
 // src/proxy.ts
+import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { validateRpcRequest } from "./rpc.js";
 import { runInterceptors, type TransactionInterceptor } from "./interceptor.js";
 import { jsonRpcError } from "./types.js";
 import { DEFAULT_MAX_BODY_BYTES } from "./config.js";
+import { logger, withRequestId } from "./logger.js";
 import {
   registry,
   rpcRequestsTotal,
@@ -13,6 +15,7 @@ import {
 } from "./metrics.js";
 
 const TRANSACTION_REJECTED = 10000;
+const REQUEST_ID_HEADER = "x-request-id";
 
 export interface HandlerOptions {
   interceptors?: TransactionInterceptor[];
@@ -37,121 +40,148 @@ export function createHandler(options: HandlerOptions = {}) {
       return;
     }
 
-    inFlightRequests.inc();
-    const startTime = Date.now();
-    function finishRequest(rpcAction: string, fields: object) {
-      const durationSeconds = (Date.now() - startTime) / 1000;
-      inFlightRequests.dec();
-      requestDuration.observe({ action: rpcAction }, durationSeconds);
-      console.log(
-        JSON.stringify({
-          method: req.method,
-          url: req.url,
-          ...fields,
-          latencyMs: Date.now() - startTime,
-        })
-      );
-    }
+    // Generate or accept a request id. Caller-supplied ids are accepted
+    // only when short and printable-ASCII — CR/LF would let a client
+    // smuggle headers into the response via `res.setHeader`, and very
+    // long values would balloon every log line for the request.
+    const incomingId = req.headers[REQUEST_ID_HEADER];
+    const candidate = Array.isArray(incomingId) ? incomingId[0] : incomingId;
+    const requestId = isSafeRequestId(candidate) ? candidate : randomUUID();
+    res.setHeader(REQUEST_ID_HEADER, requestId);
 
-    const declaredLength = parseInt(req.headers["content-length"] ?? "", 10);
-    if (!Number.isNaN(declaredLength) && declaredLength > maxBodyBytes) {
-      errorsTotal.inc({ type: "payload_too_large" });
-      finishRequest("error", { error: "payload_too_large" });
-      res.writeHead(413, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "payload too large" }));
-      req.destroy();
-      return;
-    }
-
-    let body: Buffer;
-    try {
-      body = await readBody(req, maxBodyBytes);
-    } catch {
-      errorsTotal.inc({ type: "payload_too_large" });
-      finishRequest("error", { error: "payload_too_large" });
-      res.writeHead(413, { "content-type": "application/json" });
-      res.end(JSON.stringify({ error: "payload too large" }));
-      return;
-    }
-
-    // Only accept JSON-RPC POST requests
-    if (req.method !== "POST" || !isJsonContent(req)) {
-      errorsTotal.inc({ type: "invalid_request" });
-      finishRequest("error", { error: "invalid_request" });
-      res.writeHead(400, { "content-type": "application/json" });
-      res.end(
-        JSON.stringify({ error: "only JSON-RPC POST requests accepted" })
-      );
-      return;
-    }
-
-    const verdict = validateRpcRequest(body.toString());
-
-    if (!verdict.ok) {
-      rpcRequestsTotal.inc({ action: "error", method: "" });
-      errorsTotal.inc({ type: verdict.errorType });
-      finishRequest("error", {
-        rpcAction: "error",
-        errorType: verdict.errorType,
-      });
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify(verdict.response));
-      return;
-    }
-
-    rpcRequestsTotal.inc({
-      action: "check_with_interceptors",
-      method: "starknet_checkTransaction",
-    });
-
-    const interceptorVerdict = await runInterceptors(
-      interceptors,
-      verdict.transaction
-    );
-
-    if (interceptorVerdict.action === "block") {
-      console.error(JSON.stringify({ error: "transaction_rejected" }));
-      finishRequest("check_with_interceptors", {
-        rpcAction: "check_with_interceptors",
-        interceptorVerdict: "block",
-      });
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(
-        JSON.stringify(
-          jsonRpcError(
-            verdict.requestId,
-            TRANSACTION_REJECTED,
-            "Transaction rejected",
-            interceptorVerdict.reason
-          )
-        )
-      );
-      return;
-    }
-
-    // All interceptors allowed. A verdict signature (screened deposit) is
-    // emitted inside an opaque additional_data envelope that the prover
-    // relays verbatim; otherwise allowed-only.
-    finishRequest("check_with_interceptors", {
-      rpcAction: "check_with_interceptors",
-      interceptorVerdict: "allow",
-      signed: interceptorVerdict.signature !== undefined,
-    });
-    const result = interceptorVerdict.signature
-      ? {
-          allowed: true,
-          additional_data: { signature: interceptorVerdict.signature },
-        }
-      : { allowed: true };
-    res.writeHead(200, { "content-type": "application/json" });
-    res.end(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        id: verdict.requestId,
-        result,
-      })
+    await withRequestId(requestId, () =>
+      handleRequest({ req, res, interceptors, maxBodyBytes })
     );
   };
+}
+
+interface RequestHandlerArgs {
+  req: IncomingMessage;
+  res: ServerResponse;
+  interceptors: TransactionInterceptor[];
+  maxBodyBytes: number;
+}
+
+async function handleRequest({
+  req,
+  res,
+  interceptors,
+  maxBodyBytes,
+}: RequestHandlerArgs): Promise<void> {
+  inFlightRequests.inc();
+  const startTime = Date.now();
+
+  function finishRequest(rpcAction: string, fields: object): void {
+    const latencyMs = Date.now() - startTime;
+    const durationSeconds = latencyMs / 1000;
+    inFlightRequests.dec();
+    requestDuration.observe({ action: rpcAction }, durationSeconds);
+    logger.info({
+      event: "request",
+      method: req.method,
+      url: req.url,
+      status: res.statusCode,
+      latencyMs,
+      ...fields,
+    });
+  }
+
+  const declaredLength = parseInt(req.headers["content-length"] ?? "", 10);
+  if (!Number.isNaN(declaredLength) && declaredLength > maxBodyBytes) {
+    errorsTotal.inc({ type: "payload_too_large" });
+    res.writeHead(413, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "payload too large" }));
+    req.destroy();
+    finishRequest("error", { error: "payload_too_large" });
+    return;
+  }
+
+  let body: Buffer;
+  try {
+    body = await readBody(req, maxBodyBytes);
+  } catch {
+    errorsTotal.inc({ type: "payload_too_large" });
+    res.writeHead(413, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "payload too large" }));
+    finishRequest("error", { error: "payload_too_large" });
+    return;
+  }
+
+  // Only accept JSON-RPC POST requests
+  if (req.method !== "POST" || !isJsonContent(req)) {
+    errorsTotal.inc({ type: "invalid_request" });
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "only JSON-RPC POST requests accepted" }));
+    finishRequest("error", { error: "invalid_request" });
+    return;
+  }
+
+  const verdict = validateRpcRequest(body.toString());
+
+  if (!verdict.ok) {
+    rpcRequestsTotal.inc({ action: "error", method: "" });
+    errorsTotal.inc({ type: verdict.errorType });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(verdict.response));
+    finishRequest("error", {
+      rpcAction: "error",
+      errorType: verdict.errorType,
+    });
+    return;
+  }
+
+  rpcRequestsTotal.inc({
+    action: "check_with_interceptors",
+    method: "starknet_checkTransaction",
+  });
+
+  const interceptorVerdict = await runInterceptors(
+    interceptors,
+    verdict.transaction
+  );
+
+  if (interceptorVerdict.action === "block") {
+    logger.warn({ event: "transaction_rejected" });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify(
+        jsonRpcError(
+          verdict.requestId,
+          TRANSACTION_REJECTED,
+          "Transaction rejected",
+          interceptorVerdict.reason
+        )
+      )
+    );
+    finishRequest("check_with_interceptors", {
+      rpcAction: "check_with_interceptors",
+      interceptorVerdict: "block",
+    });
+    return;
+  }
+
+  // All interceptors allowed. A verdict signature (screened deposit) is
+  // emitted inside an opaque additional_data envelope that the prover
+  // relays verbatim; otherwise allowed-only.
+  const result = interceptorVerdict.signature
+    ? {
+        allowed: true,
+        additional_data: { signature: interceptorVerdict.signature },
+      }
+    : { allowed: true };
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: verdict.requestId,
+      result,
+    })
+  );
+  finishRequest("check_with_interceptors", {
+    rpcAction: "check_with_interceptors",
+    interceptorVerdict: "allow",
+    signed: interceptorVerdict.signature !== undefined,
+  });
 }
 
 function readBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
@@ -195,4 +225,17 @@ function readBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
 function isJsonContent(req: IncomingMessage): boolean {
   const contentType = req.headers["content-type"] ?? "";
   return contentType.includes("application/json");
+}
+
+const MAX_REQUEST_ID_LEN = 128;
+// Printable ASCII excluding whitespace — same allow-list the prover uses.
+const REQUEST_ID_RE = /^[\x21-\x7e]+$/;
+
+function isSafeRequestId(value: string | undefined): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_REQUEST_ID_LEN &&
+    REQUEST_ID_RE.test(value)
+  );
 }

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -7,6 +7,7 @@ import type {
   TransactionInterceptor,
   Verdict,
 } from "./interceptor.js";
+import { logger } from "./logger.js";
 import type { ProveTxnV3 } from "./types.js";
 import {
   screeningResults,
@@ -141,13 +142,11 @@ export class ScreeningInterceptor implements TransactionInterceptor {
   async intercept(transaction: ProveTxnV3): Promise<Verdict> {
     if (!isSinglePoolCall(transaction, this.config.poolAddress)) {
       const action = this.config.blockNonPoolTx ? "block" : "allow";
-      console.log(
-        JSON.stringify({
-          screening: "non_pool_tx",
-          action,
-          blockNonPoolTx: this.config.blockNonPoolTx,
-        })
-      );
+      logger.info({
+        event: "screening_non_pool_tx",
+        action,
+        blockNonPoolTx: this.config.blockNonPoolTx,
+      });
       if (action === "block") {
         return {
           action: "block",
@@ -207,14 +206,12 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         const screeningLatencyMs = Date.now() - callStart;
         screeningResults.inc({ result });
         screeningDuration.observe({ result }, screeningLatencyMs / 1000);
-        console.log(
-          JSON.stringify({
-            screening: "complete",
-            result,
-            attempts: attempt + 1,
-            screeningLatencyMs,
-          })
-        );
+        logger.info({
+          event: "screening_complete",
+          result,
+          attempts: attempt + 1,
+          screeningLatencyMs,
+        });
         if (signResult.verdict === "allowed") {
           signaturesIssued.inc();
           return { result: "allowed", signature: signResult.signature };
@@ -225,13 +222,11 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       }
     }
 
-    console.error(
-      JSON.stringify({
-        error: "screening_failed",
-        message: lastError?.message,
-        attempts: finalAttempt + 1,
-      })
-    );
+    logger.error({
+      event: "screening_failed",
+      message: lastError?.message,
+      attempts: finalAttempt + 1,
+    });
 
     // Fail-closed: a deposit with no signature cannot proceed on-chain, so a
     // signing failure always blocks — failOpen does not apply to the sign path.

--- a/proof-interceptor/tests/logger.test.ts
+++ b/proof-interceptor/tests/logger.test.ts
@@ -1,0 +1,78 @@
+// tests/logger.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { logger, withRequestId } from "../src/logger.js";
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+function lastJson(
+  spy: ReturnType<typeof vi.spyOn>
+): Record<string, unknown> | undefined {
+  const call = spy.mock.calls[spy.mock.calls.length - 1];
+  if (!call) return undefined;
+  return JSON.parse(call[0] as string) as Record<string, unknown>;
+}
+
+describe("logger", () => {
+  it("omits request_id when called outside a request scope", () => {
+    logger.info({ event: "startup" });
+    const entry = lastJson(logSpy);
+    expect(entry).toEqual({ level: "info", event: "startup" });
+  });
+
+  it("auto-injects request_id when called inside withRequestId", async () => {
+    await withRequestId("abc-123", async () => {
+      logger.info({ event: "served" });
+    });
+    expect(lastJson(logSpy)).toEqual({
+      level: "info",
+      request_id: "abc-123",
+      event: "served",
+    });
+  });
+
+  it("propagates request_id across awaits and nested async calls", async () => {
+    await withRequestId("deep-1", async () => {
+      await Promise.resolve();
+      await (async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        logger.warn({ event: "inner" });
+      })();
+    });
+    expect(lastJson(logSpy)).toEqual({
+      level: "warn",
+      request_id: "deep-1",
+      event: "inner",
+    });
+  });
+
+  it("routes error level to console.error", () => {
+    logger.error({ event: "boom" });
+    expect(errorSpy).toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("isolates request_id between concurrent scopes", async () => {
+    const captured: Array<Record<string, unknown> | undefined> = [];
+    const work = (id: string) =>
+      withRequestId(id, async () => {
+        // Force interleaving
+        await new Promise((resolve) => setImmediate(resolve));
+        logger.info({ event: "tick", id });
+        captured.push(lastJson(logSpy));
+      });
+    await Promise.all([work("A"), work("B")]);
+    const requestIds = captured.map((entry) => entry?.request_id);
+    expect(requestIds.sort()).toEqual(["A", "B"]);
+  });
+});

--- a/proof-interceptor/tests/proxy.test.ts
+++ b/proof-interceptor/tests/proxy.test.ts
@@ -146,6 +146,93 @@ describe("handler", () => {
     expect(response.status).toBe(413);
     expect(await response.json()).toEqual({ error: "payload too large" });
   });
+
+  it("echoes x-request-id from the request when provided", async () => {
+    await startProxy();
+    const requestId = "client-supplied-id-123";
+
+    const response = await fetch(proxyUrl("/"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": requestId,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "unknown" }),
+    });
+    expect(response.headers.get("x-request-id")).toBe(requestId);
+  });
+
+  it("generates an x-request-id when none is supplied", async () => {
+    await startProxy();
+
+    const response = await fetch(proxyUrl("/"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "unknown" }),
+    });
+    const generated = response.headers.get("x-request-id");
+    expect(generated).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it("drops hostile x-request-id and generates a fresh one", async () => {
+    await startProxy();
+    // Whitespace and oversize values must be rejected — either would be
+    // unsafe to echo into a response header or to embed in a structured
+    // log field. CR/LF are already blocked by Node's HTTP parser before
+    // `req.headers` even sees them, so we don't need to test those here.
+    const hostile = ["with space", "tab\there", "a".repeat(2048)];
+    for (const value of hostile) {
+      const response = await fetch(proxyUrl("/"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": value,
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "unknown" }),
+      });
+      const echoed = response.headers.get("x-request-id") ?? "";
+      expect(echoed).not.toBe(value);
+      expect(echoed).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      );
+    }
+  });
+
+  it("includes status and request_id in the per-request log line", async () => {
+    await startProxy();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await fetch(proxyUrl("/"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "trace-XYZ",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "unknown" }),
+    });
+
+    const requestLog = logSpy.mock.calls
+      .map((call) => {
+        try {
+          return JSON.parse(call[0] as string) as Record<string, unknown>;
+        } catch {
+          return undefined;
+        }
+      })
+      .find((entry) => entry?.event === "request");
+    expect(requestLog).toBeDefined();
+    expect(requestLog).toMatchObject({
+      event: "request",
+      method: "POST",
+      url: "/",
+      status: 200,
+      request_id: "trace-XYZ",
+    });
+    expect(typeof requestLog!.latencyMs).toBe("number");
+    logSpy.mockRestore();
+  });
 });
 
 describe("handler with interceptors", () => {

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -453,7 +453,7 @@ describe("ScreeningInterceptor", () => {
 
     const logCall = logSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
-      return parsed.screening === "complete";
+      return parsed.event === "screening_complete";
     });
     expect(logCall).toBeDefined();
     const logData = JSON.parse(logCall![0] as string);
@@ -481,7 +481,7 @@ describe("ScreeningInterceptor", () => {
 
     const logCall = logSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
-      return parsed.screening === "complete";
+      return parsed.event === "screening_complete";
     });
     expect(logCall).toBeDefined();
     expect(JSON.parse(logCall![0] as string).result).toBe("blocked");
@@ -542,7 +542,7 @@ describe("ScreeningInterceptor", () => {
 
     const errorCall = errorSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
-      return parsed.error === "screening_failed";
+      return parsed.event === "screening_failed";
     });
     expect(errorCall).toBeDefined();
     expect(JSON.parse(errorCall![0] as string).attempts).toBe(1);
@@ -603,7 +603,7 @@ describe("ScreeningInterceptor", () => {
 
     const logCall = logSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
-      return parsed.screening === "complete";
+      return parsed.event === "screening_complete";
     });
     expect(logCall).toBeDefined();
     expect(JSON.parse(logCall![0] as string).attempts).toBe(3);
@@ -748,10 +748,10 @@ describe("ScreeningInterceptor", () => {
 
     const logEntry = findLogEntry(
       logSpy,
-      (entry) => entry.screening === "non_pool_tx"
+      (entry) => entry.event === "screening_non_pool_tx"
     );
-    expect(logEntry).toEqual({
-      screening: "non_pool_tx",
+    expect(logEntry).toMatchObject({
+      event: "screening_non_pool_tx",
       action: "allow",
       blockNonPoolTx: false,
     });
@@ -778,10 +778,10 @@ describe("ScreeningInterceptor", () => {
 
       const logEntry = findLogEntry(
         logSpy,
-        (entry) => entry.screening === "non_pool_tx"
+        (entry) => entry.event === "screening_non_pool_tx"
       );
-      expect(logEntry).toEqual({
-        screening: "non_pool_tx",
+      expect(logEntry).toMatchObject({
+        event: "screening_non_pool_tx",
         action: "block",
         blockNonPoolTx: true,
       });
@@ -810,7 +810,7 @@ describe("ScreeningInterceptor", () => {
 
       const logEntry = findLogEntry(
         logSpy,
-        (entry) => entry.screening === "non_pool_tx"
+        (entry) => entry.event === "screening_non_pool_tx"
       );
       expect(logEntry?.action).toBe("block");
       logSpy.mockRestore();
@@ -833,7 +833,7 @@ describe("ScreeningInterceptor", () => {
       // through the screening path instead.
       const nonPoolLog = findLogEntry(
         logSpy,
-        (entry) => entry.screening === "non_pool_tx"
+        (entry) => entry.event === "screening_non_pool_tx"
       );
       expect(nonPoolLog).toBeUndefined();
       logSpy.mockRestore();


### PR DESCRIPTION
Adds an HTTP middleware that emits one structured log line per request
with method, path, status, latency_ms, and a request_id. The id is
accepted from `x-request-id` (sanitized to a bounded printable subset)
or generated server-side. The id is echoed on the response so callers
can quote it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/763)
<!-- Reviewable:end -->
