### PR TITLE
feat(sdk): pack screening attestation into apply_actions calldata (O1c)

### DIFF
--- a/e2e/scripts/batch-operations.ts
+++ b/e2e/scripts/batch-operations.ts
@@ -84,8 +84,7 @@ function findAccount(accounts: AccountEntry[], name: string): AccountEntry {
   const entry = accounts.find(
     (account) => account.name.toLowerCase() === name.toLowerCase(),
   );
-  if (!entry)
-    throw new Error(`Account "${name}" not found in ACCOUNTS`);
+  if (!entry) throw new Error(`Account "${name}" not found in ACCOUNTS`);
   return entry;
 }
 
@@ -267,6 +266,8 @@ async function runDeposit() {
   }
   console.log("Approve tx:", approveTx.transaction_hash);
 
+  // Source-built pool: its class hash is never pinned, so force compatibility
+  // calldata until the in-repo contract accepts the screening suffix.
   const transfers = createPrivateTransfers({
     account: aliceAccount,
     viewingKeyProvider: { getViewingKey: async () => BigInt(alice.viewingKey) },
@@ -276,6 +277,7 @@ async function runDeposit() {
     ),
     discoveryProvider: discovery,
     poolContractAddress: POOL_ADDRESS,
+    poolMode: "compatibility",
   });
 
   const depositInputs = Array.from({ length: chunkSize }, () => ({
@@ -403,6 +405,8 @@ async function runTransfer() {
     ),
     discoveryProvider: discovery,
     poolContractAddress: POOL_ADDRESS,
+    // Unpinned source-built pool — see the deposit-flow comment above.
+    poolMode: "compatibility",
   });
 
   const transferOutputs = Array.from({ length: chunkSize }, () => ({

--- a/e2e/scripts/declare-class.ts
+++ b/e2e/scripts/declare-class.ts
@@ -27,8 +27,7 @@ interface AccountEntry {
 const rpcUrl = requireEnv("VITE_RPC_URL");
 const allAccounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
 const admin = allAccounts.find((a) => a.admin);
-if (!admin)
-  throw new Error("No admin account (admin: true) found in ACCOUNTS");
+if (!admin) throw new Error("No admin account (admin: true) found in ACCOUNTS");
 
 const provider = new RpcProvider({ nodeUrl: rpcUrl });
 const adminAccount = new Account({

--- a/e2e/scripts/deploy-accounts.ts
+++ b/e2e/scripts/deploy-accounts.ts
@@ -58,13 +58,13 @@ const OZ_ACCOUNT_CLASS_HASH =
 const STRK_TOKEN =
   "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d";
 
-
 const rpcUrl = requireEnv("VITE_RPC_URL");
 const allAccounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
 
 function findAdmin(entries: AccountEntry[]): AccountEntry {
   const entry = entries.find((a) => a.admin);
-  if (!entry) throw new Error("No admin account (admin: true) found in ACCOUNTS");
+  if (!entry)
+    throw new Error("No admin account (admin: true) found in ACCOUNTS");
   return entry;
 }
 
@@ -118,10 +118,7 @@ async function deployAccount(
     deployResult.transaction_hash,
   );
   if (!receipt.isSuccess()) {
-    console.error(
-      `  Deploy ${name} FAILED:`,
-      JSON.stringify(receipt, null, 2),
-    );
+    console.error(`  Deploy ${name} FAILED:`, JSON.stringify(receipt, null, 2));
     process.exit(1);
   }
   console.log(`  Deployed: ${deployResult.transaction_hash}`);
@@ -148,10 +145,7 @@ async function fundAccount(
     transferTx.transaction_hash,
   );
   if (!receipt.isSuccess()) {
-    console.error(
-      `  Fund ${name} FAILED:`,
-      JSON.stringify(receipt, null, 2),
-    );
+    console.error(`  Fund ${name} FAILED:`, JSON.stringify(receipt, null, 2));
     process.exit(1);
   }
   console.log(`  Funded: ${transferTx.transaction_hash}`);
@@ -179,12 +173,16 @@ async function main(): Promise<void> {
       console.error(
         `  ERROR: computed admin address ${computedAddress} differs from account address ${adminEntry.address}`,
       );
-      console.error(
-        "  Check class hash, salt, and public key.",
-      );
+      console.error("  Check class hash, salt, and public key.");
       process.exit(1);
     }
-    await deployAccount(adminEntry.address, adminEntry.privateKey, publicKey, addressSalt, adminEntry.name);
+    await deployAccount(
+      adminEntry.address,
+      adminEntry.privateKey,
+      publicKey,
+      addressSalt,
+      adminEntry.name,
+    );
   }
 
   const adminAccount = new Account({
@@ -214,9 +212,7 @@ async function main(): Promise<void> {
       console.warn(
         `  WARNING: computed address ${computedAddress} differs from env address ${entry.address}`,
       );
-      console.warn(
-        "  Check class hash and salt. Skipping.",
-      );
+      console.warn("  Check class hash and salt. Skipping.");
       continue;
     }
 

--- a/e2e/scripts/generate-dump.ts
+++ b/e2e/scripts/generate-dump.ts
@@ -26,8 +26,14 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "../..");
 
-const DISCOVERY_CORE_FIXTURES = join(repoRoot, "crates/discovery-core/tests/fixtures");
-const DISCOVERY_SERVICE_FIXTURES = join(repoRoot, "crates/discovery-service/tests/fixtures");
+const DISCOVERY_CORE_FIXTURES = join(
+  repoRoot,
+  "crates/discovery-core/tests/fixtures",
+);
+const DISCOVERY_SERVICE_FIXTURES = join(
+  repoRoot,
+  "crates/discovery-service/tests/fixtures",
+);
 
 const ALICE_VIEWING_KEY = BigInt("0xA11CE");
 const BOB_VIEWING_KEY = BigInt("0xB0B");
@@ -36,6 +42,8 @@ const devnet = new Devnet();
 const env = await devnet.initialize();
 const chainId = constants.StarknetChainId.SN_SEPOLIA;
 
+// Source-built pool: its class hash is never pinned, so force compatibility
+// calldata until the in-repo contract accepts the screening suffix.
 const transfers = {
   alice: createPrivateTransfers({
     account: env.alice,
@@ -43,6 +51,7 @@ const transfers = {
     provingProvider: new CallMockProofProvider(env.provider, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
+    poolMode: "compatibility",
   }),
   bob: createPrivateTransfers({
     account: env.bob,
@@ -50,6 +59,7 @@ const transfers = {
     provingProvider: new CallMockProofProvider(env.provider, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
+    poolMode: "compatibility",
   }),
 };
 
@@ -63,7 +73,10 @@ await env.alice.execute({
 
 // Register bob via outside execution (admin submits on behalf of bob)
 console.log("[2/6] Registering Bob...");
-const { callAndProof: bobReg } = await transfers.bob.build().register().execute();
+const { callAndProof: bobReg } = await transfers.bob
+  .build()
+  .register()
+  .execute();
 await devnet.executeOutside(bobReg);
 
 // Alice: deposit 100 STRK + transfer 50 to bob (representative scenario)
@@ -105,7 +118,10 @@ console.log("Scenario complete, generating fixtures...");
 const spawnTimestamp = Math.floor(Date.now() / 1000);
 
 // All dumps happen while devnet is still running — no race conditions.
-await dumpContractState(env, join(DISCOVERY_CORE_FIXTURES, "devnet-state.json"));
+await dumpContractState(
+  env,
+  join(DISCOVERY_CORE_FIXTURES, "devnet-state.json"),
+);
 await dumpDevnet(devnet.url, DISCOVERY_SERVICE_FIXTURES);
 writeFileSync(
   join(DISCOVERY_SERVICE_FIXTURES, "devnet-dump.metadata.json"),
@@ -120,8 +136,8 @@ writeFileSync(
       strk_token: env.strk,
     },
     null,
-    2
-  ) + "\n"
+    2,
+  ) + "\n",
 );
 
 await devnet.cleanup();
@@ -133,7 +149,7 @@ console.log("Fixtures written.");
  */
 async function dumpContractState(
   env: DevnetEnvironment,
-  outputPath: string
+  outputPath: string,
 ): Promise<void> {
   const latestBlock = await env.provider.getBlockNumber();
   const storageState: Record<string, string> = {};

--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -125,6 +125,8 @@ export async function createE2eTestEnv(
   });
   await indexer.waitUntilReady(devnet.url);
 
+  // Source-built pool: its class hash is never pinned, so force compatibility
+  // calldata until the in-repo contract accepts the screening suffix.
   const transfers = {
     alice: createPrivateTransfers({
       account: env.alice,
@@ -135,6 +137,7 @@ export async function createE2eTestEnv(
         env.privacy.address,
       ),
       poolContractAddress: env.privacy.address,
+      poolMode: "compatibility",
     }),
     bob: createPrivateTransfers({
       account: env.bob,
@@ -145,6 +148,7 @@ export async function createE2eTestEnv(
         env.privacy.address,
       ),
       poolContractAddress: env.privacy.address,
+      poolMode: "compatibility",
     }),
   };
 

--- a/e2e/src/indexer-client.ts
+++ b/e2e/src/indexer-client.ts
@@ -23,7 +23,8 @@ async function findFreePort(): Promise<number> {
     const srv = createServer();
     srv.listen(0, "127.0.0.1", () => {
       const addr = srv.address();
-      if (!addr || typeof addr === "string") return reject(new Error("bad addr"));
+      if (!addr || typeof addr === "string")
+        return reject(new Error("bad addr"));
       const port = addr.port;
       srv.close(() => resolve(port));
     });
@@ -34,7 +35,8 @@ async function findFreePort(): Promise<number> {
 export class IndexerClient {
   private child: ChildProcess;
   private lines: string[] = [];
-  private waiters: Array<{ pattern: string; resolve: (line: string) => void }> = [];
+  private waiters: Array<{ pattern: string; resolve: (line: string) => void }> =
+    [];
   private _apiPort: number;
   private logStream?: WriteStream;
   private rl?: Interface;
@@ -134,12 +136,19 @@ export class IndexerClient {
    * Registers the log listener BEFORE creating the block to avoid
    * the race where the indexer processes the block before the listener is set up.
    */
-  async waitForBlock(rpcUrl: string, timeoutMs = E2E_TIMEOUTS.indexerLog): Promise<string> {
+  async waitForBlock(
+    rpcUrl: string,
+    timeoutMs = E2E_TIMEOUTS.indexerLog,
+  ): Promise<string> {
     const logPromise = this.waitForNewLog("New block #", timeoutMs);
     await fetch(rpcUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "devnet_createBlock" }),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "devnet_createBlock",
+      }),
     });
     return logPromise;
   }

--- a/e2e/src/ohttp-relay.ts
+++ b/e2e/src/ohttp-relay.ts
@@ -39,7 +39,10 @@ export async function startOhttpRelay(gatewayUrl: string): Promise<OhttpRelay> {
         headers: { "content-type": "message/ohttp-req" },
       },
       (proxyResponse) => {
-        clientResponse.writeHead(proxyResponse.statusCode!, proxyResponse.headers);
+        clientResponse.writeHead(
+          proxyResponse.statusCode!,
+          proxyResponse.headers,
+        );
         proxyResponse.pipe(clientResponse);
       },
     );

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -96,7 +96,8 @@ export interface AccountEntry {
  */
 export function requireEnv(name: string): string {
   const value = process.env[name] ?? process.env[`VITE_${name}`];
-  if (!value) throw new Error(`Missing required env var: ${name} (or VITE_${name})`);
+  if (!value)
+    throw new Error(`Missing required env var: ${name} (or VITE_${name})`);
   return value;
 }
 
@@ -107,9 +108,7 @@ export function setupAdmin(): {
 } {
   const rpcUrl = requireEnv("RPC_URL");
   const accounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
-  const admin = accounts.find(
-    (entry) => entry.name.toLowerCase() === "admin",
-  );
+  const admin = accounts.find((entry) => entry.name.toLowerCase() === "admin");
   if (!admin) throw new Error('No "admin" entry found in ACCOUNTS env var');
 
   const provider = new RpcProvider({ nodeUrl: rpcUrl });
@@ -185,7 +184,11 @@ export async function declareClass(
       return classHash;
     }
     if (error instanceof Error && "code" in error) {
-      const rpcError = error as Error & { code: number; data?: unknown; baseError?: unknown };
+      const rpcError = error as Error & {
+        code: number;
+        data?: unknown;
+        baseError?: unknown;
+      };
       const shortMessage = rpcError.message.split(" with params")[0];
       const dataStr = rpcError.data
         ? ` data=${JSON.stringify(rpcError.data)}`

--- a/e2e/tests/devnet/ohttp-relay.test.ts
+++ b/e2e/tests/devnet/ohttp-relay.test.ts
@@ -89,6 +89,8 @@ describe("E2E OHTTP via relay", () => {
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     // Discover notes via relay — validates full client → relay → gateway pipeline
@@ -110,7 +112,10 @@ describe("E2E OHTTP via relay", () => {
     expect(channels!.has(BigInt(de.bob.address))).toBe(true);
 
     // Preflight check via relay
-    const requirement = await aliceOhttp.discoverRequirement(de.bob.address, de.strk);
+    const requirement = await aliceOhttp.discoverRequirement(
+      de.bob.address,
+      de.strk,
+    );
     expect(requirement).toBe(SetupRequirement.Ready);
 
     // Bob's discovery via relay
@@ -123,6 +128,8 @@ describe("E2E OHTTP via relay", () => {
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes: bobNotes } = await bobOhttp.discoverNotes();

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -85,6 +85,8 @@ describe("E2E OHTTP", () => {
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     // Discover notes via OHTTP — if this works, the full encrypt/decrypt pipeline is correct
@@ -119,6 +121,8 @@ describe("E2E OHTTP", () => {
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes: bobNotes } = await bobOhttp.discoverNotes();

--- a/e2e/tests/devnet/pagination-discovery.test.ts
+++ b/e2e/tests/devnet/pagination-discovery.test.ts
@@ -76,6 +76,8 @@ describe("Discovery pagination with small budget", () => {
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     // total-only: exercises total_n_channels
@@ -110,6 +112,8 @@ describe("Discovery pagination with small budget", () => {
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes } = await aliceTransfers.discoverNotes();
@@ -127,6 +131,8 @@ describe("Discovery pagination with small budget", () => {
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes: bobNotes } = await bobTransfers.discoverNotes();

--- a/e2e/tests/devnet/payment-service-discovery.test.ts
+++ b/e2e/tests/devnet/payment-service-discovery.test.ts
@@ -58,6 +58,8 @@ describe("Payment Service Discovery", () => {
         provingProvider: new CallMockProofProvider(de.provider, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
+        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+        poolMode: "compatibility",
       }),
     );
 
@@ -230,6 +232,8 @@ describe("Payment Service Discovery", () => {
       provingProvider: new CallMockProofProvider(de.provider, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes } = await aliceDiscover.discoverNotes();
@@ -259,6 +263,8 @@ describe("Payment Service Discovery", () => {
       provingProvider: new CallMockProofProvider(de.provider, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const allAddresses = [de.alice.address, ...users.map((u) => u.address)];
@@ -287,6 +293,8 @@ describe("Payment Service Discovery", () => {
         provingProvider: new CallMockProofProvider(de.provider, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
+        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+        poolMode: "compatibility",
       });
 
       const { notes } = await userDiscover.discoverNotes();
@@ -314,6 +322,8 @@ describe("Payment Service Discovery", () => {
         provingProvider: new CallMockProofProvider(de.provider, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
+        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+        poolMode: "compatibility",
       });
 
       const { channels } = await userDiscover.discoverChannels([

--- a/e2e/tests/devnet/smoke.test.ts
+++ b/e2e/tests/devnet/smoke.test.ts
@@ -74,6 +74,8 @@ describe("E2E Smoke", () => {
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     const { notes } = await aliceIndexer.discoverNotes();
@@ -105,6 +107,8 @@ describe("E2E Smoke", () => {
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     // Bob should discover 1 incoming note: 50 STRK from Alice

--- a/e2e/tests/integration/privacy-starknet-integration.test.ts
+++ b/e2e/tests/integration/privacy-starknet-integration.test.ts
@@ -3,7 +3,6 @@ import {
   Account,
   RpcProvider,
   OutsideExecutionVersion,
-
   type constants,
   type OutsideExecutionOptions,
 } from "starknet";
@@ -166,6 +165,8 @@ describe("Privacy StarkNet integration", () => {
       ),
       discoveryProvider: discovery,
       poolContractAddress: poolAddress,
+      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
+      poolMode: "compatibility",
     });
 
     // Mint tokens to Alice (admin is the minter)
@@ -318,8 +319,7 @@ describe("Privacy StarkNet integration", () => {
     );
     expect(
       allDeposits.find(
-        (deposit) =>
-          deposit.amount === 100n && deposit.token === BigInt(TOKEN),
+        (deposit) => deposit.amount === 100n && deposit.token === BigInt(TOKEN),
       ),
     ).toBeDefined();
   }, 300_000);
@@ -373,8 +373,7 @@ describe("Privacy StarkNet integration", () => {
     );
     expect(
       allDeposits.find(
-        (deposit) =>
-          deposit.amount === 100n && deposit.token === BigInt(TOKEN),
+        (deposit) => deposit.amount === 100n && deposit.token === BigInt(TOKEN),
       ),
     ).toBeDefined();
   }, 300_000);

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -15,6 +15,22 @@
   `address_blocked` / `screening_unavailable` reasons (JSON-RPC code 10000).
   Other code-10000 errors return `undefined` so the caller rethrows the
   original rather than mislabeling a transient fault as terminal.
+- Screening v2: `apply_actions` calldata carries the screening attestation as a
+  trailing Serde-encoded `Option` — `[0x1]` when absent, `[0x0, issued_at,
+  sig_r, sig_s]` when the prove response carries a signature (Cairo's `Option`
+  Serde tags: `Some` = 0, `None` = 1). `Proof` gains an
+  optional `additionalData` relaying the prove response's `additional_data`.
+  Emitted **only against a screening-capable pool**, identified with zero RPC
+  calls: the prove response's payload is headed by the pool's class hash, which
+  the SDK looks up against the pinned class hashes of the deployed
+  pre-screening pools on SN_MAIN and SN_SEPOLIA. A pinned
+  hash gets today's calldata (no suffix); **any other class hash is treated as
+  screening-capable**, so the SDK activates automatically when an upgraded
+  pool deploys, and one SDK build is compatible with both pool versions.
+- Screening v2: exported `PoolCapabilityMode`, and
+  `createPrivateTransfers()` gains an optional `poolMode` override for
+  deployments whose pool class hash isn't pinned (e.g. local devnet/test pools
+  built from source).
 
 ## 0.14.2-RC.6
 

--- a/sdk/src/factory.ts
+++ b/sdk/src/factory.ts
@@ -13,6 +13,7 @@ import type {
   PrivateTransfersUser,
 } from "./interfaces.js";
 import { PrivateTransfers } from "./internal/private-transfers.js";
+import type { PoolCapabilityMode } from "./internal/pool-mode.js";
 import {
   ProofInvocationFactory,
   type ProofInvocationFactoryInterface,
@@ -47,6 +48,11 @@ export interface CreatePrivateTransfersParams {
   provingProvider: ProofProviderInterface | ProofProviderConfig;
   discoveryProvider: DiscoveryProviderInterface | DiscoveryProviderConfig;
   poolContractAddress: StarknetAddress;
+  /**
+   * Overrides class-hash pool-mode detection — for pools whose class hash
+   * isn't pinned in the SDK (e.g. source-built devnet/test pools).
+   */
+  poolMode?: PoolCapabilityMode;
 }
 
 /**
@@ -109,5 +115,6 @@ export function createPrivateTransfers(
     discoveryProvider,
     proofInvocationFactory: params.proofInvocationFactory ?? new ProofInvocationFactory(),
     poolContractAddress: params.poolContractAddress,
+    poolMode: params.poolMode,
   });
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,6 +15,7 @@ export {
   ScreeningUnavailable,
   screeningErrorFromProvingError,
 } from "./internal/errors.js";
+export type { PoolCapabilityMode } from "./internal/pool-mode.js";
 export type { BlockIdentifier } from "starknet";
 export { ProvingServiceProofProvider } from "./internal/proving-service-provider.js";
 export type { ProvingServiceProofProviderOptions } from "./internal/proving-service-provider.js";

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -12,6 +12,7 @@ import type {
 import { ec } from "starknet";
 import { AddressMap } from "./utils/index.js";
 import type { OhttpOption } from "./internal/ohttp-client.js";
+import type { AdditionalData } from "./internal/proving-service.js";
 
 export type Amount = bigint;
 
@@ -91,6 +92,11 @@ export type Proof = {
   readonly output: string[];
   /** Proof facts from the proving service; must be included in the tx when submitting to the chain. */
   readonly proofFacts: string[];
+  /**
+   * Typed side-channel from the prove response. For screened deposits it
+   * carries the screening signature; absent otherwise.
+   */
+  readonly additionalData?: AdditionalData;
 };
 
 /**

--- a/sdk/src/internal/pool-mode.ts
+++ b/sdk/src/internal/pool-mode.ts
@@ -1,0 +1,39 @@
+/**
+ * Pool calldata-mode selection by deployed class hash.
+ *
+ * The mode is a lookup of the pool's class hash (the first felt of the prove
+ * response's payload) against the pinned pre-screening pools — no RPC.
+ * Unpinned class hashes are treated as screening-capable, so an upgraded pool
+ * activates without an SDK release; source-built test pools pass an explicit
+ * `poolMode` override instead.
+ */
+
+/** Whether the target pool expects the screening attestation in `apply_actions` calldata. */
+export type PoolCapabilityMode = "screening" | "compatibility";
+
+/** Class hashes of the deployed pre-screening pools. */
+export const COMPATIBILITY_POOL_CLASS_HASHES: readonly bigint[] = [
+  // SN_SEPOLIA
+  0x715b22abfb60815623f4127ba64bd2f93613d8a5c1e519841eaab444659d2afn,
+  // SN_MAIN
+  0x30b8c540cf04d8ef0f4db2a9098d9cc0e35e83af1cb3325f5a4f40144b4b30bn,
+];
+
+/**
+ * Select the calldata mode by pool class hash. `undefined` or an unparseable
+ * felt selects compatibility — such a proof is unusable on-chain anyway, so
+ * no attestation suffix is invented for it.
+ */
+export function poolModeForClassHash(classHashFelt: string | undefined): PoolCapabilityMode {
+  if (classHashFelt === undefined) return "compatibility";
+  let classHashValue: bigint;
+  try {
+    classHashValue = BigInt(classHashFelt);
+  } catch {
+    return "compatibility";
+  }
+  // Canonical-felt comparison, so zero-padded and stripped forms match.
+  return COMPATIBILITY_POOL_CLASS_HASHES.some((pinnedHash) => pinnedHash === classHashValue)
+    ? "compatibility"
+    : "screening";
+}

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -21,6 +21,8 @@ import { AbstractPrivateTransfers } from "./abstract-private-transfers.js";
 import { debugLog } from "../utils/logging.js";
 import type { ProofInvocationFactoryInterface } from "./proof-invocation-factory.js";
 import { toBigInt, toHex } from "../utils/convert.js";
+import { screeningCalldataSuffix } from "./screening-calldata.js";
+import { poolModeForClassHash, type PoolCapabilityMode } from "./pool-mode.js";
 
 // Export the specific typed contract type for the Privacy Pool
 export type PrivacyPoolContract = TypedContractV2<typeof PrivacyPoolABI>;
@@ -34,6 +36,7 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       discoveryProvider: DiscoveryProviderInterface;
       proofInvocationFactory: ProofInvocationFactoryInterface;
       poolContractAddress: StarknetAddress;
+      poolMode?: PoolCapabilityMode;
     }
   ) {
     super(params.account.address, params.viewingKeyProvider, params.discoveryProvider);
@@ -96,12 +99,20 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       this.params.proofInvocationFactory.parseOutput(serverActionsCalldata);
     debugLog("private-transfers", "execute", "parsed server actions", parsedOutput);
 
+    // The pool version — not signature presence — decides the calldata shape:
+    // a screening-capable pool expects a trailing Option<ScreeningAttestation>,
+    // the pre-screening pool none. poolMode overrides detection for pools
+    // whose class hash isn't pinned.
+    const mode = this.params.poolMode ?? poolModeForClassHash(proof.output[0]);
+    const screeningSuffix =
+      mode === "screening" ? screeningCalldataSuffix(proof.additionalData) : [];
+
     return {
       callAndProof: {
         call: {
           contractAddress: toHex(this.params.poolContractAddress),
           entrypoint: "apply_actions",
-          calldata: serverActionsCalldata,
+          calldata: [...serverActionsCalldata, ...screeningSuffix],
         },
         proof,
       },

--- a/sdk/src/internal/proving-service-provider.ts
+++ b/sdk/src/internal/proving-service-provider.ts
@@ -29,9 +29,9 @@ export type ProvingServiceProofProviderOptions = {
   // TODO: Change default to latest-verifiable.
   blockIdentifier?: ProvingBlockId;
   /**
-   * Optional RPC node URL used to fetch the pool nonce (cached; use invalidateNonceCache() after nonce errors).
-   * Requires `poolAddress` to be set. When both are provided, getDefaultDetails() returns details with the
-   * fetched nonce; no provider on account or factory needed.
+   * Optional RPC node URL used to fetch the pool nonce (cached; use invalidateNonceCache() after
+   * nonce errors). Requires `poolAddress` to be set. When both are provided, getDefaultDetails()
+   * returns details with the fetched nonce; no provider on account or factory needed.
    */
   nodeUrl?: string;
   /**
@@ -52,7 +52,7 @@ export type ProvingServiceProofProviderOptions = {
 export class ProvingServiceProofProvider implements ProofProviderInterface {
   private readonly provingService: ProvingService;
   private readonly blockIdentifier: ProvingBlockId;
-  private readonly nonceProvider: RpcProvider | null;
+  private readonly rpcProvider: RpcProvider | null;
   private readonly poolAddressHex: string | null;
   private cachedNonce: bigint | null = null;
 
@@ -80,10 +80,10 @@ export class ProvingServiceProofProvider implements ProofProviderInterface {
       if (options.poolAddress == null) {
         throw new Error("ProvingServiceProofProvider: nodeUrl requires poolAddress to be set");
       }
-      this.nonceProvider = new RpcProvider({ nodeUrl: options.nodeUrl });
+      this.rpcProvider = new RpcProvider({ nodeUrl: options.nodeUrl });
       this.poolAddressHex = toHex(options.poolAddress);
     } else {
-      this.nonceProvider = null;
+      this.rpcProvider = null;
       this.poolAddressHex = null;
     }
   }
@@ -94,12 +94,12 @@ export class ProvingServiceProofProvider implements ProofProviderInterface {
 
   async getDefaultDetails(): Promise<ProofInvocationFactoryDetails> {
     const base = getDefaultProofDetails(this.chainId);
-    if (this.nonceProvider == null || this.poolAddressHex == null) {
+    if (this.rpcProvider == null || this.poolAddressHex == null) {
       return base;
     }
     if (this.cachedNonce == null) {
       this.cachedNonce = BigInt(
-        await this.nonceProvider.getNonceForAddress(this.poolAddressHex, "latest")
+        await this.rpcProvider.getNonceForAddress(this.poolAddressHex, "latest")
       );
     }
     return { ...base, nonce: this.cachedNonce };
@@ -125,6 +125,7 @@ export class ProvingServiceProofProvider implements ProofProviderInterface {
       data: result.proof,
       output,
       proofFacts,
+      additionalData: result.additional_data,
     };
   }
 }

--- a/sdk/src/internal/screening-calldata.ts
+++ b/sdk/src/internal/screening-calldata.ts
@@ -1,0 +1,30 @@
+/**
+ * Packing of the screening attestation into `apply_actions` calldata.
+ *
+ * The attestation travels as a Serde-encoded `Option<ScreeningAttestation>`
+ * appended after the action span: `[0x1]` when absent, `[0x0, issued_at,
+ * sig_r, sig_s]` when present. It is a separately-deserialized parameter, not
+ * part of the proof-committed action span, so it can be swapped (e.g. a
+ * timestamp refresh) without re-proving.
+ */
+
+import { cairo, CairoOption, CairoOptionVariant, CallData } from "starknet";
+import type { AdditionalData } from "./proving-service.js";
+import { toHex } from "../utils/convert.js";
+
+/**
+ * Serde-encode the attestation from a prove response's `additional_data` as
+ * the trailing calldata felts, hex-encoded to match the prover-produced
+ * action felts they follow.
+ */
+export function screeningCalldataSuffix(additionalData?: AdditionalData): string[] {
+  const signature = additionalData?.signature;
+  const attestationOption =
+    signature === undefined
+      ? new CairoOption<never>(CairoOptionVariant.None)
+      : new CairoOption(CairoOptionVariant.Some, {
+          issued_at: signature.issued_at,
+          signature: cairo.tuple(signature.sig_r, signature.sig_s),
+        });
+  return CallData.compile([attestationOption]).map((felt) => toHex(BigInt(felt)));
+}

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -484,6 +484,8 @@ export async function createDevnetTestEnv(
   const env = await devnet.initialize();
   const chainId = constants.StarknetChainId.SN_SEPOLIA;
 
+  // Source-built pool: its class hash is never pinned, so force compatibility
+  // calldata until the in-repo contract accepts the screening suffix.
   const transfers = {
     alice: createPrivateTransfers({
       account: env.alice,
@@ -491,6 +493,7 @@ export async function createDevnetTestEnv(
       provingProvider: new CallMockProofProvider(env.provider, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
+      poolMode: "compatibility",
     }),
     bob: createPrivateTransfers({
       account: env.bob,
@@ -498,6 +501,7 @@ export async function createDevnetTestEnv(
       provingProvider: new CallMockProofProvider(env.provider, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
+      poolMode: "compatibility",
     }),
   };
 

--- a/sdk/src/testing/mock-pool-contract.ts
+++ b/sdk/src/testing/mock-pool-contract.ts
@@ -95,6 +95,9 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
   private nullifiers = new Set<Hash>();
   private outgoingChannels = new Map<bigint, EncOutgoingChannelInfo>();
   private outgoingChannelCounters = new AddressMap<number>(() => 0);
+  // Class hash this mock pool is "deployed" under; heads the proof payload so
+  // tests can drive the SDK's class-hash pool-mode detection.
+  classHash = "0x0";
 
   // Allow dynamic access for MockContract interface
   [key: string]: unknown;
@@ -303,16 +306,32 @@ export class MockPoolContract implements MockContract, PoolContractInterface {
 
   /**
    * Apply server actions to mutate state.
+   *
+   * Mirrors the on-chain calldata shape. Against a screening-capable pool the
+   * action span is followed by a Serde-encoded Option<ScreeningAttestation> —
+   * [0x1] when absent, [0x0, issued_at, sig_r, sig_s] when present (Cairo's
+   * Option Serde: Some=0, None=1). Against the current pool there is no suffix
+   * at all (compatibility mode).
    */
-  apply_actions(actions: string[]): void {
-    for (let i = 0; i < actions.length; i++) {
+  apply_actions(calldata: string[]): void {
+    const actionCount = this.serverActions.length;
+    for (let i = 0; i < actionCount; i++) {
       assert(
-        this.serverActions[i].type == actions[i],
-        () => `Server action ${actions[i]} does not match expected ${this.serverActions[i].type}`
+        this.serverActions[i].type == calldata[i],
+        () => `Server action ${calldata[i]} does not match expected ${this.serverActions[i].type}`
       );
       this.serverActions[i].apply();
     }
     this.serverActions = [];
+
+    const screeningSuffix = calldata.slice(actionCount);
+    const isCompatibility = screeningSuffix.length == 0;
+    const isNoneAttestation = screeningSuffix.length == 1 && screeningSuffix[0] == "0x1";
+    const isSomeAttestation = screeningSuffix.length == 4 && screeningSuffix[0] == "0x0";
+    assert(
+      isCompatibility || isNoneAttestation || isSomeAttestation,
+      () => `Malformed screening attestation suffix: [${screeningSuffix.join(", ")}]`
+    );
   }
 
   /**

--- a/sdk/src/testing/mock-proof-provider.ts
+++ b/sdk/src/testing/mock-proof-provider.ts
@@ -52,9 +52,9 @@ export class MockProofProvider implements ProofProviderInterface {
 
     return {
       data: "",
-      // L2-to-L1 message payload: [class_hash, ...callbacks].
-      // The consumer strips the class_hash prefix before passing to apply_actions.
-      output: buildMessagePayload("0x0", callbacks),
+      // L2-to-L1 message payload: [class_hash, ...callbacks], as in a real
+      // prove response.
+      output: buildMessagePayload(this.pool.classHash, callbacks),
       proofFacts: [],
     };
   }

--- a/sdk/tests/internal/pool-mode.test.ts
+++ b/sdk/tests/internal/pool-mode.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import {
+  COMPATIBILITY_POOL_CLASS_HASHES,
+  poolModeForClassHash,
+} from "../../src/internal/pool-mode.js";
+import { toHex } from "../../src/utils/convert.js";
+
+const PINNED_CLASS_HASH = toHex(COMPATIBILITY_POOL_CLASS_HASHES[0]);
+
+describe("poolModeForClassHash", () => {
+  it("selects compatibility for a pinned deployed-pool class hash", () => {
+    expect(poolModeForClassHash(PINNED_CLASS_HASH)).toBe("compatibility");
+  });
+
+  it("matches a pinned hash on the canonical felt (zero-padded form)", () => {
+    const paddedClassHash = "0x" + PINNED_CLASS_HASH.slice(2).padStart(64, "0");
+    expect(poolModeForClassHash(paddedClassHash)).toBe("compatibility");
+  });
+
+  it("selects screening for any unpinned class hash", () => {
+    expect(poolModeForClassHash("0x123abc")).toBe("screening");
+  });
+
+  it("selects compatibility for a missing class hash", () => {
+    expect(poolModeForClassHash(undefined)).toBe("compatibility");
+  });
+
+  it("selects compatibility for an unparseable class hash felt", () => {
+    expect(poolModeForClassHash("not-a-felt")).toBe("compatibility");
+  });
+});

--- a/sdk/tests/internal/private-transfers-screening.test.ts
+++ b/sdk/tests/internal/private-transfers-screening.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { PrivateTransfers } from "../../src/internal/private-transfers.js";
+import { screeningCalldataSuffix } from "../../src/internal/screening-calldata.js";
+import {
+  COMPATIBILITY_POOL_CLASS_HASHES,
+  type PoolCapabilityMode,
+} from "../../src/internal/pool-mode.js";
+import type { Proof, ProofInvocationResult, ProofProviderInterface } from "../../src/interfaces.js";
+import type { AdditionalData } from "../../src/internal/proving-service.js";
+import { toHex } from "../../src/utils/convert.js";
+
+const POOL_ADDRESS = "0x1";
+// A pinned (deployed pre-screening) pool class vs. any other class hash.
+const COMPATIBILITY_CLASS_HASH = toHex(COMPATIBILITY_POOL_CLASS_HASHES[0]);
+const SCREENING_CLASS_HASH = "0xdec1a23ed";
+const ACTIONS = ["0xaction1", "0xaction2"];
+
+const SIGNATURE: AdditionalData = {
+  signature: {
+    issued_at: 1716579600,
+    sig_r: "0x6e6f63c878a2fdebb3934de2344fbd4bc04ae47b73561f2a5a170cd0c8a0cb",
+    sig_s: "0x58a68a71ca79df6cc71d5b4b4813685f590ede2c686b9096fb350f11298429f",
+  },
+};
+
+/**
+ * Build a PrivateTransfers whose proving provider returns a fixed proof headed
+ * by the given pool class hash. Only the surface executeWithInvocation touches
+ * is stubbed.
+ */
+function makeTransfers(
+  poolClassHash: string,
+  additionalData?: AdditionalData,
+  poolMode?: PoolCapabilityMode
+): PrivateTransfers {
+  const proof: Proof = {
+    data: "",
+    output: [poolClassHash, ...ACTIONS],
+    proofFacts: [],
+    additionalData,
+  };
+  const provingProvider: ProofProviderInterface = {
+    getDefaultDetails: async () => ({}) as never,
+    prove: async () => proof,
+  };
+  return new PrivateTransfers({
+    account: { address: POOL_ADDRESS } as never,
+    viewingKeyProvider: {} as never,
+    provingProvider,
+    discoveryProvider: {} as never,
+    proofInvocationFactory: { parseOutput: () => ({}) } as never,
+    poolContractAddress: POOL_ADDRESS,
+    poolMode,
+  });
+}
+
+const EMPTY_INVOCATION = {
+  invocation: {} as never,
+  registry: undefined as never,
+  warnings: [],
+} satisfies ProofInvocationResult;
+
+async function calldataFor(
+  poolClassHash: string,
+  additionalData?: AdditionalData,
+  poolMode?: PoolCapabilityMode
+): Promise<string[]> {
+  const result = await makeTransfers(poolClassHash, additionalData, poolMode).executeWithInvocation(
+    EMPTY_INVOCATION
+  );
+  return result.callAndProof.call.calldata as string[];
+}
+
+describe("executeWithInvocation calldata gating", () => {
+  it("pinned pool class hash: no suffix, even when a signature is present", async () => {
+    expect(await calldataFor(COMPATIBILITY_CLASS_HASH, SIGNATURE)).toEqual(ACTIONS);
+  });
+
+  it("unpinned pool class hash + signature: trailing [0x0, issued_at, sig_r, sig_s]", async () => {
+    expect(await calldataFor(SCREENING_CLASS_HASH, SIGNATURE)).toEqual([
+      ...ACTIONS,
+      ...screeningCalldataSuffix(SIGNATURE),
+    ]);
+  });
+
+  it("unpinned pool class hash + no signature: trailing Option::None ([0x1])", async () => {
+    expect(await calldataFor(SCREENING_CLASS_HASH, undefined)).toEqual([...ACTIONS, "0x1"]);
+  });
+
+  it("poolMode compatibility override wins over an unpinned class hash", async () => {
+    expect(await calldataFor(SCREENING_CLASS_HASH, SIGNATURE, "compatibility")).toEqual(ACTIONS);
+  });
+
+  it("poolMode screening override wins over a pinned class hash", async () => {
+    expect(await calldataFor(COMPATIBILITY_CLASS_HASH, undefined, "screening")).toEqual([
+      ...ACTIONS,
+      "0x1",
+    ]);
+  });
+});

--- a/sdk/tests/internal/screening-calldata.test.ts
+++ b/sdk/tests/internal/screening-calldata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { screeningCalldataSuffix } from "../../src/internal/screening-calldata.js";
+import type { ScreeningSignature } from "../../src/internal/proving-service.js";
+
+const SIGNATURE: ScreeningSignature = {
+  issued_at: 1716579600,
+  sig_r: "0x6e6f63c8",
+  sig_s: "0x58a68a71",
+};
+
+// 1716579600 in hex.
+const ISSUED_AT_FELT = "0x6650ed10";
+
+// Cairo's Option Serde: Some=0, None=1.
+describe("screeningCalldataSuffix", () => {
+  it("encodes a missing additional_data as Option::None ([0x1])", () => {
+    expect(screeningCalldataSuffix(undefined)).toEqual(["0x1"]);
+  });
+
+  it("encodes additional_data without a signature as Option::None ([0x1])", () => {
+    expect(screeningCalldataSuffix({})).toEqual(["0x1"]);
+  });
+
+  it("encodes a signature as Option::Some ([0x0]) with hex issued_at and verbatim felts", () => {
+    expect(screeningCalldataSuffix({ signature: SIGNATURE })).toEqual([
+      "0x0",
+      ISSUED_AT_FELT,
+      SIGNATURE.sig_r,
+      SIGNATURE.sig_s,
+    ]);
+  });
+});

--- a/sdk/tests/screening-pool-mode.test.ts
+++ b/sdk/tests/screening-pool-mode.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createTestEnv } from "./helpers/test-fixtures.js";
+import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
+import { COMPATIBILITY_POOL_CLASS_HASHES } from "../src/internal/pool-mode.js";
+import { toHex } from "../src/utils/convert.js";
+
+/**
+ * End-to-end calldata-shape wiring: real PrivateTransfers + MockProofProvider
+ * (whose proof payload is headed by the mock pool's class hash, driving the
+ * SDK's class-hash mode detection) + the mock pool (whose apply_actions
+ * enforces a well-formed calldata shape). Proves one SDK build talks to both
+ * pool versions without reverting on calldata arity.
+ */
+async function depositCalldata(poolClassHash: string): Promise<string[]> {
+  const { mocknet, env, transfers } = createTestEnv();
+  mocknet.pool.classHash = poolClassHash;
+
+  mocknet.executeOutside(await transfers.alice.build().register().execute());
+
+  const alice = new SimplePrivateTransfersImpl(transfers.alice);
+  const result = await alice.deposit(env.ace, 100n);
+  // apply_actions asserts a well-formed (or absent) attestation suffix; a throw
+  // here would mean the emitted shape mismatches what the pool version expects.
+  mocknet.executeOutside(result);
+  return result.callAndProof.call.calldata as string[];
+}
+
+describe("deposit calldata shape per pool class hash", () => {
+  it("pinned pool class: no screening attestation suffix; unpinned: suffixed", async () => {
+    const compat = await depositCalldata(toHex(COMPATIBILITY_POOL_CLASS_HASHES[0]));
+    const screening = await depositCalldata("0xdec1a23ed");
+    // The screening-capable pool appends exactly one extra felt (the None tag,
+    // 0x1 in Cairo's Option Serde), since MockProofProvider attaches no signature.
+    expect(screening.length).toBe(compat.length + 1);
+    expect(screening[screening.length - 1]).toBe("0x1");
+  });
+});


### PR DESCRIPTION
feat(sdk): pack screening attestation into apply_actions calldata (O1c)

Every apply_actions call now carries a trailing Serde-encoded `Option<ScreeningAttestation>` after the proof-committed action span: `[0x1]` when the prove response has no signature, `[0x0, issued_at, sig_r, sig_s]` when it does (spec §6.3). The attestation is deserialized by the pool as a separate parameter, outside the proven action span, so the SDK can swap in a fresh signature (timestamp refresh) without re-proving.

**Expected-red CI (by design, until the Cairo transitional contract lands):** SDK Devnet Test and e2e deposits revert because the deployed `apply_actions` still takes only `Span<ServerAction>`. Unit/mocknet suites are green (mock pool understands the new suffix). Do not merge before the pool contract upgrade.

Follow-ups (not in this PR): Cairo transitional arity + §5.2 signature verification; SDK pre-emptive sig refresh + reactive retry (§8.2).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/809)
<!-- Reviewable:end -->

