### PR TITLE
feat(elliptic-proxy): screening-v2 signer module (O2b)

### DIFF
--- a/elliptic-proxy/package-lock.json
+++ b/elliptic-proxy/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-cloud/functions-framework": "^5.0.2",
         "@google-cloud/secret-manager": "^5.6.0",
+        "@scure/starknet": "^1.1.2",
         "lru-cache": "^11.2.7"
       },
       "devDependencies": {
@@ -760,6 +761,33 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1139,6 +1167,19 @@
         "win32"
       ]
     },
+    "node_modules/@scure/starknet": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-1.1.2.tgz",
+      "integrity": "sha512-Qo2uNQJC/1IwfXC0f2BnDjtXnY1cVyfmK1WcGNFzfnktvlNmmmbjYeUNdYe3DBiDYyMzp1MhRUFllFW5moBaMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1327,6 +1368,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1685,6 +1727,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2159,7 +2202,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2340,6 +2382,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3407,37 +3450,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
@@ -3450,7 +3462,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3471,7 +3482,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3492,7 +3502,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3513,7 +3522,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3534,7 +3542,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3555,7 +3562,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3576,7 +3582,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3597,7 +3602,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3618,7 +3622,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3639,7 +3642,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3660,7 +3662,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4031,6 +4032,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4917,6 +4919,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5028,6 +5031,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/elliptic-proxy/package.json
+++ b/elliptic-proxy/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@google-cloud/functions-framework": "^5.0.2",
     "@google-cloud/secret-manager": "^5.6.0",
