### PR TITLE
fix(privacy-contract):1. Support eth-712-account (By custom signature validation path). 2. Support SNIP-12 signature for legacy wallets

### DIFF
--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -196,12 +196,13 @@ pub mod Privacy {
                 caller_address: execution_info.caller_address, tx_version: tx_info.version,
             );
 
+            let calls = calls.span();
             let (user_addr, user_private_key, client_actions) = extract_compile_actions_inputs(
                 :calls, contract_address: execution_info.contract_address,
             );
             let server_actions = self
                 .compile_actions(:user_addr, :user_private_key, :client_actions);
-            assert_valid_signature(:user_addr, :tx_info);
+            assert_valid_signature(:user_addr, :calls, :tx_info);
             send_message_to_server(
                 :server_actions, contract_address: execution_info.contract_address,
             );

--- a/packages/privacy/src/snip12.cairo
+++ b/packages/privacy/src/snip12.cairo
@@ -1,12 +1,18 @@
 use core::ecdsa::check_ecdsa_signature;
 use core::hash::{HashStateExTrait, HashStateTrait};
-use core::poseidon::PoseidonTrait;
+use core::poseidon::{PoseidonTrait, poseidon_hash_span};
+use openzeppelin::account::extensions::src9::snip12_utils::CallStructHash;
 use openzeppelin::utils::cryptography::snip12::{StarknetDomain, StructHash};
+use starknet::account::Call;
 use starknet::{ContractAddress, get_tx_info};
 
-pub const SNIP12_NAME: felt252 = 'Screening';
+pub const SCREENING_SNIP12_NAME: felt252 = 'Screening';
 // Numeric felt (not shortstring `'2'`), matching the starknet.js/starknet-py convention.
-pub const SNIP12_VERSION: felt252 = 2;
+pub const SCREENING_SNIP12_VERSION: felt252 = 2;
+
+// SNIP-12 domain for the generic `CallSet` authorization message.
+pub const CALL_SET_SNIP12_NAME: felt252 = 'CallSet';
+pub const CALL_SET_SNIP12_VERSION: felt252 = 1;
 
 // SNIP-12 has no `u64` primitive; the type string widens `issued_at` to `u128`,
 // while the Cairo field stays `u64`. Both reduce to the same felt under Poseidon,
@@ -43,30 +49,39 @@ pub fn is_screening_attestation_valid(
     depositor: ContractAddress, attestation: ScreeningAttestation, signer_public_key: felt252,
 ) -> bool {
     let validation = DepositorValidation { depositor, issued_at: attestation.issued_at };
-    let message_hash = compute_message_hash(@validation, signer_public_key);
+    let message_hash = compute_screening_message_hash(@validation, signer_public_key);
     let (r, s) = attestation.signature;
     check_ecdsa_signature(message_hash, signer_public_key, r, s)
 }
 
