### PR TITLE
feat(elliptic-proxy): bearer-gated /metrics Prometheus endpoint

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -43,7 +43,8 @@ The secret value must be a JSON string with this structure:
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
   "additionalBlockedAddresses": [],
-  "blockOverrideAddresses": []
+  "blockOverrideAddresses": [],
+  "metricsAuthToken": "<bearer-token-for-GET-/metrics>"
 }
 ```
 
@@ -60,6 +61,7 @@ The secret value must be a JSON string with this structure:
 | `blockOverrideAddresses` _(optional)_     | Operator allow list (hex felts): listed addresses always screen as allowed, winning over the deny list, the blocked cache, and the upstream verdict — rescues addresses the upstream wrongly flags (false positives).                                                                                                                            |
 | `signingPrivateKey` _(required)_          | STARK-curve private key (felt hex, `1 <= key < curve order`) signing screening attestations; the production key is FPI-managed.                                                                                                                                                                                                                  |
 | `chainId` _(required)_                    | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN combined with a mock `elliptic.url` is rejected at config load.                                                                                                                                                                                         |
+| `metricsAuthToken` _(optional)_           | Bearer token gating `GET /metrics`, compared timing-safely. Omit it and `/metrics` returns `404` — the exposition names partners and their traffic volumes, so it fails closed. See [Metrics](#metrics).                                                                                                                                          |
 
 ### Generating partner secrets
 
@@ -159,6 +161,18 @@ and a mock url combined with the SN_MAIN `chainId` is rejected at config load.
 - The cache is capped at 20 partners; when full, least-recently-used entries are evicted.
 - Evicted partners lose their current window state and start fresh on the next request.
 - All counters reset on cold start — acceptable for a single-instance low-traffic service.
+
+## Metrics
+
+`GET /metrics` serves a Prometheus text exposition, gated by
+`Authorization: Bearer <metricsAuthToken>`. It is handled before the screening path, so a
+scrape is never counted as partner traffic and a wrong scraper token cannot show up as a
+partner `401`.
+
+Counters live in the instance's memory, like the rate-limiter and the blocked-address cache,
+so they are only coherent while a single instance serves the function — deploy with
+`--max-instances=1` if you intend to alert on them. `process_start_time_seconds` (from
+prom-client's default metrics) marks the cold start that zeroed them.
 
 ## Error handling
 

--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -70,6 +70,7 @@ re-reads it according to `configCacheTtlSeconds`.
 | `additionalBlockedAddresses` _(opt.)_ | Test-only deny list consumed by the mock upstream — listed addresses screen as sanctioned. Ignored when screening live (load-time warning).                              |
 | `signingPrivateKey` _(required)_      | STARK-curve private key (felt hex) signing screening attestations; production key is FPI-managed.                                                                        |
 | `chainId` _(required)_                | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN + mock `elliptic.url` is rejected at config load.                               |
+| `metricsAuthToken` _(opt.)_           | Bearer token gating `GET /metrics` (timing-safe compare). Omitted means `/metrics` returns `404`; the exposition names partners and traffic volumes, so it fails closed.  |
 
 ### Verdict precedence
 

--- a/elliptic-proxy/package-lock.json
+++ b/elliptic-proxy/package-lock.json
@@ -11,7 +11,8 @@
         "@google-cloud/functions-framework": "^5.0.2",
         "@google-cloud/secret-manager": "^5.6.0",
         "@scure/starknet": "^1.1.2",
-        "lru-cache": "^11.2.7"
+        "lru-cache": "^11.2.7",
+        "prom-client": "^15.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -786,6 +787,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1871,6 +1881,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -4108,6 +4124,19 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
@@ -4723,6 +4752,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/teeny-request": {

--- a/elliptic-proxy/package.json
+++ b/elliptic-proxy/package.json
@@ -21,7 +21,8 @@
     "@google-cloud/functions-framework": "^5.0.2",
     "@google-cloud/secret-manager": "^5.6.0",
     "@scure/starknet": "^1.1.2",
-    "lru-cache": "^11.2.7"
+    "lru-cache": "^11.2.7",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/elliptic-proxy/src/config.ts
+++ b/elliptic-proxy/src/config.ts
@@ -37,6 +37,10 @@ export interface Config {
   // SN_MAIN must never be combined with a mock elliptic.url — config load
   // rejects it.
   chainId: string;
+  // Bearer token gating GET /metrics, compared timing-safely against the
+  // Authorization header. When unset, /metrics is disabled (404) — the
+  // exposition leaks partner names and traffic volumes, so it fails closed.
+  metricsAuthToken?: string;
 }
 
 // 'SN_MAIN' as a Cairo short string: the felt is the big-endian ASCII bytes.
@@ -187,7 +191,20 @@ function validateConfig(raw: unknown): Config {
     ),
     signingPrivateKey: requireString(root, "signingPrivateKey"),
     chainId,
+    metricsAuthToken: parseOptionalString(root, "metricsAuthToken"),
   };
+}
+
+function parseOptionalString(
+  object: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = object[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`config: ${key} must be a non-empty string`);
+  }
+  return value;
 }
 
 // Operational warning on every fresh config load (cold start and each TTL

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -1,4 +1,5 @@
 // src/handler.ts
+import { timingSafeEqual } from "crypto";
 import type {
   HttpFunction,
   Request,
@@ -12,6 +13,44 @@ import { BlockedAddressCache } from "./cache.js";
 import { scoreResponse, type ScoringResult } from "./scoring.js";
 import type { ForwardResponse } from "./elliptic.js";
 import { signScreening, type ScreeningSignature } from "./signing.js";
+import { metricsContentType, renderMetrics } from "./metrics.js";
+
+const BEARER_PREFIX = "Bearer ";
+
+// Serves the Prometheus exposition on GET /metrics, gated by a bearer token.
+// Bypasses the screening response path so scrapes never count toward the
+// traffic metrics and a bad scraper token never trips the 401 alert.
+async function serveMetrics(
+  req: Request,
+  res: Response,
+  token: string | undefined
+): Promise<void> {
+  // Fail closed: with no configured token the endpoint does not exist.
+  if (!token) {
+    res.set("content-type", "application/json");
+    res.status(404).send(JSON.stringify({ error: "not found" }));
+    return;
+  }
+  if (!bearerTokenMatches(req.headers.authorization, token)) {
+    res.set("content-type", "application/json");
+    res.status(401).send(JSON.stringify({ error: "unauthorized" }));
+    return;
+  }
+  res.set("content-type", metricsContentType);
+  res.status(200).send(await renderMetrics());
+}
+
+function bearerTokenMatches(
+  authHeader: string | string[] | undefined,
+  expectedToken: string
+): boolean {
+  const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (!header || !header.startsWith(BEARER_PREFIX)) return false;
+  const providedBuf = Buffer.from(header.slice(BEARER_PREFIX.length));
+  const expectedBuf = Buffer.from(expectedToken);
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
 
 export interface ConfigSource {
   get(): Promise<Config>;
@@ -72,6 +111,11 @@ export function createHandler(
         })
       );
       sendResponse(503, JSON.stringify({ error: "service unavailable" }));
+      return;
+    }
+
+    if (req.method === "GET" && req.path === "/metrics") {
+      await serveMetrics(req, res, config.metricsAuthToken);
       return;
     }
 

--- a/elliptic-proxy/src/metrics.ts
+++ b/elliptic-proxy/src/metrics.ts
@@ -1,0 +1,21 @@
+// src/metrics.ts
+//
+// A dedicated Prometheus registry for the proxy, rendered on GET /metrics.
+// Kept off prom-client's global default registry so test suites can reset
+// accumulated state in isolation without touching process-wide globals.
+import { Registry, collectDefaultMetrics } from "prom-client";
+
+export const register = new Registry();
+
+// Process-level series: memory, CPU, event-loop lag, and
+// process_start_time_seconds — the last reveals a cold-start counter reset to
+// any alert that compares against increase() over a window.
+collectDefaultMetrics({ register });
+
+// The Prometheus text exposition served for a scrape.
+export function renderMetrics(): Promise<string> {
+  return register.metrics();
+}
+
+// The exposition content type prom-client expects scrapers to receive.
+export const metricsContentType = register.contentType;

--- a/elliptic-proxy/tests/config.test.ts
+++ b/elliptic-proxy/tests/config.test.ts
@@ -280,6 +280,33 @@ describe("ConfigLoader", () => {
     );
   });
 
+  it("parses an optional metricsAuthToken", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ ...VALID_CONFIG, metricsAuthToken: "scrape-token" })
+      );
+    const config = await new ConfigLoader(fetcher).get();
+    expect(config.metricsAuthToken).toBe("scrape-token");
+  });
+
+  it("leaves metricsAuthToken undefined when omitted", async () => {
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(VALID_CONFIG));
+    const config = await new ConfigLoader(fetcher).get();
+    expect(config.metricsAuthToken).toBeUndefined();
+  });
+
+  it("rejects a non-string metricsAuthToken", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(
+        JSON.stringify({ ...VALID_CONFIG, metricsAuthToken: 123 })
+      );
+    await expect(new ConfigLoader(fetcher).get()).rejects.toThrow(
+      "metricsAuthToken"
+    );
+  });
+
   describe("load-time warnings", () => {
     async function loadAndCaptureWarnings(
       config: Record<string, unknown>

--- a/elliptic-proxy/tests/metrics.test.ts
+++ b/elliptic-proxy/tests/metrics.test.ts
@@ -1,0 +1,66 @@
+// tests/metrics.test.ts
+import { describe, it, expect, vi } from "vitest";
+import type { Request } from "@google-cloud/functions-framework";
+import { createHandler } from "../src/handler.js";
+import { metricsContentType } from "../src/metrics.js";
+import { makeConfig, makeResponse } from "./helpers.js";
+
+const METRICS_TOKEN = "scrape-token";
+
+function makeMetricsRequest(authHeader?: string): Request {
+  return {
+    method: "GET",
+    path: "/metrics",
+    headers: authHeader ? { authorization: authHeader } : {},
+  } as unknown as Request;
+}
+
+describe("GET /metrics", () => {
+  const mockForward = vi.fn();
+
+  function handlerWith(token?: string) {
+    const config = makeConfig(token ? { metricsAuthToken: token } : {});
+    const configLoader = { get: vi.fn().mockResolvedValue(config) };
+    return createHandler(configLoader, mockForward);
+  }
+
+  it("returns 404 when no metricsAuthToken is configured", async () => {
+    const handler = handlerWith();
+    const res = makeResponse();
+    await handler(makeMetricsRequest(`Bearer ${METRICS_TOKEN}`), res);
+    expect(res.statusCode).toBe(404);
+    expect(mockForward).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the bearer token is missing", async () => {
+    const handler = handlerWith(METRICS_TOKEN);
+    const res = makeResponse();
+    await handler(makeMetricsRequest(), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 when the bearer token is wrong", async () => {
+    const handler = handlerWith(METRICS_TOKEN);
+    const res = makeResponse();
+    await handler(makeMetricsRequest("Bearer not-the-token"), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 401 when the token matches but the scheme is not Bearer", async () => {
+    const handler = handlerWith(METRICS_TOKEN);
+    const res = makeResponse();
+    await handler(makeMetricsRequest(METRICS_TOKEN), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("serves the Prometheus exposition with a valid token", async () => {
+    const handler = handlerWith(METRICS_TOKEN);
+    const res = makeResponse();
+    await handler(makeMetricsRequest(`Bearer ${METRICS_TOKEN}`), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe(metricsContentType);
+    // collectDefaultMetrics always emits the process start time series.
+    expect(res.body).toContain("process_start_time_seconds");
+    expect(mockForward).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a dedicated prom-client registry and serves it on GET /metrics, gated by
an optional metricsAuthToken from the Secret Manager config (timing-safe
compare; disabled with 404 when unset). The endpoint bypasses the screening
response path so scrapes never pollute traffic metrics, and a bad scraper
token never trips the partner 401 alert. Only process default metrics so far;
business counters land in following commits.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/823)
<!-- Reviewable:end -->
