### PR TITLE
fix(ekubo-anonymizer): add reentrancy guard to privacy_invoke

### DIFF
--- a/packages/ekubo_swap_anonymizer/src/ekubo_swap_anonymizer.cairo
+++ b/packages/ekubo_swap_anonymizer/src/ekubo_swap_anonymizer.cairo
@@ -89,16 +89,32 @@ pub mod EkuboSwapAnonymizer {
     use ekubo::types::i129::i129;
     use ekubo::types::keys::PoolKey;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::security::ReentrancyGuardComponent;
     use privacy::objects::OpenNoteDeposit;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use starkware_utils::erc20::erc20_utils::checked_transfer;
     use super::{IEkuboSwapAnonymizer, errors};
 
+    component!(
+        path: ReentrancyGuardComponent, storage: reentrancy_guard, event: ReentrancyGuardEvent,
+    );
+
+    impl ReentrancyGuardInternalImpl = ReentrancyGuardComponent::InternalImpl<ContractState>;
+
     #[storage]
     struct Storage {
+        #[substorage(v0)]
+        reentrancy_guard: ReentrancyGuardComponent::Storage,
         /// The privacy contract allowed to call `privacy_invoke`. Set once at construction.
         privacy_contract: ContractAddress,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ReentrancyGuardEvent: ReentrancyGuardComponent::Event,
     }
 
     #[constructor]
@@ -118,6 +134,9 @@ pub mod EkuboSwapAnonymizer {
             skip_ahead: u128,
             note_id: felt252,
         ) -> Span<OpenNoteDeposit> {
+            // Guard the whole flow: `router_addr` is caller-controlled, so a malicious router's
+            // `swap` callback must not be able to re-enter and corrupt the balance accounting.
+            self.reentrancy_guard.start();
             // Only the trusted privacy contract may invoke; otherwise an arbitrary caller would
             // receive the output-token approval below and could drain swapped funds.
             let privacy_addr = self.privacy_contract.read();
@@ -171,7 +190,10 @@ pub mod EkuboSwapAnonymizer {
             assert(out_amount.is_non_zero(), errors::ZERO_OUT_AMOUNT);
 
             out_erc20.approve(spender: privacy_addr, amount: out_amount.into());
-            [OpenNoteDeposit { note_id, token: out_token, amount: out_amount }].span()
+            let deposits = [OpenNoteDeposit { note_id, token: out_token, amount: out_amount }]
+                .span();
+            self.reentrancy_guard.end();
+            deposits
         }
     }
 }

--- a/packages/ekubo_swap_anonymizer/src/test_utils_contracts/mock_ekubo_amm.cairo
+++ b/packages/ekubo_swap_anonymizer/src/test_utils_contracts/mock_ekubo_amm.cairo
@@ -7,6 +7,8 @@
 //! - `Noop` – consumes all input but `clear` returns 0 (simulates zero output).
 //! - `PartialSwap` – consumes half the input, clears the output (simulates a partial fill
 //!   that leaves input tokens on the router).
+//! - `Reentrant` – re-enters the calling anonymizer's `privacy_invoke` during `swap`
+//!   (simulates a malicious router); used to exercise the reentrancy guard.
 
 use ekubo::interfaces::erc20::IERC20Dispatcher as EkuboIERC20Dispatcher;
 use ekubo::interfaces::router::{RouteNode, TokenAmount};
@@ -19,6 +21,7 @@ pub enum SwapBehavior {
     Normal,
     Noop,
     PartialSwap,
+    Reentrant,
 }
 
 #[starknet::interface]
