### PR TITLE
feat(discovery-core): add auditor-side viewing key recovery

### DIFF
--- a/crates/discovery-core/src/privacy_pool/hashes.rs
+++ b/crates/discovery-core/src/privacy_pool/hashes.rs
@@ -51,6 +51,10 @@ static OUTGOING_CHANNEL_ID_TAG: LazyLock<Felt> =
 static ENC_RECIPIENT_ADDR_TAG: LazyLock<Felt> =
     LazyLock::new(|| short_string_to_felt("ENC_RECIPIENT_ADDR_TAG:V1"));
 
+/// Domain separation tag for the auditor-encrypted private key.
+static ENC_PRIVATE_KEY_TAG: LazyLock<Felt> =
+    LazyLock::new(|| short_string_to_felt("ENC_PRIVATE_KEY_TAG:V1"));
+
 /// Converts a short string (up to 31 ASCII chars) to Felt.
 fn short_string_to_felt(s: &str) -> Felt {
     assert!(
@@ -74,6 +78,12 @@ pub fn compute_enc_channel_key_hash(shared_x: Felt) -> Felt {
 /// Computes the encryption mask for sender address.
 pub fn compute_enc_sender_addr_hash(shared_x: Felt) -> Felt {
     hash(&[*ENC_SENDER_ADDR_TAG, shared_x])
+}
+
+/// Computes the encryption mask for the auditor-encrypted private key.
+/// Mirrors Cairo `compute_enc_private_key_hash`: `h(ENC_PRIVATE_KEY_TAG, shared_x)`.
+pub fn compute_enc_private_key_hash(shared_x: Felt) -> Felt {
+    hash(&[*ENC_PRIVATE_KEY_TAG, shared_x])
 }
 
 /// Computes the subchannel key from channel key and index.
@@ -243,6 +253,10 @@ mod tests {
         assert_eq!(
             compute_enc_sender_addr_hash(f.inputs.shared_x),
             f.outputs.enc_sender_addr_hash
+        );
+        assert_eq!(
+            compute_enc_private_key_hash(f.inputs.shared_x),
+            f.outputs.enc_private_key_hash
         );
     }
 

--- a/crates/discovery-core/src/privacy_pool/keys.rs
+++ b/crates/discovery-core/src/privacy_pool/keys.rs
@@ -1,0 +1,111 @@
+//! Auditor-side key recovery for the privacy pool.
+//!
+//! The auditor holds a private key whose public key is registered on-chain as
+//! `auditor_public_key`. Each user's `SetViewingKey` action stores their private
+//! key encrypted to that auditor key (`EncPrivateKey`), so the auditor can recover
+//! every user's viewing key. This module is the inverse of the Cairo
+//! `encrypt_private_key` / `derive_public_key`, validated against the Cairo
+//! reference vectors.
+
+use starknet_types_core::{curve::AffinePoint, felt::Felt};
+
+use super::decryption::DecryptionError;
+use super::hashes::compute_enc_private_key_hash;
+use super::types::{EncPrivateKey, SecretFelt};
+
+/// Derives the public key (Stark-curve x-coordinate of `private_key * G`) from a
+/// private key. Mirrors Cairo `derive_public_key`.
+pub fn derive_public_key(private_key: &SecretFelt) -> Felt {
+    starknet_crypto::get_public_key(private_key)
+}
+
+/// Recovers a user's private key from their auditor-encrypted `EncPrivateKey`,
+/// using the auditor's private key.
+///
+/// Inverse of Cairo `encrypt_private_key`:
+/// 1. recover the ephemeral point `R` from its stored x-coordinate,
+/// 2. ECDH shared secret `S = auditor_private_key * R`,
+/// 3. `private_key = enc_private_key - h(ENC_PRIVATE_KEY_TAG, S.x)`.
+///
+/// As with all x-only ECDH here, the y-parity chosen when recovering `R` is
+/// irrelevant: `k*R` and `k*(-R)` share the same x-coordinate.
+pub fn decrypt_enc_private_key(
+    enc: &EncPrivateKey,
+    auditor_private_key: &SecretFelt,
+) -> Result<SecretFelt, DecryptionError> {
+    let ephemeral_point = AffinePoint::new_from_x(&enc.ephemeral_pubkey, false)
+        .ok_or(DecryptionError::InvalidEphemeralPubkey)?;
+    let shared_point = &ephemeral_point * **auditor_private_key;
+    let shared_x = shared_point.x();
+
+    let private_key = enc.enc_private_key - compute_enc_private_key_hash(shared_x);
+    Ok(SecretFelt::new(private_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::load_cairo_ref_fixture;
+
+    fn fixture_enc_private_key(f: &crate::test_fixtures::CairoRefFixture) -> EncPrivateKey {
+        EncPrivateKey {
+            auditor_public_key: f.inputs.auditor_public_key,
+            ephemeral_pubkey: f.outputs.enc_private_key_ephemeral_pubkey,
+            enc_private_key: f.outputs.enc_private_key_value,
+        }
+    }
+
+    #[test]
+    fn test_derive_public_key_with_cairo_vectors() {
+        let f = load_cairo_ref_fixture();
+        assert_eq!(
+            derive_public_key(&f.inputs.recipient_private_key),
+            f.inputs.recipient_public_key_derived
+        );
+        assert_eq!(
+            derive_public_key(&SecretFelt::new(f.inputs.auditor_private_key)),
+            f.inputs.auditor_public_key
+        );
+    }
+
+    #[test]
+    fn test_decrypt_enc_private_key_with_cairo_vectors() {
+        let f = load_cairo_ref_fixture();
+        let recovered = decrypt_enc_private_key(
+            &fixture_enc_private_key(&f),
+            &SecretFelt::new(f.inputs.auditor_private_key),
+        )
+        .expect("recovery should succeed");
+        assert_eq!(*recovered, f.inputs.user_private_key);
+    }
+
+    /// The audit's consistency check: the public key derived from the recovered
+    /// private key must equal the one derived from the true user private key.
+    #[test]
+    fn test_recovered_key_matches_registered_public_key() {
+        let f = load_cairo_ref_fixture();
+        let recovered = decrypt_enc_private_key(
+            &fixture_enc_private_key(&f),
+            &SecretFelt::new(f.inputs.auditor_private_key),
+        )
+        .unwrap();
+        assert_eq!(
+            derive_public_key(&recovered),
+            derive_public_key(&SecretFelt::new(f.inputs.user_private_key))
+        );
+    }
+
+    #[test]
+    fn test_decrypt_enc_private_key_invalid_pubkey() {
+        let enc = EncPrivateKey {
+            auditor_public_key: Felt::ONE,
+            ephemeral_pubkey: Felt::ZERO,
+            enc_private_key: Felt::TWO,
+        };
+        let result = decrypt_enc_private_key(&enc, &SecretFelt::new(Felt::from(12345u64)));
+        assert!(matches!(
+            result,
+            Err(DecryptionError::InvalidEphemeralPubkey)
+        ));
+    }
+}

--- a/crates/discovery-core/src/privacy_pool/mod.rs
+++ b/crates/discovery-core/src/privacy_pool/mod.rs
@@ -5,6 +5,7 @@ use starknet_types_core::felt::Felt;
 pub mod decryption;
 pub mod events;
 pub mod hashes;
+pub mod keys;
 pub mod storage_slots;
 pub mod types;
 pub mod views;


### PR DESCRIPTION
Add derive_public_key and decrypt_enc_private_key (inverse of Cairo encrypt_private_key) plus compute_enc_private_key_hash, validated against the existing Cairo reference vectors. Enables an auditor holding the auditor private key to recover any user's viewing key.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/787)
<!-- Reviewable:end -->
