### PR TITLE
fix(elliptic-proxy): return 504 when Elliptic is unreachable

### DIFF
--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -120,7 +120,7 @@ The proxy:
 | Rate limit exceeded                    | `429 Too Many Requests`   |
 | Body exceeds `maxBodyBytes`            | `413 Payload Too Large`   |
 | Config unavailable from Secret Manager | `503 Service Unavailable` |
-| Elliptic network error                 | `503 Service Unavailable` |
+| Elliptic network error / timeout       | `504 Gateway Timeout`     |
 | Elliptic 404 (subject not on chain)    | `200 { blocked: false }`  |
 | Elliptic other non-2xx response        | `502 Upstream Error`      |
 

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -215,7 +215,8 @@ export function createHandler(
           ...details,
         })
       );
-      sendResponse(503, JSON.stringify({ error: "service unavailable" }), {
+      // The proxy itself is healthy; the path to Elliptic is not.
+      sendResponse(504, JSON.stringify({ error: "upstream unreachable" }), {
         partner: partnerName,
         result: "error",
         errorType: "network",

--- a/elliptic-proxy/tests/handler.test.ts
+++ b/elliptic-proxy/tests/handler.test.ts
@@ -347,7 +347,7 @@ describe("createHandler", () => {
     logSpy.mockRestore();
   });
 
-  it("returns 503 when forward throws a network error", async () => {
+  it("returns 504 when forward throws a network error", async () => {
     const configLoader = { get: vi.fn().mockResolvedValue(makeConfig()) };
 
     mockForward.mockRejectedValue(new Error("fetch failed"));
@@ -358,8 +358,28 @@ describe("createHandler", () => {
     const res = makeResponse();
     await handler(req, res);
 
+    // Elliptic unreachable is the upstream's fault domain: 504, distinct from
+    // the 503 a config-load failure returns.
+    expect(res.statusCode).toBe(504);
+    expect(JSON.parse(res.body)).toEqual({ error: "upstream unreachable" });
+    spy.mockRestore();
+  });
+
+  it("returns 503 when the config cannot be loaded", async () => {
+    const configLoader = {
+      get: vi.fn().mockRejectedValue(new Error("secret manager down")),
+    };
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = createHandler(configLoader, mockForward);
+    const res = makeResponse();
+    await handler(makeRequest(), res);
+
+    // A config-load failure is the proxy's own fault domain: 503, distinct
+    // from the 504 returned when only the path to Elliptic is down.
     expect(res.statusCode).toBe(503);
     expect(JSON.parse(res.body)).toEqual({ error: "service unavailable" });
+    expect(mockForward).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 


### PR DESCRIPTION
Transport-level failures on the upstream Elliptic call (DNS/TCP/TLS/timeout)
now return 504 'upstream unreachable' instead of sharing 503 with config-load
failures. Status codes alone carry the fault domain — 4xx caller, 503 proxy
config, 502 Elliptic responded unusably, 504 Elliptic unreachable — so
status-based monitoring can separate 'our service is broken' from 'Elliptic is
down' without log parsing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/782)
<!-- Reviewable:end -->
