### PR TITLE
refactor: drop RolesComponent, use CommonRolesComponent only

### DIFF
--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -54,16 +54,14 @@ pub mod Privacy {
         get_contract_address, get_execution_info,
     };
     use starkware_utils::components::common_roles::CommonRolesComponent;
+    use starkware_utils::components::common_roles::CommonRolesComponent::InternalTrait as CommonRolesInternalTrait;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::replaceability::ReplaceabilityComponent;
     use starkware_utils::components::replaceability::ReplaceabilityComponent::InternalReplaceabilityTrait;
-    use starkware_utils::components::roles::RolesComponent;
-    use starkware_utils::components::roles::RolesComponent::InternalTrait as RolesInternalTrait;
     use starkware_utils::erc20::erc20_utils::{checked_transfer, checked_transfer_from};
 
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
     component!(path: ReplaceabilityComponent, storage: replaceability, event: ReplaceabilityEvent);
-    component!(path: RolesComponent, storage: roles, event: RolesEvent);
     component!(path: CommonRolesComponent, storage: common_roles, event: CommonRolesEvent);
     component!(path: AccessControlComponent, storage: access_control, event: AccessControlEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -77,8 +75,6 @@ pub mod Privacy {
         pausable: PausableComponent::Storage,
         #[substorage(v0)]
         replaceability: ReplaceabilityComponent::Storage,
-        #[substorage(v0)]
-        roles: RolesComponent::Storage,
         #[substorage(v0)]
         common_roles: CommonRolesComponent::Storage,
         #[substorage(v0)]
@@ -127,8 +123,6 @@ pub mod Privacy {
         #[flat]
         ReplaceabilityEvent: ReplaceabilityComponent::Event,
         #[flat]
-        RolesEvent: RolesComponent::Event,
-        #[flat]
         CommonRolesEvent: CommonRolesComponent::Event,
         #[flat]
         AccessControlEvent: AccessControlComponent::Event,
@@ -159,7 +153,7 @@ pub mod Privacy {
         screener_public_key: felt252,
         proof_validity_blocks: u64,
     ) {
-        self.roles.initialize(:governance_admin);
+        self.common_roles.initialize(:governance_admin);
         self.replaceability.initialize(upgrade_delay: Zero::zero());
         self._set_auditor_public_key(:auditor_public_key);
         self._set_screener_public_key(:screener_public_key);
@@ -173,8 +167,6 @@ pub mod Privacy {
     #[abi(embed_v0)]
     impl ReplaceabilityImpl =
         ReplaceabilityComponent::ReplaceabilityImpl<ContractState>;
-    #[abi(embed_v0)]
-    impl RolesImpl = RolesComponent::RolesImpl<ContractState>;
     #[abi(embed_v0)]
     impl CommonRolesImpl = CommonRolesComponent::CommonRolesImpl<ContractState>;
 
@@ -1064,17 +1056,17 @@ pub mod Privacy {
     #[abi(embed_v0)]
     pub impl AdminImpl of IAdmin<ContractState> {
         fn set_auditor_public_key(ref self: ContractState, auditor_public_key: felt252) {
-            self.roles.only_security_governor();
+            self.common_roles.only_security_governor();
             self._set_auditor_public_key(:auditor_public_key);
         }
 
         fn set_screener_public_key(ref self: ContractState, screener_public_key: felt252) {
-            self.roles.only_security_governor();
+            self.common_roles.only_security_governor();
             self._set_screener_public_key(:screener_public_key);
         }
 
         fn set_fee_amount(ref self: ContractState, fee_amount: u128) {
-            self.roles.only_app_governor();
+            self.common_roles.only_app_governor();
             if fee_amount.is_non_zero() {
                 assert(self.fee_collector.read().is_non_zero(), errors::ZERO_FEE_COLLECTOR);
             }
@@ -1083,7 +1075,7 @@ pub mod Privacy {
         }
 
         fn set_fee_collector(ref self: ContractState, fee_collector: ContractAddress) {
-            self.roles.only_app_governor();
+            self.common_roles.only_app_governor();
             if self.fee_amount.read().is_non_zero() {
                 assert(fee_collector.is_non_zero(), errors::ZERO_FEE_COLLECTOR);
             }
@@ -1092,14 +1084,14 @@ pub mod Privacy {
         }
 
         fn set_proof_validity_blocks(ref self: ContractState, proof_validity_blocks: u64) {
-            self.roles.only_app_governor();
+            self.common_roles.only_app_governor();
             self._set_proof_validity_blocks(:proof_validity_blocks);
         }
 
         fn set_open_note_depositor_blocked(
             ref self: ContractState, depositor: ContractAddress, blocked: bool,
         ) {
-            self.roles.only_security_governor();
+            self.common_roles.only_security_governor();
             assert(depositor.is_non_zero(), errors::ZERO_CONTRACT_ADDRESS);
             self.blocked_open_note_depositors.entry(depositor).write(blocked);
             self.emit(events::OpenNoteDepositorBlockSet { depositor, blocked });

--- a/packages/privacy/src/tests/test_views.cairo
+++ b/packages/privacy/src/tests/test_views.cairo
@@ -13,7 +13,9 @@ use snforge_std::TokenTrait;
 use starkware_utils::components::replaceability::interface::{
     IReplaceableDispatcher, IReplaceableDispatcherTrait,
 };
-use starkware_utils::components::roles::interface::{IRolesDispatcher, IRolesDispatcherTrait};
+use starkware_utils::components::roles::interface::{
+    ICommonRolesDispatcher, ICommonRolesDispatcherTrait, Role,
+};
 use starkware_utils_testing::test_utils::assert_panic_with_error;
 
 
@@ -26,12 +28,18 @@ fn test_constructor() {
     assert_eq!(test.privacy.get_screener_public_key(), screener_key_pair().public_key);
     assert_eq!(test.privacy.get_version(), '2.0');
     // Test roles.
-    let contract_roles = IRolesDispatcher { contract_address: test.privacy.address };
-    assert!(contract_roles.is_governance_admin(account: test.privacy.roles.governance_admin));
-    assert!(contract_roles.is_security_admin(account: test.privacy.roles.governance_admin));
+    let contract_roles = ICommonRolesDispatcher { contract_address: test.privacy.address };
+    assert!(
+        contract_roles
+            .has_role(role: Role::GovernanceAdmin, account: test.privacy.roles.governance_admin),
+    );
+    assert!(
+        contract_roles
+            .has_role(role: Role::SecurityAdmin, account: test.privacy.roles.governance_admin),
+    );
     let user = test.new_user();
-    assert!(!contract_roles.is_governance_admin(account: user.address));
-    assert!(!contract_roles.is_security_admin(account: user.address));
+    assert!(!contract_roles.has_role(role: Role::GovernanceAdmin, account: user.address));
+    assert!(!contract_roles.has_role(role: Role::SecurityAdmin, account: user.address));
     // Test replaceability.
     let contract_replaceability = IReplaceableDispatcher { contract_address: test.privacy.address };
     assert_eq!(contract_replaceability.get_upgrade_delay(), Zero::zero());

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -75,10 +75,11 @@ use starknet::{
 use starkware_utils::components::pausable::interface::{
     IPausableDispatcher, IPausableDispatcherTrait,
 };
+use starkware_utils::components::roles::interface::{
+    ICommonRolesDispatcher, ICommonRolesDispatcherTrait, Role,
+};
 use starkware_utils_testing::test_utils::{
     Deployable, TokenConfig, TokenHelperTrait, cheat_caller_address_once, generic_load,
-    set_account_as_app_governor, set_account_as_app_role_admin, set_account_as_security_agent,
-    set_account_as_security_governor,
 };
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
@@ -2276,18 +2277,15 @@ pub(crate) fn deploy_mock_vesu_vault_overflow(
 }
 
 fn _set_privacy_roles(contract: ContractAddress, roles: Roles) -> Roles {
-    set_account_as_security_agent(
-        :contract, account: roles.security_agent, security_admin: roles.governance_admin,
-    );
-    set_account_as_app_role_admin(
-        :contract, account: roles.app_role_admin, governance_admin: roles.governance_admin,
-    );
-    set_account_as_security_governor(
-        :contract, account: roles.security_governor, security_admin: roles.governance_admin,
-    );
-    set_account_as_app_governor(
-        :contract, account: roles.app_governor, app_role_admin: roles.app_role_admin,
-    );
+    let roles_dispatcher = ICommonRolesDispatcher { contract_address: contract };
+    cheat_caller_address_once(contract_address: contract, caller_address: roles.governance_admin);
+    roles_dispatcher.grant_role(role: Role::SecurityAgent, account: roles.security_agent);
+    cheat_caller_address_once(contract_address: contract, caller_address: roles.governance_admin);
+    roles_dispatcher.grant_role(role: Role::AppRoleAdmin, account: roles.app_role_admin);
+    cheat_caller_address_once(contract_address: contract, caller_address: roles.governance_admin);
+    roles_dispatcher.grant_role(role: Role::SecurityGovernor, account: roles.security_governor);
+    cheat_caller_address_once(contract_address: contract, caller_address: roles.app_role_admin);
+    roles_dispatcher.grant_role(role: Role::AppGovernor, account: roles.app_governor);
     roles
 }
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking
+
+- Privacy pool role-management ABI changed (`PrivacyPoolABI` regenerated). The
+  `starkware_utils` upgrade replaced the monolithic `RolesComponent` with
+  `CommonRolesComponent`, so the per-role typed selectors
+  (`is_app_governor`/`register_app_governor`/`remove_security_governor`/…) are
+  removed and replaced by the generic `grant_role(role, account)`,
+  `revoke_role(role, account)`, `has_role(role, account)`, and `renounce(role)`
+  taking a `Role` enum. Tooling that called the old role selectors must migrate.
+
 ## 0.14.3-RC.0
 
 ### Added

--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -466,15 +466,25 @@ export const PrivacyPoolABI = [
         "type": "privacy::objects::EncUserAddr"
       },
       {
-        "name": "depositor",
-        "type": "core::starknet::contract_address::ContractAddress"
-      },
-      {
         "name": "token",
         "type": "core::starknet::contract_address::ContractAddress"
       },
       {
         "name": "note_id",
+        "type": "core::felt252"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "privacy::events::EncNoteCreated",
+    "members": [
+      {
+        "name": "note_id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "packed_value",
         "type": "core::felt252"
       }
     ]
@@ -538,6 +548,10 @@ export const PrivacyPoolABI = [
       {
         "name": "EmitOpenNoteCreated",
         "type": "privacy::events::OpenNoteCreated"
+      },
+      {
+        "name": "EmitEncNoteCreated",
+        "type": "privacy::events::EncNoteCreated"
       },
       {
         "name": "EmitNoteUsed",
@@ -643,6 +657,34 @@ export const PrivacyPoolABI = [
     "interface_name": "privacy::interface::IServer"
   },
   {
+    "type": "struct",
+    "name": "privacy::snip12::ScreeningAttestation",
+    "members": [
+      {
+        "name": "issued_at",
+        "type": "core::integer::u64"
+      },
+      {
+        "name": "signature",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<privacy::snip12::ScreeningAttestation>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "privacy::snip12::ScreeningAttestation"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
     "type": "interface",
     "name": "privacy::interface::IServer",
     "items": [
@@ -653,26 +695,10 @@ export const PrivacyPoolABI = [
           {
             "name": "actions",
             "type": "core::array::Span::<privacy::actions::ServerAction>"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "deposit_to_open_note",
-        "inputs": [
-          {
-            "name": "note_id",
-            "type": "core::felt252"
           },
           {
-            "name": "token",
-            "type": "core::starknet::contract_address::ContractAddress"
-          },
-          {
-            "name": "amount",
-            "type": "core::integer::u128"
+            "name": "screening",
+            "type": "core::option::Option::<privacy::snip12::ScreeningAttestation>"
           }
         ],
         "outputs": [],
@@ -922,6 +948,28 @@ export const PrivacyPoolABI = [
       },
       {
         "type": "function",
+        "name": "get_screener_public_key",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_version",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
         "name": "get_fee_amount",
         "inputs": [],
         "outputs": [
@@ -952,6 +1000,22 @@ export const PrivacyPoolABI = [
           }
         ],
         "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "is_open_note_depositor_blocked",
+        "inputs": [
+          {
+            "name": "depositor",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "view"
       }
     ]
   },
@@ -970,6 +1034,18 @@ export const PrivacyPoolABI = [
         "inputs": [
           {
             "name": "auditor_public_key",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_screener_public_key",
+        "inputs": [
+          {
+            "name": "screener_public_key",
             "type": "core::felt252"
           }
         ],
@@ -1007,6 +1083,22 @@ export const PrivacyPoolABI = [
           {
             "name": "proof_validity_blocks",
             "type": "core::integer::u64"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_open_note_depositor_blocked",
+        "inputs": [
+          {
+            "name": "depositor",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "blocked",
+            "type": "core::bool"
           }
         ],
         "outputs": [],
@@ -1146,6 +1238,18 @@ export const PrivacyPoolABI = [
       },
       {
         "type": "function",
+        "name": "add_new_implementation_unsafe",
+        "inputs": [
+          {
+            "name": "implementation_data",
+            "type": "starkware_utils::components::replaceability::interface::ImplementationData"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
         "name": "remove_implementation",
         "inputs": [
           {
@@ -1167,13 +1271,71 @@ export const PrivacyPoolABI = [
         ],
         "outputs": [],
         "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "validate_upgradeability",
+        "inputs": [
+          {
+            "name": "implementation_data",
+            "type": "starkware_utils::components::replaceability::interface::ImplementationData"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
       }
     ]
   },
   {
     "type": "impl",
-    "name": "RolesImpl",
-    "interface_name": "starkware_utils::components::roles::interface::IRoles"
+    "name": "CommonRolesImpl",
+    "interface_name": "starkware_utils::components::roles::interface::ICommonRoles"
+  },
+  {
+    "type": "enum",
+    "name": "starkware_utils::components::roles::interface::Role",
+    "variants": [
+      {
+        "name": "AppGovernor",
+        "type": "()"
+      },
+      {
+        "name": "AppRoleAdmin",
+        "type": "()"
+      },
+      {
+        "name": "GovernanceAdmin",
+        "type": "()"
+      },
+      {
+        "name": "Operator",
+        "type": "()"
+      },
+      {
+        "name": "TokenAdmin",
+        "type": "()"
+      },
+      {
+        "name": "UpgradeAgent",
+        "type": "()"
+      },
+      {
+        "name": "UpgradeGovernor",
+        "type": "()"
+      },
+      {
+        "name": "SecurityAdmin",
+        "type": "()"
+      },
+      {
+        "name": "SecurityAgent",
+        "type": "()"
+      },
+      {
+        "name": "SecurityGovernor",
+        "type": "()"
+      }
+    ]
   },
   {
     "type": "struct",
@@ -1187,12 +1349,48 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "interface",
-    "name": "starkware_utils::components::roles::interface::IRoles",
+    "name": "starkware_utils::components::roles::interface::ICommonRoles",
     "items": [
       {
         "type": "function",
-        "name": "is_app_governor",
+        "name": "grant_role",
         "inputs": [
+          {
+            "name": "role",
+            "type": "starkware_utils::components::roles::interface::Role"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "revoke_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "starkware_utils::components::roles::interface::Role"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "has_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "starkware_utils::components::roles::interface::Role"
+          },
           {
             "name": "account",
             "type": "core::starknet::contract_address::ContractAddress"
@@ -1204,318 +1402,6 @@ export const PrivacyPoolABI = [
           }
         ],
         "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_app_role_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_governance_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_operator",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_token_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_upgrade_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_upgrade_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_security_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_security_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "is_security_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [
-          {
-            "type": "core::bool"
-          }
-        ],
-        "state_mutability": "view"
-      },
-      {
-        "type": "function",
-        "name": "register_app_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_app_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_app_role_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_app_role_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_governance_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_governance_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_operator",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_operator",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_token_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_token_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_upgrade_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_upgrade_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_upgrade_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_upgrade_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
       },
       {
         "type": "function",
@@ -1523,79 +1409,7 @@ export const PrivacyPoolABI = [
         "inputs": [
           {
             "name": "role",
-            "type": "core::felt252"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_security_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_security_admin",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_security_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_security_agent",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "register_security_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
-          }
-        ],
-        "outputs": [],
-        "state_mutability": "external"
-      },
-      {
-        "type": "function",
-        "name": "remove_security_governor",
-        "inputs": [
-          {
-            "name": "account",
-            "type": "core::starknet::contract_address::ContractAddress"
+            "type": "starkware_utils::components::roles::interface::Role"
           }
         ],
         "outputs": [],
@@ -1639,6 +1453,10 @@ export const PrivacyPoolABI = [
       },
       {
         "name": "auditor_public_key",
+        "type": "core::felt252"
+      },
+      {
+        "name": "screener_public_key",
         "type": "core::felt252"
       },
       {
@@ -1765,450 +1583,9 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "event",
-    "name": "starkware_utils::components::roles::interface::AppGovernorAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::AppGovernorRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::AppRoleAdminAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::AppRoleAdminRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::GovernanceAdminAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::GovernanceAdminRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::OperatorAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::OperatorRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityAdminAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityAdminRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityAgentAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityAgentRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityGovernorAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::SecurityGovernorRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::TokenAdminAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::TokenAdminRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::UpgradeGovernorAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::UpgradeGovernorRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::UpgradeAgentAdded",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "added_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "added_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::interface::UpgradeAgentRemoved",
-    "kind": "struct",
-    "members": [
-      {
-        "name": "removed_account",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      },
-      {
-        "name": "removed_by",
-        "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "data"
-      }
-    ]
-  },
-  {
-    "type": "event",
-    "name": "starkware_utils::components::roles::roles::RolesComponent::Event",
+    "name": "starkware_utils::components::common_roles::common_roles::CommonRolesComponent::Event",
     "kind": "enum",
-    "variants": [
-      {
-        "name": "AppGovernorAdded",
-        "type": "starkware_utils::components::roles::interface::AppGovernorAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "AppGovernorRemoved",
-        "type": "starkware_utils::components::roles::interface::AppGovernorRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "AppRoleAdminAdded",
-        "type": "starkware_utils::components::roles::interface::AppRoleAdminAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "AppRoleAdminRemoved",
-        "type": "starkware_utils::components::roles::interface::AppRoleAdminRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "GovernanceAdminAdded",
-        "type": "starkware_utils::components::roles::interface::GovernanceAdminAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "GovernanceAdminRemoved",
-        "type": "starkware_utils::components::roles::interface::GovernanceAdminRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "OperatorAdded",
-        "type": "starkware_utils::components::roles::interface::OperatorAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "OperatorRemoved",
-        "type": "starkware_utils::components::roles::interface::OperatorRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityAdminAdded",
-        "type": "starkware_utils::components::roles::interface::SecurityAdminAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityAdminRemoved",
-        "type": "starkware_utils::components::roles::interface::SecurityAdminRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityAgentAdded",
-        "type": "starkware_utils::components::roles::interface::SecurityAgentAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityAgentRemoved",
-        "type": "starkware_utils::components::roles::interface::SecurityAgentRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityGovernorAdded",
-        "type": "starkware_utils::components::roles::interface::SecurityGovernorAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "SecurityGovernorRemoved",
-        "type": "starkware_utils::components::roles::interface::SecurityGovernorRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "TokenAdminAdded",
-        "type": "starkware_utils::components::roles::interface::TokenAdminAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "TokenAdminRemoved",
-        "type": "starkware_utils::components::roles::interface::TokenAdminRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "UpgradeGovernorAdded",
-        "type": "starkware_utils::components::roles::interface::UpgradeGovernorAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "UpgradeGovernorRemoved",
-        "type": "starkware_utils::components::roles::interface::UpgradeGovernorRemoved",
-        "kind": "nested"
-      },
-      {
-        "name": "UpgradeAgentAdded",
-        "type": "starkware_utils::components::roles::interface::UpgradeAgentAdded",
-        "kind": "nested"
-      },
-      {
-        "name": "UpgradeAgentRemoved",
-        "type": "starkware_utils::components::roles::interface::UpgradeAgentRemoved",
-        "kind": "nested"
-      }
-    ]
+    "variants": []
   },
   {
     "type": "event",
@@ -2421,7 +1798,19 @@ export const PrivacyPoolABI = [
       {
         "name": "auditor_public_key",
         "type": "core::felt252",
-        "kind": "key"
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "privacy::events::ScreenerPublicKeySet",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "screener_public_key",
+        "type": "core::felt252",
+        "kind": "data"
       }
     ]
   },
@@ -2444,6 +1833,23 @@ export const PrivacyPoolABI = [
         "name": "note_id",
         "type": "core::felt252",
         "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "privacy::events::EncNoteCreated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "note_id",
+        "type": "core::felt252",
+        "kind": "key"
+      },
+      {
+        "name": "packed_value",
+        "type": "core::felt252",
+        "kind": "data"
       }
     ]
   },
@@ -2494,7 +1900,7 @@ export const PrivacyPoolABI = [
       {
         "name": "fee_amount",
         "type": "core::integer::u128",
-        "kind": "key"
+        "kind": "data"
       }
     ]
   },
@@ -2506,7 +1912,7 @@ export const PrivacyPoolABI = [
       {
         "name": "fee_collector",
         "type": "core::starknet::contract_address::ContractAddress",
-        "kind": "key"
+        "kind": "data"
       }
     ]
   },
@@ -2518,7 +1924,24 @@ export const PrivacyPoolABI = [
       {
         "name": "proof_validity_blocks",
         "type": "core::integer::u64",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "privacy::events::OpenNoteDepositorBlockSet",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "depositor",
+        "type": "core::starknet::contract_address::ContractAddress",
         "kind": "key"
+      },
+      {
+        "name": "blocked",
+        "type": "core::bool",
+        "kind": "data"
       }
     ]
   },
@@ -2538,8 +1961,8 @@ export const PrivacyPoolABI = [
         "kind": "flat"
       },
       {
-        "name": "RolesEvent",
-        "type": "starkware_utils::components::roles::roles::RolesComponent::Event",
+        "name": "CommonRolesEvent",
+        "type": "starkware_utils::components::common_roles::common_roles::CommonRolesComponent::Event",
         "kind": "flat"
       },
       {
@@ -2578,8 +2001,18 @@ export const PrivacyPoolABI = [
         "kind": "nested"
       },
       {
+        "name": "ScreenerPublicKeySet",
+        "type": "privacy::events::ScreenerPublicKeySet",
+        "kind": "nested"
+      },
+      {
         "name": "OpenNoteCreated",
         "type": "privacy::events::OpenNoteCreated",
+        "kind": "nested"
+      },
+      {
+        "name": "EncNoteCreated",
+        "type": "privacy::events::EncNoteCreated",
         "kind": "nested"
       },
       {
@@ -2605,6 +2038,11 @@ export const PrivacyPoolABI = [
       {
         "name": "ProofValidityBlocksSet",
         "type": "privacy::events::ProofValidityBlocksSet",
+        "kind": "nested"
+      },
+      {
+        "name": "OpenNoteDepositorBlockSet",
+        "type": "privacy::events::OpenNoteDepositorBlockSet",
         "kind": "nested"
       }
     ]


### PR DESCRIPTION
Removes the RolesComponent ABI facade now that CommonRolesComponent provides the
role API directly. Switches internal guards to self.common_roles.*, migrates
tests off the IRoles dispatcher and set_account_as_* helpers to
ICommonRolesDispatcher.grant_role, and regenerates the SDK ABI.

BREAKING: the per-role IRoles selectors (is_*/register_*/remove_*) are removed
and replaced by generic grant_role/revoke_role/has_role/renounce over a Role
enum. Off-chain tooling calling the old selectors must migrate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/830)
<!-- Reviewable:end -->
