### PR TITLE
fix(anonymizers): restrict privacy_invoke to the trusted privacy contract

### DIFF
--- a/e2e/scripts/deploy-ekubo.ts
+++ b/e2e/scripts/deploy-ekubo.ts
@@ -16,7 +16,7 @@
 import { appendFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { setupAdmin } from "../src/utils.js";
+import { setupAdmin, requireEnv } from "../src/utils.js";
 import {
   deployEkuboInfra,
   deployEkuboExecutor,
@@ -86,7 +86,11 @@ const ekubo = await deployEkuboInfra(
 );
 
 console.log("\n=== Deploying Ekubo executor ===");
-const executorAddress = await deployEkuboExecutor(adminAccount, provider);
+const executorAddress = await deployEkuboExecutor(
+  adminAccount,
+  provider,
+  requireEnv("VITE_POOL_ADDRESS"),
+);
 
 const ekuboPool = {
   token0: ekubo.poolToken0,

--- a/e2e/scripts/deploy-vesu.ts
+++ b/e2e/scripts/deploy-vesu.ts
@@ -16,7 +16,7 @@
 import { writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { setupAdmin } from "../src/utils.js";
+import { setupAdmin, requireEnv } from "../src/utils.js";
 import {
   deployTestTokens,
   deployVesuInfra,
@@ -53,7 +53,11 @@ const vesu = await deployVesuInfra(adminAccount, provider, {
 });
 
 console.log("\n=== Deploying Vesu lending anonymizer ===");
-const anonymizerAddress = await deployVesuAnonymizer(adminAccount, provider);
+const anonymizerAddress = await deployVesuAnonymizer(
+  adminAccount,
+  provider,
+  requireEnv("VITE_POOL_ADDRESS"),
+);
 
 // Build output env vars
 const tokens = [

--- a/e2e/src/ekubo-setup.ts
+++ b/e2e/src/ekubo-setup.ts
@@ -174,6 +174,7 @@ export async function deployEkuboInfra(
 export async function deployEkuboExecutor(
   admin: Account,
   provider: RpcProvider,
+  privacyAddress: string,
 ): Promise<string> {
   const executorArtifact = artifactPair(
     join(repoRoot(), "target/dev"),
@@ -192,7 +193,7 @@ export async function deployEkuboExecutor(
     admin,
     provider,
     executorClassHash,
-    [], // stateless — no constructor args
+    [privacyAddress], // constructor: trusted privacy contract allowed to call privacy_invoke
     "0x100",
   );
 }

--- a/e2e/src/vesu-setup.ts
+++ b/e2e/src/vesu-setup.ts
@@ -367,6 +367,7 @@ export async function deployVesuInfra(
 export async function deployVesuAnonymizer(
   admin: Account,
   provider: RpcProvider,
+  privacyAddress: string,
 ): Promise<string> {
   const anonymizerArtifact = artifactPair(
     join(repoRoot(), "target/dev"),
@@ -381,5 +382,12 @@ export async function deployVesuAnonymizer(
     anonymizerArtifact.compiledPath,
   );
 
-  return deployContract(admin, provider, anonymizerClassHash, [], "0x700");
+  // constructor: trusted privacy contract allowed to call privacy_invoke
+  return deployContract(
+    admin,
+    provider,
+    anonymizerClassHash,
+    [privacyAddress],
+    "0x700",
+  );
 }

--- a/e2e/tests/devnet/swap-ekubo.test.ts
+++ b/e2e/tests/devnet/swap-ekubo.test.ts
@@ -27,7 +27,11 @@ describe("Ekubo swap on devnet", () => {
     const { admin, provider } = env.env;
     tokens = await deployTestTokens(admin, provider);
     ekubo = await deployEkuboInfra(admin, provider, tokens);
-    executorAddress = await deployEkuboExecutor(admin, provider);
+    executorAddress = await deployEkuboExecutor(
+      admin,
+      provider,
+      env.env.privacy.address,
+    );
   });
 
   afterAll(async () => {

--- a/e2e/tests/devnet/vesu-lending.test.ts
+++ b/e2e/tests/devnet/vesu-lending.test.ts
@@ -27,7 +27,11 @@ describe("Vesu lending on devnet", () => {
     const { admin, provider } = env.env;
     tokens = await deployTestTokens(admin, provider);
     vesu = await deployVesuInfra(admin, provider, tokens);
-    anonymizerAddress = await deployVesuAnonymizer(admin, provider);
+    anonymizerAddress = await deployVesuAnonymizer(
+      admin,
+      provider,
+      env.env.privacy.address,
+    );
   });
 
   afterAll(async () => {

--- a/packages/ekubo_swap_anonymizer/src/ekubo_swap_anonymizer.cairo
+++ b/packages/ekubo_swap_anonymizer/src/ekubo_swap_anonymizer.cairo
@@ -12,6 +12,8 @@ use privacy::objects::OpenNoteDeposit;
 use starknet::ContractAddress;
 
 pub mod errors {
+    pub const ZERO_PRIVACY_CONTRACT: felt252 = 'ZERO_PRIVACY_CONTRACT';
+    pub const CALLER_NOT_PRIVACY: felt252 = 'CALLER_NOT_PRIVACY';
     pub const ZERO_ROUTER: felt252 = 'ZERO_ROUTER';
     pub const ZERO_IN_TOKEN: felt252 = 'ZERO_IN_TOKEN';
     pub const ZERO_IN_AMOUNT: felt252 = 'ZERO_IN_AMOUNT';
@@ -48,6 +50,8 @@ pub trait IEkuboSwapAnonymizer<T> {
     /// - `token_amount.token` must be one of the two tokens in `pool_key`.
     ///
     /// #### Reverts
+    /// - [`CALLER_NOT_PRIVACY`](errors::CALLER_NOT_PRIVACY): Thrown if the caller is not the
+    ///   trusted privacy contract set at construction.
     /// - [`ZERO_ROUTER`](errors::ZERO_ROUTER): Thrown if `router_addr` is zero.
     /// - [`ZERO_IN_TOKEN`](errors::ZERO_IN_TOKEN): Thrown if `token_amount.token` is zero.
     /// - [`NEGATIVE_AMOUNT`](errors::NEGATIVE_AMOUNT): Thrown if `token_amount.amount` is negative.
@@ -86,15 +90,22 @@ pub mod EkuboSwapAnonymizer {
     use ekubo::types::keys::PoolKey;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use privacy::objects::OpenNoteDeposit;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use starkware_utils::erc20::erc20_utils::checked_transfer;
     use super::{IEkuboSwapAnonymizer, errors};
 
     #[storage]
-    struct Storage {}
+    struct Storage {
+        /// The privacy contract allowed to call `privacy_invoke`. Set once at construction.
+        privacy_contract: ContractAddress,
+    }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {}
+    fn constructor(ref self: ContractState, privacy_contract: ContractAddress) {
+        assert(privacy_contract.is_non_zero(), errors::ZERO_PRIVACY_CONTRACT);
+        self.privacy_contract.write(privacy_contract);
+    }
 
     #[abi(embed_v0)]
     pub impl EkuboSwapAnonymizerImpl of IEkuboSwapAnonymizer<ContractState> {
@@ -107,6 +118,10 @@ pub mod EkuboSwapAnonymizer {
             skip_ahead: u128,
             note_id: felt252,
         ) -> Span<OpenNoteDeposit> {
+            // Only the trusted privacy contract may invoke; otherwise an arbitrary caller would
+            // receive the output-token approval below and could drain swapped funds.
+            let privacy_addr = self.privacy_contract.read();
+            assert(get_caller_address() == privacy_addr, errors::CALLER_NOT_PRIVACY);
             assert(router_addr.is_non_zero(), errors::ZERO_ROUTER);
 
             let TokenAmount {
@@ -124,7 +139,6 @@ pub mod EkuboSwapAnonymizer {
             };
 
             let self_addr = get_contract_address();
-            let privacy_addr = get_caller_address();
             let out_erc20 = IERC20Dispatcher { contract_address: out_token };
 
             checked_transfer(

--- a/packages/ekubo_swap_anonymizer/src/tests/test_ekubo_swap_anonymizer.cairo
+++ b/packages/ekubo_swap_anonymizer/src/tests/test_ekubo_swap_anonymizer.cairo
@@ -13,6 +13,7 @@ use ekubo_swap_anonymizer::tests::test_utils::{
 };
 use privacy::objects::OpenNoteDeposit;
 use snforge_std::TokenTrait;
+use starknet::ContractAddress;
 use starkware_utils::constants::MAX_U128;
 use starkware_utils_testing::test_utils::{TokenHelperTrait, assert_panic_with_felt_error};
 
@@ -96,6 +97,35 @@ fn test_ekubo_same_anonymizer_different_pool() {
     assert_eq!(token_a.balance_of(address: anonymizer.address), Zero::zero());
     assert_eq!(token_c.balance_of(address: anonymizer.address), swap_amount.into());
     assert_eq!(token_c.balance_of(address: anonymizer.router), Zero::zero());
+}
+
+#[test]
+fn test_ekubo_privacy_invoke_unauthorized_caller() {
+    let anonymizer = deploy_anonymizer_with_router();
+    let input_token = new_token();
+    let output_token = new_token();
+    let swap_amount = DEFAULT_AMOUNT;
+
+    // Fund the anonymizer and router so the swap would otherwise succeed: the only thing that
+    // stops a non-privacy caller from draining the output is the caller-authorization guard.
+    input_token.supply(address: anonymizer.address, amount: swap_amount);
+    output_token.supply(address: anonymizer.router, amount: swap_amount);
+
+    let in_addr = input_token.contract_address();
+    let out_addr = output_token.contract_address();
+    let pool_key = pool_key_for_tokens(in_addr, out_addr);
+
+    let attacker: ContractAddress = 'ATTACKER'.try_into().unwrap();
+    let result = anonymizer
+        .safe_privacy_invoke_from(
+            caller: attacker,
+            token_amount: make_token_amount(in_addr, swap_amount),
+            :pool_key,
+            minimum_received: 0,
+            skip_ahead: 0,
+            note_id: 'note',
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::CALLER_NOT_PRIVACY);
 }
 
 #[test]

--- a/packages/ekubo_swap_anonymizer/src/tests/test_utils.cairo
+++ b/packages/ekubo_swap_anonymizer/src/tests/test_utils.cairo
@@ -11,7 +11,13 @@ use privacy::objects::OpenNoteDeposit;
 use snforge_std::{CustomToken, DeclareResultTrait, Token, declare};
 use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
-use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
+use starkware_utils_testing::test_utils::{Deployable, TokenConfig, cheat_caller_address_once};
+
+/// Trusted privacy contract used by the anonymizer in tests. `privacy_invoke` rejects any other
+/// caller, so the wrappers below cheat the caller to this address.
+pub fn privacy_contract() -> ContractAddress {
+    'PRIVACY_CONTRACT'.try_into().unwrap()
+}
 
 pub fn deploy_mock_ekubo_amm() -> ContractAddress {
     let class_hash = declare(contract: "MockEkuboAMM").unwrap_syscall().contract_class().class_hash;
@@ -23,14 +29,14 @@ pub fn deploy_mock_ekubo_amm() -> ContractAddress {
     contract_address
 }
 
-pub fn deploy_ekubo_swap_anonymizer() -> ContractAddress {
+pub fn deploy_ekubo_swap_anonymizer(privacy_contract: ContractAddress) -> ContractAddress {
     let class_hash = declare(contract: "EkuboSwapAnonymizer")
         .unwrap_syscall()
         .contract_class()
         .class_hash;
     let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
     let (contract_address, _) = EkuboSwapAnonymizer::deploy_for_test(
-        class_hash: *class_hash, :deployment_params,
+        class_hash: *class_hash, :deployment_params, :privacy_contract,
     )
         .expect('EkuboSwap deploy failed');
     contract_address
@@ -72,6 +78,8 @@ pub fn make_token_amount(token: ContractAddress, amount: u128) -> TokenAmount {
 pub struct EkuboSwapAnonymizerCfg {
     pub address: ContractAddress,
     pub router: ContractAddress,
+    /// The privacy contract the anonymizer trusts; the wrappers cheat the caller to this address.
+    pub privacy_address: ContractAddress,
 }
 
 #[generate_trait]
@@ -84,6 +92,9 @@ pub impl EkuboSwapAnonymizerCfgImpl of EkuboSwapAnonymizerCfgTrait {
         skip_ahead: u128,
         note_id: felt252,
     ) -> Span<OpenNoteDeposit> {
+        cheat_caller_address_once(
+            contract_address: *self.address, caller_address: *self.privacy_address,
+        );
         IEkuboSwapAnonymizerDispatcher { contract_address: *self.address }
             .privacy_invoke(
                 router_addr: *self.router,
@@ -105,15 +116,43 @@ pub impl EkuboSwapAnonymizerCfgImpl of EkuboSwapAnonymizerCfgTrait {
         skip_ahead: u128,
         note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        cheat_caller_address_once(
+            contract_address: *self.address, caller_address: *self.privacy_address,
+        );
         IEkuboSwapAnonymizerSafeDispatcher { contract_address: *self.address }
             .privacy_invoke(
                 :router_addr, :token_amount, :pool_key, :minimum_received, :skip_ahead, :note_id,
+            )
+    }
+
+    /// Calls `privacy_invoke` from `caller` (no cheat to the trusted privacy address), used to
+    /// exercise the caller-authorization guard.
+    #[feature("safe_dispatcher")]
+    fn safe_privacy_invoke_from(
+        self: @EkuboSwapAnonymizerCfg,
+        caller: ContractAddress,
+        token_amount: TokenAmount,
+        pool_key: PoolKey,
+        minimum_received: u256,
+        skip_ahead: u128,
+        note_id: felt252,
+    ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        cheat_caller_address_once(contract_address: *self.address, caller_address: caller);
+        IEkuboSwapAnonymizerSafeDispatcher { contract_address: *self.address }
+            .privacy_invoke(
+                router_addr: *self.router,
+                :token_amount,
+                :pool_key,
+                :minimum_received,
+                :skip_ahead,
+                :note_id,
             )
     }
 }
 
 pub fn deploy_anonymizer_with_router() -> EkuboSwapAnonymizerCfg {
     let mock_router = deploy_mock_ekubo_amm();
-    let anonymizer_address = deploy_ekubo_swap_anonymizer();
-    EkuboSwapAnonymizerCfg { address: anonymizer_address, router: mock_router }
+    let privacy_address = privacy_contract();
+    let anonymizer_address = deploy_ekubo_swap_anonymizer(privacy_contract: privacy_address);
+    EkuboSwapAnonymizerCfg { address: anonymizer_address, router: mock_router, privacy_address }
 }

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -1503,7 +1503,9 @@ pub(crate) impl TestImpl of TestTrait {
     fn deploy_vesu_components(ref self: Test) -> Vesu {
         let underlying_token = self.new_token();
         let vault = deploy_mock_vesu_vault(underlying_token: underlying_token.contract_address());
-        let lending_anonymizer = deploy_vesu_lending_anonymizer();
+        let lending_anonymizer = deploy_vesu_lending_anonymizer(
+            privacy_contract: self.privacy.address,
+        );
         Vesu { underlying_token, vault, lending_anonymizer }
     }
 
@@ -2207,14 +2209,14 @@ fn deploy_privacy(
     }
 }
 
-fn deploy_vesu_lending_anonymizer() -> ContractAddress {
+fn deploy_vesu_lending_anonymizer(privacy_contract: ContractAddress) -> ContractAddress {
     let class_hash = declare(contract: "VesuLendingAnonymizer")
         .unwrap_syscall()
         .contract_class()
         .class_hash;
     let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
     let (address, _) = VesuLendingAnonymizer::deploy_for_test(
-        class_hash: *class_hash, :deployment_params,
+        class_hash: *class_hash, :deployment_params, :privacy_contract,
     )
         .expect('VesuLending deploy failed');
     address
@@ -2407,7 +2409,7 @@ pub(crate) fn deploy_ekubo_swap_anonymizer(
         .class_hash;
     let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
     let (contract_address, _) = deploy_ekubo_swap_anonymizer_for_test(
-        class_hash: *class_hash, :deployment_params,
+        class_hash: *class_hash, :deployment_params, privacy_contract: privacy_address,
     )
         .expect('EkuboSwap deploy failed');
     EkuboSwapAnonymizerCfg { address: contract_address, router, privacy_address }
@@ -2466,6 +2468,9 @@ pub(crate) impl EkuboSwapAnonymizerCfgImpl of EkuboSwapAnonymizerCfgTrait {
         skip_ahead: u128,
         note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        cheat_caller_address_once(
+            contract_address: *self.address, caller_address: *self.privacy_address,
+        );
         IEkuboSwapAnonymizerSafeDispatcher { contract_address: *self.address }
             .privacy_invoke(
                 :router_addr, :token_amount, :pool_key, :minimum_received, :skip_ahead, :note_id,

--- a/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
@@ -3,7 +3,13 @@ use privacy::objects::OpenNoteDeposit;
 use snforge_std::{CustomToken, DeclareResultTrait, Token, TokenTrait, declare};
 use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
-use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
+use starkware_utils_testing::test_utils::{Deployable, TokenConfig, cheat_caller_address_once};
+
+/// Trusted privacy contract used by the anonymizer in tests. `privacy_invoke` rejects any other
+/// caller, so the wrappers below cheat the caller to this address.
+pub fn privacy_contract() -> ContractAddress {
+    'PRIVACY_CONTRACT'.try_into().unwrap()
+}
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow::deploy_for_test as deploy_mock_vesu_vault_overflow_for_test;
@@ -18,6 +24,8 @@ pub struct Vesu {
     pub underlying_token: Token,
     pub vault: ContractAddress,
     pub lending_anonymizer: ContractAddress,
+    /// The privacy contract the anonymizer trusts; the wrappers cheat the caller to this address.
+    pub privacy_address: ContractAddress,
 }
 
 #[generate_trait]
@@ -25,6 +33,7 @@ pub impl VesuImpl of VesuTrait {
     fn privacy_invoke_deposit(
         self: @Vesu, amount: u128, note_id: felt252,
     ) -> Span<OpenNoteDeposit> {
+        self.cheat_privacy_caller();
         IVesuLendingAnonymizerDispatcher { contract_address: *self.lending_anonymizer }
             .privacy_invoke(
                 operation: LendingOperation::Deposit,
@@ -38,6 +47,7 @@ pub impl VesuImpl of VesuTrait {
     fn privacy_invoke_withdraw(
         self: @Vesu, amount: u128, note_id: felt252,
     ) -> Span<OpenNoteDeposit> {
+        self.cheat_privacy_caller();
         IVesuLendingAnonymizerDispatcher { contract_address: *self.lending_anonymizer }
             .privacy_invoke(
                 operation: LendingOperation::Withdraw,
@@ -52,6 +62,7 @@ pub impl VesuImpl of VesuTrait {
     fn safe_privacy_invoke_deposit(
         self: @Vesu, amount: u128, note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        self.cheat_privacy_caller();
         IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
             .privacy_invoke(
                 operation: LendingOperation::Deposit,
@@ -66,6 +77,7 @@ pub impl VesuImpl of VesuTrait {
     fn safe_privacy_invoke_withdraw(
         self: @Vesu, amount: u128, note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        self.cheat_privacy_caller();
         IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
             .privacy_invoke(
                 operation: LendingOperation::Withdraw,
@@ -85,8 +97,34 @@ pub impl VesuImpl of VesuTrait {
         assets: u128,
         note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        self.cheat_privacy_caller();
         IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
             .privacy_invoke(:operation, :in_token, :out_token, assets: assets.into(), :note_id)
+    }
+
+    /// Calls `privacy_invoke` from `caller` (no cheat to the trusted privacy address), used to
+    /// exercise the caller-authorization guard.
+    #[feature("safe_dispatcher")]
+    fn safe_privacy_invoke_from(
+        self: @Vesu, caller: ContractAddress, amount: u128, note_id: felt252,
+    ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
+        cheat_caller_address_once(
+            contract_address: *self.lending_anonymizer, caller_address: caller,
+        );
+        IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
+            .privacy_invoke(
+                operation: LendingOperation::Deposit,
+                in_token: self.underlying_token.contract_address(),
+                out_token: *self.vault,
+                assets: amount.into(),
+                :note_id,
+            )
+    }
+
+    fn cheat_privacy_caller(self: @Vesu) {
+        cheat_caller_address_once(
+            contract_address: *self.lending_anonymizer, caller_address: *self.privacy_address,
+        );
     }
 
     fn vault_balance_of(self: @Vesu, address: ContractAddress) -> u256 {
@@ -97,18 +135,19 @@ pub impl VesuImpl of VesuTrait {
 pub fn deploy_vesu_components() -> Vesu {
     let underlying_token = deploy_test_erc20_token();
     let vault = deploy_mock_vesu_vault(underlying_token: underlying_token.contract_address());
-    let lending_anonymizer = deploy_vesu_lending_anonymizer();
-    Vesu { underlying_token, vault, lending_anonymizer }
+    let privacy_address = privacy_contract();
+    let lending_anonymizer = deploy_vesu_lending_anonymizer(privacy_contract: privacy_address);
+    Vesu { underlying_token, vault, lending_anonymizer, privacy_address }
 }
 
-pub fn deploy_vesu_lending_anonymizer() -> ContractAddress {
+pub fn deploy_vesu_lending_anonymizer(privacy_contract: ContractAddress) -> ContractAddress {
     let class_hash = declare(contract: "VesuLendingAnonymizer")
         .unwrap_syscall()
         .contract_class()
         .class_hash;
     let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
     let (address, _) = VesuLendingAnonymizer::deploy_for_test(
-        class_hash: *class_hash, :deployment_params,
+        class_hash: *class_hash, :deployment_params, :privacy_contract,
     )
         .expect('VesuLending deploy failed');
     address

--- a/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
@@ -1,6 +1,7 @@
 use core::num::traits::Zero;
 use privacy::objects::OpenNoteDeposit;
 use snforge_std::TokenTrait;
+use starknet::ContractAddress;
 use starkware_utils::constants::MAX_U128;
 use starkware_utils_testing::test_utils::{TokenHelperTrait, assert_panic_with_felt_error};
 use vesu_lending_anonymizer::tests::test_utils::{
@@ -61,6 +62,21 @@ fn test_privacy_invoke_deposit_withdraw(preexisting_balance: u128) {
         (preexisting_balance + amount).into(),
     );
     assert_eq!(vesu.underlying_token.balance_of(address: vesu.vault), 0);
+}
+
+#[test]
+fn test_privacy_invoke_unauthorized_caller() {
+    let vesu = deploy_vesu_components();
+    let amount = DEFAULT_AMOUNT;
+    let note_id: felt252 = 'NOTE_ID';
+
+    // Fund the anonymizer so the deposit would otherwise succeed: the only thing that stops a
+    // non-privacy caller from draining the output is the caller-authorization guard.
+    vesu.underlying_token.supply(address: vesu.lending_anonymizer, amount: amount);
+
+    let attacker: ContractAddress = 'ATTACKER'.try_into().unwrap();
+    let result = vesu.safe_privacy_invoke_from(caller: attacker, :amount, :note_id);
+    assert_panic_with_felt_error(:result, expected_error: errors::CALLER_NOT_PRIVACY);
 }
 
 #[test]

--- a/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
@@ -69,6 +69,10 @@ pub trait IVesuLendingAnonymizer<T> {
     /// - ([`Span<OpenNoteDeposit>`](privacy::objects::OpenNoteDeposit)) - span of deposits for the
     /// privacy contract to apply.
     ///
+    /// #### Reverts
+    /// - [`CALLER_NOT_PRIVACY`](errors::CALLER_NOT_PRIVACY) - Thrown if the caller is not the
+    /// trusted privacy contract set at construction.
+    ///
     /// #### Preconditions
     /// - `in_token` must not be zero.
     /// - `out_token` must not be zero.
@@ -96,6 +100,8 @@ pub trait IVesuLendingAnonymizer<T> {
 
 /// Error codes for Vesu lending operations.
 pub mod errors {
+    pub const ZERO_PRIVACY_CONTRACT: felt252 = 'ZERO_PRIVACY_CONTRACT';
+    pub const CALLER_NOT_PRIVACY: felt252 = 'CALLER_NOT_PRIVACY';
     pub const ZERO_IN_TOKEN: felt252 = 'ZERO_IN_TOKEN';
     pub const ZERO_OUT_TOKEN: felt252 = 'ZERO_OUT_TOKEN';
     pub const ZERO_ASSETS: felt252 = 'ZERO_ASSETS';
@@ -111,16 +117,23 @@ pub mod VesuLendingAnonymizer {
     use core::num::traits::Zero;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use privacy::objects::OpenNoteDeposit;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use super::{
         IVTokenDispatcher, IVTokenDispatcherTrait, IVesuLendingAnonymizer, LendingOperation, errors,
     };
 
     #[storage]
-    struct Storage {}
+    struct Storage {
+        /// The privacy contract allowed to call `privacy_invoke`. Set once at construction.
+        privacy_contract: ContractAddress,
+    }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {}
+    fn constructor(ref self: ContractState, privacy_contract: ContractAddress) {
+        assert(privacy_contract.is_non_zero(), errors::ZERO_PRIVACY_CONTRACT);
+        self.privacy_contract.write(privacy_contract);
+    }
 
     #[abi(embed_v0)]
     pub impl VesuLendingAnonymizerImpl of IVesuLendingAnonymizer<ContractState> {
@@ -132,13 +145,16 @@ pub mod VesuLendingAnonymizer {
             assets: u256,
             note_id: felt252,
         ) -> Span<OpenNoteDeposit> {
+            // Only the trusted privacy contract may invoke; otherwise an arbitrary caller would
+            // receive the output-token approval below and could drain the funds.
+            let privacy_addr = self.privacy_contract.read();
+            assert(get_caller_address() == privacy_addr, errors::CALLER_NOT_PRIVACY);
             assert(in_token.is_non_zero(), errors::ZERO_IN_TOKEN);
             assert(out_token.is_non_zero(), errors::ZERO_OUT_TOKEN);
             assert(assets.is_non_zero(), errors::ZERO_ASSETS);
             assert(in_token != out_token, errors::TOKENS_EQUAL);
 
             let self_addr = get_contract_address();
-            let privacy_addr = get_caller_address();
             let in_erc20 = IERC20Dispatcher { contract_address: in_token };
             let out_erc20 = IERC20Dispatcher { contract_address: out_token };
 


### PR DESCRIPTION
EkuboSwapAnonymizer and VesuLendingAnonymizer issued the output-token approval to get_caller_address() with no access control. Any address could call privacy_invoke directly, execute the swap/lend, and have the proceeds approved to itself, then drain them via transferFrom.

Store the trusted privacy contract address at construction and assert get_caller_address() == privacy_contract at the entry of privacy_invoke. The constructor arg is threaded through the test fixtures and the e2e deploy scripts/tests.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/819)
<!-- Reviewable:end -->
