### PR TITLE
test(sdk): exercise screening + compatibility deposit paths on devnet

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -31,6 +31,12 @@
   `createPrivateTransfers()` gains an optional `poolMode` override for
   deployments whose pool class hash isn't pinned (e.g. local devnet/test pools
   built from source).
+- Screening v2 (testing): `ScreeningCallMockProofProvider` signs each deposit's
+  screening attestation with the canonical fixture screener key, and
+  `createCompatibilityAliceTransfers()` builds a compatibility-mode transfers
+  object. The devnet suite deploys the screening-capable pool, exercises an
+  attested deposit (screening mode), and asserts the pool rejects an un-attested
+  deposit (compatibility mode).
 
 ## 0.14.2-RC.6
 

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -25,6 +25,8 @@ import { TracingRpcProvider } from "./tracing-provider.js";
 import type { CallAndProof, PrivateTransfersInterface } from "../interfaces.js";
 import { createPrivateTransfers } from "../factory.js";
 import { CallMockProofProvider } from "./mock-proving.js";
+import { ScreeningCallMockProofProvider } from "./screening-mock-proving.js";
+import { SCREENING_SIGNER_PUBLIC_KEY } from "./screening-signer.js";
 import {
   ContractDiscoveryProvider,
   type DiscoveryOptions,
@@ -332,13 +334,17 @@ export class Devnet {
     debugLog("devnet", "setup", "class hash:", classHash);
 
     // Deploy the contract
-    // Constructor params: governance_admin, auditor_public_key, proof_validity_blocks
+    // Constructor params: governance_admin, auditor_public_key, screener_public_key, proof_validity_blocks
     const deployResponse = await deployer.deployContract(
       {
         classHash,
         constructorCalldata: [
           deployer.address, // governance_admin
           "0x1", // auditor_public_key (dummy value)
+          // screener_public_key: verifies deposit screening attestations. The
+          // canonical test screener key, so the signing mock provider's
+          // attestations validate on-chain.
+          "0x" + SCREENING_SIGNER_PUBLIC_KEY.toString(16),
           "450", // proof_validity_blocks (~15 min at 2s/block)
         ],
         salt: "0x0", // Deterministic salt for reproducible contract address
@@ -484,26 +490,50 @@ export async function createDevnetTestEnv(
   const env = await devnet.initialize();
   const chainId = constants.StarknetChainId.SN_SEPOLIA;
 
-  // Source-built pool: its class hash is never pinned, so force compatibility
-  // calldata until the in-repo contract accepts the screening suffix.
+  // The in-repo pool screens deposits, so drive it in screening mode and use a
+  // proving provider that signs each deposit's attestation with the screener
+  // key the pool was deployed with. poolMode is set explicitly because the
+  // source-built pool's class hash is unpinned (auto-detection is covered by
+  // the pool-mode unit tests).
   const transfers = {
     alice: createPrivateTransfers({
       account: env.alice,
       viewingKeyProvider: { getViewingKey: async () => toBigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
-      poolMode: "compatibility",
+      poolMode: "screening",
     }),
     bob: createPrivateTransfers({
       account: env.bob,
       viewingKeyProvider: { getViewingKey: async () => toBigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
-      poolMode: "compatibility",
+      poolMode: "screening",
     }),
   };
 
   return { devnet, env, transfers };
+}
+
+/**
+ * A compatibility-mode transfers object for `env.alice`: it omits the screening
+ * attestation suffix, exactly as a pre-screening client would. Against the
+ * in-repo screening pool a deposit through it is expected to revert, so this is
+ * used to assert the pool rejects an un-attested deposit. It shares alice's
+ * account and viewing key, so register/setup performed by the screening
+ * transfers apply to it too.
+ */
+export function createCompatibilityAliceTransfers(
+  env: DevnetEnvironment
+): PrivateTransfersInterface {
+  return createPrivateTransfers({
+    account: env.alice,
+    viewingKeyProvider: { getViewingKey: async () => toBigInt("0xA11CE") },
+    provingProvider: new CallMockProofProvider(env.provider, constants.StarknetChainId.SN_SEPOLIA),
+    discoveryProvider: new ContractDiscoveryProvider(env.privacy),
+    poolContractAddress: env.privacy.address,
+    poolMode: "compatibility",
+  });
 }

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -45,6 +45,7 @@ export {
 export {
   Devnet,
   createDevnetTestEnv,
+  createCompatibilityAliceTransfers,
   type DevnetConfig,
   type DevnetEnvironment,
   type DevnetTestEnv,

--- a/sdk/src/testing/mock-proving.ts
+++ b/sdk/src/testing/mock-proving.ts
@@ -24,8 +24,8 @@ const VALIDATED = encode.utf8ToBigInt("VALID");
  */
 export class CallMockProofProvider implements ProofProviderInterface {
   constructor(
-    private readonly provider: ProviderInterface,
-    private readonly chainId: constants.StarknetChainId
+    protected readonly provider: ProviderInterface,
+    protected readonly chainId: constants.StarknetChainId
   ) {}
 
   async getDefaultDetails() {

--- a/sdk/src/testing/screening-mock-proving.ts
+++ b/sdk/src/testing/screening-mock-proving.ts
@@ -1,0 +1,68 @@
+/**
+ * A mock proving provider that also fabricates a screening attestation for
+ * regular-pool deposits, so the devnet suite can exercise the screening-capable
+ * pool's deposit path end to end.
+ *
+ * The real proving service screens a deposit's depositor and relays the
+ * screener's signature in the proof's `additional_data`; the screening-capable
+ * contract rejects a deposit whose attestation is missing or invalid. This
+ * provider mirrors that: when the proven actions contain a `Deposit`, it signs
+ * an attestation over the depositor with the canonical test screener key (whose
+ * public key the pool is deployed with) and attaches it. Non-deposit actions
+ * carry no attestation — the contract requires `Option::None` for those.
+ */
+
+import { CallData, num, type BlockIdentifier } from "starknet";
+import { PrivacyPoolABI } from "../internal/abi.js";
+import type { Proof, ProofInvocation } from "../interfaces.js";
+import { extractExecuteViewCalldata } from "../internal/proof-invocation-factory.js";
+import { CallMockProofProvider } from "./mock-proving.js";
+import { signScreeningAttestation, SCREENING_SIGNER_PRIVATE_KEY } from "./screening-signer.js";
+
+const CLIENT_ACTIONS_TYPE = "core::array::Span::<privacy::actions::ClientAction>" as const;
+
+export class ScreeningCallMockProofProvider extends CallMockProofProvider {
+  private readonly actionsDecoder = new CallData(PrivacyPoolABI);
+
+  async prove(invocation: ProofInvocation, blockIdentifier?: BlockIdentifier): Promise<Proof> {
+    const proof = await super.prove(invocation, blockIdentifier);
+
+    const depositor = this.depositorToScreen(invocation);
+    if (depositor === undefined) return proof;
+
+    // Sign over the chain id the contract actually verifies against
+    // (get_tx_info().chain_id), queried from the chain rather than assumed, and
+    // an issued_at <= the block timestamp the contract reads (else
+    // SCREENING_FUTURE_DATED) — use the chain's own clock, not the host's.
+    const chainId = await this.provider.getChainId();
+    const block = await this.provider.getBlock(blockIdentifier ?? "latest");
+    const signature = signScreeningAttestation(
+      SCREENING_SIGNER_PRIVATE_KEY,
+      BigInt(chainId),
+      BigInt(depositor),
+      Number(block.timestamp)
+    );
+    return { ...proof, additionalData: { signature } };
+  }
+
+  /**
+   * The depositor to attest, or `undefined` when the invocation carries no
+   * regular-pool deposit. Inner calldata is `[user_addr, user_private_key,
+   * ...client actions]`; the depositor is `user_addr`, matching the
+   * `TransferFrom.from_addr` a self-funded deposit proves on-chain.
+   */
+  private depositorToScreen(invocation: ProofInvocation): string | undefined {
+    const innerCalldata = extractExecuteViewCalldata(invocation.calldata as string[]);
+    if (innerCalldata.length < 3) return undefined;
+    try {
+      const decoded = this.actionsDecoder.decodeParameters(
+        CLIENT_ACTIONS_TYPE,
+        innerCalldata.slice(2)
+      ) as Array<{ activeVariant: () => string }>;
+      const hasDeposit = decoded.some((action) => action.activeVariant() === "Deposit");
+      return hasDeposit ? num.toHex(innerCalldata[0]) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/sdk/src/testing/screening-signer.ts
+++ b/sdk/src/testing/screening-signer.ts
@@ -1,0 +1,108 @@
+/**
+ * Test-only signer for screening attestations.
+ *
+ * Produces the STARK-curve ECDSA signature over the SNIP-12 (revision 1)
+ * typed-data message the privacy-pool contract verifies on-chain
+ * (packages/privacy/src/snip12.cairo) for a regular-pool deposit. In production
+ * this signature comes from the off-chain screener (the proving service relays
+ * it); tests fabricate it here so the devnet suite can exercise the screening
+ * path without a live screener.
+ *
+ * The message hash and signature stay byte-compatible with the canonical
+ * cross-language vectors in fixtures/screening-vectors.json — screening-signer
+ * test asserts this signer reproduces every committed vector.
+ *
+ * SNIP-12 revision-1 message hash:
+ *   poseidon_hash_span([
+ *     shortstring("StarkNet Message"),
+ *     domain_hash,           // poseidon(DOMAIN_TYPE_HASH, name, version, chain_id, 1)
+ *     signer_public_key,     // SNIP-12 "account" slot
+ *     message_struct_hash,   // poseidon(DEPOSITOR_VALIDATION_TYPE_HASH, depositor, issued_at)
+ *   ])
+ */
+
+import { ec } from "starknet";
+import type { ScreeningSignature } from "../internal/proving-service.js";
+
+/** A Cairo short string is its ASCII bytes read big-endian as a felt (<= 31 chars). */
+function shortStringToFelt(text: string): bigint {
+  return BigInt("0x" + Buffer.from(text, "ascii").toString("hex"));
+}
+
+const STARKNET_MESSAGE = shortStringToFelt("StarkNet Message");
+// starknet_keccak of the SNIP-12 encodeType strings, pinned as felts so an
+// encodeType edit can't silently shift the digest. The deployed Cairo verifier
+// bakes in the same constants; the cross-language vectors reproduce them.
+const STARKNET_DOMAIN_TYPE_HASH =
+  0x1ff2f602e42168014d405a94f75e8a93d640751d71d16311266e140d8b0a210n;
+const DEPOSITOR_VALIDATION_TYPE_HASH =
+  0x32d43b7372c9ea8a35daf12b02c5f6f74837910ecbaf2a3ecfe71fec901913dn;
+const DOMAIN_NAME = shortStringToFelt("Screening");
+// Numeric felt (not the shortstring '2'), matching the on-chain verifier.
+const DOMAIN_VERSION = 2n;
+const DOMAIN_REVISION = 1n;
+
+// The canonical screening signer keypair from fixtures/screening-vectors.json.
+// The pool is deployed with this public key as its `screener_public_key`, and
+// the signing mock proof provider signs deposits with this private key.
+export const SCREENING_SIGNER_PRIVATE_KEY = "0xCAFEBABE";
+export const SCREENING_SIGNER_PUBLIC_KEY = BigInt(
+  ec.starkCurve.getStarkKey(SCREENING_SIGNER_PRIVATE_KEY)
+);
+
+/**
+ * Recompute the SNIP-12 message hash the contract verifies. `chainId` and
+ * `depositor` are field elements; `signerPublicKey` fills the SNIP-12 account
+ * slot and is the key `check_ecdsa_signature` verifies against.
+ */
+export function computeScreeningMessageHash(
+  chainId: bigint,
+  depositor: bigint,
+  issuedAt: bigint,
+  signerPublicKey: bigint
+): bigint {
+  const domainHash = ec.starkCurve.poseidonHashMany([
+    STARKNET_DOMAIN_TYPE_HASH,
+    DOMAIN_NAME,
+    DOMAIN_VERSION,
+    chainId,
+    DOMAIN_REVISION,
+  ]);
+  const messageStructHash = ec.starkCurve.poseidonHashMany([
+    DEPOSITOR_VALIDATION_TYPE_HASH,
+    depositor,
+    issuedAt,
+  ]);
+  return ec.starkCurve.poseidonHashMany([
+    STARKNET_MESSAGE,
+    domainHash,
+    signerPublicKey,
+    messageStructHash,
+  ]);
+}
+
+/**
+ * Sign a screening attestation. `issuedAt` is unix seconds. The signer's public
+ * key (derived from `privateKey`) fills the SNIP-12 account slot, so the
+ * signature is bound to the exact key that verifies it on-chain.
+ */
+export function signScreeningAttestation(
+  privateKey: string,
+  chainId: bigint,
+  depositor: bigint,
+  issuedAt: number
+): ScreeningSignature {
+  const signerPublicKey = BigInt(ec.starkCurve.getStarkKey(privateKey));
+  const messageHash = computeScreeningMessageHash(
+    chainId,
+    depositor,
+    BigInt(issuedAt),
+    signerPublicKey
+  );
+  const signature = ec.starkCurve.sign("0x" + messageHash.toString(16), privateKey);
+  return {
+    issued_at: issuedAt,
+    sig_r: "0x" + signature.r.toString(16),
+    sig_s: "0x" + signature.s.toString(16),
+  };
+}

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -10,7 +10,12 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hash } from "starknet";
-import { Devnet, createDevnetTestEnv, type DevnetTestEnv } from "../src/testing/index.js";
+import {
+  Devnet,
+  createDevnetTestEnv,
+  createCompatibilityAliceTransfers,
+  type DevnetTestEnv,
+} from "../src/testing/index.js";
 import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
 import { debugLog } from "../src/utils/logging.js";
 
@@ -137,6 +142,35 @@ describe("Devnet Integration", () => {
     debugLog("test", "should deposit", "channels", channels);
 
     expect(channels!.get(env.bob.address)?.tokens.get(env.strk)?.noteNonce).toBe(1);
+  });
+
+  it("rejects a compatibility-mode deposit (no attestation) on the screening pool", async () => {
+    const { env } = testEnv;
+
+    // alice is registered and set up by the deposit test above. A compatibility
+    // client omits the screening attestation suffix, which the screening pool
+    // requires for every deposit, so the deposit must revert. This is the
+    // safety property: an un-attested deposit cannot slip through.
+    await env.alice.execute({
+      contractAddress: env.strk,
+      entrypoint: "approve",
+      calldata: [env.privacy.address, 100n, 0n],
+    });
+
+    const compatibilityAlice = createCompatibilityAliceTransfers(env);
+    const { callAndProof } = await compatibilityAlice
+      .build({
+        autoRegister: false,
+        autoSetup: false,
+        autoDiscover: { notes: "refresh", channels: "refresh" },
+      })
+      .with(env.strk)
+      .deposit({ amount: 100n })
+      .surplusTo(env.alice.address)
+      .execute();
+
+    const receipt = await devnet.executeOutside(callAndProof);
+    expect(receipt.isReverted()).toBe(true);
   });
 
   it("should swap STRK to ETH through Cairo mock executor and create open note", async () => {

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -169,8 +169,10 @@ describe("Devnet Integration", () => {
       .surplusTo(env.alice.address)
       .execute();
 
-    const receipt = await devnet.executeOutside(callAndProof);
-    expect(receipt.isReverted()).toBe(true);
+    // executeOutside throws on an on-chain revert rather than returning a
+    // reverted receipt. The pool can't deserialize apply_actions without the
+    // trailing screening Option, so the deposit is rejected.
+    await expect(devnet.executeOutside(callAndProof)).rejects.toThrow(/reverted|deserialize/i);
   });
 
   it("should swap STRK to ETH through Cairo mock executor and create open note", async () => {

--- a/sdk/tests/testing/screening-signer.test.ts
+++ b/sdk/tests/testing/screening-signer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import {
+  computeScreeningMessageHash,
+  signScreeningAttestation,
+  SCREENING_SIGNER_PRIVATE_KEY,
+  SCREENING_SIGNER_PUBLIC_KEY,
+} from "../../src/testing/screening-signer.js";
+
+// The committed cross-language vectors: the contract between the reference
+// Python signer, this signer, and the Cairo verifier (packages/privacy). Each
+// vector binds {chain_id, depositor, issued_at} to a message hash + signature
+// under the fixture's signer key.
+interface ScreeningVector {
+  name: string;
+  chain_id: string;
+  depositor: string;
+  issued_at: number;
+  message_hash: string;
+  sig_r: string;
+  sig_s: string;
+}
+
+const FIXTURE = JSON.parse(
+  readFileSync(new URL("../../../fixtures/screening-vectors.json", import.meta.url), "utf8")
+) as {
+  signer_private_key: string;
+  signer_public_key: string;
+  vectors: ScreeningVector[];
+};
+
+describe("screening-signer", () => {
+  it("uses the fixture's signer keypair", () => {
+    expect(SCREENING_SIGNER_PRIVATE_KEY.toLowerCase()).toBe(
+      FIXTURE.signer_private_key.toLowerCase()
+    );
+    expect(SCREENING_SIGNER_PUBLIC_KEY).toBe(BigInt(FIXTURE.signer_public_key));
+  });
+
+  it("reproduces the committed message hash for every vector", () => {
+    for (const vector of FIXTURE.vectors) {
+      const messageHash = computeScreeningMessageHash(
+        BigInt(vector.chain_id),
+        BigInt(vector.depositor),
+        BigInt(vector.issued_at),
+        BigInt(FIXTURE.signer_public_key)
+      );
+      expect("0x" + messageHash.toString(16)).toBe("0x" + BigInt(vector.message_hash).toString(16));
+    }
+  });
+
+  it("reproduces the committed signature for every vector", () => {
+    for (const vector of FIXTURE.vectors) {
+      const signature = signScreeningAttestation(
+        FIXTURE.signer_private_key,
+        BigInt(vector.chain_id),
+        BigInt(vector.depositor),
+        vector.issued_at
+      );
+      expect(signature.issued_at).toBe(vector.issued_at);
+      expect(BigInt(signature.sig_r)).toBe(BigInt(vector.sig_r));
+      expect(BigInt(signature.sig_s)).toBe(BigInt(vector.sig_s));
+    }
+  });
+
+  it("signs arbitrary (non-vector) inputs with the right issued_at and hex felts", () => {
+    const signature = signScreeningAttestation(
+      SCREENING_SIGNER_PRIVATE_KEY,
+      BigInt("0x534e5f5345504f4c4941"),
+      BigInt("0xabc123"),
+      1_800_000_000
+    );
+    expect(signature.issued_at).toBe(1_800_000_000);
+    expect(signature.sig_r).toMatch(/^0x[0-9a-f]+$/);
+    expect(signature.sig_s).toMatch(/^0x[0-9a-f]+$/);
+  });
+});


### PR DESCRIPTION
Stacked on #813. Makes the SDK devnet suite drive the screening-capable pool that #813 introduces — #813's contract changes alone left the devnet test red (the harness deployed with the old 3-arg constructor and ran in compatibility mode, which the new pool rejects).

## What this does
- **Deploy fix:** the pool is deployed with the new 4-arg constructor, supplying `screener_public_key` (the canonical fixture screener key).
- **Screening mode:** `createDevnetTestEnv` drives alice/bob in `poolMode: "screening"` via a new `ScreeningCallMockProofProvider` that signs each deposit's SNIP-12 attestation with the fixture screener private key, over the chain id the contract verifies against (`get_tx_info().chain_id`, queried from the provider) and an `issued_at` ≤ the block timestamp. It attaches an attestation only for actions that contain a `Deposit` (the contract requires `Option::None` otherwise).
- **Compatibility (negative):** `createCompatibilityAliceTransfers` builds a compatibility-mode (no-attestation) client; a new test asserts the screening pool **rejects** its deposit — the safety property that an un-attested deposit can't slip through. (A positive compatibility deposit is only possible against a pre-screening pool, not this one.)
- **Signer:** `screening-signer.ts` ports the SNIP-12 signer; a unit test asserts it reproduces every committed cross-language vector in `fixtures/screening-vectors.json` (message hash + signature).

## Verification
- ✅ Signer reproduces all committed vectors (unit test); SDK build, lint, and the 239-test unit suite pass.
- ⏳ The devnet integration (SDK Devnet Test) is verified by CI here — it couldn't be run in my local environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/816)
<!-- Reviewable:end -->
