### PR TITLE
docs(elliptic-proxy): metrics catalog and alert rules

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -41,7 +41,8 @@ The secret value must be a JSON string with this structure:
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
   "additionalBlockedAddresses": [],
-  "blockOverrideAddresses": []
+  "blockOverrideAddresses": [],
+  "metricsAuthToken": "<bearer-token-for-GET-/metrics>"
 }
 ```
 
@@ -60,6 +61,7 @@ The secret value must be a JSON string with this structure:
 | `blockOverrideAddresses` _(optional)_     | Operator allow list (hex felts): listed addresses always screen as allowed, winning over the deny list, the blocked cache, and the upstream verdict — rescues addresses the upstream wrongly flags (false positives).                                                                                                                            |
 | `signingPrivateKey` _(required)_          | STARK-curve private key (felt hex, `1 <= key < curve order`) signing screening attestations; the production key is FPI-managed.                                                                                                                                                                                                                  |
 | `chainId` _(required)_                    | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN combined with a mock `elliptic.url` is rejected at config load.                                                                                                                                                                                         |
+| `metricsAuthToken` _(optional)_           | Bearer token gating `GET /metrics` (timing-safe compare). When unset, `/metrics` is disabled (`404`); the exposition leaks partner names and traffic volumes, so it fails closed. See [Metrics & alerting](#metrics--alerting).                                                                                                                   |
 
 ### Generating partner secrets
 
@@ -260,3 +262,39 @@ Errors are logged to stderr:
 - `error: "config_load_failed"` — Secret Manager fetch / parse failure.
 - `error: "upstream_request_failed"` — fetch to Elliptic threw at the transport layer (DNS, TLS, TCP, timeout). Includes `cause.code` (e.g. `ENOTFOUND`, `ECONNREFUSED`) so the underlying reason is visible without code changes.
 - `error: "upstream_error"` — Elliptic returned a non-2xx response. Includes `ellipticStatus` and the first 2KB of the response body, so HTTP-level errors (`401 AuthenticationError`, `400 ValidationError`, etc.) are diagnosable from logs alone.
+- `error: "unhandled_exception"` — a bug escaped the handler; the proxy fails closed with a `500`. Surfaced as a metric too (see below), since FPI holds the logs.
+
+## Metrics & alerting
+
+`GET /metrics` serves a Prometheus exposition gated by a bearer token
+(`Authorization: Bearer <metricsAuthToken>`; `404` when the token is unset).
+FPI deploys the function and holds its logs, so this endpoint is how we observe
+the proxy — point a Prometheus / GCP Managed Service for Prometheus scrape at
+the function URL with the token. Scrapes bypass the screening response path, so
+they never count toward the traffic metrics.
+
+| Metric                                   | Type    | Labels                | Meaning                                                                                                        |
+| ---------------------------------------- | ------- | --------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `elliptic_proxy_elliptic_requests_total` | counter | `partner`, `upstream` | Calls forwarded to the Elliptic upstream — the billed resource. Counted at dispatch, so short-circuited requests (auth failure, rate-limit, operator lists, blocked cache) are excluded. |
+| `elliptic_proxy_http_responses_total`    | counter | `status`, `partner`   | Every response by HTTP status. `partner` is a known partner or `"unknown"` (the `x-access-key` header is untrusted). |
+| `process_*`                              | various | —                     | prom-client defaults; `process_start_time_seconds` reveals a cold-start counter reset.                          |
+
+Counters are per-instance in-memory state (like the rate-limiter and blocked
+cache); they are coherent under the recommended `--max-instances=1`.
+
+```promql
+# Elliptic abuse by partner — names whose secret to revoke under a DDoS
+sum by (partner) (rate(elliptic_proxy_elliptic_requests_total{upstream="elliptic"}[5m])) > <rate>
+
+# Absolute Elliptic usage over the budget window — increase() tolerates resets
+sum(increase(elliptic_proxy_elliptic_requests_total{upstream="elliptic"}[30d])) > <budget>
+
+# Our bug — alert on a single 500/503
+sum(increase(elliptic_proxy_http_responses_total{status=~"500|503"}[10m])) > 0
+
+# Elliptic upstream down — high rate of 502/504
+sum(rate(elliptic_proxy_http_responses_total{status=~"502|504"}[5m])) > <rate>
+
+# Partner-secret problem — high rate of 401, by partner
+sum by (partner) (rate(elliptic_proxy_http_responses_total{status="401"}[5m])) > <rate>
+```

--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -46,7 +46,8 @@ re-reads it according to `configCacheTtlSeconds`.
   },
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
-  "additionalBlockedAddresses": []
+  "additionalBlockedAddresses": [],
+  "metricsAuthToken": "<bearer-token-for-GET-/metrics>"
 }
 ```
 
