### PR TITLE
ci: verify README contract class hashes match compiled contracts

### DIFF
--- a/.github/workflows/check-class-hashes.yaml
+++ b/.github/workflows/check-class-hashes.yaml
@@ -1,0 +1,44 @@
+name: Check Class Hashes
+
+# Fails if the contract class hashes documented in the README compatibility
+# matrix drift from what the pinned Scarb toolchain compiles the contracts to.
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'README.md'
+      - 'scripts/check_class_hashes.sh'
+      - '.github/workflows/check-class-hashes.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'README.md'
+      - 'scripts/check_class_hashes.sh'
+      - '.github/workflows/check-class-hashes.yaml'
+
+jobs:
+  check-class-hashes:
+    name: Check README class hashes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.17.0"
+
+      - name: Install starkli
+        run: |
+          curl https://get.starkli.sh | sh
+          "$HOME/.starkli/bin/starkliup"
+          echo "$HOME/.starkli/bin" >> "$GITHUB_PATH"
+
+      - name: Build contracts (release)
+        env:
+          # TODO: remove once openzeppelin upgrades to Cairo >=2.17
+          SCARB_IGNORE_CAIRO_VERSION: "true"
+        run: scarb --profile release build -p privacy -p ekubo_swap_anonymizer -p vesu_lending_anonymizer
+
+      - name: Verify README class hashes match compiled contracts
+        run: ./scripts/check_class_hashes.sh

--- a/scripts/check_class_hashes.sh
+++ b/scripts/check_class_hashes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verify the contract class hashes documented in README.md match the hashes
+# produced by compiling the contracts with the pinned Scarb toolchain
+# (.tool-versions). A class hash is deterministic from the Sierra class, so it
+# changes whenever the Cairo source OR the compiler version changes.
+#
+# Prerequisite: `scarb --profile release build -p privacy \
+#   -p ekubo_swap_anonymizer -p vesu_lending_anonymizer` has been run, and
+# `starkli` is on PATH.
+#
+# Exits non-zero if any documented hash is missing or stale.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+README="README.md"
+ARTIFACT_DIR="target/release"
+
+# README compatibility-matrix label  ->  compiled Sierra artifact basename
+declare -A ARTIFACTS=(
+  ["Privacy Pool"]="privacy_Privacy"
+  ["Ekubo Anonymizer"]="ekubo_swap_anonymizer_EkuboSwapAnonymizer"
+  ["Vesu Anonymizer"]="vesu_lending_anonymizer_VesuLendingAnonymizer"
+)
+
+# Normalize a hex string for numeric comparison (256-bit values overflow shell
+# arithmetic): drop 0x, lowercase, strip leading zeros.
+norm() {
+  local h="${1#0x}"
+  h="$(printf '%s' "$h" | tr 'A-F' 'a-f' | sed 's/^0*//')"
+  printf '%s' "${h:-0}"
+}
+
+fail=0
+for label in "${!ARTIFACTS[@]}"; do
+  artifact="$ARTIFACT_DIR/${ARTIFACTS[$label]}.contract_class.json"
+  if [[ ! -f "$artifact" ]]; then
+    echo "ERROR: missing artifact '$artifact' — run 'scarb --profile release build' first." >&2
+    fail=1; continue
+  fi
+  computed="$(starkli class-hash "$artifact")"
+  documented="$(grep -E "\| *${label} " "$README" | grep -oE '0x[0-9a-fA-F]{50,}' | tail -1 || true)"
+  if [[ -z "$documented" ]]; then
+    echo "ERROR: no class hash documented for '$label' in $README." >&2
+    fail=1; continue
+  fi
+  if [[ "$(norm "$computed")" == "$(norm "$documented")" ]]; then
+    echo "OK    $label -> $documented"
+  else
+    echo "DRIFT $label:" >&2
+    echo "        README:   $documented" >&2
+    echo "        compiled: $computed" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo >&2
+  echo "Contract class hashes in $README are out of date — update them to the compiled values above." >&2
+  exit 1
+fi
+echo "All contract class hashes in $README are up to date."


### PR DESCRIPTION
Adds a CI check so the **Contracts** compatibility-matrix class hashes in `README.md` can't silently go stale (the RC.5→RC.6 drift caught in #781).

**What it does** — on PRs touching `packages/**` or `README.md`:
1. builds the contracts with the pinned `scarb 2.17.0` (`--profile release`, matching the declared artifacts),
2. computes each Sierra class hash with `starkli class-hash`,
3. asserts it matches the hash documented in the README (numeric compare — 256-bit values, leading-zero-insensitive),
4. fails with a clear diff on drift.

`scripts/check_class_hashes.sh` maps the 3 README rows → compiled artifacts (`privacy_Privacy`, `ekubo_swap_anonymizer_EkuboSwapAnonymizer`, `vesu_lending_anonymizer_VesuLendingAnonymizer`). Offline & deterministic.

Verified locally against current `main`: all 3 hashes ✅ match; a tampered hash correctly fails the check.

Note: the check is only sound when the on-chain DECLARE uses the same `scarb 2.17.0` — the workflow pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/783)
<!-- Reviewable:end -->
