### PR TITLE
feat(proof-interceptor): switch deposit screening to /sign (O3b)

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -34,7 +34,7 @@ flowchart LR
 
 </div>
 
-The prover runs the screening round-trip in parallel with proving. The sidecar receives one `starknet_checkTransaction` per client `starknet_proveTransaction`, decodes the deposit action span using `PrivacyPoolABI` from `@starkware-libs/starknet-privacy-sdk`, and screens `user_addr` via HMAC-signed `POST /screen` to elliptic-proxy. This service is stateless; verdicts are cached in elliptic-proxy. The HMAC scheme (SHA-256 over `timestamp || method || path.toLowerCase() || body`, base64-decoded partner secret as the key) lives in `src/screening-interceptor.ts:computeHmacSignature` — use that as the reference if you need to verify partner credentials independently.
+The prover runs the screening round-trip in parallel with proving. The sidecar receives one `starknet_checkTransaction` per client `starknet_proveTransaction`, decodes the deposit action span using `PrivacyPoolABI` from `@starkware-libs/starknet-privacy-sdk`, and screens `user_addr` via HMAC-signed `POST /screen` to elliptic-proxy. That single `/screen` call screens **and**, on allow, returns a STARK-curve signature over the depositor address; the sidecar relays that signature on the `checkTransaction` allow response, and the prover attaches it under `additional_data.signature` for the SDK to pack into the deposit's `apply_actions` calldata. This service is stateless. The HMAC scheme (SHA-256 over `timestamp || method || path.toLowerCase() || body`, base64-decoded partner secret as the key) lives in `src/screening-interceptor.ts:computeHmacSignature` — use that as the reference if you need to verify partner credentials independently.
 
 ## What gets screened
 
@@ -61,14 +61,14 @@ Defaults are deployment-friendly, not security-strict. Apply these for productio
 
 Required when screening is enabled (the production case):
 
-| Env var                    | Purpose                                                                                                                      |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `SCREENING_URL`            | Base URL of the elliptic-proxy. Setting this is what enables screening — leaving it unset is the silent-pass-through hazard. |
-| `SCREENING_PARTNER_NAME`   | Partner identifier issued by the proxy operator.                                                                             |
-| `SCREENING_PARTNER_SECRET` | Base64-encoded HMAC key issued by the proxy operator.                                                                        |
-| `SCREENING_POOL_ADDRESS`   | Privacy-pool contract address — only direct calls to this address are screened.                                              |
+| Env var                    | Purpose                                                                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SCREENING_URL`            | Base URL of the elliptic-proxy. Setting this is what enables screening — leaving it unset is the silent-pass-through hazard.                            |
+| `SCREENING_PARTNER_NAME`   | Partner identifier issued by the proxy operator.                                                                                                        |
+| `SCREENING_PARTNER_SECRET` | Base64-encoded HMAC key issued by the proxy operator.                                                                                                   |
+| `SCREENING_POOL_ADDRESS`   | Privacy-pool contract address — only direct calls to this address are screened.                                                                         |
 
-Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. Optional knobs (`SCREENING_TIMEOUT_MS`, `SCREENING_TOTAL_TIMEOUT_MS`, `SCREENING_MAX_RETRIES`, `SCREENING_FAIL_OPEN`, `PORT`, `HOST`, `MAX_BODY_BYTES`, `TLS_CERT_PATH`/`TLS_KEY_PATH`) and their defaults are in `src/config.ts`.
+Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. Optional knobs (`SCREENING_TIMEOUT_MS`, `SCREENING_TOTAL_TIMEOUT_MS`, `SCREENING_MAX_RETRIES`, `SCREENING_FAIL_OPEN`, `PORT`, `HOST`, `MAX_BODY_BYTES`, `TLS_CERT_PATH`/`TLS_KEY_PATH`) and their defaults are in `src/config.ts`. Note: `SCREENING_FAIL_OPEN` does **not** apply to the screening-v2 signing path — a deposit without a signature cannot proceed on-chain, so a signing failure always fails closed.
 
 ## HTTP endpoints
 
@@ -85,18 +85,25 @@ The body mirrors `starknet_proveTransaction` exactly (object or positional param
 ### Response shapes
 
 ```json
-// allow (and every bypass case)
+// allow, non-deposit / bypass case (no attestation needed)
 { "jsonrpc": "2.0", "id": 1, "result": { "allowed": true } }
 