+    "@scure/starknet": "^1.1.2",
     "lru-cache": "^11.2.7"
   },
   "devDependencies": {

--- a/elliptic-proxy/scripts/local-sign.mjs
+++ b/elliptic-proxy/scripts/local-sign.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Produce a screening attestation locally with the proxy's own signer.
+// Reuses signScreening + computeScreeningMessageHash from dist/ so the digest
+// and signature stay byte-identical to what the deployed /screen route emits —
+// useful for debugging against the on-chain verifier or the canonical
+// cross-language vectors (fixtures/screening-vectors.json at the repo root).
+//
+// Usage:
+//   node scripts/local-sign.mjs <private-key> <chain-id> <depositor> [issued-at]
+//
+// issued-at defaults to now (unix seconds). The key is test/ops material —
+// the production key never leaves the cloud function.
+//
+// Build first: `npm run build` (imports from dist/).
+
+import { getStarkKey } from "@scure/starknet";
+import { computeScreeningMessageHash, signScreening } from "../dist/signing.js";
+
+const [, , privateKey, chainIdArg, depositorArg, issuedAtArg] = process.argv;
+if (!privateKey || !chainIdArg || !depositorArg) {
+  console.error(
+    "usage: local-sign.mjs <private-key> <chain-id> <depositor> [issued-at]"
+  );
+  process.exit(2);
+}
+
+const chainId = BigInt(chainIdArg);
+const depositor = BigInt(depositorArg);
+const issuedAt = issuedAtArg
+  ? Number(issuedAtArg)
+  : Math.floor(Date.now() / 1000);
+
+const signerPublicKey = BigInt(getStarkKey(privateKey));
+const messageHash = computeScreeningMessageHash(
+  chainId,
+  depositor,
+  BigInt(issuedAt),
+  signerPublicKey
+);
+const signature = signScreening(privateKey, chainId, depositor, issuedAt);
+
+console.log(
+  JSON.stringify(
+    {
+      signer_public_key: "0x" + signerPublicKey.toString(16),
+      message_hash: "0x" + messageHash.toString(16),
+      ...signature,
+    },
+    null,
+    2
+  )
+);

--- a/elliptic-proxy/src/signing.ts
+++ b/elliptic-proxy/src/signing.ts
@@ -1,0 +1,122 @@
+// src/signing.ts
+//
+// Screening attestation signer. Produces a STARK-curve ECDSA signature over a
+// SNIP-12 (revision 1) typed-data message binding a deposit's source address,
+// which the privacy-pool contract verifies on-chain
+// (packages/privacy/src/snip12.cairo, verify_depositor_validation). The message
+// hash and signature stay byte-compatible with the canonical cross-language
+// vectors in fixtures/screening-vectors.json (regenerate with
+// scripts/gen_screening_fixtures.py, which signs with the reference signer
+// in scripts/address_validation_signer/py).
+//
+// SNIP-12 revision-1 message hash:
+//   poseidon_hash_span([
+//     shortstring("StarkNet Message"),
+//     domain_hash,           // poseidon(DOMAIN_TYPE_HASH, name, version, chain_id, 1)
+//     signer_public_key,     // SNIP-12 "account" slot (OZ get_message_hash(signer))
+//     message_struct_hash,   // poseidon(DEPOSITOR_VALIDATION_TYPE_HASH, depositor, issued_at)
+//   ])
+// poseidonHashMany (@scure/starknet) is poseidon_hash_span; the type hashes are
+// the starknet_keccak of the SNIP-12 encodeType strings, pinned as constants
+// below and reproduced by the reference vectors.
+
+import { poseidonHashMany, sign, getStarkKey } from "@scure/starknet";
+
+/** A Cairo short string is its ASCII bytes read big-endian as a felt (<= 31 chars). */
+function shortStringToFelt(text: string): bigint {
+  return BigInt("0x" + Buffer.from(text, "ascii").toString("hex"));
+}
+
+const STARKNET_MESSAGE = shortStringToFelt("StarkNet Message");
+// The two type hashes below are pinned felts, deliberately not derived at
+// runtime from their encodeType strings: the deployed Cairo verifier bakes the
+// same values in at compile time (selector!), so they are frozen by the
+// contract. Deriving them here would let an accidental edit to an encodeType
+// string silently shift the digest into something self-consistent off-chain
+// but rejected on-chain. The unit tests re-derive both from the documented
+// strings and assert equality, so provenance stays checked without putting the
+// derivation in the signing path.
+//
+// starknet_keccak("StarknetDomain"("name":"shortstring","version":"shortstring",
+// "chainId":"shortstring","revision":"shortstring")) — the canonical SNIP-12
+// revision-1 domain type hash (also hardcoded in OZ's Cairo snip12 utilities).
+export const STARKNET_DOMAIN_TYPE_HASH =
+  0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210n;
+// starknet_keccak('"DepositorValidation"("depositor":"ContractAddress","issued_at":"u128")')
+export const DEPOSITOR_VALIDATION_TYPE_HASH =
+  0x32d43b7372c9ea8a35daf12b02c5f6f74837910ecbaf2a3ecfe71fec901913dn;
+const DOMAIN_NAME = shortStringToFelt("Screening");
+// Numeric felt (not the shortstring '2' = 0x32), matching the starknet.js /
+// starknet-py domain-version convention the on-chain verifier follows.
+const DOMAIN_VERSION = 2n;
+const DOMAIN_REVISION = 1n; // SNIP-12 revision 1, encoded as the integer 1
+
+/** Wire shape returned to the caller and packed into apply_actions calldata. */
+export interface ScreeningSignature {
+  issued_at: number;
+  sig_r: string;
+  sig_s: string;
+}
+
+/**
+ * Recompute the SNIP-12 message hash the contract will verify. `chainId` and
+ * `depositor` are field elements (the contract derives chain_id from
+ * get_tx_info and `depositor` from the proven TransferFrom action), and
+ * `signerPublicKey` is the trusted signer's x-only stark key, which fills the
+ * SNIP-12 account slot and is the key check_ecdsa_signature verifies against.
+ */
+export function computeScreeningMessageHash(
+  chainId: bigint,
+  depositor: bigint,
+  issuedAt: bigint,
+  signerPublicKey: bigint
+): bigint {
+  const domainHash = poseidonHashMany([
+    STARKNET_DOMAIN_TYPE_HASH,
+    DOMAIN_NAME,
+    DOMAIN_VERSION,
+    chainId,
+    DOMAIN_REVISION,
+  ]);
+  const messageStructHash = poseidonHashMany([
+    DEPOSITOR_VALIDATION_TYPE_HASH,
+    depositor,
+    issuedAt,
+  ]);
+  return poseidonHashMany([
+    STARKNET_MESSAGE,
+    domainHash,
+    signerPublicKey,
+    messageStructHash,
+  ]);
+}
+
+/**
+ * Sign a screening attestation. `issuedAt` is unix seconds. The signer's public
+ * key (derived from `privateKey`) fills the SNIP-12 account slot, so a signature
+ * is bound to the exact key that will verify it on-chain.
+ *
+ * Throws if the message hash is >= 2**251 (the STARK ECDSA message bound) — a
+ * negligibly rare Poseidon output that the contract would also reject. Callers
+ * treat a throw as a transient signing failure (fail closed).
+ */
+export function signScreening(
+  privateKey: string,
+  chainId: bigint,
+  depositor: bigint,
+  issuedAt: number
+): ScreeningSignature {
+  const signerPublicKey = BigInt(getStarkKey(privateKey));
+  const messageHash = computeScreeningMessageHash(
+    chainId,
+    depositor,
+    BigInt(issuedAt),
+    signerPublicKey
+  );
+  const signature = sign("0x" + messageHash.toString(16), privateKey);
+  return {
+    issued_at: issuedAt,
+    sig_r: "0x" + signature.r.toString(16),
+    sig_s: "0x" + signature.s.toString(16),
+  };
+}

--- a/elliptic-proxy/tests/signing.test.ts
+++ b/elliptic-proxy/tests/signing.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { keccak } from "@scure/starknet";
+import {
+  computeScreeningMessageHash,
+  signScreening,
+  DEPOSITOR_VALIDATION_TYPE_HASH,
+  STARKNET_DOMAIN_TYPE_HASH,
+} from "../src/signing.js";
+
+// The committed reference vectors are the cross-language contract: the signer
+// here, the reference Python signer that produced them, and the on-chain Cairo
+// verifier must all reproduce them exactly. Single producer: regenerate with
+// `scripts/gen_screening_fixtures.py` (signs with
+// `scripts/address_validation_signer/py/validation_signer.py`; plain RFC 6979,
+// so its (r, s) is bit-identical to the @scure/starknet signature here).
+const fixturePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "fixtures",
+  "screening-vectors.json"
+);
+
+interface Vector {
+  name: string;
+  chain_id: string;
+  depositor: string;
+  issued_at: number;
+  message_hash: string;
+  sig_r: string;
+  sig_s: string;
+}
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as {
+  signer_private_key: string;
+  signer_public_key: string;
+  vectors: Vector[];
+};
+
+const signerPublicKey = BigInt(fixture.signer_public_key);
+
+// The signer pins both type hashes as felts (the deployed verifier freezes
+// them at compile time). Re-derive each from its SNIP-12 encodeType string so
+// the pinned constants keep an executable provenance.
+describe("pinned type hashes derive from their encodeType strings", () => {
+  const snKeccak = (text: string) => keccak(new TextEncoder().encode(text));
+
+  it("STARKNET_DOMAIN_TYPE_HASH is sn_keccak of the StarknetDomain type", () => {
+    expect(
+      snKeccak(
+        '"StarknetDomain"("name":"shortstring","version":"shortstring","chainId":"shortstring","revision":"shortstring")'
+      )
+    ).toBe(STARKNET_DOMAIN_TYPE_HASH);
+  });
+
+  it("DEPOSITOR_VALIDATION_TYPE_HASH is sn_keccak of the DepositorValidation type", () => {
+    expect(
+      snKeccak(
+        '"DepositorValidation"("depositor":"ContractAddress","issued_at":"u128")'
+      )
+    ).toBe(DEPOSITOR_VALIDATION_TYPE_HASH);
+  });
+});
+
+describe("screening signer reproduces the reference vectors", () => {
+  it("has vectors to check", () => {
+    expect(fixture.vectors.length).toBeGreaterThan(0);
+  });
+
+  for (const vector of fixture.vectors) {
+    it(`message hash matches for ${vector.name}`, () => {
+      const messageHash = computeScreeningMessageHash(
+        BigInt(vector.chain_id),
+        BigInt(vector.depositor),
+        BigInt(vector.issued_at),
+        signerPublicKey
+      );
+      expect("0x" + messageHash.toString(16)).toBe(vector.message_hash);
+    });
+
+    it(`signature matches for ${vector.name}`, () => {
+      const signature = signScreening(
+        fixture.signer_private_key,
+        BigInt(vector.chain_id),
+        BigInt(vector.depositor),
+        vector.issued_at
+      );
+      expect(signature).toEqual({
+        issued_at: vector.issued_at,
+        sig_r: vector.sig_r,
+        sig_s: vector.sig_s,
+      });
+    });
+  }
+
+  it("a different depositor yields a different message hash (binding)", () => {
+    const base = fixture.vectors[0];
+    const hashA = computeScreeningMessageHash(
+      BigInt(base.chain_id),
+      BigInt(base.depositor),
+      BigInt(base.issued_at),
+      signerPublicKey
+    );
+    const hashB = computeScreeningMessageHash(
+      BigInt(base.chain_id),
+      BigInt(base.depositor) + 1n,
+      BigInt(base.issued_at),
+      signerPublicKey
+    );
+    expect(hashA).not.toBe(hashB);
+  });
+});


### PR DESCRIPTION
signing.ts: domain-tagged Poseidon digest (poseidon_hash_span-compatible, matching the pool's hashes.cairo) + STARK-curve ECDSA. Unit-tested against the F1 golden vectors.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/773)
<!-- Reviewable:end -->
