### PR TITLE
feat(proof-interceptor): relay screening signature through the verdict (O3a)

### DIFF
--- a/proof-interceptor/src/interceptor.ts
+++ b/proof-interceptor/src/interceptor.ts
@@ -6,7 +6,19 @@ import {
   errorsTotal,
 } from "./metrics.js";
 
-export type Verdict = { action: "allow" } | { action: "block"; reason: string };
+/**
+ * Screening attestation relayed on an allowed deposit. Snake_case mirrors the
+ * wire shape it is relayed through unchanged.
+ */
+export interface ScreeningSignature {
+  issued_at: number;
+  sig_r: string;
+  sig_s: string;
+}
+
+export type Verdict =
+  | { action: "allow"; signature?: ScreeningSignature }
+  | { action: "block"; reason: string };
 
 export interface TransactionInterceptor {
   name: string;
@@ -57,9 +69,15 @@ export async function runInterceptors(
     return new Promise<Verdict>(() => {});
   });
 
-  const allAllow = Promise.all(promises).then(
-    (): Verdict => ({ action: "allow" })
-  );
+  // When every interceptor allows, preserve any signature one of them
+  // attached. All verdicts here are allows — a block would have won the race
+  // below before this resolves.
+  const allAllow = Promise.all(promises).then((verdicts): Verdict => {
+    const signed = verdicts.find(
+      (verdict) => verdict.action === "allow" && verdict.signature !== undefined
+    );
+    return signed ?? { action: "allow" };
+  });
 
   return Promise.race([...blockPromises, allAllow]);
 }

--- a/proof-interceptor/src/proxy.ts
+++ b/proof-interceptor/src/proxy.ts
@@ -129,17 +129,26 @@ export function createHandler(options: HandlerOptions = {}) {
       return;
     }
 
-    // All interceptors allowed the transaction
+    // All interceptors allowed. A verdict signature (screened deposit) is
+    // emitted inside an opaque additional_data envelope that the prover
+    // relays verbatim; otherwise allowed-only.
     finishRequest("check_with_interceptors", {
       rpcAction: "check_with_interceptors",
       interceptorVerdict: "allow",
+      signed: interceptorVerdict.signature !== undefined,
     });
+    const result = interceptorVerdict.signature
+      ? {
+          allowed: true,
+          additional_data: { signature: interceptorVerdict.signature },
+        }
+      : { allowed: true };
     res.writeHead(200, { "content-type": "application/json" });
     res.end(
       JSON.stringify({
         jsonrpc: "2.0",
         id: verdict.requestId,
-        result: { allowed: true },
+        result,
       })
     );
   };

--- a/proof-interceptor/tests/proxy.test.ts
+++ b/proof-interceptor/tests/proxy.test.ts
@@ -162,6 +162,27 @@ describe("handler with interceptors", () => {
     expect(body.result).toEqual({ allowed: true });
   });
 
+  it("relays the screening signature inside additional_data on the allow response when present", async () => {
+    const signature = {
+      issued_at: 1716579600,
+      sig_r: "0x6e6f63c8",
+      sig_s: "0x58a68a71",
+    };
+    const allowSigned: TransactionInterceptor = {
+      name: "test",
+      intercept: async () => ({ action: "allow", signature }),
+    };
+    await startProxy({ interceptors: [allowSigned] });
+
+    const response = await rpcPost(proxyUrl("/"), checkRequest());
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result).toEqual({
+      allowed: true,
+      additional_data: { signature },
+    });
+  });
+
   it("returns 10000 when interceptor blocks", async () => {
     const blocker: TransactionInterceptor = {
       name: "test",


### PR DESCRIPTION
Verdict allow can carry an optional ScreeningSignature; runInterceptors preserves it through the all-allow collapse and the proxy relays it on the starknet_checkTransaction allow-response. Provable with a fake interceptor; no screening change yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/775)
<!-- Reviewable:end -->
