### PR TITLE
feat(solvency-audit): reconstruct contract storage by folding state diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,9 +2682,11 @@ dependencies = [
 name = "solvency-audit"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "starknet-types-core",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/solvency-audit/Cargo.toml
+++ b/crates/solvency-audit/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 starknet-types-core = { version = "0.2", features = ["curve", "serde"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/solvency-audit/src/fetch.rs
+++ b/crates/solvency-audit/src/fetch.rs
@@ -1,0 +1,115 @@
+//! Reconstructs the contract's storage at a pinned block by folding state
+//! diffs, and writes it into a snapshot.
+
+use std::collections::HashMap;
+
+use starknet_types_core::felt::Felt;
+
+use crate::snapshot::Snapshot;
+use crate::state_source::StateSource;
+
+/// Final value of a slot with its first-written (created) and last-written
+/// (modified) blocks. Equal for write-once slots; differ for ones rewritten
+/// (e.g. an open note funded by a later deposit).
+type SlotState = (Felt, u64, u64);
+
+/// Folds per-block storage diffs across `from..=to` into the contract's final
+/// non-zero storage. Last write wins; a write of zero deletes the slot (so a
+/// slot set and later cleared does not appear). For each surviving slot we keep
+/// the block it was first written and the block it last changed — useful for
+/// later tracing an unexplained slot back to its transaction(s).
+pub async fn fold_storage<S: StateSource>(
+    source: &S,
+    from: u64,
+    to: u64,
+) -> Result<HashMap<Felt, SlotState>, S::Error> {
+    let mut state: HashMap<Felt, SlotState> = HashMap::new();
+    for block in from..=to {
+        for (slot, value) in source.storage_diffs_at(block).await? {
+            if value == Felt::ZERO {
+                state.remove(&slot);
+            } else {
+                state
+                    .entry(slot)
+                    .and_modify(|entry| {
+                        entry.0 = value;
+                        entry.2 = block; // modified
+                    })
+                    .or_insert((value, block, block)); // created == modified
+            }
+        }
+    }
+    Ok(state)
+}
+
+/// Writes a folded storage map into the snapshot's `slots` (with `kind` left
+/// null until `analyze` classifies each slot).
+pub fn populate_storage(snapshot: &mut Snapshot, state: &HashMap<Felt, SlotState>) {
+    for (slot, (value, created, modified)) in state {
+        snapshot.insert_slot(*slot, *value, *created, *modified);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use async_trait::async_trait;
+
+    use super::*;
+
+    /// Block -> the storage writes applied in that block.
+    struct MockSource(HashMap<u64, Vec<(Felt, Felt)>>);
+
+    #[async_trait]
+    impl StateSource for MockSource {
+        type Error = Infallible;
+        async fn storage_diffs_at(&self, block: u64) -> Result<Vec<(Felt, Felt)>, Infallible> {
+            Ok(self.0.get(&block).cloned().unwrap_or_default())
+        }
+    }
+
+    fn slot(n: u64) -> Felt {
+        Felt::from(n)
+    }
+
+    #[tokio::test]
+    async fn test_fold_last_write_wins_and_zero_deletes() {
+        let source = MockSource(HashMap::from([
+            (
+                1,
+                vec![
+                    (slot(0xA), Felt::from(10u64)),
+                    (slot(0xB), Felt::from(20u64)),
+                ],
+            ),
+            (2, vec![(slot(0xA), Felt::from(11u64))]), // overwrite A
+            (3, vec![(slot(0xB), Felt::ZERO)]),        // clear B
+        ]));
+
+        let state = fold_storage(&source, 1, 3).await.unwrap();
+
+        assert_eq!(state.len(), 1);
+        // A: created at block 1, last modified at block 2, final value 11.
+        assert_eq!(state[&slot(0xA)], (Felt::from(11u64), 1, 2));
+        assert!(!state.contains_key(&slot(0xB))); // cleared slot is gone
+    }
+
+    #[tokio::test]
+    async fn test_populate_storage_writes_folded_state() {
+        let source = MockSource(HashMap::from([
+            (5, vec![(slot(0xA), Felt::from(10u64))]),
+            (7, vec![(slot(0xA), Felt::from(99u64))]),
+        ]));
+        let state = fold_storage(&source, 5, 7).await.unwrap();
+
+        let mut snapshot = Snapshot::default();
+        populate_storage(&mut snapshot, &state);
+
+        let entry = &snapshot.slots[&slot(0xA)];
+        assert_eq!(entry.value, Felt::from(99u64));
+        assert_eq!(entry.created_block, 5);
+        assert_eq!(entry.modified_block, 7);
+        assert!(entry.kind.is_none());
+    }
+}

--- a/crates/solvency-audit/src/lib.rs
+++ b/crates/solvency-audit/src/lib.rs
@@ -5,4 +5,6 @@
 //! an enclave) classifies every slot and sums unspent notes. This crate holds
 //! the shared snapshot type and those stages.
 
+pub mod fetch;
 pub mod snapshot;
+pub mod state_source;

--- a/crates/solvency-audit/src/state_source.rs
+++ b/crates/solvency-audit/src/state_source.rs
@@ -1,0 +1,20 @@
+//! Source of the privacy-pool contract's storage writes, per block.
+//!
+//! `fetch` reconstructs the full contract storage by folding every block's
+//! storage diffs (last-write-wins). State diffs are the protocol-level write
+//! record, so they capture writes that emitted no event — exactly the footprint
+//! we hunt for. The JSON-RPC implementation (a later branch) wraps
+//! `starknet_getStateUpdate`; tests use an in-memory mock.
+
+use async_trait::async_trait;
+use starknet_types_core::felt::Felt;
+
+#[async_trait]
+pub trait StateSource {
+    /// Error type produced by the underlying data source.
+    type Error;
+
+    /// Returns the `(slot, value)` storage writes to the contract in `block`.
+    /// A `value` of zero means the slot was cleared in that block.
+    async fn storage_diffs_at(&self, block: u64) -> Result<Vec<(Felt, Felt)>, Self::Error>;
+}


### PR DESCRIPTION
Add the StateSource trait (per-block storage diffs) and fetch::fold_storage, which folds diffs across a block range into the contract's final non-zero storage (last-write-wins; a zero write deletes a slot) and records each slot's last-change block. populate_storage writes the folded state into a Snapshot. State diffs are the protocol-level write record, so they capture writes that emitted no event. The live JSON-RPC StateSource and event/meta scans follow; the fold is unit-tested with an in-memory mock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/789)
<!-- Reviewable:end -->
