### PR TITLE
feat(sdk): parse screening-v2 additional_data from prove response (O1a)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Screening v2: `ProveTransactionResult.additional_data` (typed, optional)
+  parsed from the prove response, carrying an optional `signature`
+  (`ScreeningSignature`). Backward-compatible: responses without it parse
+  unchanged; unknown fields are still rejected by the strict schema. Exported
+  `AdditionalData` / `ScreeningSignature` types.
+
 ## 0.14.2-RC.6
 
 ### Changed

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -7,6 +7,8 @@ export type {
   MessageToL1,
   ProvingServiceConfig,
   ProveTransactionResult,
+  AdditionalData,
+  ScreeningSignature,
 } from "./internal/proving-service.js";
 export type { BlockIdentifier } from "starknet";
 export { ProvingServiceProofProvider } from "./internal/proving-service-provider.js";

--- a/sdk/src/internal/proving-service.ts
+++ b/sdk/src/internal/proving-service.ts
@@ -56,12 +56,37 @@ export interface ProveTransactionResult {
   proof: string;
   proof_facts: string[];
   l2_to_l1_messages: MessageToL1[];
+  /**
+   * Optional typed side-channel the prover attaches alongside the proof.
+   * For screened deposits it carries the screening signature; absent for
+   * transactions that need no attestation. Forward-compatible: new capabilities
+   * add sibling keys without breaking existing consumers.
+   */
+  additional_data?: AdditionalData;
 }
 
 export interface MessageToL1 {
   from_address: string;
   to_address: string;
   payload: string[];
+}
+
+/**
+ * Screening attestation produced by the FPI cloud function and relayed by the
+ * proof interceptor / prover. The contract verifies it against the proven
+ * deposit's `from_addr`.
+ *
+ * Felts are 0x-hex strings on the wire; `issued_at` is unix seconds.
+ */
+export interface ScreeningSignature {
+  issued_at: number;
+  sig_r: string;
+  sig_s: string;
+}
+
+/** Typed `additional_data` side-channel on a prove response. */
+export interface AdditionalData {
+  signature?: ScreeningSignature;
 }
 
 const MessageToL1Schema = z
@@ -72,11 +97,26 @@ const MessageToL1Schema = z
   })
   .strict();
 
+const ScreeningSignatureSchema = z
+  .object({
+    issued_at: z.number(),
+    sig_r: z.string(),
+    sig_s: z.string(),
+  })
+  .strict();
+
+const AdditionalDataSchema = z
+  .object({
+    signature: ScreeningSignatureSchema.optional(),
+  })
+  .strict();
+
 const ProveTransactionResultSchema = z
   .object({
     proof: z.string().min(1),
     proof_facts: z.array(z.string()),
     l2_to_l1_messages: z.array(MessageToL1Schema),
+    additional_data: AdditionalDataSchema.optional(),
   })
   .strict();
 

--- a/sdk/tests/internal/screening.test.ts
+++ b/sdk/tests/internal/screening.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ProvingService } from "../../src/internal/proving-service.js";
+
+const PROVER_URL = "https://prover.test";
+
+const MINIMAL_INVOKE_TX = {
+  type: "INVOKE" as const,
+  sender_address: "0x1",
+  calldata: [] as string[],
+  version: "0x3" as const,
+  signature: [] as string[],
+  nonce: "0x0",
+  resource_bounds: {
+    l1_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+    l2_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+    l1_data_gas: { max_amount: "0x1", max_price_per_unit: "0x1" },
+  },
+  tip: "0x0",
+  paymaster_data: [] as string[],
+  account_deployment_data: [] as string[],
+  nonce_data_availability_mode: "L2" as const,
+  fee_data_availability_mode: "L2" as const,
+};
+
+const BASE_RESULT = {
+  proof: "YQ==",
+  proof_facts: [] as string[],
+  l2_to_l1_messages: [] as Array<{ from_address: string; to_address: string; payload: string[] }>,
+};
+
+function mockProveResponse(result: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify({ jsonrpc: "2.0", id: 1, result })),
+  } as Response;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("prove response additional_data parsing", () => {
+  it("parses additional_data.signature when present", async () => {
+    const signature = {
+      issued_at: 1716579600,
+      sig_r: "0x6e6f63c878a2fdebb3934de2344fbd4bc04ae47b73561f2a5a170cd0c8a0cb",
+      sig_s: "0x58a68a71ca79df6cc71d5b4b4813685f590ede2c686b9096fb350f11298429f",
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockProveResponse({ ...BASE_RESULT, additional_data: { signature } })
+    );
+
+    const service = new ProvingService({ baseUrl: PROVER_URL });
+    const result = await service.proveTransaction("latest", MINIMAL_INVOKE_TX);
+
+    expect(result.additional_data?.signature).toEqual(signature);
+  });
+
+  it("parses a response without additional_data (backward compatible)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(mockProveResponse(BASE_RESULT));
+
+    const service = new ProvingService({ baseUrl: PROVER_URL });
+    const result = await service.proveTransaction("latest", MINIMAL_INVOKE_TX);
+
+    expect(result.additional_data).toBeUndefined();
+    expect(result.proof).toBe("YQ==");
+  });
+
+  it("still rejects an unknown top-level field (strict schema preserved)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockProveResponse({ ...BASE_RESULT, surprise_field: "nope" })
+    );
+
+    const service = new ProvingService({ baseUrl: PROVER_URL });
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+
+  it("rejects an unknown field inside additional_data", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockProveResponse({ ...BASE_RESULT, additional_data: { unexpected: "x" } })
+    );
+
+    const service = new ProvingService({ baseUrl: PROVER_URL });
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+
+  it("rejects a signature missing a required felt field", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockProveResponse({
+        ...BASE_RESULT,
+        additional_data: { signature: { issued_at: 1, sig_r: "0x1" } },
+      })
+    );
+
+    const service = new ProvingService({ baseUrl: PROVER_URL });
+    await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
+      /invalid result/
+    );
+  });
+});


### PR DESCRIPTION
Adds optional ProveTransactionResult.additional_data (typed, strict-schema-safe) carrying an optional ScreeningSignature. Backward-compatible; unknown fields still rejected. Exports AdditionalData / ScreeningSignature.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/770)
<!-- Reviewable:end -->
