### PR TITLE
feat(elliptic-proxy): count HTTP responses by status for health alerts

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -177,6 +177,26 @@ prom-client's default metrics) marks the cold start that zeroed them.
 | Metric                                   | Labels                | Meaning                                                                                                                                                                                       |
 | ---------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `elliptic_proxy_elliptic_requests_total` | `partner`, `upstream` | Calls actually forwarded to Elliptic — the billed, allotment-capped resource. Counted at the dispatch site, so requests short-circuited by auth, the rate limiter, the operator lists, or the blocked cache are excluded. `upstream` separates live `elliptic` cost from `mock` traffic. |
+| `elliptic_proxy_http_responses_total`     | `status`, `partner`   | Every response the proxy returns, by HTTP status. `partner` is a known partner name or `"unknown"` — the `x-access-key` header is attacker-controlled, so unknown values collapse rather than minting unbounded series. |
+
+### Alerting on it
+
+```promql
+# our bug — one is already too many
+sum(increase(elliptic_proxy_http_responses_total{status=~"500|503"}[10m])) > 0
+
+# Elliptic is down — 502 is a non-2xx reply, 504 an unreachable upstream
+sum(rate(elliptic_proxy_http_responses_total{status=~"502|504"}[5m]))
+
+# a partner's secret is wrong, or someone is guessing it
+sum by (partner) (rate(elliptic_proxy_http_responses_total{status="401"}[5m]))
+
+# Elliptic spend by partner — names whose secret to revoke under abuse
+sum by (partner) (rate(elliptic_proxy_elliptic_requests_total{upstream="elliptic"}[5m]))
+```
+
+Thresholds depend on baseline traffic and the Elliptic allotment, so they are left to the
+alerting config rather than fixed here.
 
 ## Error handling
 
@@ -278,3 +298,4 @@ Errors are logged to stderr:
 - `error: "config_load_failed"` — Secret Manager fetch / parse failure.
 - `error: "upstream_request_failed"` — fetch to Elliptic threw at the transport layer (DNS, TLS, TCP, timeout). Includes `cause.code` (e.g. `ENOTFOUND`, `ECONNREFUSED`) so the underlying reason is visible without code changes.
 - `error: "upstream_error"` — Elliptic returned a non-2xx response. Includes `ellipticStatus` and the first 2KB of the response body, so HTTP-level errors (`401 AuthenticationError`, `400 ValidationError`, etc.) are diagnosable from logs alone.
+- `error: "unhandled_exception"` — a bug escaped the handler. The proxy fails closed with a `500` and counts it in `elliptic_proxy_http_responses_total{status="500"}`.

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -15,11 +15,22 @@ import type { ForwardResponse } from "./elliptic.js";
 import { signScreening, type ScreeningSignature } from "./signing.js";
 import {
   ellipticRequests,
+  httpResponses,
   metricsContentType,
   renderMetrics,
 } from "./metrics.js";
 
 const BEARER_PREFIX = "Bearer ";
+
+// Bounds the partner metric label to known partners. The x-access-key header
+// is attacker-controlled, so an unknown value collapses to "unknown" rather
+// than minting an unbounded metric series (a memory-exhaustion vector).
+function sanitizePartner(
+  name: string | undefined,
+  partners: Record<string, unknown>
+): string {
+  return name && Object.hasOwn(partners, name) ? name : "unknown";
+}
 
 // Serves the Prometheus exposition on GET /metrics, gated by a bearer token.
 // Bypasses the screening response path so scrapes never count toward the
@@ -56,6 +67,30 @@ function bearerTokenMatches(
   return timingSafeEqual(providedBuf, expectedBuf);
 }
 
+// Catches any exception that escapes the inner handler — a bug in our code, not
+// the partner's or Elliptic's. Records it as a 500 (so the single-occurrence
+// alert fires) and fails closed. Normal responses are counted by sendResponse,
+// so only the unhandled path reaches here; no double counting.
+function withMetrics(handler: HttpFunction): HttpFunction {
+  return async (req, res) => {
+    try {
+      await handler(req, res);
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          error: "unhandled_exception",
+          message: error instanceof Error ? error.message : String(error),
+        })
+      );
+      httpResponses.inc({ status: "500", partner: "unknown" });
+      if (!res.headersSent) {
+        res.set("content-type", "application/json");
+        res.status(500).send(JSON.stringify({ error: "internal error" }));
+      }
+    }
+  };
+}
+
 export interface ConfigSource {
   get(): Promise<Config>;
 }