-/// SNIP-12 off-chain message hash for a `DepositorValidation`.
-///
-/// `signer` is the trusted signer's STARK-curve public key (felt252). The
-/// SNIP-12 envelope binds the hash to this identity. Exposed so off-chain
-/// tooling (TS/Python reference signers, test-vector generators) can derive
-/// the exact hash the verifier will check against.
-pub(crate) fn compute_message_hash(validation: @DepositorValidation, signer: felt252) -> felt252 {
+/// SNIP-12 off-chain message hash envelope:
+/// `poseidon('StarkNet Message', hash(domain), signer, struct_hash)`, the domain bound to the
+/// current chain (revision 1). `signer` is the identity the envelope binds (e.g. account address).
+fn snip12_message_hash(
+    name: felt252, version: felt252, signer: felt252, struct_hash: felt252,
+) -> felt252 {
     let domain = StarknetDomain {
-        name: SNIP12_NAME,
-        version: SNIP12_VERSION,
-        chain_id: get_tx_info().unbox().chain_id,
-        revision: 1,
+        name, version, chain_id: get_tx_info().unbox().chain_id, revision: 1,
     };
     PoseidonTrait::new()
         .update_with('StarkNet Message')
         .update_with(domain.hash_struct())
         .update_with(signer)
-        .update_with(validation.hash_struct())
+        .update_with(struct_hash)
         .finalize()
+}
+
+/// SNIP-12 off-chain message hash for a `DepositorValidation`.
+///
+/// `signer` is the trusted signer's STARK-curve public key (felt252). Exposed so off-chain tooling
+/// (TS/Python reference signers, test-vector generators) can derive the exact hash the verifier
+/// will check against.
+pub(crate) fn compute_screening_message_hash(
+    validation: @DepositorValidation, signer: felt252,
+) -> felt252 {
+    snip12_message_hash(
+        SCREENING_SNIP12_NAME, SCREENING_SNIP12_VERSION, signer, validation.hash_struct(),
+    )
 }
 
 impl DepositorValidationStructHashImpl of StructHash<DepositorValidation> {
@@ -76,4 +91,39 @@ impl DepositorValidationStructHashImpl of StructHash<DepositorValidation> {
             .update_with(*self)
             .finalize()
     }
+}
+
+// SNIP-12 type hash `CallSet`.
+const CALL_SET_TYPE_HASH: felt252 = selector!(
+    "\"CallSet\"(\"Calls\":\"Call*\")\"Call\"(\"To\":\"ContractAddress\",\"Selector\":\"selector\",\"Calldata\":\"felt*\")",
+);
+
+#[derive(Drop)]
+pub(crate) struct CallSet {
+    pub(crate) calls: Span<Call>,
+}
+
+impl CallSetStructHashImpl of StructHash<CallSet> {
+    fn hash_struct(self: @CallSet) -> felt252 {
+        let mut hashed_calls = array![];
+        for call in *self.calls {
+            hashed_calls.append(call.hash_struct());
+        }
+        PoseidonTrait::new()
+            .update_with(CALL_SET_TYPE_HASH)
+            .update_with(poseidon_hash_span(hashed_calls.span()))
+            .finalize()
+    }
+}
+
+/// SNIP-12 off-chain message hash for a `CallSet` authorized by `signer` (the depositor account
+/// address — the SNIP-12 envelope binds the signing account, matching starknet.js
+/// `typedData.getMessageHash(td, accountAddress)`). The off-chain golden oracle for the SDK.
+pub(crate) fn compute_call_set_hash(signer: ContractAddress, calls: Span<Call>) -> felt252 {
+    snip12_message_hash(
+        CALL_SET_SNIP12_NAME,
+        CALL_SET_SNIP12_VERSION,
+        signer.into(),
+        CallSet { calls }.hash_struct(),
+    )
 }

--- a/packages/privacy/src/tests.cairo
+++ b/packages/privacy/src/tests.cairo
@@ -1,7 +1,9 @@
 pub mod generate_reference_data;
 pub mod mock_account;
+pub mod mock_custom_account;
 pub mod mock_invoke_returns;
 pub mod mock_reentrancy;
+pub mod mock_stark_account;
 pub mod screening_vectors;
 pub mod test_admin;
 pub mod test_client;

--- a/packages/privacy/src/tests/mock_account.cairo
+++ b/packages/privacy/src/tests/mock_account.cairo
@@ -1,6 +1,7 @@
 #[starknet::contract]
 pub mod MockAccount {
     use core::num::traits::Zero;
+    use openzeppelin::interfaces::introspection::ISRC5;
     use privacy::utils::IAccount;
     use starknet::VALIDATED;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
@@ -25,6 +26,14 @@ pub mod MockAccount {
             self: @ContractState, hash: felt252, signature: Array<felt252>,
         ) -> felt252 {
             self.is_valid.read()
+        }
+    }
+
+    /// Default always false SRC5 support impl.
+    #[abi(embed_v0)]
+    impl MockAccountSRC5Impl of ISRC5<ContractState> {
+        fn supports_interface(self: @ContractState, interface_id: felt252) -> bool {
+            false
         }
     }
 }

