### PR TITLE
feat(elliptic-proxy): count Elliptic upstream calls by partner

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -174,6 +174,10 @@ so they are only coherent while a single instance serves the function — deploy
 `--max-instances=1` if you intend to alert on them. `process_start_time_seconds` (from
 prom-client's default metrics) marks the cold start that zeroed them.
 
+| Metric                                   | Labels                | Meaning                                                                                                                                                                                       |
+| ---------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `elliptic_proxy_elliptic_requests_total` | `partner`, `upstream` | Calls actually forwarded to Elliptic — the billed, allotment-capped resource. Counted at the dispatch site, so requests short-circuited by auth, the rate limiter, the operator lists, or the blocked cache are excluded. `upstream` separates live `elliptic` cost from `mock` traffic. |
+
 ## Error handling
 
 | Condition                              | Response                  |

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -13,7 +13,11 @@ import { BlockedAddressCache } from "./cache.js";
 import { scoreResponse, type ScoringResult } from "./scoring.js";
 import type { ForwardResponse } from "./elliptic.js";
 import { signScreening, type ScreeningSignature } from "./signing.js";
-import { metricsContentType, renderMetrics } from "./metrics.js";
+import {
+  ellipticRequests,
+  metricsContentType,
+  renderMetrics,
+} from "./metrics.js";
 
 const BEARER_PREFIX = "Bearer ";
 
@@ -258,6 +262,12 @@ export function createHandler(
       });
       return;
     }
+
+    // Counts every dispatched upstream call — the abuse/cost signal. Recorded
+    // at the dispatch site so it captures only requests that survive auth,
+    // rate-limiting, the operator lists, and the blocked cache (each of which
+    // returns earlier without spending an Elliptic call).
+    ellipticRequests.inc({ partner: partnerName, upstream: upstreamSource });
 
     let result: ForwardResponse;
     try {

--- a/elliptic-proxy/src/metrics.ts
+++ b/elliptic-proxy/src/metrics.ts
@@ -3,7 +3,7 @@
 // A dedicated Prometheus registry for the proxy, rendered on GET /metrics.
 // Kept off prom-client's global default registry so test suites can reset
 // accumulated state in isolation without touching process-wide globals.
-import { Registry, collectDefaultMetrics } from "prom-client";
+import { Counter, Registry, collectDefaultMetrics } from "prom-client";
 
 export const register = new Registry();
 
@@ -12,6 +12,16 @@ export const register = new Registry();
 // any alert that compares against increase() over a window.
 collectDefaultMetrics({ register });
 
+// Outbound calls to the Elliptic upstream — the billed, allotment-capped
+// resource. Split by partner so an abuse spike names whose secret to revoke,
+// and by upstream so live ("elliptic") cost is separable from mock traffic.
+export const ellipticRequests = new Counter({
+  name: "elliptic_proxy_elliptic_requests_total",
+  help: "Total requests forwarded to the Elliptic upstream.",
+  labelNames: ["partner", "upstream"],
+  registers: [register],
+});
+
 // The Prometheus text exposition served for a scrape.
 export function renderMetrics(): Promise<string> {
   return register.metrics();
@@ -19,3 +29,8 @@ export function renderMetrics(): Promise<string> {
 
 // The exposition content type prom-client expects scrapers to receive.
 export const metricsContentType = register.contentType;
+
+// Test-only: zero accumulated counter values between cases.
+export function resetMetricsForTest(): void {
+  register.resetMetrics();
+}

--- a/elliptic-proxy/tests/metrics.test.ts
+++ b/elliptic-proxy/tests/metrics.test.ts
@@ -1,9 +1,33 @@
 // tests/metrics.test.ts
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Request } from "@google-cloud/functions-framework";
 import { createHandler } from "../src/handler.js";
-import { metricsContentType } from "../src/metrics.js";
-import { makeConfig, makeResponse } from "./helpers.js";
+import {
+  ellipticRequests,
+  metricsContentType,
+  resetMetricsForTest,
+} from "../src/metrics.js";
+import {
+  makeConfig,
+  makeMockEllipticConfig,
+  makeRequest,
+  makeResponse,
+} from "./helpers.js";
+
+// An upstream reply the handler treats as "not on chain" → allowed, so the
+// flow reaches the dispatch site and completes without crafting a score body.
+const NOT_ON_CHAIN = { status: 404, body: "", durationMs: 5 };
+
+async function ellipticCount(
+  partner: string,
+  upstream: string
+): Promise<number> {
+  const metric = await ellipticRequests.get();
+  const series = metric.values.find(
+    (v) => v.labels.partner === partner && v.labels.upstream === upstream
+  );
+  return series?.value ?? 0;
+}
 
 const METRICS_TOKEN = "scrape-token";
 
@@ -62,5 +86,53 @@ describe("GET /metrics", () => {
     // collectDefaultMetrics always emits the process start time series.
     expect(res.body).toContain("process_start_time_seconds");
     expect(mockForward).not.toHaveBeenCalled();
+  });
+});
+
+describe("elliptic_proxy_elliptic_requests_total", () => {
+  beforeEach(() => resetMetricsForTest());
+
+  function handlerFor(config = makeConfig(), forward = vi.fn()) {
+    const configLoader = { get: vi.fn().mockResolvedValue(config) };
+    return { handler: createHandler(configLoader, forward), forward };
+  }
+
+  it("increments by partner and upstream on a forwarded call", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue(NOT_ON_CHAIN);
+    await handler(makeRequest(), makeResponse());
+    expect(forward).toHaveBeenCalledTimes(1);
+    expect(await ellipticCount("test-partner", "elliptic")).toBe(1);
+  });
+
+  it("labels the mock upstream when screening against it", async () => {
+    const { handler, forward } = handlerFor(makeMockEllipticConfig());
+    forward.mockResolvedValue(NOT_ON_CHAIN);
+    await handler(makeRequest(), makeResponse());
+    expect(await ellipticCount("test-partner", "mock")).toBe(1);
+    expect(await ellipticCount("test-partner", "elliptic")).toBe(0);
+  });
+
+  it("does not count an allowlist hit (no upstream call)", async () => {
+    const { handler, forward } = handlerFor(
+      makeConfig({ blockOverrideAddresses: ["0xabc123"] })
+    );
+    await handler(makeRequest(), makeResponse());
+    expect(forward).not.toHaveBeenCalled();
+    expect(await ellipticCount("test-partner", "elliptic")).toBe(0);
+  });
+
+  it("does not count a request rejected before auth", async () => {
+    const { handler, forward } = handlerFor();
+    const req = makeRequest({
+      headers: {
+        "x-access-key": "test-partner",
+        "x-access-sign": "bad-signature",
+        "x-access-timestamp": Date.now().toString(),
+      },
+    });
+    await handler(req, makeResponse());
+    expect(forward).not.toHaveBeenCalled();
+    expect(await ellipticCount("test-partner", "elliptic")).toBe(0);
   });
 });


### PR DESCRIPTION
Adds elliptic_proxy_elliptic_requests_total{partner,upstream}, incremented at
the upstream dispatch site so it captures only calls that survive auth,
rate-limiting, the operator lists, and the blocked cache — each of which
returns earlier without spending an Elliptic call. This is the cost/abuse
signal: rate by partner names whose secret to revoke under a DDoS, and the
sum gives absolute usage against the allotment.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/824)
<!-- Reviewable:end -->