@@ -66,6 +67,7 @@ re-reads it according to `configCacheTtlSeconds`.
 | `additionalBlockedAddresses` _(opt.)_ | Test-only deny list consumed by the mock upstream — listed addresses screen as sanctioned. Ignored when screening live (load-time warning).                              |
 | `signingPrivateKey` _(required)_      | STARK-curve private key (felt hex) signing screening attestations; production key is FPI-managed.                                                                        |
 | `chainId` _(required)_                | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN + mock `elliptic.url` is rejected at config load.                               |
+| `metricsAuthToken` _(opt.)_           | Bearer token gating `GET /metrics` (timing-safe compare). When unset, `/metrics` is disabled (`404`) — the exposition leaks partner names and traffic volumes, so it fails closed. |
 
 ### Verdict precedence
 
@@ -162,6 +164,51 @@ block), everything else returns Elliptic's 404 "not in blockchain" and is
 allowed. Mock verdicts report `source: "mock"` (cached repeats report
 `cache`). A `mock_mode` warning is logged on every config load, and a mock url
 combined with the SN_MAIN `chainId` is rejected at config load.
+
+## Metrics & Alerting
+
+`GET /metrics` serves a Prometheus text exposition, gated by a bearer token
+(`Authorization: Bearer <metricsAuthToken>`; `404` when the token is unset).
+FPI deploys the function and holds its logs, so this endpoint is how we observe
+the proxy: point a Prometheus / GCP Managed Service for Prometheus scrape at the
+function URL with the token. The endpoint bypasses the screening response path,
+so scrapes never count toward the traffic metrics and a wrong scraper token
+never trips the `401` alert.
+
+| Metric                                    | Type    | Labels             | Meaning                                                                  |
+| ----------------------------------------- | ------- | ------------------ | ------------------------------------------------------------------------ |
+| `elliptic_proxy_elliptic_requests_total`  | counter | `partner`, `upstream` | Calls forwarded to the Elliptic upstream — the billed, allotment-capped resource. Counted at dispatch, so auth failures, rate-limits, operator-list hits, and blocked-cache hits are excluded. |
+| `elliptic_proxy_http_responses_total`     | counter | `status`, `partner`   | Every response the proxy returns, by HTTP status. `partner` is a known partner or `"unknown"`. |
+| `process_*`                               | various | —                  | prom-client default metrics; `process_start_time_seconds` reveals cold-start counter resets. |
+
+**Single-instance assumption.** Counters are per-instance in-memory state, like
+the rate-limiter and blocked-address cache. They are coherent under the
+recommended `--max-instances=1`; multiple instances would each keep independent
+counters that the function URL load-balances across opaquely.
+
+### Alert rules
+
+```promql
+# Elliptic abuse by partner — names whose partner secret to revoke under a DDoS
+sum by (partner) (rate(elliptic_proxy_elliptic_requests_total{upstream="elliptic"}[5m])) > <rate>
+
+# Absolute Elliptic usage over the budget window — increase() tolerates resets
+sum(increase(elliptic_proxy_elliptic_requests_total{upstream="elliptic"}[30d])) > <budget>
+
+# Our bug — alert on a single 500/503
+sum(increase(elliptic_proxy_http_responses_total{status=~"500|503"}[10m])) > 0
+
+# Elliptic upstream down — high rate of 502/504
+sum(rate(elliptic_proxy_http_responses_total{status=~"502|504"}[5m])) > <rate>
+
+# Partner-secret problem — high rate of 401, by partner
+sum by (partner) (rate(elliptic_proxy_http_responses_total{status="401"}[5m])) > <rate>
+```
+
+Pick `<rate>`/`<budget>` thresholds from observed baseline traffic and the
+Elliptic allotment. Cross-check the absolute-usage alert against
+`changes(process_start_time_seconds[1h])` to spot a restart that zeroed the
+counters.
 
 ## Deployment
 


### PR DESCRIPTION
Documents GET /metrics, the metricsAuthToken config field, the metric catalog,
the single-instance counter caveat, and the PromQL alert rules for Elliptic
abuse/cost (by partner and absolute) and pipeline health (500/503, 502/504,
401-by-partner) in design.md and README.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/826)
<!-- Reviewable:end -->
