### PR TITLE
feat(solvency-audit): add RawStorageAccess backend over the snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,8 +2683,10 @@ name = "solvency-audit"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "discovery-core",
  "serde",
  "serde_json",
+ "starknet-rust-core",
  "starknet-types-core",
  "tokio",
 ]

--- a/crates/solvency-audit/Cargo.toml
+++ b/crates/solvency-audit/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
+discovery-core = { path = "../discovery-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = { version = "0.2", features = ["curve", "serde"] }
 
 [dev-dependencies]

--- a/crates/solvency-audit/src/backend.rs
+++ b/crates/solvency-audit/src/backend.rs
@@ -1,0 +1,101 @@
+//! `RawStorageAccess` over a snapshot's slots, so discovery-core can run
+//! directly against the snapshot (it gets `IViews` via the blanket impl).
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use discovery_core::storage_backend::{RawStorageAccess, StorageError};
+use starknet_core::types::StorageResult;
+use starknet_types_core::felt::Felt;
+
+use crate::snapshot::Snapshot;
+
+/// In-memory view of a snapshot's storage for discovery reads. Built once, then
+/// reads are pure lookups — so it is `Send + Sync` and safe for concurrent
+/// discovery, and missing slots read as zero (mirroring a Cairo map).
+pub struct SnapshotBackend {
+    slots: HashMap<Felt, (Felt, u64)>,
+}
+
+impl SnapshotBackend {
+    /// Builds a read backend from a snapshot's slots.
+    pub fn from_snapshot(snapshot: &Snapshot) -> Self {
+        let slots = snapshot
+            .slots
+            .iter()
+            .map(|(slot, entry)| (*slot, (entry.value, entry.modified_block)))
+            .collect();
+        Self { slots }
+    }
+
+    fn get(&self, slot: Felt) -> (Felt, u64) {
+        self.slots.get(&slot).copied().unwrap_or((Felt::ZERO, 0))
+    }
+}
+
+#[async_trait]
+impl RawStorageAccess for SnapshotBackend {
+    async fn read_slot(&self, slot: Felt) -> Result<Felt, StorageError> {
+        Ok(self.get(slot).0)
+    }
+
+    async fn read_slots(&self, slots: Vec<Felt>) -> Result<Vec<Felt>, StorageError> {
+        Ok(slots.into_iter().map(|slot| self.get(slot).0).collect())
+    }
+
+    async fn read_slots_with_block(
+        &self,
+        slots: Vec<Felt>,
+    ) -> Result<Vec<StorageResult>, StorageError> {
+        Ok(slots
+            .into_iter()
+            .map(|slot| {
+                let (value, last_update_block) = self.get(slot);
+                StorageResult {
+                    value,
+                    last_update_block,
+                }
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_reads_present_and_missing_slots() {
+        let mut snapshot = Snapshot::default();
+        snapshot.insert_slot(Felt::from(0xA_u64), Felt::from(111u64), 4, 7);
+        let backend = SnapshotBackend::from_snapshot(&snapshot);
+
+        // Present slot.
+        assert_eq!(
+            backend.read_slot(Felt::from(0xA_u64)).await.unwrap(),
+            Felt::from(111u64)
+        );
+        // Missing slot reads as zero.
+        assert_eq!(
+            backend.read_slot(Felt::from(0xB_u64)).await.unwrap(),
+            Felt::ZERO
+        );
+
+        // Batch read preserves order and zero-fills misses.
+        let values = backend
+            .read_slots(vec![Felt::from(0xA_u64), Felt::from(0xB_u64)])
+            .await
+            .unwrap();
+        assert_eq!(values, vec![Felt::from(111u64), Felt::ZERO]);
+
+        // With-block read carries the recorded block (0 for misses).
+        let with_block = backend
+            .read_slots_with_block(vec![Felt::from(0xA_u64), Felt::from(0xB_u64)])
+            .await
+            .unwrap();
+        assert_eq!(with_block[0].value, Felt::from(111u64));
+        assert_eq!(with_block[0].last_update_block, 7);
+        assert_eq!(with_block[1].value, Felt::ZERO);
+        assert_eq!(with_block[1].last_update_block, 0);
+    }
+}

--- a/crates/solvency-audit/src/lib.rs
+++ b/crates/solvency-audit/src/lib.rs
@@ -5,6 +5,7 @@
 //! an enclave) classifies every slot and sums unspent notes. This crate holds
 //! the shared snapshot type and those stages.
 
+pub mod backend;
 pub mod fetch;
 pub mod snapshot;
 pub mod state_source;


### PR DESCRIPTION
SnapshotBackend builds a slot lookup from a Snapshot and implements discovery-core's RawStorageAccess (read_slot/read_slots/read_slots_with_block), so discovery runs directly against the snapshot and gets IViews via the blanket impl. Built once and read-only, so it is Send+Sync for concurrent discovery; missing slots read as zero like a Cairo map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/790)
<!-- Reviewable:end -->