--- a/packages/privacy/src/tests/mock_custom_account.cairo
+++ b/packages/privacy/src/tests/mock_custom_account.cairo
@@ -1,0 +1,54 @@
+/// A mock depositor account that advertises the custom-signature-validation interface (SRC5) and
+/// answers `is_custom_signature_valid` with a constructor-configured verdict. Used to exercise the
+/// pool's custom-validation branch (`assert_valid_signature`).
+#[starknet::contract]
+pub mod MockCustomAccount {
+    use core::num::traits::Zero;
+    use openzeppelin::interfaces::introspection::ISRC5;
+    use privacy::utils::{IAccount, ICUSTOM_SIGNATURE_VALIDATION_ID, ICustomSignatureValidation};
+    use starknet::VALIDATED;
+    use starknet::account::Call;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        // Felt the custom EP returns: `VALIDATED` when the configured verdict is "valid", else 0.
+        custom_result: felt252,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, is_valid: bool) {
+        if is_valid {
+            self.custom_result.write(VALIDATED);
+        } else {
+            self.custom_result.write(Zero::zero());
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl SRC5Impl of ISRC5<ContractState> {
+        fn supports_interface(self: @ContractState, interface_id: felt252) -> bool {
+            interface_id == ICUSTOM_SIGNATURE_VALIDATION_ID
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl CustomSignatureValidationImpl of ICustomSignatureValidation<ContractState> {
+        fn is_custom_signature_valid(
+            self: @ContractState, calls: Span<Call>, signature: Span<felt252>,
+        ) -> felt252 {
+            self.custom_result.read()
+        }
+    }
+
+    /// Raw-hash signature path: always rejects, so any accidental fallback to the legacy check is
+    /// visible (the custom path is the only way this account authenticates).
+    #[abi(embed_v0)]
+    impl AccountImpl of IAccount<ContractState> {
+        fn is_valid_signature(
+            self: @ContractState, hash: felt252, signature: Array<felt252>,
+        ) -> felt252 {
+            Zero::zero()
+        }
+    }
+}

--- a/packages/privacy/src/tests/mock_stark_account.cairo
+++ b/packages/privacy/src/tests/mock_stark_account.cairo
@@ -1,0 +1,42 @@
+/// A standard-style Starknet account mock that verifies a STARK-curve signature over the passed
+/// hash via `check_ecdsa_signature` (like a real SNIP-6 account, which returns `0` on mismatch
+/// instead of panicking). Implements no `supports_interface` (SRC5) entrypoint at all, so a call to
+/// it reverts with ENTRYPOINT_NOT_FOUND — exercising the pool's safe-dispatcher routing, which
+/// must treat the revert as "no custom validation" and fall through to the raw-hash path (case II:
+/// tx hash, or case III: SNIP-12 `CallSet` hash) rather than reverting the whole transaction.
+#[starknet::contract]
+pub mod MockStarkAccount {
+    use core::ecdsa::check_ecdsa_signature;
+    use privacy::utils::IAccount;
+    use starknet::VALIDATED;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        public_key: felt252,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, public_key: felt252) {
+        self.public_key.write(public_key);
+    }
+
+    #[abi(embed_v0)]
+    impl MockStarkAccountImpl of IAccount<ContractState> {
+        fn is_valid_signature(
+            self: @ContractState, hash: felt252, signature: Array<felt252>,
+        ) -> felt252 {
+            if signature.len() != 2 {
+                return 0;
+            }
+            let valid = check_ecdsa_signature(
+                hash, self.public_key.read(), *signature[0], *signature[1],
+            );
+            if valid {
+                VALIDATED
+            } else {
+                0
+            }
+        }
+    }
+}

--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -7,11 +7,13 @@ use privacy::actions::{
 };
 use privacy::hashes::{compute_note_id, compute_nullifier, compute_subchannel_id};
 use privacy::objects::{EncSubchannelInfo, EncUserAddr, OpenNoteDeposit};
+use privacy::snip12::compute_call_set_hash;
 use privacy::test_contracts::mock_swap_executor::errors as mock_swap_executor_errors;
 use privacy::tests::utils_for_tests::{
     AuditorTrait, CreateEncNoteInputIntoServerActionTrait, CreateOpenNoteInputIntoServerActionTrait,
     InvokeExternalInputIntoServerActionTrait, NoteZero, PrivacyCfgTrait, Test, TestTrait, UserTrait,
     constants, decrypt_channel_info, decrypt_outgoing_channel_info, decrypt_subchannel_token,
+    deploy_mock_stark_account,
 };
 use privacy::utils::constants::{ESTIMATION_BASE_TX_VERSION, OPEN_NOTE_SALT, TWO_POW_120, TX_V3};
 use privacy::utils::{
@@ -19,9 +21,14 @@ use privacy::utils::{
     is_canonical_key, to_write_once_action, unpack,
 };
 use privacy::{errors, events};
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPair, StarkCurveKeyPairImpl, StarkCurveSignerImpl,
+};
+use snforge_std::signature::{KeyPairTrait, SignerTrait};
 use snforge_std::{
     CheatSpan, EventSpyTrait, EventsFilterTrait, MessageToL1SpyTrait, TokenTrait, cheat_tip,
     cheat_transaction_version, get_class_hash, map_entry_address, spy_events, spy_messages_to_l1,
+    start_cheat_chain_id_global, start_cheat_signature, stop_cheat_chain_id_global,
 };
 use starknet::account::Call;
 use starknet::{ContractAddress, VALIDATED};
@@ -6632,4 +6639,114 @@ fn test_send_message_to_server() {
     (*message).serialize(ref message_data);
     let message_hash = poseidon_hash_span(message_data.span());
     assert_eq!(expected_message_hash, message_hash);
+}
+
+// ── Custom-signature-validation depositor (L2)
+// ──────────────────────────────────────────────────
+
+/// A depositor account that advertises the custom-signature-validation interface and approves the
+/// transaction takes the custom path. Its raw-hash `is_valid_signature` returns 0, so success here
+/// proves the pool used the custom path (a fallback to the legacy check would reject).
+#[test]
+fn test_deposit_custom_account_valid() {
+    let mut test: Test = Default::default();
+    let mut user = test.new_user_with_custom(is_valid: true);
+    let random = user.get_random();
+    let result = user.safe_set_viewing_key(:random);
+    assert!(result.is_ok());
+}
+
+/// A capable account whose `is_custom_signature_valid` returns 0 must hard-fail with
+/// INVALID_SIGNATURE — no silent fallback to the legacy raw-hash check.
+#[test]
+fn test_deposit_custom_account_rejected() {
+    let mut test: Test = Default::default();
+    let mut user = test.new_user_with_custom(is_valid: false);
+    let random = user.get_random();
+    let result = user.safe_set_viewing_key(:random);
+    assert_panic_with_felt_error(:result, expected_error: errors::INVALID_SIGNATURE);
+}
+
+/// A legacy SN wallet that signs the SNIP-12 `CallSet` message (not the tx hash).
+/// The account verifies a real STARK signature over the SNIP-12 message.
+/// The pool's OR-fallback must reach the SNIP-12 branch
+/// (the first branch over the tx hash fails, since the signature is over the CallSet hash).
+/// `MockStarkAccount` implements no `supports_interface` entrypoint, so this also guards the
+/// safe-dispatcher routing: the SRC5 probe reverts and must be treated as "no custom validation".
+#[test]
+fn test_deposit_legacy_sn_wallet_via_snip12_call_set() {
+    start_cheat_chain_id_global('TEST');
+    let test: Test = Default::default();
+    let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('CALLSET_WALLET_SK');
+    let depositor = deploy_mock_stark_account(salt: 7, public_key: key.public_key);
+
+    let client_actions = [ClientAction::SetViewingKey(SetViewingKeyInput { random: 0x777 })].span();
+    let calls = test
+        .privacy
+        .wrap_inputs_into_calls(
+            user_addr: depositor, user_private_key: 'CALLSET_PROTOCOL_PK', :client_actions,
+        );
+
+    // The wallet signs the SNIP-12 CallSet message over exactly these calls.
+    let hash = compute_call_set_hash(depositor, calls.span());
+    let (r, s) = key.sign(hash).unwrap();
+    start_cheat_signature(test.privacy.address, array![r, s].span());
+
+    let result = test.privacy.safe_execute_with_calls(calls);
+    assert!(result.is_ok(), "case II (SNIP-12 CallSet) deposit should succeed");
+    stop_cheat_chain_id_global();
+}
+
+/// A STARK signature over the wrong message (a different CallSet) must fail both OR branches.
+#[test]
+fn test_deposit_legacy_sn_wallet_wrong_call_set_reverts() {
+    start_cheat_chain_id_global('TEST');
+    let test: Test = Default::default();
+    let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('CALLSET_WALLET_SK');
+    let depositor = deploy_mock_stark_account(salt: 8, public_key: key.public_key);
+
+    let client_actions = [ClientAction::SetViewingKey(SetViewingKeyInput { random: 0x777 })].span();
+    let calls = test
+        .privacy
+        .wrap_inputs_into_calls(
+            user_addr: depositor, user_private_key: 'CALLSET_PROTOCOL_PK', :client_actions,
+        );
+
+    // Sign a DIFFERENT CallSet (empty calls) — neither the tx hash nor the real CallSet hash.
+    let wrong_hash = compute_call_set_hash(depositor, [].span());
+    let (r, s) = key.sign(wrong_hash).unwrap();
+    start_cheat_signature(test.privacy.address, array![r, s].span());
+
+    let result = test.privacy.safe_execute_with_calls(calls);
+    assert_panic_with_felt_error(:result, expected_error: errors::INVALID_SIGNATURE);
+    stop_cheat_chain_id_global();
+}
+
+/// Regression: an account with no SRC5 `supports_interface` entrypoint must not abort the whole
+/// transaction at the custom-validation probe. The safe dispatcher catches the ENTRYPOINT_NOT_FOUND
+/// revert, routes to the legacy path, and a valid SNIP-12 `CallSet` signature authenticates.
+/// If a regular dispatcher us used, the SRC5 probe reverted and this deposit failed
+/// unconditionally, making the legacy path unreachable for any account that doesn't implement
+/// SRC5.)
+#[test]
+fn test_deposit_account_without_src5_routes_to_legacy() {
+    start_cheat_chain_id_global('TEST');
+    let test: Test = Default::default();
+    let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('NO_SRC5_WALLET_SK');
+    let depositor = deploy_mock_stark_account(salt: 9, public_key: key.public_key);
+
+    let client_actions = [ClientAction::SetViewingKey(SetViewingKeyInput { random: 0x777 })].span();
+    let calls = test
+        .privacy
+        .wrap_inputs_into_calls(
+            user_addr: depositor, user_private_key: 'NO_SRC5_PROTOCOL_PK', :client_actions,
+        );
+
+    let hash = compute_call_set_hash(depositor, calls.span());
+    let (r, s) = key.sign(hash).unwrap();
+    start_cheat_signature(test.privacy.address, array![r, s].span());
+
+    let result = test.privacy.safe_execute_with_calls(calls);
+    assert!(result.is_ok(), "no-SRC5 account should route to the legacy path, not revert");
+    stop_cheat_chain_id_global();
 }

--- a/packages/privacy/src/tests/test_screening_vectors.cairo
+++ b/packages/privacy/src/tests/test_screening_vectors.cairo
@@ -1,6 +1,7 @@
 use snforge_std::{start_cheat_chain_id, test_address};
 use crate::snip12::{
-    DepositorValidation, ScreeningAttestation, compute_message_hash, is_screening_attestation_valid,
+    DepositorValidation, ScreeningAttestation, compute_screening_message_hash,
+    is_screening_attestation_valid,
 };
 use super::screening_vectors::screening_vectors;
 
@@ -21,7 +22,8 @@ fn test_committed_screening_vectors_validate() {
             depositor: vector.depositor.try_into().unwrap(), issued_at: vector.issued_at,
         };
         assert_eq!(
-            compute_message_hash(@validation, vector.signer_public_key), vector.message_hash,
+            compute_screening_message_hash(@validation, vector.signer_public_key),
+            vector.message_hash,
         );
         let attestation = ScreeningAttestation {
             issued_at: vector.issued_at, signature: (vector.sig_r, vector.sig_s),

--- a/packages/privacy/src/tests/test_snip12.cairo
+++ b/packages/privacy/src/tests/test_snip12.cairo
@@ -1,10 +1,14 @@
+use core::ecdsa::check_ecdsa_signature;
 use snforge_std::signature::stark_curve::{
     StarkCurveKeyPair, StarkCurveKeyPairImpl, StarkCurveSignerImpl,
 };
 use snforge_std::signature::{KeyPairTrait, SignerTrait};
 use snforge_std::{start_cheat_chain_id, test_address};
+use starknet::ContractAddress;
+use starknet::account::Call;
 use crate::snip12::{
-    DepositorValidation, ScreeningAttestation, compute_message_hash, is_screening_attestation_valid,
+    DepositorValidation, ScreeningAttestation, compute_call_set_hash,
+    compute_screening_message_hash, is_screening_attestation_valid,
 };
 
 const TEST_CHAIN_ID: felt252 = 'TEST';
@@ -29,7 +33,7 @@ fn sample_validation() -> DepositorValidation {
 }
 
 fn sign_validation(key: StarkCurveKeyPair, validation: DepositorValidation) -> (felt252, felt252) {
-    let hash = compute_message_hash(@validation, key.public_key);
+    let hash = compute_screening_message_hash(@validation, key.public_key);
     key.sign(hash).unwrap()
 }
 
@@ -85,4 +89,46 @@ fn test_tampered_signature_r_returns_false() {
         issued_at: attestation.issued_at, signature: (signature_r + 1, signature_s),
     };
     assert!(!is_screening_attestation_valid(validation.depositor, tampered, key.public_key));
+}
+
+// ── CallSet
+// ──────────
+
+fn sample_calls() -> Span<Call> {
+    array![
+        Call {
+            to: 0x111.try_into().unwrap(),
+            selector: selector!("approve"),
+            calldata: array![0x1, 0x2].span(),
+        },
+    ]
+        .span()
+}
+
+#[test]
+fn test_call_set_hash_signature_roundtrip() {
+    setup_chain_id();
+    let key = trusted_signer();
+    let signer: ContractAddress = 0x1234.try_into().unwrap();
+    let hash = compute_call_set_hash(signer, sample_calls());
+    let (r, s) = key.sign(hash).unwrap();
+    assert!(check_ecdsa_signature(hash, key.public_key, r, s));
+}
+
+#[test]
+fn test_call_set_hash_binds_calls() {
+    setup_chain_id();
+    let signer: ContractAddress = 0x1234.try_into().unwrap();
+    // The hash binds the exact call set: a different set (here, empty) yields a different hash.
+    assert!(
+        compute_call_set_hash(signer, sample_calls()) != compute_call_set_hash(signer, [].span()),
+    );
+}
+
+#[test]
+fn test_call_set_hash_binds_signer() {
+    setup_chain_id();
+    let a = compute_call_set_hash(0x1.try_into().unwrap(), sample_calls());
+    let b = compute_call_set_hash(0x2.try_into().unwrap(), sample_calls());
+    assert!(a != b);
 }

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -35,10 +35,7 @@ use privacy::objects::{
 };
 use privacy::privacy::Privacy;
 use privacy::privacy::Privacy::{ClientInternalTrait, deploy_for_test as deploy_privacy_for_test};
-use privacy::snip12::{
-    DepositorValidation, ScreeningAttestation,
-    compute_message_hash as compute_screening_message_hash,
-};
+use privacy::snip12::{DepositorValidation, ScreeningAttestation, compute_screening_message_hash};
 use privacy::test_contracts::mock_amm::MockAMM::deploy_for_test as deploy_mock_amm_for_test;
 use privacy::test_contracts::mock_swap_executor::MockSwapExecutor::deploy_for_test as deploy_mock_swap_executor_for_test;
 use privacy::test_contracts::mock_swap_executor::{
@@ -46,10 +43,12 @@ use privacy::test_contracts::mock_swap_executor::{
     ISwapExecutorSafeDispatcherTrait,
 };
 use privacy::tests::mock_account::MockAccount::deploy_for_test as deploy_mock_account_for_test;
+use privacy::tests::mock_custom_account::MockCustomAccount::deploy_for_test as deploy_mock_custom_account_for_test;
 use privacy::tests::mock_invoke_returns::MockEcho::deploy_for_test as deploy_mock_echo_for_test;
 use privacy::tests::mock_invoke_returns::MockReturnGarbage::deploy_for_test as deploy_mock_return_garbage_for_test;
 use privacy::tests::mock_invoke_returns::MockReturnTrailingGarbage::deploy_for_test as deploy_mock_return_trailing_garbage_for_test;
 use privacy::tests::mock_reentrancy::MockReentrancy::deploy_for_test as deploy_mock_reentrancy_for_test;
+use privacy::tests::mock_stark_account::MockStarkAccount::deploy_for_test as deploy_mock_stark_account_for_test;
 use privacy::tests::utils_for_tests::constants::DEFAULT_PROOF_VALIDITY_BLOCKS;
 use privacy::utils::constants::{ENTRYPOINT_FAILED, OK_WRAPPER, OPEN_NOTE_SALT, TWO_POW_120};
 use privacy::utils::{
@@ -1408,6 +1407,19 @@ pub(crate) impl TestImpl of TestTrait {
         User { address, privacy: self.privacy, private_key, public_key, nonce: Zero::zero() }
     }
 
+    /// Like `new_user_with_is_valid`, but with account that supports custom-signature-validation.
+    fn new_user_with_custom(ref self: Test, is_valid: bool) -> User {
+        self.nonce += 1;
+        let mut private_key = 'PRIVATE_KEY' + self.nonce.into();
+        if !is_canonical_key(key: private_key) {
+            private_key = Neg::neg(private_key);
+        }
+        let public_key = derive_public_key(:private_key);
+        self.nonce += 1;
+        let address = deploy_mock_custom_account(salt: self.nonce.into(), :is_valid);
+        User { address, privacy: self.privacy, private_key, public_key, nonce: Zero::zero() }
+    }
+
     /// Mock function to generate a new token address.
     fn mock_new_token(ref self: Test) -> ContractAddress {
         self.nonce += 1;
@@ -2292,6 +2304,35 @@ pub(crate) fn deploy_mock_account(salt: felt252, is_valid: bool) -> ContractAddr
         class_hash: *contract_class_hash, :deployment_params, :is_valid,
     )
         .expect('MockAccount deployment failed');
+    contract_address
+}
+
+/// Deploy a depositor account with custom-signature-validation.
+/// `is_valid` controls the signature validation result.
+pub(crate) fn deploy_mock_custom_account(salt: felt252, is_valid: bool) -> ContractAddress {
+    let contract_class_hash = declare(contract: "MockCustomAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt, deploy_from_zero: true };
+    let (contract_address, _) = deploy_mock_custom_account_for_test(
+        class_hash: *contract_class_hash, :deployment_params, :is_valid,
+    )
+        .expect('MockCustomAccount deploy failed');
+    contract_address
+}
+
+/// Deploy a standard-style STARK account mock that verifies a real signature against `public_key`.
+pub(crate) fn deploy_mock_stark_account(salt: felt252, public_key: felt252) -> ContractAddress {
+    let contract_class_hash = declare(contract: "MockStarkAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt, deploy_from_zero: true };
+    let (contract_address, _) = deploy_mock_stark_account_for_test(
+        class_hash: *contract_class_hash, :deployment_params, :public_key,
+    )
+        .expect('MockStarkAccount deploy failed');
     contract_address
 }
 

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -6,6 +6,7 @@ use core::ec::{EcPoint, EcPointTrait};
 use core::never;
 use core::num::traits::{WrappingAdd, WrappingSub, Zero};
 use core::poseidon::poseidon_hash_span;
+use openzeppelin::interfaces::introspection::{ISRC5SafeDispatcher, ISRC5SafeDispatcherTrait};
 use privacy::actions::{ClientAction, ServerAction, WriteOnceInput};
 use privacy::errors;
 use privacy::errors::internal_errors;
@@ -17,6 +18,7 @@ use privacy::hashes::{
 use privacy::objects::{
     EncChannelInfo, EncOutgoingChannelInfo, EncPrivateKey, EncSubchannelInfo, EncUserAddr, Note,
 };
+use privacy::snip12::compute_call_set_hash;
 use privacy::utils::constants::{
     ENTRYPOINT_FAILED, HALF_ORDER, OK_WRAPPER, OPEN_NOTE_PACKED_VALUE, OPEN_NOTE_SALT, TWO_POW_120,
 };
@@ -28,6 +30,18 @@ use starknet::{ContractAddress, Store, SyscallResultTrait, TxInfo, VALIDATED};
 #[starknet::interface]
 pub(crate) trait IAccount<TState> {
     fn is_valid_signature(self: @TState, hash: felt252, signature: Array<felt252>) -> felt252;
+}
+
+/// SRC5 interface ID advertised by accounts that require custom signature validation.
+/// selector(is_custom_signature_valid) =
+/// 0x2eb9faa4ce06e09879e93803798b87d22877b73964334356bf9e0d8cc22ded
+pub(crate) const ICUSTOM_SIGNATURE_VALIDATION_ID: felt252 = selector!("is_custom_signature_valid");
+
+#[starknet::interface]
+pub(crate) trait ICustomSignatureValidation<TState> {
+    fn is_custom_signature_valid(
+        self: @TState, calls: Span<Call>, signature: Span<felt252>,
+    ) -> felt252;
 }
 
 pub mod constants {
@@ -325,7 +339,7 @@ pub(crate) fn unpack(packed_value: felt252) -> (u128, u128) {
 /// Asserts that the calls are valid and deserializes the calldata.
 /// Returns the input for `compile_actions` function: (user_addr, user_private_key, client_actions).
 pub(crate) fn extract_compile_actions_inputs(
-    calls: Array<Call>, contract_address: ContractAddress,
+    calls: Span<Call>, contract_address: ContractAddress,
 ) -> (ContractAddress, felt252, Span<ClientAction>) {
     assert(calls.len() == 1, errors::EXPECTED_ONE_CALL);
     let call = calls[0];
@@ -340,13 +354,45 @@ pub(crate) fn extract_compile_actions_inputs(
     (user_addr, user_private_key, client_actions)
 }
 
-pub(crate) fn assert_valid_signature(user_addr: ContractAddress, tx_info: Box<TxInfo>) {
-    let tx_hash = tx_info.transaction_hash;
-    let signature = tx_info.signature.into();
+/// Authenticates the user account that authorized `calls`.
+/// Three cases:
+///
+/// I. **Custom validation** (e.g. an Eth712Account advertising SRC5):
+///    delegate to the account's `is_custom_signature_valid(calls, signature)`.
+/// II. Supported SN Wallet:
+///    `is_valid_signature` is checked against the SN tx hash that was signed by the SN Wallet.
+/// III. Legacy SN Wallet:
+///    `is_valid_signature` is checked against the SNIP-12 `CallSet` hash of `calls`.
+pub(crate) fn assert_valid_signature(
+    user_addr: ContractAddress, calls: Span<Call>, tx_info: Box<TxInfo>,
+) {
+    if supports_custom_validation(user_addr) {
+        let res = ICustomSignatureValidationDispatcher { contract_address: user_addr }
+            .is_custom_signature_valid(calls, tx_info.signature);
+        assert(res == VALIDATED, errors::INVALID_SIGNATURE);
+    } else {
+        let user_account = IAccountDispatcher { contract_address: user_addr };
+        let is_valid = user_account
+            .is_valid_signature(
+                hash: tx_info.transaction_hash, signature: tx_info.signature.into(),
+            ) == VALIDATED
+            || user_account
+                .is_valid_signature(
+                    hash: compute_call_set_hash(user_addr, calls),
+                    signature: tx_info.signature.into(),
+                ) == VALIDATED;
+        assert(is_valid, errors::INVALID_SIGNATURE);
+    }
+}
 
-    let user_account = IAccountDispatcher { contract_address: user_addr };
-    let is_valid = user_account.is_valid_signature(hash: tx_hash, :signature);
-    assert(is_valid == VALIDATED, errors::INVALID_SIGNATURE);
+/// Returns whether `user_addr` advertises SRC5 `ICUSTOM_SIGNATURE_VALIDATION_ID`.
+/// Uses the safe dispatcher so an account that doesn't implement SRC5 at all
+/// is treated as "no custom validation" instead of reverting.
+#[feature("safe_dispatcher")]
+fn supports_custom_validation(user_addr: ContractAddress) -> bool {
+    ISRC5SafeDispatcher { contract_address: user_addr }
+        .supports_interface(ICUSTOM_SIGNATURE_VALIDATION_ID)
+        .unwrap_or(false)
 }
 
 /// Sends server actions to L1.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/822)
<!-- Reviewable:end -->