@@ -50,6 +53,9 @@ pub mod MockEkuboAMM {
     use ekubo::types::i129::i129;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use crate::ekubo_swap_anonymizer::{
+        IEkuboSwapAnonymizerDispatcher, IEkuboSwapAnonymizerDispatcherTrait,
+    };
     use super::{IClear, IMockEkuboAMMControl, IRouter, SwapBehavior};
 
     const DEAD_ADDRESS: ContractAddress = 'DEAD_ADDRESS'.try_into().unwrap();
@@ -79,6 +85,20 @@ pub mod MockEkuboAMM {
             let consumed = match self.swap_behavior.read() {
                 SwapBehavior::Noop | SwapBehavior::Normal => amount_u128,
                 SwapBehavior::PartialSwap => amount_u128 / 2,
+                SwapBehavior::Reentrant => {
+                    // Re-enter the calling anonymizer mid-swap. A correctly guarded anonymizer
+                    // panics with `REENTRANT_CALL` here, which propagates out of `swap`.
+                    IEkuboSwapAnonymizerDispatcher { contract_address: get_caller_address() }
+                        .privacy_invoke(
+                            router_addr: get_contract_address(),
+                            :token_amount,
+                            pool_key: node.pool_key,
+                            minimum_received: 0,
+                            skip_ahead: 0,
+                            note_id: 'reentry',
+                        );
+                    amount_u128
+                },
             };
 
             // Simulate consuming input tokens so clear(in_token) returns the remainder.
@@ -106,8 +126,8 @@ pub mod MockEkuboAMM {
         ) -> u256 {
             match self.swap_behavior.read() {
                 SwapBehavior::Noop => Zero::zero(),
-                SwapBehavior::Normal |
-                SwapBehavior::PartialSwap => {
+                SwapBehavior::Normal | SwapBehavior::PartialSwap |
+                SwapBehavior::Reentrant => {
                     let balance = token.balanceOf(get_contract_address());
                     assert(balance >= minimum, 'CLEAR_MINIMUM_NOT_MET');
                     if balance.is_non_zero() {

--- a/packages/ekubo_swap_anonymizer/src/tests/test_ekubo_swap_anonymizer.cairo
+++ b/packages/ekubo_swap_anonymizer/src/tests/test_ekubo_swap_anonymizer.cairo
@@ -11,6 +11,7 @@ use ekubo_swap_anonymizer::tests::test_utils::{
     EkuboSwapAnonymizerCfgTrait, deploy_anonymizer_with_router, make_token_amount, new_token,
     pool_key_for_tokens,
 };
+use openzeppelin::security::ReentrancyGuardComponent::Errors as ReentrancyGuardErrors;
 use privacy::objects::OpenNoteDeposit;
 use snforge_std::TokenTrait;
 use starknet::ContractAddress;
@@ -126,6 +127,35 @@ fn test_ekubo_privacy_invoke_unauthorized_caller() {
             note_id: 'note',
         );
     assert_panic_with_felt_error(:result, expected_error: errors::CALLER_NOT_PRIVACY);
+}
+
+#[test]
+fn test_ekubo_privacy_invoke_reentrancy_guarded() {
+    let anonymizer = deploy_anonymizer_with_router();
+    let input_token = new_token();
+    let output_token = new_token();
+    let swap_amount = DEFAULT_AMOUNT;
+
+    input_token.supply(address: anonymizer.address, amount: swap_amount);
+    output_token.supply(address: anonymizer.router, amount: swap_amount);
+
+    // Make the router re-enter privacy_invoke during the swap callback.
+    IMockEkuboAMMControlDispatcher { contract_address: anonymizer.router }
+        .set_swap_behavior(SwapBehavior::Reentrant);
+
+    let in_addr = input_token.contract_address();
+    let out_addr = output_token.contract_address();
+    let pool_key = pool_key_for_tokens(in_addr, out_addr);
+    let result = anonymizer
+        .safe_privacy_invoke(
+            router_addr: anonymizer.router,
+            token_amount: make_token_amount(in_addr, swap_amount),
+            :pool_key,
+            minimum_received: 0,
+            skip_ahead: 0,
+            note_id: 'note',
+        );
+    assert_panic_with_felt_error(:result, expected_error: ReentrancyGuardErrors::REENTRANT_CALL);
 }
 
 #[test]


### PR DESCRIPTION
router_addr is caller-controlled, so a malicious router's swap callback could re-enter privacy_invoke and corrupt the balance_before/balance_after accounting, letting the outer approve overwrite the inner one.

Embed OpenZeppelin's ReentrancyGuardComponent and lock the whole privacy_invoke body. A re-entering MockEkuboAMM behavior exercises the guard.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/820)
<!-- Reviewable:end -->
