### PR TITLE
fix(vesu-anonymizer): redeem exact shares instead of withdraw

### DIFF
--- a/e2e/tests/devnet/vesu-lending.test.ts
+++ b/e2e/tests/devnet/vesu-lending.test.ts
@@ -144,7 +144,7 @@ describe("Vesu lending on devnet", () => {
             1n, // LendingOperation::Withdraw
             vesu.usdVToken,
             tokens.usdToken,
-            lendAmount, // withdraw same amount of underlying assets
+            vTokenAmount, // redeem the exact vToken (share) count transferred to the anonymizer
             0n,
             openNote.noteId,
           ],

--- a/e2e/tests/devnet/vesu-lending.test.ts
+++ b/e2e/tests/devnet/vesu-lending.test.ts
@@ -141,10 +141,10 @@ describe("Vesu lending on devnet", () => {
         return {
           contractAddress: anonymizerAddress,
           calldata: [
-            1n, // LendingOperation::Withdraw
+            1n, // LendingOperation::Withdraw (Vault::redeem internally).
             vesu.usdVToken,
             tokens.usdToken,
-            vTokenAmount, // redeem the exact vToken (share) count transferred to the anonymizer
+            vTokenAmount, // The amount of vToken shares to be redeemed.
             0n,
             openNote.noteId,
           ],

--- a/packages/privacy/src/tests/test_e2e.cairo
+++ b/packages/privacy/src/tests/test_e2e.cairo
@@ -1305,7 +1305,7 @@ fn test_e2e_vesu_invoke() {
         .new_open_note_with_generated_random(recipient: user, token_addr: vault_addr, index: 0);
     let (open_note_vault_id, _) = user.compute_open_note(create_note_input: create_open_vault);
     let invoke_deposit = vesu
-        .invoke_vesu_deposit_external_input(assets: amount, note_id: open_note_vault_id);
+        .invoke_vesu_deposit_external_input(amount: amount, note_id: open_note_vault_id);
     test
         .privacy
         .execute_actions_e2e(
@@ -1345,7 +1345,7 @@ fn test_e2e_vesu_invoke() {
     let (open_note_underlying_id, _) = user
         .compute_open_note(create_note_input: create_open_underlying);
     let invoke_withdraw = vesu
-        .invoke_vesu_withdraw_external_input(assets: amount, note_id: open_note_underlying_id);
+        .invoke_vesu_withdraw_external_input(amount: amount, note_id: open_note_underlying_id);
     test
         .privacy
         .execute_actions_e2e(

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -1611,7 +1611,7 @@ fn test_apply_invoke_vesu_deposit() {
     let mut spy = spy_events();
 
     // Execute the invoke action.
-    let invoke_input = vesu.invoke_vesu_deposit_input(assets: deposit_amount, :note_id);
+    let invoke_input = vesu.invoke_vesu_deposit_input(amount: deposit_amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_note_input
         .into_server_actions(:user)
         .into();
@@ -1686,7 +1686,7 @@ fn test_apply_invoke_vesu_withdraw() {
     vesu.underlying_token.supply(address: anonymizer_addr, amount: deposit_amount);
 
     // Deposit before withdraw.
-    let invoke_input = vesu.invoke_vesu_deposit_input(assets: deposit_amount, :note_id);
+    let invoke_input = vesu.invoke_vesu_deposit_input(amount: deposit_amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_note_input
         .into_server_actions(:user)
         .into();
@@ -1720,7 +1720,7 @@ fn test_apply_invoke_vesu_withdraw() {
         );
 
     // Create Invoke input for withdraw.
-    let invoke_input = vesu.invoke_vesu_withdraw_input(assets: deposit_amount, :note_id);
+    let invoke_input = vesu.invoke_vesu_withdraw_input(amount: deposit_amount, :note_id);
 
     // Spy on events before executing.
     let mut spy = spy_events();
@@ -1798,14 +1798,14 @@ fn test_apply_invoke_vesu_assertions() {
     let (note_id, _) = user.compute_open_note(:create_note_input);
 
     // Base valid invoke input (will be modified for each error case).
-    let valid_invoke_input_deposit = vesu.invoke_vesu_deposit_input(assets: amount, :note_id);
-    let valid_invoke_input_withdraw = vesu.invoke_vesu_withdraw_input(assets: amount, :note_id);
+    let valid_invoke_input_deposit = vesu.invoke_vesu_deposit_input(amount: amount, :note_id);
+    let valid_invoke_input_withdraw = vesu.invoke_vesu_withdraw_input(amount: amount, :note_id);
 
     // Catch ZERO_IN_TOKEN
     let mut vesu_zero_vault = vesu;
     vesu_zero_vault.vault = Zero::zero();
     let zero_in_token_invoke_input = vesu_zero_vault
-        .invoke_vesu_withdraw_input(assets: amount, :note_id);
+        .invoke_vesu_withdraw_input(amount: amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
     server_actions.append(ServerAction::Invoke(zero_in_token_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
@@ -1813,24 +1813,24 @@ fn test_apply_invoke_vesu_assertions() {
 
     // Catch ZERO_OUT_TOKEN
     let zero_out_token_invoke_input = vesu_zero_vault
-        .invoke_vesu_deposit_input(assets: amount, :note_id);
+        .invoke_vesu_deposit_input(amount: amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
     server_actions.append(ServerAction::Invoke(zero_out_token_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
     assert_panic_with_felt_error(:result, expected_error: vesu_errors::ZERO_OUT_TOKEN);
 
-    // Catch ZERO_ASSETS
-    let zero_assets_invoke_input = vesu.invoke_vesu_deposit_input(assets: 0, :note_id);
+    // Catch ZERO_AMOUNT
+    let zero_amount_invoke_input = vesu.invoke_vesu_deposit_input(amount: 0, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
-    server_actions.append(ServerAction::Invoke(zero_assets_invoke_input));
+    server_actions.append(ServerAction::Invoke(zero_amount_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
-    assert_panic_with_felt_error(:result, expected_error: vesu_errors::ZERO_ASSETS);
+    assert_panic_with_felt_error(:result, expected_error: vesu_errors::ZERO_AMOUNT);
 
     // Catch TOKENS_EQUAL
     let mut vesu_tokens_equal = vesu;
     vesu_tokens_equal.vault = vesu.underlying_token.contract_address();
     let tokens_equal_invoke_input = vesu_tokens_equal
-        .invoke_vesu_deposit_input(assets: amount, :note_id);
+        .invoke_vesu_deposit_input(amount: amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
     server_actions.append(ServerAction::Invoke(tokens_equal_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
@@ -1853,12 +1853,12 @@ fn test_apply_invoke_vesu_assertions() {
     let mut vesu_noop = vesu;
     vesu_noop.vault = noop_vault;
     vesu_noop.underlying_token.supply(address: anonymizer_addr, :amount);
-    let noop_invoke_input = vesu_noop.invoke_vesu_deposit_input(assets: amount, :note_id);
+    let noop_invoke_input = vesu_noop.invoke_vesu_deposit_input(amount: amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
     server_actions.append(ServerAction::Invoke(noop_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
     assert_panic_with_felt_error(:result, expected_error: vesu_errors::ZERO_OUT_AMOUNT);
-    let noop_invoke_input = vesu_noop.invoke_vesu_withdraw_input(assets: amount, :note_id);
+    let noop_invoke_input = vesu_noop.invoke_vesu_withdraw_input(amount: amount, :note_id);
     let mut server_actions: Array<ServerAction> = create_actions.into();
     server_actions.append(ServerAction::Invoke(noop_invoke_input));
     let result = test.privacy.safe_apply_actions(server_actions.span());
@@ -1886,7 +1886,7 @@ fn test_apply_invoke_vesu_open_note_deposit_assertions() {
 
     // Catch NOTE_NOT_FOUND
     let nonexistent_note_id = 'NONEXISTENT_NOTE';
-    let invoke_input = vesu.invoke_vesu_deposit_input(assets: amount, note_id: nonexistent_note_id);
+    let invoke_input = vesu.invoke_vesu_deposit_input(amount: amount, note_id: nonexistent_note_id);
     let result = test.privacy.safe_apply_actions([ServerAction::Invoke(invoke_input)].span());
     assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_FOUND);
 
@@ -1898,7 +1898,7 @@ fn test_apply_invoke_vesu_open_note_deposit_assertions() {
     user.cheat_create_enc_note_e2e(:create_note_input);
     let (note_id_enc, _) = user.compute_enc_note(:create_note_input);
 
-    let invoke_input = vesu.invoke_vesu_deposit_input(assets: amount, note_id: note_id_enc);
+    let invoke_input = vesu.invoke_vesu_deposit_input(amount: amount, note_id: note_id_enc);
     let result = test.privacy.safe_apply_actions([ServerAction::Invoke(invoke_input)].span());
     assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_OPEN);
 
@@ -1907,7 +1907,7 @@ fn test_apply_invoke_vesu_open_note_deposit_assertions() {
         .new_open_note_with_generated_random(:recipient, token_addr: vault_addr, index: 1);
     let (note_id_filled, _) = user.compute_open_note(:create_note_input);
     // First deposit succeeds.
-    let invoke_input = vesu.invoke_vesu_deposit_input(assets: amount, note_id: note_id_filled);
+    let invoke_input = vesu.invoke_vesu_deposit_input(amount: amount, note_id: note_id_filled);
     let mut server_actions: Array<ServerAction> = create_note_input
         .into_server_actions(:user)
         .into();
@@ -1931,7 +1931,7 @@ fn test_apply_invoke_vesu_open_note_deposit_assertions() {
     let (note_id_token_mismatch, _) = user.compute_open_note(:create_note_input);
 
     let invoke_input = vesu
-        .invoke_vesu_deposit_input(assets: amount, note_id: note_id_token_mismatch);
+        .invoke_vesu_deposit_input(amount: amount, note_id: note_id_token_mismatch);
     let mut server_actions: Array<ServerAction> = create_note_input
         .into_server_actions(:user)
         .into();

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -1277,7 +1277,7 @@ pub(crate) impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Deposit,
                 in_token: self.underlying_token.contract_address(),
                 out_token: *self.vault,
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -1290,7 +1290,7 @@ pub(crate) impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Withdraw,
                 in_token: *self.vault,
                 out_token: self.underlying_token.contract_address(),
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -1304,7 +1304,7 @@ pub(crate) impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Deposit,
                 in_token: self.underlying_token.contract_address(),
                 out_token: *self.vault,
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -1318,7 +1318,7 @@ pub(crate) impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Withdraw,
                 in_token: *self.vault,
                 out_token: self.underlying_token.contract_address(),
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -1329,32 +1329,32 @@ pub(crate) impl VesuImpl of VesuTrait {
         operation: LendingOperation,
         in_token: ContractAddress,
         out_token: ContractAddress,
-        assets: u128,
+        amount: u128,
         note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
         IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
-            .privacy_invoke(:operation, :in_token, :out_token, assets: assets.into(), :note_id)
+            .privacy_invoke(:operation, :in_token, :out_token, amount: amount.into(), :note_id)
     }
 
     /// Creates an `InvokeInput` for the Vesu lending anonymizer from the given parameters.
-    fn invoke_vesu_deposit_input(self: @Vesu, assets: u128, note_id: felt252) -> InvokeInput {
-        let assets: u256 = assets.into();
+    fn invoke_vesu_deposit_input(self: @Vesu, amount: u128, note_id: felt252) -> InvokeInput {
+        let amount: u256 = amount.into();
         let mut calldata: Array<felt252> = array![];
         LendingOperation::Deposit.serialize(ref calldata);
         self.underlying_token.contract_address().serialize(ref calldata);
         self.vault.serialize(ref calldata);
-        assets.serialize(ref calldata);
+        amount.serialize(ref calldata);
         note_id.serialize(ref calldata);
         InvokeInput { contract_address: *self.lending_anonymizer, calldata: calldata.span() }
     }
 
-    fn invoke_vesu_withdraw_input(self: @Vesu, assets: u128, note_id: felt252) -> InvokeInput {
-        let assets: u256 = assets.into();
+    fn invoke_vesu_withdraw_input(self: @Vesu, amount: u128, note_id: felt252) -> InvokeInput {
+        let amount: u256 = amount.into();
         let mut calldata: Array<felt252> = array![];
         LendingOperation::Withdraw.serialize(ref calldata);
         self.vault.serialize(ref calldata);
         self.underlying_token.contract_address().serialize(ref calldata);
-        assets.serialize(ref calldata);
+        amount.serialize(ref calldata);
         note_id.serialize(ref calldata);
         InvokeInput { contract_address: *self.lending_anonymizer, calldata: calldata.span() }
     }
@@ -1362,18 +1362,18 @@ pub(crate) impl VesuImpl of VesuTrait {
     /// Creates an `InvokeExternalInput` for Vesu deposit (for use with
     /// ClientAction::InvokeExternal).
     fn invoke_vesu_deposit_external_input(
-        self: @Vesu, assets: u128, note_id: felt252,
+        self: @Vesu, amount: u128, note_id: felt252,
     ) -> InvokeExternalInput {
-        let invoke = self.invoke_vesu_deposit_input(:assets, :note_id);
+        let invoke = self.invoke_vesu_deposit_input(:amount, :note_id);
         InvokeExternalInput { contract_address: invoke.contract_address, calldata: invoke.calldata }
     }
 
     /// Creates an `InvokeExternalInput` for Vesu withdraw (for use with
     /// ClientAction::InvokeExternal).
     fn invoke_vesu_withdraw_external_input(
-        self: @Vesu, assets: u128, note_id: felt252,
+        self: @Vesu, amount: u128, note_id: felt252,
     ) -> InvokeExternalInput {
-        let invoke = self.invoke_vesu_withdraw_input(:assets, :note_id);
+        let invoke = self.invoke_vesu_withdraw_input(:amount, :note_id);
         InvokeExternalInput { contract_address: invoke.contract_address, calldata: invoke.calldata }
     }
 

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -2235,6 +2235,7 @@ fn deploy_mock_vesu_vault(underlying_token: ContractAddress) -> ContractAddress 
         name: "MockVesuVault",
         symbol: "MV",
         :underlying_token,
+        redeem_rate: 1,
     )
         .expect('MockVesuVault deploy failed');
     address

--- a/packages/vesu_lending_anonymizer/README.md
+++ b/packages/vesu_lending_anonymizer/README.md
@@ -17,7 +17,7 @@ fn privacy_invoke(
     operation: LendingOperation,
     in_token: ContractAddress,
     out_token: ContractAddress,
-    assets: u256,
+    amount: u256,
     note_id: felt252,
 ) -> Span<OpenNoteDeposit>
 ```
@@ -27,25 +27,25 @@ fn privacy_invoke(
 | `operation` | `Deposit` or `Withdraw` |
 | `in_token` | Input token address (underlying for deposit; vToken for withdraw) |
 | `out_token` | Output token address (vToken for deposit; underlying for withdraw) |
-| `assets` | Amount of assets to deposit or withdraw |
+| `amount` | Underlying to supply (Deposit) or vToken shares to redeem (Withdraw) |
 | `note_id` | Open note identifier to deposit output funds into |
 
 Returns a single-element `Span<OpenNoteDeposit>` containing `(note_id, out_token, out_amount)`.
 
 ### IVToken
 
-Subset of the Vesu vToken interface used internally: `deposit` and `withdraw`.
+Subset of the Vesu vToken interface used internally: `deposit` and `redeem`.
 
 ## Operations
 
 **Deposit** (`in_token` → `out_token` vToken):
-1. Approves the vToken contract to spend `assets` of `in_token`.
-2. Calls `vToken.deposit(assets, self)` — vault pulls `in_token` from this contract.
+1. Approves the vToken contract to spend `amount` of `in_token`.
+2. Calls `vToken.deposit(amount, self)` — vault pulls `in_token` from this contract.
 3. Measures received vToken balance delta.
 4. Approves the privacy contract to transfer the received vTokens.
 
 **Withdraw** (`in_token` vToken → `out_token`):
-1. Calls `vToken.withdraw(assets, self, self)` — burns shares from this contract, sends underlying here.
+1. Calls `vToken.redeem(amount, self, self)` — burns the exact share count from this contract, sends underlying here.
 2. Measures received underlying balance delta.
 3. Approves the privacy contract to transfer the received underlying.
 
@@ -55,7 +55,7 @@ Subset of the Vesu vToken interface used internally: `deposit` and `withdraw`.
 |----------|-------|-----------|
 | `ZERO_IN_TOKEN` | `'ZERO_IN_TOKEN'` | `in_token` is the zero address |
 | `ZERO_OUT_TOKEN` | `'ZERO_OUT_TOKEN'` | `out_token` is the zero address |
-| `ZERO_ASSETS` | `'ZERO_ASSETS'` | `assets` is zero |
+| `ZERO_AMOUNT` | `'ZERO_AMOUNT'` | `amount` is zero |
 | `TOKENS_EQUAL` | `'TOKENS_EQUAL'` | `in_token == out_token` |
 | `RECEIVED_AMOUNT_OVERFLOW` | `'RECEIVED_AMOUNT_OVERFLOW'` | Received amount exceeds `u128::MAX` |
 | `ZERO_OUT_AMOUNT` | `'ZERO_OUT_AMOUNT'` | Vault returned zero output tokens |

--- a/packages/vesu_lending_anonymizer/Scarb.toml
+++ b/packages/vesu_lending_anonymizer/Scarb.toml
@@ -32,6 +32,7 @@ build-external-contracts = [
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow",
+    "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultInterest",
 ]
 
 [scripts]

--- a/packages/vesu_lending_anonymizer/Scarb.toml
+++ b/packages/vesu_lending_anonymizer/Scarb.toml
@@ -32,7 +32,6 @@ build-external-contracts = [
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow",
-    "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultInterest",
 ]
 
 [scripts]

--- a/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
+++ b/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
@@ -1,5 +1,5 @@
-/// Mock Vesu vault for testing deposit/withdraw. Implements 1:1 asset/share exchange.
-/// Must be pre-funded with underlying_token (for withdraw).
+/// Mock Vesu vault for testing deposit/redeem. Implements 1:1 asset/share exchange.
+/// Must be pre-funded with underlying_token (for redeem).
 #[starknet::contract]
 pub mod MockVesuVault {
     use openzeppelin::access::ownable::OwnableComponent;
@@ -52,18 +52,6 @@ pub mod MockVesuVault {
                     sender: get_caller_address(), recipient: get_contract_address(), amount: assets,
                 );
             self.erc20.mint(recipient: receiver, amount: assets);
-            assets
-        }
-
-        fn withdraw(
-            ref self: ContractState,
-            assets: u256,
-            receiver: ContractAddress,
-            owner: ContractAddress,
-        ) -> u256 {
-            self.erc20.burn(account: owner, amount: assets);
-            IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer(recipient: receiver, amount: assets);
             assets
         }
 
@@ -129,15 +117,6 @@ pub mod MockVesuVaultNoop {
     #[abi(embed_v0)]
     impl MockVesuVaultImpl of IVToken<ContractState> {
         fn deposit(ref self: ContractState, assets: u256, receiver: ContractAddress) -> u256 {
-            Zero::zero()
-        }
-
-        fn withdraw(
-            ref self: ContractState,
-            assets: u256,
-            receiver: ContractAddress,
-            owner: ContractAddress,
-        ) -> u256 {
             Zero::zero()
         }
 
@@ -208,18 +187,6 @@ pub mod MockVesuVaultOverflow {
             overflow_amount
         }
 
-        fn withdraw(
-            ref self: ContractState,
-            assets: u256,
-            receiver: ContractAddress,
-            owner: ContractAddress,
-        ) -> u256 {
-            let overflow_amount: u256 = MAX_U128.into() + 1;
-            IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer(recipient: receiver, amount: overflow_amount);
-            Zero::zero()
-        }
-
         fn redeem(
             ref self: ContractState,
             shares: u256,
@@ -247,7 +214,7 @@ pub mod MockVesuVaultInterest {
     use starknet::{ContractAddress, get_caller_address, get_contract_address};
     use vesu_lending_anonymizer::vesu_lending_anonymizer::IVToken;
 
-    /// Underlying assets per share on redeem (and shares burned per asset on withdraw).
+    /// Underlying assets paid out per share on redeem.
     const REDEEM_RATE: u256 = 2;
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
@@ -294,21 +261,6 @@ pub mod MockVesuVaultInterest {
                 );
             self.erc20.mint(recipient: receiver, amount: assets);
             assets
-        }
-
-        fn withdraw(
-            ref self: ContractState,
-            assets: u256,
-            receiver: ContractAddress,
-            owner: ContractAddress,
-        ) -> u256 {
-            // ERC-4626 withdraw semantics: burn `assets / rate` shares to return `assets`
-            // underlying.
-            let shares = assets / REDEEM_RATE;
-            self.erc20.burn(account: owner, amount: shares);
-            IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer(recipient: receiver, amount: assets);
-            shares
         }
 
         fn redeem(

--- a/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
+++ b/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
@@ -66,6 +66,18 @@ pub mod MockVesuVault {
                 .transfer(recipient: receiver, amount: assets);
             assets
         }
+
+        fn redeem(
+            ref self: ContractState,
+            shares: u256,
+            receiver: ContractAddress,
+            owner: ContractAddress,
+        ) -> u256 {
+            self.erc20.burn(account: owner, amount: shares);
+            IERC20Dispatcher { contract_address: self.underlying_token.read() }
+                .transfer(recipient: receiver, amount: shares);
+            shares
+        }
     }
 }
 
@@ -123,6 +135,15 @@ pub mod MockVesuVaultNoop {
         fn withdraw(
             ref self: ContractState,
             assets: u256,
+            receiver: ContractAddress,
+            owner: ContractAddress,
+        ) -> u256 {
+            Zero::zero()
+        }
+
+        fn redeem(
+            ref self: ContractState,
+            shares: u256,
             receiver: ContractAddress,
             owner: ContractAddress,
         ) -> u256 {
@@ -197,6 +218,110 @@ pub mod MockVesuVaultOverflow {
             IERC20Dispatcher { contract_address: self.underlying_token.read() }
                 .transfer(recipient: receiver, amount: overflow_amount);
             Zero::zero()
+        }
+
+        fn redeem(
+            ref self: ContractState,
+            shares: u256,
+            receiver: ContractAddress,
+            owner: ContractAddress,
+        ) -> u256 {
+            let overflow_amount: u256 = MAX_U128.into() + 1;
+            IERC20Dispatcher { contract_address: self.underlying_token.read() }
+                .transfer(recipient: receiver, amount: overflow_amount);
+            Zero::zero()
+        }
+    }
+}
+
+/// Mock Vesu vault modeling accrued interest at a 2:1 share→asset rate. `deposit` mints one share
+/// per underlying asset; `redeem` burns the exact share count and pays out twice as many underlying
+/// assets (so the vault must be pre-funded with the extra underlying). Used to verify the
+/// anonymizer redeems an exact share count instead of treating the amount as underlying.
+#[starknet::contract]
+pub mod MockVesuVaultInterest {
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::token::erc20::{DefaultConfig, ERC20Component, ERC20HooksEmptyImpl};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_caller_address, get_contract_address};
+    use vesu_lending_anonymizer::vesu_lending_anonymizer::IVToken;
+
+    /// Underlying assets per share on redeem (and shares burned per asset on withdraw).
+    const REDEEM_RATE: u256 = 2;
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    #[abi(embed_v0)]
+    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC20CamelOnlyImpl = ERC20Component::ERC20CamelOnlyImpl<ContractState>;
+    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage,
+        underlying_token: ContractAddress,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        name: ByteArray,
+        symbol: ByteArray,
+        underlying_token: ContractAddress,
+    ) {
+        self.erc20.initializer(name, symbol);
+        self.underlying_token.write(underlying_token);
+    }
+
+    #[abi(embed_v0)]
+    impl MockVesuVaultImpl of IVToken<ContractState> {
+        fn deposit(ref self: ContractState, assets: u256, receiver: ContractAddress) -> u256 {
+            IERC20Dispatcher { contract_address: self.underlying_token.read() }
+                .transfer_from(
+                    sender: get_caller_address(), recipient: get_contract_address(), amount: assets,
+                );
+            self.erc20.mint(recipient: receiver, amount: assets);
+            assets
+        }
+
+        fn withdraw(
+            ref self: ContractState,
+            assets: u256,
+            receiver: ContractAddress,
+            owner: ContractAddress,
+        ) -> u256 {
+            // ERC-4626 withdraw semantics: burn `assets / rate` shares to return `assets`
+            // underlying.
+            let shares = assets / REDEEM_RATE;
+            self.erc20.burn(account: owner, amount: shares);
+            IERC20Dispatcher { contract_address: self.underlying_token.read() }
+                .transfer(recipient: receiver, amount: assets);
+            shares
+        }
+
+        fn redeem(
+            ref self: ContractState,
+            shares: u256,
+            receiver: ContractAddress,
+            owner: ContractAddress,
+        ) -> u256 {
+            self.erc20.burn(account: owner, amount: shares);
+            let assets = shares * REDEEM_RATE;
+            IERC20Dispatcher { contract_address: self.underlying_token.read() }
+                .transfer(recipient: receiver, amount: assets);
+            assets
         }
     }
 }

--- a/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
+++ b/packages/vesu_lending_anonymizer/src/test_utils_contracts/mock_vesu_vault.cairo
@@ -1,5 +1,7 @@
-/// Mock Vesu vault for testing deposit/redeem. Implements 1:1 asset/share exchange.
-/// Must be pre-funded with underlying_token (for redeem).
+/// Mock Vesu vault for testing deposit/redeem. `deposit` mints one share per underlying asset
+/// (1:1); `redeem` burns the exact share count and pays out `redeem_rate` underlying per share. A
+/// `redeem_rate` above 1 models a vault that has accrued interest (and must be pre-funded with the
+/// extra underlying); deploy with `redeem_rate: 1` for a plain 1:1 vault.
 #[starknet::contract]
 pub mod MockVesuVault {
     use openzeppelin::access::ownable::OwnableComponent;
@@ -22,6 +24,8 @@ pub mod MockVesuVault {
         #[substorage(v0)]
         erc20: ERC20Component::Storage,
         underlying_token: ContractAddress,
+        /// Underlying assets paid out per share on redeem (1 = plain 1:1 vault).
+        redeem_rate: u256,
     }
 
     #[event]
@@ -39,9 +43,11 @@ pub mod MockVesuVault {
         name: ByteArray,
         symbol: ByteArray,
         underlying_token: ContractAddress,
+        redeem_rate: u256,
     ) {
         self.erc20.initializer(name, symbol);
         self.underlying_token.write(underlying_token);
+        self.redeem_rate.write(redeem_rate);
     }
 
     #[abi(embed_v0)]
@@ -62,9 +68,10 @@ pub mod MockVesuVault {
             owner: ContractAddress,
         ) -> u256 {
             self.erc20.burn(account: owner, amount: shares);
+            let assets = shares * self.redeem_rate.read();
             IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer(recipient: receiver, amount: shares);
-            shares
+                .transfer(recipient: receiver, amount: assets);
+            assets
         }
     }
 }
@@ -197,83 +204,6 @@ pub mod MockVesuVaultOverflow {
             IERC20Dispatcher { contract_address: self.underlying_token.read() }
                 .transfer(recipient: receiver, amount: overflow_amount);
             Zero::zero()
-        }
-    }
-}
-
-/// Mock Vesu vault modeling accrued interest at a 2:1 share→asset rate. `deposit` mints one share
-/// per underlying asset; `redeem` burns the exact share count and pays out twice as many underlying
-/// assets (so the vault must be pre-funded with the extra underlying). Used to verify the
-/// anonymizer redeems an exact share count instead of treating the amount as underlying.
-#[starknet::contract]
-pub mod MockVesuVaultInterest {
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use openzeppelin::token::erc20::{DefaultConfig, ERC20Component, ERC20HooksEmptyImpl};
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
-    use starknet::{ContractAddress, get_caller_address, get_contract_address};
-    use vesu_lending_anonymizer::vesu_lending_anonymizer::IVToken;
-
-    /// Underlying assets paid out per share on redeem.
-    const REDEEM_RATE: u256 = 2;
-
-    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-
-    #[abi(embed_v0)]
-    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20CamelOnlyImpl = ERC20Component::ERC20CamelOnlyImpl<ContractState>;
-    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
-
-    #[storage]
-    struct Storage {
-        #[substorage(v0)]
-        erc20: ERC20Component::Storage,
-        underlying_token: ContractAddress,
-    }
-
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        #[flat]
-        ERC20Event: ERC20Component::Event,
-        #[flat]
-        OwnableEvent: OwnableComponent::Event,
-    }
-
-    #[constructor]
-    fn constructor(
-        ref self: ContractState,
-        name: ByteArray,
-        symbol: ByteArray,
-        underlying_token: ContractAddress,
-    ) {
-        self.erc20.initializer(name, symbol);
-        self.underlying_token.write(underlying_token);
-    }
-
-    #[abi(embed_v0)]
-    impl MockVesuVaultImpl of IVToken<ContractState> {
-        fn deposit(ref self: ContractState, assets: u256, receiver: ContractAddress) -> u256 {
-            IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer_from(
-                    sender: get_caller_address(), recipient: get_contract_address(), amount: assets,
-                );
-            self.erc20.mint(recipient: receiver, amount: assets);
-            assets
-        }
-
-        fn redeem(
-            ref self: ContractState,
-            shares: u256,
-            receiver: ContractAddress,
-            owner: ContractAddress,
-        ) -> u256 {
-            self.erc20.burn(account: owner, amount: shares);
-            let assets = shares * REDEEM_RATE;
-            IERC20Dispatcher { contract_address: self.underlying_token.read() }
-                .transfer(recipient: receiver, amount: assets);
-            assets
         }
     }
 }

--- a/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
@@ -31,7 +31,7 @@ pub impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Deposit,
                 in_token: self.underlying_token.contract_address(),
                 out_token: *self.vault,
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -44,7 +44,7 @@ pub impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Withdraw,
                 in_token: *self.vault,
                 out_token: self.underlying_token.contract_address(),
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -58,7 +58,7 @@ pub impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Deposit,
                 in_token: self.underlying_token.contract_address(),
                 out_token: *self.vault,
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -72,7 +72,7 @@ pub impl VesuImpl of VesuTrait {
                 operation: LendingOperation::Withdraw,
                 in_token: *self.vault,
                 out_token: self.underlying_token.contract_address(),
-                assets: amount.into(),
+                amount: amount.into(),
                 :note_id,
             )
     }
@@ -83,11 +83,11 @@ pub impl VesuImpl of VesuTrait {
         operation: LendingOperation,
         in_token: ContractAddress,
         out_token: ContractAddress,
-        assets: u128,
+        amount: u128,
         note_id: felt252,
     ) -> Result<Span<OpenNoteDeposit>, Array<felt252>> {
         IVesuLendingAnonymizerSafeDispatcher { contract_address: *self.lending_anonymizer }
-            .privacy_invoke(:operation, :in_token, :out_token, assets: assets.into(), :note_id)
+            .privacy_invoke(:operation, :in_token, :out_token, amount: amount.into(), :note_id)
     }
 
     fn vault_balance_of(self: @Vesu, address: ContractAddress) -> u256 {

--- a/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
@@ -5,6 +5,7 @@ use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
+use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultInterest::deploy_for_test as deploy_mock_vesu_vault_interest_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow::deploy_for_test as deploy_mock_vesu_vault_overflow_for_test;
 use vesu_lending_anonymizer::vesu_lending_anonymizer::{
@@ -162,6 +163,25 @@ pub fn deploy_mock_vesu_vault_overflow(underlying_token: ContractAddress) -> Con
         :underlying_token,
     )
         .expect('MockVesuVaultOverflow failed');
+    address
+}
+
+/// Deploys a vault whose shares redeem for twice as much underlying (2:1), modeling accrued
+/// interest so withdraw exercises an exchange rate above 1:1.
+pub fn deploy_mock_vesu_vault_interest(underlying_token: ContractAddress) -> ContractAddress {
+    let class_hash = declare(contract: "MockVesuVaultInterest")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt: 1, deploy_from_zero: true };
+    let (address, _) = deploy_mock_vesu_vault_interest_for_test(
+        class_hash: *class_hash,
+        :deployment_params,
+        name: "MockVesuVaultInterest",
+        symbol: "MVI",
+        :underlying_token,
+    )
+        .expect('MockVesuVaultInterest failed');
     address
 }
 

--- a/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
@@ -5,7 +5,6 @@ use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
-use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultInterest::deploy_for_test as deploy_mock_vesu_vault_interest_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow::deploy_for_test as deploy_mock_vesu_vault_overflow_for_test;
 use vesu_lending_anonymizer::vesu_lending_anonymizer::{
@@ -127,6 +126,7 @@ fn deploy_mock_vesu_vault(underlying_token: ContractAddress) -> ContractAddress 
         name: "MockVesuVault",
         symbol: "MV",
         :underlying_token,
+        redeem_rate: 1,
     )
         .expect('MockVesuVault deploy failed');
     address
@@ -169,17 +169,18 @@ pub fn deploy_mock_vesu_vault_overflow(underlying_token: ContractAddress) -> Con
 /// Deploys a vault whose shares redeem for twice as much underlying (2:1), modeling accrued
 /// interest so withdraw exercises an exchange rate above 1:1.
 pub fn deploy_mock_vesu_vault_interest(underlying_token: ContractAddress) -> ContractAddress {
-    let class_hash = declare(contract: "MockVesuVaultInterest")
+    let class_hash = declare(contract: "MockVesuVault")
         .unwrap_syscall()
         .contract_class()
         .class_hash;
     let deployment_params = DeploymentParams { salt: 1, deploy_from_zero: true };
-    let (address, _) = deploy_mock_vesu_vault_interest_for_test(
+    let (address, _) = deploy_mock_vesu_vault_for_test(
         class_hash: *class_hash,
         :deployment_params,
         name: "MockVesuVaultInterest",
         symbol: "MVI",
         :underlying_token,
+        redeem_rate: 2,
     )
         .expect('MockVesuVaultInterest failed');
     address

--- a/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
@@ -92,55 +92,52 @@ fn test_privacy_invoke_assertions() {
     // Catch ZERO_IN_TOKEN.
     let result = vesu
         .safe_privacy_invoke(
-            operation: deposit, in_token: Zero::zero(), :out_token, assets: amount, :note_id,
+            operation: deposit, in_token: Zero::zero(), :out_token, :amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_IN_TOKEN);
     let result = vesu
         .safe_privacy_invoke(
-            operation: withdraw, in_token: Zero::zero(), :out_token, assets: amount, :note_id,
+            operation: withdraw, in_token: Zero::zero(), :out_token, :amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_IN_TOKEN);
 
     // Catch ZERO_OUT_TOKEN.
     let result = vesu
         .safe_privacy_invoke(
-            operation: deposit, :in_token, out_token: Zero::zero(), assets: amount, :note_id,
+            operation: deposit, :in_token, out_token: Zero::zero(), :amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_OUT_TOKEN);
     let result = vesu
         .safe_privacy_invoke(
-            operation: withdraw, :in_token, out_token: Zero::zero(), assets: amount, :note_id,
+            operation: withdraw, :in_token, out_token: Zero::zero(), :amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_OUT_TOKEN);
 
-    // Catch ZERO_ ASSETS.
+    // Catch ZERO_AMOUNT.
     let result = vesu
         .safe_privacy_invoke(
-            operation: deposit, :in_token, :out_token, assets: Zero::zero(), :note_id,
+            operation: deposit, :in_token, :out_token, amount: Zero::zero(), :note_id,
         );
-    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_ASSETS);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_AMOUNT);
     let result = vesu
         .safe_privacy_invoke(
-            operation: withdraw, :in_token, :out_token, assets: Zero::zero(), :note_id,
+            operation: withdraw, :in_token, :out_token, amount: Zero::zero(), :note_id,
         );
-    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_ASSETS);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_AMOUNT);
 
     // Catch TOKENS_EQUAL.
     let result = vesu
-        .safe_privacy_invoke(
-            operation: deposit, :in_token, out_token: in_token, assets: amount, :note_id,
-        );
+        .safe_privacy_invoke(operation: deposit, :in_token, out_token: in_token, :amount, :note_id);
     assert_panic_with_felt_error(:result, expected_error: errors::TOKENS_EQUAL);
     let result = vesu
         .safe_privacy_invoke(
-            operation: withdraw, :in_token, out_token: in_token, assets: amount, :note_id,
+            operation: withdraw, :in_token, out_token: in_token, :amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::TOKENS_EQUAL);
 }
 
-/// At an exchange rate above 1:1, withdraw must redeem the exact share count the pool transferred
-/// in (burning all of it) rather than treating the amount as underlying assets, which would strand
-/// the unburned shares in the stateless anonymizer.
+/// Withdraw must redeem the exact share count the pool holds, not an underlying amount; otherwise
+/// shares are stranded in the stateless anonymizer.
 #[test]
 fn test_privacy_invoke_withdraw_redeems_exact_shares() {
     let mut vesu = deploy_vesu_components();

--- a/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
@@ -4,7 +4,8 @@ use snforge_std::TokenTrait;
 use starkware_utils::constants::MAX_U128;
 use starkware_utils_testing::test_utils::{TokenHelperTrait, assert_panic_with_felt_error};
 use vesu_lending_anonymizer::tests::test_utils::{
-    VesuTrait, deploy_mock_vesu_vault_noop, deploy_mock_vesu_vault_overflow, deploy_vesu_components,
+    VesuTrait, deploy_mock_vesu_vault_interest, deploy_mock_vesu_vault_noop,
+    deploy_mock_vesu_vault_overflow, deploy_vesu_components,
 };
 use vesu_lending_anonymizer::vesu_lending_anonymizer::{LendingOperation, errors};
 
@@ -135,6 +136,39 @@ fn test_privacy_invoke_assertions() {
             operation: withdraw, :in_token, out_token: in_token, assets: amount, :note_id,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::TOKENS_EQUAL);
+}
+
+/// At an exchange rate above 1:1, withdraw must redeem the exact share count the pool transferred
+/// in (burning all of it) rather than treating the amount as underlying assets, which would strand
+/// the unburned shares in the stateless anonymizer.
+#[test]
+fn test_privacy_invoke_withdraw_redeems_exact_shares() {
+    let mut vesu = deploy_vesu_components();
+    let amount = DEFAULT_AMOUNT;
+
+    // Swap in a vault whose shares redeem for 2x underlying (models accrued interest).
+    let vault = deploy_mock_vesu_vault_interest(
+        underlying_token: vesu.underlying_token.contract_address(),
+    );
+    vesu.vault = vault;
+
+    // Deposit `amount` underlying → anonymizer receives `amount` shares (1:1 deposit).
+    vesu.underlying_token.supply(address: vesu.lending_anonymizer, amount: amount);
+    vesu.privacy_invoke_deposit(:amount, note_id: 'DEPOSIT_NOTE');
+    assert_eq!(vesu.vault_balance_of(address: vesu.lending_anonymizer), amount.into());
+
+    // Pre-fund the vault so it can pay out the 2x redemption.
+    vesu.underlying_token.supply(address: vesu.vault, amount: amount);
+
+    // Withdraw redeems the exact share count (`amount`), not an underlying amount.
+    let deposits = vesu.privacy_invoke_withdraw(:amount, note_id: 'WITHDRAW_NOTE');
+    let OpenNoteDeposit { note_id: _, token: ret_out_token, amount: ret_out_amount } = *deposits[0];
+
+    // All shares burned: nothing stranded in the stateless anonymizer.
+    assert_eq!(vesu.vault_balance_of(address: vesu.lending_anonymizer), 0);
+    // Received the full 2x underlying value of the redeemed shares.
+    assert_eq!(ret_out_token, vesu.underlying_token.contract_address());
+    assert_eq!(ret_out_amount, amount * 2);
 }
 
 #[test]

--- a/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_vesu_lending_anonymizer.cairo
@@ -136,8 +136,7 @@ fn test_privacy_invoke_assertions() {
     assert_panic_with_felt_error(:result, expected_error: errors::TOKENS_EQUAL);
 }
 
-/// Withdraw must redeem the exact share count the pool holds, not an underlying amount; otherwise
-/// shares are stranded in the stateless anonymizer.
+/// Withdraw must redeem the exact share count, not an underlying amount, else shares are stranded.
 #[test]
 fn test_privacy_invoke_withdraw_redeems_exact_shares() {
     let mut vesu = deploy_vesu_components();

--- a/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
@@ -10,9 +10,12 @@
 //! the vault (`out_token`). The vault pulls `in_token` (underlying) from the caller after prior
 //! approval.
 //!
-//! **Withdraw** (shares → underlying): Calls `withdraw(assets: u256, receiver: ContractAddress,
-//! owner: ContractAddress)` on the vault (`in_token`). Burns shares from `owner` and sends
-//! underlying to `receiver`.
+//! **Withdraw** (shares → underlying): Calls `redeem(shares: u256, receiver: ContractAddress,
+//! owner: ContractAddress)` on the vault (`in_token`). Burns the exact share count from `owner` and
+//! sends the corresponding underlying to `receiver`. `redeem` (burn an exact number of shares) is
+//! used rather than `withdraw` (receive an exact amount of underlying) because the pool holds and
+//! spends vToken shares: at any exchange rate above 1:1, `withdraw(shares)` would burn fewer shares
+//! than the pool transferred in and strand the remainder in this stateless contract.
 
 use privacy::objects::OpenNoteDeposit;
 use starknet::ContractAddress;
@@ -40,6 +43,15 @@ pub trait IVToken<T> {
     fn withdraw(
         ref self: T, assets: u256, receiver: ContractAddress, owner: ContractAddress,
     ) -> u256;
+    /// Redeems an exact number of vTokens (shares), burning them from `owner` and sending the
+    /// corresponding underlying assets to `receiver`.
+    /// # Arguments
+    /// * `shares` - amount of vToken shares to burn [SCALE]
+    /// * `receiver` - address to receive the withdrawn underlying assets
+    /// * `owner` - address of the owner of the vToken shares
+    /// # Returns
+    /// * amount of underlying assets withdrawn [asset scale]
+    fn redeem(ref self: T, shares: u256, receiver: ContractAddress, owner: ContractAddress) -> u256;
 }
 
 /// Lending operation to perform on a Vesu vault.
@@ -62,7 +74,8 @@ pub trait IVesuLendingAnonymizer<T> {
     /// vToken).
     /// - `out_token` (`ContractAddress`) - The token address of the output funds (in deposit -
     /// vToken).
-    /// - `assets` (`u256`) - amount of assets to deposit/withdraw.
+    /// - `assets` (`u256`) - For Deposit, the amount of underlying assets to deposit. For Withdraw,
+    /// the number of vToken shares to redeem.
     /// - `note_id` (`felt252`) - The identifier of the open note to deposit the output to.
     ///
     /// #### Returns
@@ -155,8 +168,9 @@ pub mod VesuLendingAnonymizer {
                         .deposit(:assets, receiver: self_addr)
                 },
                 LendingOperation::Withdraw => {
+                    // `assets` carries the vToken share count to redeem (see `assets` doc).
                     IVTokenDispatcher { contract_address: in_token }
-                        .withdraw(:assets, receiver: self_addr, owner: self_addr)
+                        .redeem(shares: assets, receiver: self_addr, owner: self_addr)
                 },
             }
 

--- a/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
@@ -44,10 +44,10 @@ pub trait IVesuLendingAnonymizer<T> {
     /// #### Parameters
     /// - `operation` ([`LendingOperation`](LendingOperation)) - `Deposit` (supply underlying,
     /// receive vToken shares) or `Withdraw` (redeem vToken shares, receive underlying).
-    /// - `in_token` (`ContractAddress`) - The token the contract spends: the underlying on Deposit,
-    /// the vToken on Withdraw.
-    /// - `out_token` (`ContractAddress`) - The token the contract receives: the vToken on Deposit,
-    /// the underlying on Withdraw.
+    /// - `in_token` (`ContractAddress`) - The token that flows from the anonymizer into the Vesu
+    /// vault: the underlying on Deposit, the vToken on Withdraw.
+    /// - `out_token` (`ContractAddress`) - The token that flows out of the Vesu vault back to the
+    /// anonymizer: the vToken on Deposit, the underlying on Withdraw.
     /// - `amount` (`u256`) - On Deposit, the amount of underlying to supply; on Withdraw, the
     /// number of vToken shares to redeem.
     /// - `note_id` (`felt252`) - The identifier of the open note to deposit the output to.
@@ -72,7 +72,7 @@ pub trait IVesuLendingAnonymizer<T> {
     /// received amount.
     /// 3. Approves the caller (privacy contract) to transfer the received output funds.
     /// 4. Returns (note_id, out_token, out_amount).
-    // TODO: rename `in_token`/`out_token` to clearer names; their meaning flips per operation.
+    // TODO: consider renaming `in_token`/`out_token` to e.g. `spend_token`/`receive_token`.
     fn privacy_invoke(
         ref self: T,
         operation: LendingOperation,

--- a/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
+++ b/packages/vesu_lending_anonymizer/src/vesu_lending_anonymizer.cairo
@@ -11,46 +11,19 @@
 //! approval.
 //!
 //! **Withdraw** (shares → underlying): Calls `redeem(shares: u256, receiver: ContractAddress,
-//! owner: ContractAddress)` on the vault (`in_token`). Burns the exact share count from `owner` and
-//! sends the corresponding underlying to `receiver`. `redeem` (burn an exact number of shares) is
-//! used rather than `withdraw` (receive an exact amount of underlying) because the pool holds and
-//! spends vToken shares: at any exchange rate above 1:1, `withdraw(shares)` would burn fewer shares
-//! than the pool transferred in and strand the remainder in this stateless contract.
+//! owner: ContractAddress)` on the vault (`in_token`), burning the given share count from `owner`
+//! and sending the corresponding underlying to `receiver`.
 
 use privacy::objects::OpenNoteDeposit;
 use starknet::ContractAddress;
 
-/// Interface for Vesu Token contract that supports deposit and withdraw operations.
+/// Interface for the Vesu vToken contract, copied here only to build a dispatcher; the canonical
+/// interface and its semantics are documented upstream.
 ///
-/// Reference: [vToken deposit &
-/// withdraw](https://docs.vesu.xyz/developers/core/vtoken#deposit--withdraw)
+/// Reference: [vToken docs](https://docs.vesu.xyz/developers/core/vtoken#deposit--withdraw)
 #[starknet::interface]
 pub trait IVToken<T> {
-    /// Deposits assets into the pool and mints vTokens (shares) to the receiver
-    /// # Arguments
-    /// * `assets` - amount of assets to deposit [asset scale]
-    /// * `receiver` - address to receive the vToken shares
-    /// # Returns
-    /// * amount of vToken shares minted [SCALE]
     fn deposit(ref self: T, assets: u256, receiver: ContractAddress) -> u256;
-    /// Withdraws assets from the pool and burns vTokens (shares) from the owner of the vTokens
-    /// # Arguments
-    /// * `assets` - amount of assets to withdraw [asset scale]
-    /// * `receiver` - address to receive the withdrawn assets
-    /// * `owner` - address of the owner of the vToken shares
-    /// # Returns
-    /// * amount of vTokens (shares) burned [SCALE]
-    fn withdraw(
-        ref self: T, assets: u256, receiver: ContractAddress, owner: ContractAddress,
-    ) -> u256;
-    /// Redeems an exact number of vTokens (shares), burning them from `owner` and sending the
-    /// corresponding underlying assets to `receiver`.
-    /// # Arguments
-    /// * `shares` - amount of vToken shares to burn [SCALE]
-    /// * `receiver` - address to receive the withdrawn underlying assets
-    /// * `owner` - address of the owner of the vToken shares
-    /// # Returns
-    /// * amount of underlying assets withdrawn [asset scale]
     fn redeem(ref self: T, shares: u256, receiver: ContractAddress, owner: ContractAddress) -> u256;
 }
 
@@ -69,13 +42,14 @@ pub trait IVesuLendingAnonymizer<T> {
     /// [`INVOKE_SELECTOR`](privacy::utils::constants::INVOKE_SELECTOR) selector.
     ///
     /// #### Parameters
-    /// - `operation` ([`LendingOperation`](LendingOperation)) - The lending operation to perform.
-    /// - `in_token` (`ContractAddress`) - The token address of the input funds (in withdraw -
-    /// vToken).
-    /// - `out_token` (`ContractAddress`) - The token address of the output funds (in deposit -
-    /// vToken).
-    /// - `assets` (`u256`) - For Deposit, the amount of underlying assets to deposit. For Withdraw,
-    /// the number of vToken shares to redeem.
+    /// - `operation` ([`LendingOperation`](LendingOperation)) - `Deposit` (supply underlying,
+    /// receive vToken shares) or `Withdraw` (redeem vToken shares, receive underlying).
+    /// - `in_token` (`ContractAddress`) - The token the contract spends: the underlying on Deposit,
+    /// the vToken on Withdraw.
+    /// - `out_token` (`ContractAddress`) - The token the contract receives: the vToken on Deposit,
+    /// the underlying on Withdraw.
+    /// - `amount` (`u256`) - On Deposit, the amount of underlying to supply; on Withdraw, the
+    /// number of vToken shares to redeem.
     /// - `note_id` (`felt252`) - The identifier of the open note to deposit the output to.
     ///
     /// #### Returns
@@ -85,24 +59,26 @@ pub trait IVesuLendingAnonymizer<T> {
     /// #### Preconditions
     /// - `in_token` must not be zero.
     /// - `out_token` must not be zero.
-    /// - `assets` must not be zero.
+    /// - `amount` must not be zero.
     /// - `in_token` must not be equal to `out_token`.
     /// - The contract must have sufficient input token balance.
     /// - On deposit, `out_token` must be a Vesu Token contract.
     /// - On withdraw, `in_token` must be a Vesu Token contract.
     ///
     /// #### Flow
-    /// 1. If operation is Deposit, approves Vesu Token contract to spend `in_amount` of in tokens.
+    /// 1. If operation is Deposit, approves the Vesu Token contract to spend `amount` of
+    /// `in_token`.
     /// 2. Records output token balance, calls the corresponding lending function, calculates
     /// received amount.
     /// 3. Approves the caller (privacy contract) to transfer the received output funds.
     /// 4. Returns (note_id, out_token, out_amount).
+    // TODO: rename `in_token`/`out_token` to clearer names; their meaning flips per operation.
     fn privacy_invoke(
         ref self: T,
         operation: LendingOperation,
         in_token: ContractAddress,
         out_token: ContractAddress,
-        assets: u256,
+        amount: u256,
         note_id: felt252,
     ) -> Span<OpenNoteDeposit>;
 }
@@ -111,7 +87,7 @@ pub trait IVesuLendingAnonymizer<T> {
 pub mod errors {
     pub const ZERO_IN_TOKEN: felt252 = 'ZERO_IN_TOKEN';
     pub const ZERO_OUT_TOKEN: felt252 = 'ZERO_OUT_TOKEN';
-    pub const ZERO_ASSETS: felt252 = 'ZERO_ASSETS';
+    pub const ZERO_AMOUNT: felt252 = 'ZERO_AMOUNT';
     pub const TOKENS_EQUAL: felt252 = 'TOKENS_EQUAL';
     pub const RECEIVED_AMOUNT_OVERFLOW: felt252 = 'RECEIVED_AMOUNT_OVERFLOW';
     pub const ZERO_OUT_AMOUNT: felt252 = 'ZERO_OUT_AMOUNT';
@@ -142,12 +118,12 @@ pub mod VesuLendingAnonymizer {
             operation: LendingOperation,
             in_token: ContractAddress,
             out_token: ContractAddress,
-            assets: u256,
+            amount: u256,
             note_id: felt252,
         ) -> Span<OpenNoteDeposit> {
             assert(in_token.is_non_zero(), errors::ZERO_IN_TOKEN);
             assert(out_token.is_non_zero(), errors::ZERO_OUT_TOKEN);
-            assert(assets.is_non_zero(), errors::ZERO_ASSETS);
+            assert(amount.is_non_zero(), errors::ZERO_AMOUNT);
             assert(in_token != out_token, errors::TOKENS_EQUAL);
 
             let self_addr = get_contract_address();
@@ -162,15 +138,15 @@ pub mod VesuLendingAnonymizer {
             // Return value (minted/burned shares) is ignored.
             match operation {
                 LendingOperation::Deposit => {
-                    // Approve Vesu Token contract to spend `assets` of `in_token`.
-                    in_erc20.approve(spender: out_token, amount: assets);
+                    // Approve Vesu Token contract to spend `amount` of `in_token`.
+                    in_erc20.approve(spender: out_token, :amount);
                     IVTokenDispatcher { contract_address: out_token }
-                        .deposit(:assets, receiver: self_addr)
+                        .deposit(assets: amount, receiver: self_addr)
                 },
                 LendingOperation::Withdraw => {
-                    // `assets` carries the vToken share count to redeem (see `assets` doc).
+                    // `amount` is the vToken share count to redeem.
                     IVTokenDispatcher { contract_address: in_token }
-                        .redeem(shares: assets, receiver: self_addr, owner: self_addr)
+                        .redeem(shares: amount, receiver: self_addr, owner: self_addr)
                 },
             }
 


### PR DESCRIPTION
The withdraw branch called IVToken.withdraw(assets), which interprets the amount as underlying to receive and burns convertToShares(amount) shares. The pool holds and spends vToken shares, so at any exchange rate above 1:1 fewer shares burn than were transferred in, stranding the remainder in the stateless anonymizer.

Call IVToken.redeem(shares) to burn the exact share count the pool transferred. Adds redeem to the IVToken interface and mocks, a 2:1 MockVesuVaultInterest, a regression test, and updates the e2e unlend to pass the share count. The mock's 1:1 rate previously masked this.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/821)
<!-- Reviewable:end -->
