### PR TITLE
chore: bump starkware_utils rev

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=0e12df09afe29f59a877a5b04801fedd8b31c50d#0e12df09afe29f59a877a5b04801fedd8b31c50d"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=f74a835454a692fbb1e4bc828ea896a3ee3d5c6a#f74a835454a692fbb1e4bc828ea896a3ee3d5c6a"
 dependencies = [
  "openzeppelin",
 ]
@@ -195,7 +195,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=0e12df09afe29f59a877a5b04801fedd8b31c50d#0e12df09afe29f59a877a5b04801fedd8b31c50d"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=f74a835454a692fbb1e4bc828ea896a3ee3d5c6a#f74a835454a692fbb1e4bc828ea896a3ee3d5c6a"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -18,20 +18,14 @@ assert_macros = "2.17.0"
 # flags from CI workflows and sdk/package.json scripts
 openzeppelin = "3.0.0"
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts", rev = "8b4de8b5701d10b101c06b786740bf45b6cf15cb" }
-starkware_utils = { git ="https://github.com/starkware-libs/starkware-starknet-utils", rev="0e12df09afe29f59a877a5b04801fedd8b31c50d" }
-starkware_utils_testing = { git="https://github.com/starkware-libs/starkware-starknet-utils", rev="0e12df09afe29f59a877a5b04801fedd8b31c50d" }
+starkware_utils = { git ="https://github.com/starkware-libs/starkware-starknet-utils", rev="f74a835454a692fbb1e4bc828ea896a3ee3d5c6a" }
+starkware_utils_testing = { git="https://github.com/starkware-libs/starkware-starknet-utils", rev="f74a835454a692fbb1e4bc828ea896a3ee3d5c6a" }
 
 [workspace.tool.fmt]
 sort-module-level-items = true
 
 [workspace.tool.scarb]
 allow-prebuilt-plugins = ["snforge_std"]
-
-# Redirect transitive `starkware_utils_testing` requests for snforge_std (pinned to
-# scarbs.dev) to the stable 0.59.0 release on scarbs.xyz, so we don't end up with
-# two snforge_scarb_plugin copies from incompatible registries.
-[patch."https://scarbs.dev/"]
-snforge_std = "0.59.0"
 
 [scripts]
 test = "SNFORGE_BACKTRACE=1 snforge test"

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -53,6 +53,7 @@ pub mod Privacy {
         ContractAddress, SyscallResultTrait, VALIDATED, get_block_timestamp, get_caller_address,
         get_contract_address, get_execution_info,
     };
+    use starkware_utils::components::common_roles::CommonRolesComponent;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::replaceability::ReplaceabilityComponent;
     use starkware_utils::components::replaceability::ReplaceabilityComponent::InternalReplaceabilityTrait;
@@ -63,6 +64,7 @@ pub mod Privacy {
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
     component!(path: ReplaceabilityComponent, storage: replaceability, event: ReplaceabilityEvent);
     component!(path: RolesComponent, storage: roles, event: RolesEvent);
+    component!(path: CommonRolesComponent, storage: common_roles, event: CommonRolesEvent);
     component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(
@@ -77,6 +79,8 @@ pub mod Privacy {
         replaceability: ReplaceabilityComponent::Storage,
         #[substorage(v0)]
         roles: RolesComponent::Storage,
+        #[substorage(v0)]
+        common_roles: CommonRolesComponent::Storage,
         #[substorage(v0)]
         access_control: AccessControlComponent::Storage,
         #[substorage(v0)]
@@ -125,6 +129,8 @@ pub mod Privacy {
         #[flat]
         RolesEvent: RolesComponent::Event,
         #[flat]
+        CommonRolesEvent: CommonRolesComponent::Event,
+        #[flat]
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
         SRC5Event: SRC5Component::Event,
@@ -169,6 +175,8 @@ pub mod Privacy {
         ReplaceabilityComponent::ReplaceabilityImpl<ContractState>;
     #[abi(embed_v0)]
     impl RolesImpl = RolesComponent::RolesImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl CommonRolesImpl = CommonRolesComponent::CommonRolesImpl<ContractState>;
 
     #[abi(embed_v0)]
     pub impl ClientImpl of IClient<ContractState> {


### PR DESCRIPTION
The new starkware_utils rev makes CommonRolesComponent a required dependency of
RolesComponent. Wire CommonRolesComponent alongside the existing RolesComponent
(additive) and drop the obsolete snforge scarbs.dev patch redirect, since the
new rev ships snforge_std 0.59.0 directly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/829)
<!-- Reviewable:end -->
