### PR TITLE
feat(sdk): typed screening errors + interceptor error mapper (O1b)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,6 +9,12 @@
   (`ScreeningSignature`). Backward-compatible: responses without it parse
   unchanged; unknown fields are still rejected by the strict schema. Exported
   `AdditionalData` / `ScreeningSignature` types.
+- Screening v2: `ScreeningRejected` (terminal — sanctioned address) and
+  `ScreeningUnavailable` (transient — screener unreachable) error classes, plus
+  `screeningErrorFromProvingError()` mapping the interceptor's opaque
+  `address_blocked` / `screening_unavailable` reasons (JSON-RPC code 10000).
+  Other code-10000 errors return `undefined` so the caller rethrows the
+  original rather than mislabeling a transient fault as terminal.
 
 ## 0.14.2-RC.6
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -10,6 +10,11 @@ export type {
   AdditionalData,
   ScreeningSignature,
 } from "./internal/proving-service.js";
+export {
+  ScreeningRejected,
+  ScreeningUnavailable,
+  screeningErrorFromProvingError,
+} from "./internal/errors.js";
 export type { BlockIdentifier } from "starknet";
 export { ProvingServiceProofProvider } from "./internal/proving-service-provider.js";
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";

--- a/sdk/src/internal/errors.ts
+++ b/sdk/src/internal/errors.ts
@@ -1,7 +1,67 @@
+import { ProvingServiceError } from "./proving-service.js";
+
 /** Error thrown when a block reorg is detected (HTTP 409 status). */
 export class ReorgError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ReorgError";
   }
+}
+
+/**
+ * The deposit's source address is on the sanctions list. Terminal — retrying
+ * with the same address will not succeed.
+ */
+export class ScreeningRejected extends Error {
+  override readonly name = "ScreeningRejected";
+  constructor(reason?: string) {
+    super(reason ? `Deposit screening rejected: ${reason}` : "Deposit screening rejected");
+  }
+}
+
+/**
+ * Screening could not be completed (FPI cloud function or upstream unreachable).
+ * Transient — the caller may retry later. Deposits fail closed: no signature
+ * means no deposit.
+ */
+export class ScreeningUnavailable extends Error {
+  override readonly name = "ScreeningUnavailable";
+  constructor(reason?: string) {
+    super(reason ? `Deposit screening unavailable: ${reason}` : "Deposit screening unavailable");
+  }
+}
+
+/**
+ * Opaque `data` reasons the proof interceptor emits on the screening checkpoint.
+ * These are the *only* values that denote a screening verdict — a wire
+ * contract with the proof interceptor; keep both sides in sync.
+ */
+const SCREENING_BLOCKED_REASON = "address_blocked";
+const SCREENING_UNAVAILABLE_REASON = "screening_unavailable";
+
+/**
+ * Map a {@link ProvingServiceError} to a typed screening error, or `undefined`
+ * if it is not a screening verdict so the caller can rethrow the original.
+ *
+ * Code 10000 ("Transaction rejected") is overloaded — the interceptor also
+ * emits it for non-pool blocks and for unexpected interceptor exceptions
+ * (whose `data` is the raw error message). We therefore switch on the *exact*
+ * opaque reasons above rather than treating every 10000 as terminal: a
+ * transient interceptor fault must not be reported as a permanent sanctions
+ * rejection the user is told never to retry.
+ */
+export function screeningErrorFromProvingError(
+  error: ProvingServiceError
+): ScreeningRejected | ScreeningUnavailable | undefined {
+  const TRANSACTION_REJECTED = 10000;
+  if (error.code !== TRANSACTION_REJECTED) {
+    return undefined;
+  }
+  if (error.data === SCREENING_UNAVAILABLE_REASON) {
+    return new ScreeningUnavailable(error.data);
+  }
+  if (error.data === SCREENING_BLOCKED_REASON) {
+    return new ScreeningRejected(error.data);
+  }
+  return undefined;
 }

--- a/sdk/tests/internal/screening.test.ts
+++ b/sdk/tests/internal/screening.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { ProvingService } from "../../src/internal/proving-service.js";
+import { ProvingService, ProvingServiceError } from "../../src/internal/proving-service.js";
+import {
+  ScreeningRejected,
+  ScreeningUnavailable,
+  screeningErrorFromProvingError,
+} from "../../src/internal/errors.js";
 
 const PROVER_URL = "https://prover.test";
 
@@ -99,5 +104,50 @@ describe("prove response additional_data parsing", () => {
     await expect(service.proveTransaction("latest", MINIMAL_INVOKE_TX)).rejects.toThrow(
       /invalid result/
     );
+  });
+});
+
+describe("screeningErrorFromProvingError", () => {
+  it("maps code 10000 + screening_unavailable to ScreeningUnavailable", () => {
+    const mapped = screeningErrorFromProvingError(
+      new ProvingServiceError(10000, "Transaction rejected", "screening_unavailable")
+    );
+    expect(mapped).toBeInstanceOf(ScreeningUnavailable);
+  });
+
+  it("maps code 10000 + address_blocked to ScreeningRejected", () => {
+    const mapped = screeningErrorFromProvingError(
+      new ProvingServiceError(10000, "Transaction rejected", "address_blocked")
+    );
+    expect(mapped).toBeInstanceOf(ScreeningRejected);
+  });
+
+  it("returns undefined for code 10000 with no data (not a screening verdict)", () => {
+    const mapped = screeningErrorFromProvingError(
+      new ProvingServiceError(10000, "Transaction rejected")
+    );
+    expect(mapped).toBeUndefined();
+  });
+
+  it("returns undefined for code 10000 from a non-screening block or interceptor fault", () => {
+    // The interceptor reuses 10000 for non-pool blocks and unexpected
+    // exceptions; those must NOT be misclassified as a terminal sanctions
+    // rejection, or the caller would never retry a transient fault.
+    for (const data of [
+      "transaction is not a direct call to the privacy pool",
+      "network timeout",
+    ]) {
+      const mapped = screeningErrorFromProvingError(
+        new ProvingServiceError(10000, "Transaction rejected", data)
+      );
+      expect(mapped).toBeUndefined();
+    }
+  });
+
+  it("returns undefined for a non-screening error code", () => {
+    const mapped = screeningErrorFromProvingError(
+      new ProvingServiceError(55, "Account validation failed")
+    );
+    expect(mapped).toBeUndefined();
   });
 });


### PR DESCRIPTION
ScreeningRejected (terminal) / ScreeningUnavailable (transient) + screeningErrorFromProvingError(). Maps only the interceptor's opaque address_blocked / screening_unavailable reasons; other code-10000s (non-pool blocks, interceptor faults) return undefined so the caller rethrows instead of misclassifying a transient fault as a terminal rejection.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/771)
<!-- Reviewable:end -->
