### PR TITLE
refactor(elliptic-proxy): hoist address validators to module scope (O2a)

### DIFF
--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -15,6 +15,10 @@ export interface ConfigSource {
   get(): Promise<Config>;
 }
 
+// StarkNet addresses: "0x" + up to 64 hex chars.
+const MAX_ADDRESS_LENGTH = 66;
+const HEX_FELT = /^0x[0-9a-fA-F]+$/;
+
 export type Forwarder = (request: {
   ellipticUrl: string;
   ellipticKey: string;
@@ -115,12 +119,7 @@ export function createHandler(
       return;
     }
 
-    // StarkNet addresses: "0x" + up to 64 hex chars
-    const MAX_ADDRESS_LENGTH = 66;
-    if (
-      address.length > MAX_ADDRESS_LENGTH ||
-      !/^0x[0-9a-fA-F]+$/.test(address)
-    ) {
+    if (address.length > MAX_ADDRESS_LENGTH || !HEX_FELT.test(address)) {
       sendResponse(400, JSON.stringify({ error: "invalid address format" }), {
         partner: partnerName,
       });


### PR DESCRIPTION
Pure refactor, no behavior change: MAX_ADDRESS_LENGTH and the hex-felt regex move to module scope so a second route (POST /sign) can reuse them. Isolated as prep so the /sign change shows only new logic.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/772)
<!-- Reviewable:end -->
