### PR TITLE
feat(proof-interceptor): /health reflects upstream screening reachability

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -75,7 +75,7 @@ Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. O
 | Path       | Method | Description                                                                                                           |
 | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
 | `/`        | POST   | JSON-RPC entrypoint. Only `starknet_checkTransaction` is accepted; everything else returns `-32601 Method not found`. |
-| `/health`  | GET    | Liveness/readiness. Returns `200 {"status":"ok"}`.                                                                    |
+| `/health`  | GET    | Liveness/readiness. `200 {"status":"ok"}`, or `503` naming the unhealthy interceptors. See [Health checks](#health-checks). |
 | `/metrics` | GET    | Prometheus metrics.                                                                                                   |
 
 Every response carries an `x-request-id` header. An inbound `x-request-id` is reused when it
@@ -139,6 +139,29 @@ Prometheus counters/histograms exported on `/metrics` (defined in `src/metrics.t
 - `proof_interceptor_process_crashes_total{source}` — `uncaught_exception` / `unhandled_rejection`. Non-zero means the process died and was restarted.
 
 Plus default Node.js process metrics from `prom-client`.
+
+## Health checks
+
+`/health` asks every registered interceptor whether it is healthy. Interceptors that do not
+implement the optional `health()` are treated as healthy, so with no interceptors registered
+`/health` is still `200`. If any reports unhealthy the response is `503` with
+
+```json
+{ "status": "unhealthy", "interceptors": [{ "name": "screening", "reason": "screening_unreachable" }] }
+```
+
+The body carries only names and opaque reason codes — no timestamps, counts, or upstream URLs —
+because `/health` is unauthenticated.
+
+The screening interceptor reports unhealthy once the proxy has been continuously unreachable for
+`SCREENING_HEALTH_MAX_UNAVAILABLE_MS` (default 30000). It is always healthy when
+`SCREENING_FAIL_OPEN=true`, since fail-open means an unreachable proxy is tolerated by choice.
+
+**The window only advances on traffic.** It is opened by a failing screening call and cleared by
+a succeeding one; `/health` itself never probes the proxy. A load balancer that drains the pod on
+`503` therefore removes the very traffic that would clear the flag, so the pod stays unhealthy
+until something sends it another request. Pair the probe with a retry or a traffic source that
+survives draining.
 
 ## Logging
 

--- a/proof-interceptor/src/config.ts
+++ b/proof-interceptor/src/config.ts
@@ -43,6 +43,10 @@ export function loadConfig(): Config {
       totalTimeoutMs: parseIntEnv("SCREENING_TOTAL_TIMEOUT_MS", 10000),
       poolAddress: requiredEnv("SCREENING_POOL_ADDRESS"),
       blockNonPoolTx: process.env.SCREENING_BLOCK_NON_POOL_TX === "true",
+      healthMaxUnavailableMs: parseIntEnv(
+        "SCREENING_HEALTH_MAX_UNAVAILABLE_MS",
+        30000
+      ),
     };
   }
 

--- a/proof-interceptor/src/interceptor.ts
+++ b/proof-interceptor/src/interceptor.ts
@@ -22,9 +22,26 @@ export type Verdict =
   | { action: "allow"; signature?: ScreeningSignature }
   | { action: "block"; reason: string };
 
+/**
+ * Optional health snapshot exposed by an interceptor. Returned by the
+ * /health endpoint when any interceptor implements `health()`. The body
+ * intentionally contains no internal state (timestamps, error counts) —
+ * /health is a load-balancer probe, not a debug endpoint.
+ */
+export interface InterceptorHealth {
+  healthy: boolean;
+  /** Short, opaque code summarizing why the interceptor is unhealthy. */
+  reason?: string;
+}
+
 export interface TransactionInterceptor {
   name: string;
   intercept(transaction: ProveTxnV3): Promise<Verdict>;
+  /**
+   * Optional. When provided, /health calls it for each registered interceptor.
+   * /health returns 503 if any interceptor reports `healthy: false`.
+   */
+  health?(): InterceptorHealth;
 }
 
 /**

--- a/proof-interceptor/src/proxy.ts
+++ b/proof-interceptor/src/proxy.ts
@@ -28,6 +28,29 @@ export function createHandler(options: HandlerOptions = {}) {
 
   return async (req: IncomingMessage, res: ServerResponse) => {
     if (req.url === "/health" && req.method === "GET") {
+      // Probe each interceptor that opted in to health reporting. The body
+      // intentionally exposes only interceptor names + opaque reason codes —
+      // no internal state (timestamps, error counts) reaches the response.
+      const unhealthy = interceptors
+        .map((interceptor) => ({
+          name: interceptor.name,
+          health: interceptor.health?.() ?? { healthy: true },
+        }))
+        .filter((entry) => !entry.health.healthy);
+
+      if (unhealthy.length > 0) {
+        res.writeHead(503, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            status: "unhealthy",
+            interceptors: unhealthy.map((entry) => ({
+              name: entry.name,
+              reason: entry.health.reason,
+            })),
+          })
+        );
+        return;
+      }
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ status: "ok" }));
       return;

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -3,6 +3,7 @@ import { createHmac } from "node:crypto";
 import { CallData } from "starknet";
 import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import type {
+  InterceptorHealth,
   ScreeningSignature,
   TransactionInterceptor,
   Verdict,
@@ -55,6 +56,10 @@ export interface ScreeningConfig {
   // `poolAddress` are blocked outright. When false (default), such transactions
   // bypass screening and are allowed through.
   blockNonPoolTx: boolean;
+  // Maximum duration the upstream may stay unreachable before /health reports
+  // 503 (only when `failOpen` is false — when fail-open is on, an unreachable
+  // upstream is operationally tolerated, so health stays green).
+  healthMaxUnavailableMs: number;
 }
 
 const ACTIONS_TYPE =
@@ -160,7 +165,27 @@ type SignOutcome =
 export class ScreeningInterceptor implements TransactionInterceptor {
   readonly name = "screening";
 
+  // Reachability tracking for /health. `null` means the upstream is healthy
+  // (either no failures yet, or the most recent call succeeded). When a call
+  // fails and this field is null, it's set to `Date.now()`. The /health
+  // endpoint flips to 503 once the window exceeds `healthMaxUnavailableMs`.
+  // Only relevant when `failOpen` is false — see `health()`.
+  private consecutiveFailureStartAt: number | null = null;
+
   constructor(private readonly config: ScreeningConfig) {}
+
+  health(): InterceptorHealth {
+    // Fail-open means the operator has accepted that we ship transactions
+    // through even when screening is down, so unreachability does not make
+    // the *service* unhealthy.
+    if (this.config.failOpen) return { healthy: true };
+    if (this.consecutiveFailureStartAt === null) return { healthy: true };
+    const unavailableMs = Date.now() - this.consecutiveFailureStartAt;
+    if (unavailableMs > this.config.healthMaxUnavailableMs) {
+      return { healthy: false, reason: "screening_unreachable" };
+    }
+    return { healthy: true };
+  }
 
   async intercept(transaction: ProveTxnV3): Promise<Verdict> {
     if (!isSinglePoolCall(transaction, this.config.poolAddress)) {
@@ -230,6 +255,8 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         screeningResults.inc({ result });
         screeningDuration.observe({ result }, screeningLatencyMs / 1000);
         screeningAvailability.inc({ outcome: "success" });
+        // A successful call clears the unreachability window.
+        this.consecutiveFailureStartAt = null;
         logger.info({
           event: "screening_complete",
           result,
@@ -246,6 +273,10 @@ export class ScreeningInterceptor implements TransactionInterceptor {
         const outcome: ScreeningErrorCategory =
           error instanceof ScreeningError ? error.category : "network_error";
         screeningAvailability.inc({ outcome });
+        // Start (or extend) the unreachability window for /health.
+        if (this.consecutiveFailureStartAt === null) {
+          this.consecutiveFailureStartAt = Date.now();
+        }
       }
     }
 

--- a/proof-interceptor/tests/config.test.ts
+++ b/proof-interceptor/tests/config.test.ts
@@ -92,6 +92,7 @@ describe("loadConfig", () => {
       totalTimeoutMs: 10000,
       poolAddress: "0xpool",
       blockNonPoolTx: false,
+      healthMaxUnavailableMs: 30000,
     });
   });
 

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -112,6 +112,8 @@ async function startInterceptor(): Promise<void> {
     maxRetries: 0,
     totalTimeoutMs: 10000,
     poolAddress: "0xpool",
+    blockNonPoolTx: false,
+    healthMaxUnavailableMs: 30000,
   });
 
   const handler = createHandler({ interceptors: [interceptor] });

--- a/proof-interceptor/tests/health-reachability.test.ts
+++ b/proof-interceptor/tests/health-reachability.test.ts
@@ -1,0 +1,225 @@
+// tests/health-reachability.test.ts
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import { createHandler } from "../src/proxy.js";
+import {
+  ScreeningInterceptor,
+  type ScreeningConfig,
+} from "../src/screening-interceptor.js";
+
+const POOL_ADDR = "0xpool";
+const USER_ADDR = "0xaaa111";
+const PRIVATE_KEY = "0xbbb222";
+const TOKEN = "0xdead";
+const AMOUNT = "0x64";
+
+interface ProveTxn {
+  type: "INVOKE";
+  version: "0x3";
+  sender_address: string;
+  calldata: string[];
+  signature: string[];
+  nonce: string;
+  resource_bounds: Record<string, unknown>;
+  tip: string;
+  paymaster_data: string[];
+  account_deployment_data: string[];
+  nonce_data_availability_mode: string;
+  fee_data_availability_mode: string;
+}
+
+function sampleTransaction(): ProveTxn {
+  return {
+    type: "INVOKE",
+    version: "0x3",
+    sender_address: "0xcontract",
+    calldata: [
+      "0x1",
+      POOL_ADDR,
+      "0xselector",
+      "0x6",
+      USER_ADDR,
+      PRIVATE_KEY,
+      "0x1",
+      "0x5",
+      TOKEN,
+      AMOUNT,
+    ],
+    signature: ["0x1"],
+    nonce: "0x0",
+    resource_bounds: {},
+    tip: "0x0",
+    paymaster_data: [],
+    account_deployment_data: [],
+    nonce_data_availability_mode: "L1",
+    fee_data_availability_mode: "L1",
+  };
+}
+
+function makeConfig(overrides: Partial<ScreeningConfig> = {}): ScreeningConfig {
+  return {
+    ellipticProxyUrl: "http://127.0.0.1:1",
+    partnerName: "test-partner",
+    partnerSecret: Buffer.from("secret").toString("base64"),
+    timeoutMs: 200,
+    failOpen: false,
+    maxRetries: 0,
+    totalTimeoutMs: 500,
+    poolAddress: POOL_ADDR,
+    blockNonPoolTx: false,
+    healthMaxUnavailableMs: 50,
+    ...overrides,
+  };
+}
+
+let upstream: Server | undefined;
+let interceptorServer: Server | undefined;
+
+afterEach(async () => {
+  for (const s of [upstream, interceptorServer]) {
+    if (s) await new Promise<void>((resolve) => s.close(() => resolve()));
+  }
+  upstream = undefined;
+  interceptorServer = undefined;
+});
+
+function startServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse
+  ) => void
+): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve({ port, server });
+    });
+  });
+}
+
+describe("ScreeningInterceptor.health()", () => {
+  it("starts healthy when no calls have been made yet", () => {
+    const interceptor = new ScreeningInterceptor(makeConfig());
+    expect(interceptor.health()).toEqual({ healthy: true });
+  });
+
+  it("remains healthy when failOpen is true even after failures", async () => {
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({ failOpen: true, ellipticProxyUrl: "http://127.0.0.1:1" })
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await interceptor.intercept(sampleTransaction());
+    // wait past the unavailability window
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(interceptor.health()).toEqual({ healthy: true });
+    errSpy.mockRestore();
+  });
+
+  it("reports unhealthy when failures span the window and failOpen is false", async () => {
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({
+        failOpen: false,
+        ellipticProxyUrl: "http://127.0.0.1:1",
+        healthMaxUnavailableMs: 30,
+      })
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await interceptor.intercept(sampleTransaction());
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(interceptor.health()).toMatchObject({
+      healthy: false,
+      reason: "screening_unreachable",
+    });
+    errSpy.mockRestore();
+  });
+
+  it("returns to healthy after a successful screening call", async () => {
+    const { port } = await startServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ blocked: false }));
+      });
+    });
+    upstream = (await startServer(() => {})).server;
+    upstream.close();
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({
+        ellipticProxyUrl: `http://127.0.0.1:${port}`,
+        healthMaxUnavailableMs: 10,
+      })
+    );
+    await interceptor.intercept(sampleTransaction());
+    expect(interceptor.health()).toEqual({ healthy: true });
+  });
+});
+
+describe("/health endpoint reflects interceptor health", () => {
+  it("returns 503 with unhealthy interceptor name when screening is unreachable", async () => {
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({
+        failOpen: false,
+        ellipticProxyUrl: "http://127.0.0.1:1",
+        healthMaxUnavailableMs: 20,
+      })
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await interceptor.intercept(sampleTransaction());
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    errSpy.mockRestore();
+
+    const handler = createHandler({ interceptors: [interceptor] });
+    const { port, server } = await startServer(handler);
+    interceptorServer = server;
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as {
+      status: string;
+      interceptors: Array<{ name: string; reason?: string }>;
+    };
+    expect(body.status).toBe("unhealthy");
+    expect(body.interceptors).toEqual([
+      { name: "screening", reason: "screening_unreachable" },
+    ]);
+  });
+
+  it("returns 200 when no interceptors are registered", async () => {
+    const handler = createHandler({ interceptors: [] });
+    const { port, server } = await startServer(handler);
+    interceptorServer = server;
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "ok" });
+  });
+
+  it("/health body does not include internal timestamps or counters", async () => {
+    const interceptor = new ScreeningInterceptor(
+      makeConfig({
+        failOpen: false,
+        ellipticProxyUrl: "http://127.0.0.1:1",
+        healthMaxUnavailableMs: 20,
+      })
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await interceptor.intercept(sampleTransaction());
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    errSpy.mockRestore();
+
+    const handler = createHandler({ interceptors: [interceptor] });
+    const { port, server } = await startServer(handler);
+    interceptorServer = server;
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const raw = await response.text();
+    // No timestamps, no error counts, no upstream URL — only the opaque
+    // shape declared by InterceptorHealth.
+    expect(raw).not.toMatch(/consecutiveFailure/);
+    expect(raw).not.toMatch(/[0-9]{10}/); // millis-since-epoch timestamps
+    expect(raw).not.toContain("127.0.0.1");
+  });
+});

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -384,6 +384,7 @@ function makeConfig(overrides?: Partial<ScreeningConfig>): ScreeningConfig {
     totalTimeoutMs: 10000,
     poolAddress: POOL_ADDR,
     blockNonPoolTx: false,
+    healthMaxUnavailableMs: 30000,
     ...overrides,
   };
 }


### PR DESCRIPTION
The Slack ask called for /health to return 503 when the screening
service has been unreachable for N seconds in non-fail-open mode, so
load balancers can drain a sick pod. Implements that:

- New optional `health()` on `TransactionInterceptor`; the /health
  endpoint probes every registered interceptor.
- `ScreeningInterceptor` tracks `consecutiveFailureStartAt` — null while
  the upstream is reachable, set to `Date.now()` on the first failure
  after a success, cleared when a call succeeds again.
- `health()` returns `{healthy: true}` while `failOpen` is true (since
  the operator has accepted that we ship transactions through anyway).
  Otherwise reports `{healthy: false, reason: "screening_unreachable"}`
  once the window exceeds `healthMaxUnavailableMs` (env var
  `SCREENING_HEALTH_MAX_UNAVAILABLE_MS`, default 30s).
- /health response body intentionally contains only the interceptor
  name and an opaque reason code. Internal timestamps and counters do
  not reach the response — /health is a load-balancer probe, not a
  debug endpoint.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/766)
<!-- Reviewable:end -->