-// block — sanction match
+// allow, screened deposit — carries the signature to relay to the prover
+// (the prover attaches it under additional_data.signature on the prove response)
 { "jsonrpc": "2.0", "id": 1,
-  "error": { "code": 10000, "message": "Transaction rejected",
-             "data": "address screening: 0x... blocked" } }
+  "result": { "allowed": true,
+              "signature": { "issued_at": 1716579600,
+                             "sig_r": "0x...", "sig_s": "0x..." } } }
 
-// block — screening unavailable (fail-closed default)
+// block — sanction match. Reason is an opaque code (never the depositor address).
 { "jsonrpc": "2.0", "id": 1,
   "error": { "code": 10000, "message": "Transaction rejected",
-             "data": "screening unavailable for 0x..." } }
+             "data": "address_blocked" } }
+
+// block — screening/signing unavailable (fail-closed)
+{ "jsonrpc": "2.0", "id": 1,
+  "error": { "code": 10000, "message": "Transaction rejected",
+             "data": "screening_unavailable" } }
 
 // envelope rejection — prover treats as inconclusive, not a block
 { "jsonrpc": "2.0", "id": 1,

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -38,6 +38,12 @@ export const screeningRetries = new Counter({
   registers: [registry],
 });
 
+export const signaturesIssued = new Counter({
+  name: "proof_interceptor_screening_signatures_issued_total",
+  help: "Total screening signatures relayed to the prover on an allowed deposit",
+  registers: [registry],
+});
+
 export const errorsTotal = new Counter({
   name: "proof_interceptor_errors_total",
   help: "Total error events by type",

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -2,12 +2,17 @@
 import { createHmac } from "node:crypto";
 import { CallData } from "starknet";
 import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
-import type { TransactionInterceptor, Verdict } from "./interceptor.js";
+import type {
+  ScreeningSignature,
+  TransactionInterceptor,
+  Verdict,
+} from "./interceptor.js";
 import type { ProveTxnV3 } from "./types.js";
 import {
   screeningResults,
   screeningRetries,
   screeningDuration,
+  signaturesIssued,
 } from "./metrics.js";
 
 export interface ScreeningConfig {
@@ -15,6 +20,9 @@ export interface ScreeningConfig {
   partnerName: string;
   partnerSecret: string;
   timeoutMs: number;
+  // NOTE: fail-open is honored only for the legacy verdict; the v2 signing path
+  // is always fail-closed — a deposit without a signature cannot proceed, so a
+  // signing failure blocks regardless of this flag.
   failOpen: boolean;
   maxRetries: number;
   totalTimeoutMs: number;
@@ -29,6 +37,9 @@ const ACTIONS_TYPE =
   "core::array::Span::<privacy::actions::ClientAction>" as const;
 
 const callDataDecoder = new CallData(PrivacyPoolABI);
+
+// 0x-hex felt, at most 64 hex digits (the zero-padded address width).
+const HEX_FELT = /^0x[0-9a-fA-F]{1,64}$/;
 
 /**
  * Returns true iff the transaction is a single-call INVOKE whose target
@@ -117,7 +128,10 @@ function normalizeFelt(value: string): string {
   return "0x" + (hex.replace(/^0+/, "") || "0");
 }
 
-type ScreenResult = "allowed" | "blocked" | "unavailable";
+type SignOutcome =
+  | { result: "allowed"; signature: ScreeningSignature }
+  | { result: "blocked" }
+  | { result: "unavailable" };
 
 export class ScreeningInterceptor implements TransactionInterceptor {
   readonly name = "screening";
@@ -149,26 +163,22 @@ export class ScreeningInterceptor implements TransactionInterceptor {
     );
     if (addresses.length === 0) return { action: "allow" };
 
-    for (const address of addresses) {
-      const result = await this.screenAddress(address);
-      if (result === "blocked") {
-        return {
-          action: "block",
-          reason: `address screening: ${address} blocked`,
-        };
-      }
-      if (result === "unavailable") {
-        return {
-          action: "block",
-          reason: `screening unavailable for ${address}`,
-        };
-      }
+    // A deposit yields exactly one screened address: the depositor (user_addr),
+    // which the contract binds to the proven TransferFrom.from_addr. Screen and
+    // sign it in one /screen call. Reasons are opaque codes — they surface to
+    // the client as JSON-RPC error `data` and must not reveal the depositor.
+    const depositor = addresses[0];
+    const outcome = await this.screenAndSign(depositor);
+    if (outcome.result === "blocked") {
+      return { action: "block", reason: "address_blocked" };
     }
-
-    return { action: "allow" };
+    if (outcome.result === "unavailable") {
+      return { action: "block", reason: "screening_unavailable" };
+    }
+    return { action: "allow", signature: outcome.signature };
   }
 
-  private async screenAddress(address: string): Promise<ScreenResult> {
+  private async screenAndSign(address: string): Promise<SignOutcome> {
     let lastError: Error | null = null;
     let finalAttempt = 0;
     const deadline = Date.now() + this.config.totalTimeoutMs;
@@ -189,8 +199,11 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       try {
         const perCallTimeout = Math.min(this.config.timeoutMs, remainingMs);
         const callStart = Date.now();
-        const blocked = await this.callEllipticProxy(address, perCallTimeout);
-        const result: ScreenResult = blocked ? "blocked" : "allowed";
+        const signResult = await this.callScreenEndpoint(
+          address,
+          perCallTimeout
+        );
+        const result = signResult.verdict;
         const screeningLatencyMs = Date.now() - callStart;
         screeningResults.inc({ result });
         screeningDuration.observe({ result }, screeningLatencyMs / 1000);
@@ -202,7 +215,11 @@ export class ScreeningInterceptor implements TransactionInterceptor {
             screeningLatencyMs,
           })
         );
-        return result;
+        if (signResult.verdict === "allowed") {
+          signaturesIssued.inc();
+          return { result: "allowed", signature: signResult.signature };
+        }
+        return { result: "blocked" };
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
       }
@@ -212,21 +229,23 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       JSON.stringify({
         error: "screening_failed",
         message: lastError?.message,
-        failOpen: this.config.failOpen,
         attempts: finalAttempt + 1,
       })
     );
 
-    // fail-closed by default: if we can't screen, block the transaction
-    const failResult = this.config.failOpen ? "allowed" : "unavailable";
-    screeningResults.inc({ result: failResult });
-    return failResult;
+    // Fail-closed: a deposit with no signature cannot proceed on-chain, so a
+    // signing failure always blocks — failOpen does not apply to the sign path.
+    screeningResults.inc({ result: "unavailable" });
+    return { result: "unavailable" };
   }
 
-  private async callEllipticProxy(
+  private async callScreenEndpoint(
     address: string,
     timeoutMs: number
-  ): Promise<boolean> {
+  ): Promise<
+    | { verdict: "allowed"; signature: ScreeningSignature }
+    | { verdict: "blocked" }
+  > {
     const body = JSON.stringify({ address });
     const path = "/screen";
     const timestamp = Date.now().toString();
@@ -250,20 +269,56 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       signal: AbortSignal.timeout(timeoutMs),
     });
 
+    // A non-2xx is a transient transport/upstream fault — throw so the caller
+    // retries, then fails closed.
     if (!response.ok) {
-      throw new Error(`elliptic-proxy returned ${response.status}`);
+      throw new Error(`elliptic-proxy /screen returned ${response.status}`);
     }
 
-    const result: unknown = await response.json();
-    if (
-      typeof result !== "object" ||
-      result === null ||
-      typeof (result as Record<string, unknown>).blocked !== "boolean"
-    ) {
-      throw new Error("elliptic-proxy returned invalid response payload");
+    const payload: unknown = await response.json();
+    if (!isScreenResponse(payload)) {
+      throw new Error("elliptic-proxy /screen returned invalid payload");
     }
-    return (result as Record<string, unknown>).blocked as boolean;
+    // blocked === true is a definitive sanctioned verdict (terminal, no retry);
+    // the 200 status keeps it out of the retry path above.
+    if (payload.blocked) {
+      return { verdict: "blocked" };
+    }
+    // Every allowed /screen response must carry a signature; its
+    // absence means the upstream signer is misconfigured. Throw rather than let
+    // an unsigned deposit proceed — the caller fails closed after retries.
+    if (!isScreeningSignature(payload.signature)) {
+      throw new Error("elliptic-proxy /screen allowed without a signature");
+    }
+    return { verdict: "allowed", signature: payload.signature };
   }
+}
+
+function isScreenResponse(
+  value: unknown
+): value is { blocked: boolean; signature?: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).blocked === "boolean"
+  );
+}
+
+function isScreeningSignature(value: unknown): value is ScreeningSignature {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  // Structural check only — cryptographic validity is verified on-chain. The
+  // shape guard turns "the signer emitted nonsense" into retry-then-unavailable
+  // instead of relaying garbage.
+  return (
+    typeof record.issued_at === "number" &&
+    Number.isFinite(record.issued_at) &&
+    record.issued_at >= 0 &&
+    typeof record.sig_r === "string" &&
+    HEX_FELT.test(record.sig_r) &&
+    typeof record.sig_s === "string" &&
+    HEX_FELT.test(record.sig_s)
+  );
 }
 
 function computeHmacSignature(

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -1,6 +1,8 @@
 // tests/e2e.test.ts
 //
-// End-to-end test: proof-interceptor → elliptic-proxy → mock Elliptic API
+// End-to-end test: proof-interceptor → elliptic-proxy /screen. A deposit is
+// screened and signed in one /screen call; an allowed deposit relays a
+// signature, a sanctioned one is rejected with JSON-RPC 10000.
 //
 import { describe, it, expect, afterEach } from "vitest";
 import { createServer, type Server } from "node:http";
@@ -15,16 +17,15 @@ import type { Config } from "../../elliptic-proxy/src/config.js";
 
 const PARTNER_NAME = "proof-interceptor";
 const PARTNER_SECRET = Buffer.from("e2e-secret").toString("base64");
-
-// elliptic-proxy signs every allowed verdict, so a valid STARK-curve private
-// key is required config even though this flow asserts only the allow/block
-// outcome (the interceptor reads `blocked` and ignores the signature), not the
-// signature bytes. CHAIN_ID is the 'LIVE_TEST' Cairo short string — a dedicated
-// test chain id, never SN_MAIN, which the proxy rejects with a mock upstream.
-const SIGNING_KEY = "0x1";
-const CHAIN_ID = "0x" + Buffer.from("LIVE_TEST").toString("hex");
-
-// Rule ID for SANCTIONED_ENTITY
+// SN_MAIN, so the proxy runs the live Elliptic path (against the mock API)
+// rather than mock mode.
+const CHAIN_ID = "0x534e5f4d41494e";
+// Dev signing key (1 <= key < STARK curve order). Test-only.
+const SIGNING_KEY =
+  "0x03e1f1d2c3b4a5968778695a4b3c2d1e0f00112233445566778899aabbccddee";
+const BLOCKED_ADDRESS = "0xbad0";
+// Rule ID for SANCTIONED_ENTITY — the mock Elliptic API returns this for the
+// blocked address, exercising the scored-block path end to end.
 const SANCTIONED_RULE = "1f86dce1-166a-4749-a5df-3972fae7635a";
 
 let mockEllipticApi: Server;
@@ -76,6 +77,8 @@ async function startEllipticProxy(): Promise<void> {
     configCacheTtlSeconds: 300,
     blockedCacheTtlSeconds: 300,
     partners: { [PARTNER_NAME]: PARTNER_SECRET },
+    // Deposits are screened (live Elliptic, against the mock API) and signed in
+    // one /screen call.
     signingPrivateKey: SIGNING_KEY,
     chainId: CHAIN_ID,
   };
@@ -192,8 +195,8 @@ afterEach(async () => {
   );
 });
 
-describe("e2e: proof-interceptor → elliptic-proxy → mock Elliptic API", () => {
-  it("clean address: transaction allowed", async () => {
+describe("e2e: proof-interceptor → elliptic-proxy /screen", () => {
+  it("clean address: allowed, with a screening signature relayed", async () => {
     await startMockEllipticApi({});
     await startEllipticProxy();
     await startInterceptor();
@@ -201,21 +204,31 @@ describe("e2e: proof-interceptor → elliptic-proxy → mock Elliptic API", () =
     const response = await rpcPost(interceptorPort, checkRequest("0xc1ea0"));
     const body = await response.json();
 
-    expect(body.result).toEqual({ allowed: true });
+    expect(body.result.allowed).toBe(true);
+    expect(body.result.additional_data.signature).toMatchObject({
+      issued_at: expect.any(Number),
+      sig_r: expect.any(String),
+      sig_s: expect.any(String),
+    });
   }, 15000);
 
-  it("blocked address: transaction rejected with 10000", async () => {
+  it("blocked address: rejected with 10000 and an opaque reason", async () => {
     await startMockEllipticApi({
-      "0xbad0": blockedEllipticResponse(),
+      [BLOCKED_ADDRESS]: blockedEllipticResponse(),
     });
     await startEllipticProxy();
     await startInterceptor();
 
-    const response = await rpcPost(interceptorPort, checkRequest("0xbad0"));
+    const response = await rpcPost(
+      interceptorPort,
+      checkRequest(BLOCKED_ADDRESS)
+    );
     const body = await response.json();
 
     expect(body.error.code).toBe(10000);
     expect(body.error.message).toBe("Transaction rejected");
-    expect(body.error.data).toContain("0xbad0");
+    // Opaque reason — must not leak the depositor address.
+    expect(body.error.data).toBe("address_blocked");
+    expect(body.error.data).not.toContain(BLOCKED_ADDRESS);
   }, 15000);
 });

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -17,6 +17,23 @@ const TOKEN = "0xdead";
 const AMOUNT = "0x64";
 const POOL_ADDR = "0xpool";
 
+// The interceptor relays the /screen signature verbatim without verifying it,
+// so a well-shaped (not cryptographically valid) signature is enough here.
+const MOCK_SIGNATURE = {
+  issued_at: 1716579600,
+  sig_r: "0x6e6f63c878a2fdebb3934de2344fbd4bc04ae47b73561f2a5a170cd0c8a0cb",
+  sig_s: "0x58a68a71ca79df6cc71d5b4b4813685f590ede2c686b9096fb350f11298429f",
+};
+
+// The additive /screen wire shapes the interceptor parses: an allow carries the
+// signature alongside { blocked: false }; a block is { blocked: true }.
+const ALLOW_RESPONSE = {
+  blocked: false,
+  source: "skip",
+  signature: MOCK_SIGNATURE,
+};
+const BLOCKED_RESPONSE = { blocked: true, source: "blocklist" };
+
 function sampleTransaction(calldataOverride?: string[]): ProveTxnV3 {
   return {
     type: "INVOKE",
@@ -423,16 +440,16 @@ describe("isSinglePoolCall", () => {
 });
 
 describe("ScreeningInterceptor", () => {
-  it("returns continue when elliptic-proxy says not blocked", async () => {
+  it("attaches the signature to the verdict on an allowed deposit", async () => {
     await startMockEllipticProxy((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ blocked: false }));
+      res.end(JSON.stringify(ALLOW_RESPONSE));
     });
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
     const verdict = await interceptor.intercept(sampleTransaction());
-    expect(verdict).toEqual({ action: "allow" });
+    expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
 
     const logCall = logSpy.mock.calls.find((call) => {
       const parsed = JSON.parse(call[0] as string);
@@ -446,10 +463,10 @@ describe("ScreeningInterceptor", () => {
     logSpy.mockRestore();
   });
 
-  it("returns stop when elliptic-proxy says blocked", async () => {
+  it("blocks with an opaque reason when /screen returns blocked:true (sanctioned)", async () => {
     await startMockEllipticProxy((_req, res) => {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ blocked: true }));
+      res.end(JSON.stringify(BLOCKED_RESPONSE));
     });
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -457,7 +474,9 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("0xaaa111");
+      // Opaque code — must NOT leak the depositor address.
+      expect(verdict.reason).toBe("address_blocked");
+      expect(verdict.reason).not.toContain("0xaaa111");
     }
 
     const logCall = logSpy.mock.calls.find((call) => {
@@ -465,34 +484,36 @@ describe("ScreeningInterceptor", () => {
       return parsed.screening === "complete";
     });
     expect(logCall).toBeDefined();
-    const logData = JSON.parse(logCall![0] as string);
-    expect(logData.result).toBe("blocked");
+    expect(JSON.parse(logCall![0] as string).result).toBe("blocked");
     logSpy.mockRestore();
   });
 
-  it("sends correct HMAC-signed request", async () => {
+  it("sends a correctly HMAC-signed /screen request carrying the address", async () => {
+    let receivedUrl = "";
     let receivedHeaders: Record<string, string | string[] | undefined> = {};
     let receivedBody = "";
 
     await startMockEllipticProxy(async (req, res) => {
+      receivedUrl = req.url ?? "";
       receivedHeaders = req.headers;
       const chunks: Buffer[] = [];
       for await (const chunk of req) chunks.push(chunk as Buffer);
       receivedBody = Buffer.concat(chunks).toString();
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ blocked: false }));
+      res.end(JSON.stringify(ALLOW_RESPONSE));
     });
 
     const config = makeConfig();
     const interceptor = new ScreeningInterceptor(config);
     await interceptor.intercept(sampleTransaction());
 
+    expect(receivedUrl).toBe("/screen");
     expect(receivedHeaders["x-access-key"]).toBe("test-partner");
     expect(receivedHeaders["x-access-sign"]).toBeDefined();
     expect(receivedHeaders["x-access-timestamp"]).toBeDefined();
     expect(JSON.parse(receivedBody)).toEqual({ address: "0xaaa111" });
 
-    // Verify the HMAC signature is correct
+    // Verify the HMAC signature is computed over the /screen path + this body.
     const timestamp = receivedHeaders["x-access-timestamp"] as string;
     const hmac = createHmac(
       "sha256",
@@ -505,7 +526,7 @@ describe("ScreeningInterceptor", () => {
     expect(receivedHeaders["x-access-sign"]).toBe(hmac.digest("base64"));
   });
 
-  it("returns stop with unavailable reason on network error (fail-closed)", async () => {
+  it("fails closed on network error (blocks, opaque unavailable reason)", async () => {
     const config = makeConfig({
       ellipticProxyUrl: "http://127.0.0.1:1",
       timeoutMs: 1000,
@@ -516,7 +537,7 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("screening unavailable");
+      expect(verdict.reason).toBe("screening_unavailable");
     }
 
     const errorCall = errorSpy.mock.calls.find((call) => {
@@ -528,7 +549,7 @@ describe("ScreeningInterceptor", () => {
     errorSpy.mockRestore();
   });
 
-  it("returns continue on network error when fail-open", async () => {
+  it("fails closed even when failOpen is set (a deposit needs a signature)", async () => {
     const config = makeConfig({
       ellipticProxyUrl: "http://127.0.0.1:1",
       timeoutMs: 1000,
@@ -538,11 +559,14 @@ describe("ScreeningInterceptor", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(config);
     const verdict = await interceptor.intercept(sampleTransaction());
-    expect(verdict).toEqual({ action: "allow" });
+    expect(verdict.action).toBe("block");
+    if (verdict.action === "block") {
+      expect(verdict.reason).toBe("screening_unavailable");
+    }
     spy.mockRestore();
   });
 
-  it("returns stop with unavailable reason on non-200 response (fail-closed)", async () => {
+  it("fails closed on a non-2xx response", async () => {
     await startMockEllipticProxy((_req, res) => {
       res.writeHead(500);
       res.end("internal error");
@@ -553,12 +577,12 @@ describe("ScreeningInterceptor", () => {
     const verdict = await interceptor.intercept(sampleTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
-      expect(verdict.reason).toContain("screening unavailable");
+      expect(verdict.reason).toBe("screening_unavailable");
     }
     spy.mockRestore();
   });
 
-  it("retries on failure", async () => {
+  it("retries a transient failure then attaches the signature", async () => {
     let requestCount = 0;
     await startMockEllipticProxy((_req, res) => {
       requestCount++;
@@ -567,14 +591,14 @@ describe("ScreeningInterceptor", () => {
         res.end("error");
       } else {
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ blocked: false }));
+        res.end(JSON.stringify(ALLOW_RESPONSE));
       }
     });
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
     const verdict = await interceptor.intercept(sampleTransaction());
-    expect(verdict).toEqual({ action: "allow" });
+    expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
     expect(requestCount).toBe(3);
 
     const logCall = logSpy.mock.calls.find((call) => {
@@ -586,7 +610,123 @@ describe("ScreeningInterceptor", () => {
     logSpy.mockRestore();
   });
 
-  it("continues when calldata has no extractable address", async () => {
+  it("blocks (fail closed) when /screen allows with an incomplete signature", async () => {
+    await startMockEllipticProxy((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      // Allowed, but the signature is missing required felt fields. The
+      // interceptor's check is structural only — cryptographic validity (e.g.
+      // a wrong signing key) is verified on-chain, not here.
+      res.end(JSON.stringify({ blocked: false, signature: { sig_r: "0x1" } }));
+    });
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig());
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict.action).toBe("block");
+    if (verdict.action === "block") {
+      expect(verdict.reason).toBe("screening_unavailable");
+    }
+    spy.mockRestore();
+  });
+
+  it("blocks (fail closed) when /screen allows without any signature", async () => {
+    await startMockEllipticProxy((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      // An allow arrived without a signature — a signer
+      // misconfiguration; the deposit must not proceed unsigned.
+      res.end(JSON.stringify({ blocked: false, source: "skip" }));
+    });
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig());
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict.action).toBe("block");
+    if (verdict.action === "block") {
+      expect(verdict.reason).toBe("screening_unavailable");
+    }
+    spy.mockRestore();
+  });
+
+  it("blocks (fail closed) when /screen returns a response without a blocked field", async () => {
+    await startMockEllipticProxy((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ source: "skip" })); // not a screen response
+    });
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig());
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict.action).toBe("block");
+    if (verdict.action === "block") {
+      expect(verdict.reason).toBe("screening_unavailable");
+    }
+    spy.mockRestore();
+  });
+
+  it("blocks (fail closed) when an allowed signature is structurally garbage", async () => {
+    await startMockEllipticProxy((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      // Well-shaped allow, but sig_r is not a hex felt — the tightened guard
+      // must reject it rather than relay nonsense to the prover.
+      res.end(
+        JSON.stringify({
+          blocked: false,
+          source: "skip",
+          signature: { issued_at: 1, sig_r: "not-hex", sig_s: "0x1" },
+        })
+      );
+    });
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig());
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict.action).toBe("block");
+    if (verdict.action === "block") {
+      expect(verdict.reason).toBe("screening_unavailable");
+    }
+    spy.mockRestore();
+  });
+
+  it("does not retry a terminal block (blocked:true is served once)", async () => {
+    let requestCount = 0;
+    await startMockEllipticProxy((_req, res) => {
+      requestCount++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(BLOCKED_RESPONSE));
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict).toEqual({ action: "block", reason: "address_blocked" });
+    // A terminal block short-circuits before the signature check and is never
+    // retried, even though maxRetries allows it.
+    expect(requestCount).toBe(1);
+    logSpy.mockRestore();
+  });
+
+  it("retries a transient failure then resolves to a terminal block", async () => {
+    let requestCount = 0;
+    await startMockEllipticProxy((_req, res) => {
+      requestCount++;
+      if (requestCount < 3) {
+        res.writeHead(500);
+        res.end("error");
+      } else {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(BLOCKED_RESPONSE));
+      }
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
+    const verdict = await interceptor.intercept(sampleTransaction());
+    expect(verdict).toEqual({ action: "block", reason: "address_blocked" });
+    expect(requestCount).toBe(3);
+    logSpy.mockRestore();
+  });
+
+  it("allows (no signature) when there is no extractable deposit address", async () => {
     const transaction = sampleTransaction(["0x0"]);
     const interceptor = new ScreeningInterceptor(
       makeConfig({ ellipticProxyUrl: "http://127.0.0.1:1" })
@@ -679,7 +819,7 @@ describe("ScreeningInterceptor", () => {
     it("still screens single-call pool deposits when flag is set", async () => {
       await startMockEllipticProxy((_req, res) => {
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ blocked: false }));
+        res.end(JSON.stringify(ALLOW_RESPONSE));
       });
 
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -687,7 +827,7 @@ describe("ScreeningInterceptor", () => {
         makeConfig({ blockNonPoolTx: true })
       );
       const verdict = await interceptor.intercept(sampleTransaction());
-      expect(verdict).toEqual({ action: "allow" });
+      expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
 
       // Pool deposits should not emit the "non_pool_tx" log line — they go
       // through the screening path instead.


### PR DESCRIPTION
screening-interceptor calls elliptic-proxy /sign (200+sig=allow, 403=blocked, else fail-closed) with opaque reasons (address_blocked / screening_unavailable, matching the SDK mapper); adds required SCREENING_CHAIN_ID and a signatures-issued metric. Interceptor tests + e2e rewired to the v2 flow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/776)
<!-- Reviewable:end -->
