### PR TITLE
docs(privacy): correct set_auditor_public_key access control to security governor

### DIFF
--- a/packages/privacy/README.md
+++ b/packages/privacy/README.md
@@ -20,7 +20,7 @@ Read-only queries: channel/subchannel existence, note lookup, nullifier checks, 
 
 ### IAdmin
 
-Governance: auditor public key, fee amount, fee collector. Access-controlled to token admin / app governor.
+Governance: auditor public key, depositor block list, fee amount, fee collector. Access-controlled to security governor / app governor.
 
 ## Client action phases
 
@@ -48,7 +48,7 @@ Actions must be ordered by phase. Actions within the same phase can appear in an
 
 - **Reentrancy guard**: `apply_actions()` is protected by OpenZeppelin's `ReentrancyGuardComponent`. Reentrant calls (e.g. via `InvokeExternal` callbacks) are rejected.
 - **Pausable**: Both `apply_actions()` and `deposit_to_open_note()` require the contract to be unpaused (`PausableComponent`).
-- **Access control**: Admin functions use role-based access via `RolesComponent` and `AccessControlComponent`. `set_auditor_public_key` requires `token_admin` role. `set_fee_amount`, `set_fee_collector`, and `set_proof_validity_blocks` require `app_governor` role.
+- **Access control**: Admin functions use role-based access via `RolesComponent` and `AccessControlComponent`. `set_auditor_public_key` and `set_depositor_blocked` require `security_governor` role. `set_fee_amount`, `set_fee_collector`, and `set_proof_validity_blocks` require `app_governor` role.
 - **Replaceability**: Contract supports upgrades via `ReplaceabilityComponent`.
 
 ## Fees

--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -708,7 +708,8 @@ pub trait IAdmin<T> {
     /// Sets the auditor public key used for encrypting user private keys and withdrawal addresses.
     ///
     /// This key is used to encrypt user private keys (so only the auditor can decrypt them) and to
-    /// encrypt the user address when withdrawing. Only the token admin can call this function.
+    /// encrypt the user address when withdrawing. Only the security governor can call this
+    /// function.
     ///
     /// #### Parameters
     /// - `auditor_public_key` (`felt252`): The new auditor public key. Must be non-zero.
@@ -725,7 +726,7 @@ pub trait IAdmin<T> {
     /// `auditor_public_key` is zero.
     ///
     /// #### Access Control
-    /// - Only token admin.
+    /// - Only security governor.
     ///
     /// #### Notes
     /// - Rotating the auditor key creates a persistent audit gap:


### PR DESCRIPTION
## What

Fixes a doc/behavior mismatch on `set_auditor_public_key`:

- `interface.cairo` documented the access control as **token admin** (both the intro sentence and the `#### Access Control` section), but the implementation enforces `self.roles.only_security_governor()` (`privacy.cairo:988`). Updated both to **security governor**.
- `packages/privacy/README.md` had the same stale `token_admin` claim. Corrected the IAdmin overview and the Access control bullet to reflect the roles actually present on `main`:
  - `set_auditor_public_key` and `set_depositor_blocked` → `security_governor`
  - `set_fee_amount`, `set_fee_collector`, `set_proof_validity_blocks` → `app_governor`

## Why

Surfaced during an audit of the privacy Cairo diff. The access-control docs misstated who can rotate the auditor key — a security-relevant privilege — which could mislead integrators and reviewers. Doc-only change; no runtime behavior is affected.

## Scope

Documentation only — no code paths or tests changed. Deliberately does **not** reference `set_screener_public_key`, since that setter is not wired into `main` yet (it lands with the screening-v2 attestation flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/815)
<!-- Reviewable:end -->