@@ -86,8 +121,11 @@ export function createHandler(
   let blockedCache: BlockedAddressCache | null = null;
   let currentCacheTtlMs = 0;
 
-  return async (req: Request, res: Response) => {
+  const handler: HttpFunction = async (req: Request, res: Response) => {
     const startTime = Date.now();
+    // Bounded to a known partner or "unknown" once auth runs (see below); read
+    // by sendResponse so every counted response is attributed safely.
+    let metricsPartner = "unknown";
 
     function sendResponse(status: number, body: string, logFields?: object) {
       const latencyMs = Date.now() - startTime;
@@ -100,6 +138,7 @@ export function createHandler(
           ...logFields,
         })
       );
+      httpResponses.inc({ status: String(status), partner: metricsPartner });
       res.set("content-type", "application/json");
       res.status(status).send(body);
     }
@@ -139,6 +178,7 @@ export function createHandler(
     }
 
     const authResult = authenticateRequest(req, config);
+    metricsPartner = sanitizePartner(authResult.partnerName, config.partners);
     if (!isAuthenticated(authResult)) {
       sendResponse(401, JSON.stringify({ error: authResult.error }), {
         partner: authResult.partnerName,
@@ -393,4 +433,6 @@ export function createHandler(
       cacheSize: blockedCache.size,
     });
   };
+
+  return withMetrics(handler);
 }

--- a/elliptic-proxy/src/metrics.ts
+++ b/elliptic-proxy/src/metrics.ts
@@ -22,6 +22,17 @@ export const ellipticRequests = new Counter({
   registers: [register],
 });
 
+// Every response the proxy returns, by HTTP status. Drives the pipeline-health
+// alerts: 500/503 (our fault, alert on one), 502/504 (Elliptic down, alert on a
+// rate), 401 by partner (a partner-secret problem). The partner label is bounded
+// to known partners or "unknown" — see the handler's sanitizer.
+export const httpResponses = new Counter({
+  name: "elliptic_proxy_http_responses_total",
+  help: "Total HTTP responses returned by the proxy, by status code.",
+  labelNames: ["status", "partner"],
+  registers: [register],
+});
+
 // The Prometheus text exposition served for a scrape.
 export function renderMetrics(): Promise<string> {
   return register.metrics();

--- a/elliptic-proxy/tests/metrics.test.ts
+++ b/elliptic-proxy/tests/metrics.test.ts
@@ -4,6 +4,7 @@ import type { Request } from "@google-cloud/functions-framework";
 import { createHandler } from "../src/handler.js";
 import {
   ellipticRequests,
+  httpResponses,
   metricsContentType,
   resetMetricsForTest,
 } from "../src/metrics.js";
@@ -25,6 +26,14 @@ async function ellipticCount(
   const metric = await ellipticRequests.get();
   const series = metric.values.find(
     (v) => v.labels.partner === partner && v.labels.upstream === upstream
+  );
+  return series?.value ?? 0;
+}
+
+async function httpCount(status: string, partner: string): Promise<number> {
+  const metric = await httpResponses.get();
+  const series = metric.values.find(
+    (v) => v.labels.status === status && v.labels.partner === partner
   );
   return series?.value ?? 0;
 }
@@ -134,5 +143,71 @@ describe("elliptic_proxy_elliptic_requests_total", () => {
     await handler(req, makeResponse());
     expect(forward).not.toHaveBeenCalled();
     expect(await ellipticCount("test-partner", "elliptic")).toBe(0);
+  });
+});
+
+describe("elliptic_proxy_http_responses_total", () => {
+  beforeEach(() => resetMetricsForTest());
+
+  function handlerFor(config = makeConfig(), forward = vi.fn()) {
+    const configLoader = { get: vi.fn().mockResolvedValue(config) };
+    return { handler: createHandler(configLoader, forward), forward };
+  }
+
+  it("counts an allowed verdict as a 200 for the partner", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue(NOT_ON_CHAIN);
+    await handler(makeRequest(), makeResponse());
+    expect(await httpCount("200", "test-partner")).toBe(1);
+  });
+
+  it("labels an unknown-partner 401 as unknown", async () => {
+    const { handler } = handlerFor();
+    await handler(makeRequest({ headers: {} }), makeResponse());
+    expect(await httpCount("401", "unknown")).toBe(1);
+  });
+
+  it("attributes an invalid-signature 401 to the known partner", async () => {
+    const { handler } = handlerFor();
+    const req = makeRequest({
+      headers: {
+        "x-access-key": "test-partner",
+        "x-access-sign": "bad-signature",
+        "x-access-timestamp": Date.now().toString(),
+      },
+    });
+    await handler(req, makeResponse());
+    expect(await httpCount("401", "test-partner")).toBe(1);
+    expect(await httpCount("401", "unknown")).toBe(0);
+  });
+
+  it("counts a non-2xx upstream reply as a 502", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue({ status: 500, body: "{}", durationMs: 5 });
+    await handler(makeRequest(), makeResponse());
+    expect(await httpCount("502", "test-partner")).toBe(1);
+  });
+
+  it("counts an upstream network failure as a 504", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockRejectedValue(new Error("fetch failed"));
+    await handler(makeRequest(), makeResponse());
+    expect(await httpCount("504", "test-partner")).toBe(1);
+  });
+
+  it("records a 500 when an unexpected error escapes the handler", async () => {
+    // A malformed chainId makes BigInt() throw mid-flow — an uncaught bug path.
+    const { handler } = handlerFor(makeConfig({ chainId: "0xnothex" }));
+    const res = makeResponse();
+    await handler(makeRequest(), res);
+    expect(res.statusCode).toBe(500);
+    expect(await httpCount("500", "unknown")).toBe(1);
+  });
+
+  it("does not count a /metrics scrape", async () => {
+    const { handler } = handlerFor(makeConfig({ metricsAuthToken: "tok" }));
+    await handler(makeMetricsRequest("Bearer tok"), makeResponse());
+    expect(await httpCount("200", "unknown")).toBe(0);
+    expect(await httpCount("200", "test-partner")).toBe(0);
   });
 });


### PR DESCRIPTION
Adds elliptic_proxy_http_responses_total{status,partner}, incremented in the
single sendResponse choke point, plus a withMetrics wrapper that records any
exception escaping the handler as a 500. Together these drive the pipeline
health alerts: 500/503 (our bug, alert on one), 502/504 (Elliptic down, alert
on a rate), 401 by partner (a partner-secret problem). The partner label is
bounded to known partners or 'unknown' so an attacker-controlled x-access-key
cannot mint unbounded metric series.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/825)
<!-- Reviewable:end -->
