### PR TITLE
feat(elliptic-proxy): add allowByok config gate

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -1,6 +1,6 @@
 # Elliptic Proxy
 
-A GCP Cloud Function that proxies requests to the [Elliptic API](https://www.elliptic.co/), swapping partner credentials for real Elliptic credentials. Partners authenticate with their own HMAC keys; the proxy verifies, rate-limits, re-signs, forwards to Elliptic, and scores the response to return a blocked/allowed verdict.
+A GCP Cloud Function that proxies requests to the [Elliptic API](https://www.elliptic.co/), swapping each partner's HMAC auth for that partner's own Elliptic credentials. Partners authenticate with their own HMAC keys; the proxy verifies, rate-limits, re-signs with the partner's Elliptic key + secret, forwards to Elliptic, and scores the response to return a blocked/allowed verdict.
 
 ## Request flow
 
@@ -10,7 +10,7 @@ Partner → Cloud Function → Elliptic API
             ├─ Verify partner HMAC signature
             ├─ Check body size
             ├─ Rate limit (per-partner, per-minute)
-            ├─ Re-sign with real Elliptic credentials
+            ├─ Re-sign with the partner's own Elliptic credentials
             ├─ Forward to Elliptic
             └─ Score response → { blocked: true/false }
 ```
@@ -27,8 +27,6 @@ The secret value must be a JSON string with this structure:
 {
   "elliptic": {
     "url": "https://aml-api.elliptic.co",
-    "key": "your-elliptic-api-key",
-    "secret": "<base64-encoded-elliptic-secret>",
     "timeoutMs": 10000
   },
   "rateLimitPerMinute": 100,
@@ -36,7 +34,11 @@ The secret value must be a JSON string with this structure:
   "configCacheTtlSeconds": 300,
   "blockedCacheTtlSeconds": 3600,
   "partners": {
-    "partner-name": "<base64-encoded-partner-secret>"
+    "partner-name": {
+      "hmacSecret": "<base64-encoded-partner-secret>",
+      "ellipticKey": "<partner-elliptic-api-key>",
+      "ellipticSecret": "<base64-encoded-elliptic-secret>"
+    }
   },
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
@@ -48,14 +50,12 @@ The secret value must be a JSON string with this structure:
 | Field                                     | Description                                                                                                                                                                                                                                                                                                                                      |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `elliptic.url`                            | Elliptic AML API base URL. Use `https://aml-api.elliptic.co` (note `aml-api`, **not** `api`). `mock:` selects the in-process mock upstream (test deployments only).                                                                                                                                                                              |
-| `elliptic.key`                            | Real Elliptic API key                                                                                                                                                                                                                                                                                                                            |
-| `elliptic.secret`                         | Real Elliptic HMAC secret. Paste the value Elliptic provides exactly as-is. **Caution**: a base64 secret can look identical to hex — any 32-character string drawn entirely from `[0-9a-f]` is valid in both alphabets. Don't run a value through `xxd -r -p \| base64` just because it "looks like hex" — trust Elliptic's label, not the string's appearance. |
 | `elliptic.timeoutMs`                      | Timeout for upstream Elliptic requests (ms)                                                                                                                                                                                                                                                                                                      |
 | `rateLimitPerMinute`                      | Per-partner rate limit (requests per minute)                                                                                                                                                                                                                                                                                                     |
 | `maxBodyBytes`                            | Max request body size                                                                                                                                                                                                                                                                                                                            |
 | `configCacheTtlSeconds`                   | How long to cache the config before re-reading from Secret Manager (seconds)                                                                                                                                                                                                                                                                     |
 | `blockedCacheTtlSeconds`                  | How long to cache blocked address verdicts (seconds)                                                                                                                                                                                                                                                                                             |
-| `partners.<name>`                         | Partner HMAC secret (base64-encoded). The key is the partner name, sent in `x-access-key`                                                                                                                                                                                                                                                        |
+| `partners.<name>`                         | Per-partner credentials, keyed by the partner name (sent in `x-access-key`). Object with `hmacSecret` (base64) verifying the inbound HMAC, plus `ellipticKey` and `ellipticSecret` (base64) — the partner's own Elliptic credentials used to re-sign that partner's upstream calls. **Caution** on `ellipticSecret`: a base64 secret can look identical to hex — any 32-char `[0-9a-f]` string is valid in both. Paste Elliptic's value as-is; don't run it through `xxd -r -p \| base64` just because it "looks like hex".                                                                                                                                                                                                                                                        |
 | `additionalBlockedAddresses` _(optional)_ | Operator deny list (hex felts): listed addresses always screen as blocked, in every mode, regardless of the upstream verdict — covers sanctioned addresses the upstream misses (false negatives). Entries match on the canonical felt value, so zero-padded entries match stripped addresses.                                                    |
 | `blockOverrideAddresses` _(optional)_     | Operator allow list (hex felts): listed addresses always screen as allowed, winning over the deny list, the blocked cache, and the upstream verdict — rescues addresses the upstream wrongly flags (false positives).                                                                                                                            |
 | `signingPrivateKey` _(required)_          | STARK-curve private key (felt hex, `1 <= key < curve order`) signing screening attestations; the production key is FPI-managed.                                                                                                                                                                                                                  |
@@ -68,7 +68,7 @@ The secret value must be a JSON string with this structure:
 openssl rand -base64 32
 ```
 
-Share the raw secret with the partner. Store the base64-encoded value in the config.
+Share the raw secret with the partner. Store the base64-encoded value as that partner's `hmacSecret` in the config. The partner's `ellipticKey`/`ellipticSecret` are issued by Elliptic, not generated here.
 
 ## Partner authentication
 

--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -4,8 +4,8 @@
 
 A GCP Cloud Function (TypeScript/Node.js) that screens blockchain addresses via
 Elliptic's API. Third-party partners send an address; the proxy authenticates
-the request, re-signs with real Elliptic credentials, forwards to Elliptic,
-scores the response, and returns a `{ blocked: true/false }` verdict.
+the request, re-signs with that partner's own Elliptic credentials, forwards to
+Elliptic, scores the response, and returns a `{ blocked: true/false }` verdict.
 
 ## Request Flow
 
@@ -16,7 +16,7 @@ Partner → Cloud Function → Elliptic API
          3. Verify partner's HMAC signature
          4. Check request body size limit
          5. Check rate limit
-         6. Re-sign with real Elliptic key + secret
+         6. Re-sign with the partner's own Elliptic key + secret
          7. Forward address to Elliptic for screening
          8. Score Elliptic response and return blocked/allowed verdict
 ```
@@ -32,8 +32,6 @@ re-reads it according to `configCacheTtlSeconds`.
 {
   "elliptic": {
     "url": "https://api.elliptic.co",
-    "key": "real-elliptic-api-key",
-    "secret": "real-elliptic-hmac-secret-base64",
     "timeoutMs": 10000
   },
   "rateLimitPerMinute": 100,
@@ -41,8 +39,16 @@ re-reads it according to `configCacheTtlSeconds`.
   "configCacheTtlSeconds": 300,
   "blockedCacheTtlSeconds": 3600,
   "partners": {
-    "partner-a": "issued-hmac-secret-base64",
-    "partner-b": "issued-hmac-secret-base64"
+    "partner-a": {
+      "hmacSecret": "issued-hmac-secret-base64",
+      "ellipticKey": "partner-a-elliptic-api-key",
+      "ellipticSecret": "partner-a-elliptic-hmac-secret-base64"
+    },
+    "partner-b": {
+      "hmacSecret": "issued-hmac-secret-base64",
+      "ellipticKey": "partner-b-elliptic-api-key",
+      "ellipticSecret": "partner-b-elliptic-hmac-secret-base64"
+    }
   },
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
@@ -55,14 +61,12 @@ re-reads it according to `configCacheTtlSeconds`.
 | Field                                 | Description                                                                                                                                                              |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `elliptic.url`                        | Elliptic API base URL; `mock:` selects the in-process mock upstream (test deployments only)                                                                              |
-| `elliptic.key`                        | Real Elliptic API key                                                                                                                                                    |
-| `elliptic.secret`                     | Real Elliptic HMAC secret (base64)                                                                                                                                       |
 | `elliptic.timeoutMs`                  | Timeout for upstream Elliptic requests (ms)                                                                                                                              |
 | `rateLimitPerMinute`                  | Global per-partner rate limit                                                                                                                                            |
 | `maxBodyBytes`                        | Max request body size                                                                                                                                                    |
 | `configCacheTtlSeconds`               | How often the proxy re-reads config from Secret Manager (seconds)                                                                                                        |
 | `blockedCacheTtlSeconds`              | How long to cache blocked address verdicts (seconds)                                                                                                                     |
-| `partners.<name>`                     | Partner HMAC secret (base64). The key is the partner name, sent in `x-access-key`                                                                                        |
+| `partners.<name>`                     | Per-partner credentials object, keyed by partner name (sent in `x-access-key`). Fields: `hmacSecret` (base64, verifies inbound auth), `ellipticKey` + `ellipticSecret` (base64) — the partner's own Elliptic credentials, used to re-sign that partner's upstream calls. |
 | `additionalBlockedAddresses` _(opt.)_ | Test-only deny list consumed by the mock upstream — listed addresses screen as sanctioned. Ignored when screening live (load-time warning).                              |
 | `signingPrivateKey` _(required)_      | STARK-curve private key (felt hex) signing screening attestations; production key is FPI-managed.                                                                        |
 | `chainId` _(required)_                | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN + mock `elliptic.url` is rejected at config load.                               |
@@ -94,9 +98,9 @@ signature = HMAC-SHA256(
 The proxy:
 
 1. Looks up the partner's HMAC secret by name (`x-access-key` header value)
-2. Recomputes the HMAC using the partner's secret and verifies it matches
+2. Recomputes the HMAC using the partner's `hmacSecret` and verifies it matches
    `x-access-sign`
-3. Re-signs the request with the real Elliptic key and secret
+3. Re-signs the request with that partner's own Elliptic key and secret
 4. Forwards with the new `x-access-key`, `x-access-sign`, `x-access-timestamp`
 
 ## Rate Limiting

--- a/elliptic-proxy/scripts/local-screen.mjs
+++ b/elliptic-proxy/scripts/local-screen.mjs
@@ -5,7 +5,7 @@
 // prints the verdict the proxy would return.
 //
 // Usage:
-//   node scripts/local-screen.mjs <config.json> <address>
+//   node scripts/local-screen.mjs <config.json> <address> <partner>
 //
 // Build first: `npm run build` (imports from dist/).
 
@@ -14,20 +14,30 @@ import { ConfigLoader } from "../dist/config.js";
 import { forwardToElliptic } from "../dist/elliptic.js";
 import { scoreResponse } from "../dist/scoring.js";
 
-const [, , configPath, addressArg] = process.argv;
-if (!configPath || !addressArg) {
-  console.error("usage: local-screen.mjs <config.json> <address>");
+const [, , configPath, addressArg, partnerArg] = process.argv;
+if (!configPath || !addressArg || !partnerArg) {
+  console.error("usage: local-screen.mjs <config.json> <address> <partner>");
   process.exit(2);
 }
 
 const loader = new ConfigLoader(() => readFile(configPath, "utf8"));
 const config = await loader.get();
 
+// Screen with the named partner's own Elliptic credentials. The partner is
+// required and never defaulted, so the script can't silently spend an
+// arbitrary partner's Elliptic quota.
+const partner = config.partners[partnerArg];
+if (!partner) {
+  console.error(`partner not found in config: ${partnerArg}`);
+  process.exit(2);
+}
+console.error(`screening as partner: ${partnerArg}`);
+
 const address = addressArg.toLowerCase();
 const upstream = await forwardToElliptic({
   ellipticUrl: config.elliptic.url,
-  ellipticKey: config.elliptic.key,
-  ellipticSecret: config.elliptic.secret,
+  ellipticKey: partner.ellipticKey,
+  ellipticSecret: partner.ellipticSecret,
   ellipticTimeoutMs: config.elliptic.timeoutMs,
   address,
 });

--- a/elliptic-proxy/src/auth.ts
+++ b/elliptic-proxy/src/auth.ts
@@ -34,7 +34,7 @@ export function authenticateRequest(
     return { error: "unauthorized", reason: "unknown_partner", partnerName };
   }
 
-  const partnerSecret = config.partners[partnerName];
+  const partnerSecret = config.partners[partnerName]?.hmacSecret;
   if (!partnerSecret) {
     return { error: "unauthorized", reason: "unknown_partner", partnerName };
   }

--- a/elliptic-proxy/src/config.ts
+++ b/elliptic-proxy/src/config.ts
@@ -37,6 +37,12 @@ export interface Config {
   // SN_MAIN must never be combined with a mock elliptic.url — config load
   // rejects it.
   chainId: string;
+  // When true, clients may screen without being a registered partner by
+  // supplying their own Elliptic key + secret (BYOK). Such verdicts are still
+  // signed with this deployment's signingPrivateKey, so the attestation is
+  // pool-trusted exactly like a partner's — enable deliberately. Defaults
+  // false (opt-in per deployment).
+  allowByok: boolean;
 }
 
 // 'SN_MAIN' as a Cairo short string: the felt is the big-endian ASCII bytes.
@@ -187,6 +193,9 @@ function validateConfig(raw: unknown): Config {
     ),
     signingPrivateKey: requireString(root, "signingPrivateKey"),
     chainId,
+    // Only the literal `true` enables BYOK; absent/any other value is false, so
+    // the path stays off unless a deployment opts in explicitly (fail closed).
+    allowByok: root.allowByok === true,
   };
 }
 

--- a/elliptic-proxy/src/config.ts
+++ b/elliptic-proxy/src/config.ts
@@ -1,18 +1,28 @@
 // src/config.ts
 import { isHexFelt } from "./felt.js";
 
+// Each partner carries its own Elliptic credentials: the proxy re-signs that
+// partner's upstream calls with the partner's own key + secret, so usage and
+// revocation are isolated per partner.
+export interface PartnerCredentials {
+  // Partner's HMAC auth secret (base64) — verifies the inbound x-access-sign.
+  hmacSecret: string;
+  // Partner's own Elliptic API key, sent as x-access-key to Elliptic.
+  ellipticKey: string;
+  // Partner's own Elliptic HMAC secret (base64), used to sign the upstream call.
+  ellipticSecret: string;
+}
+
 export interface Config {
   elliptic: {
     url: string;
-    key: string;
-    secret: string;
     timeoutMs: number;
   };
   rateLimitPerMinute: number;
   maxBodyBytes: number;
   configCacheTtlSeconds: number;
   blockedCacheTtlSeconds: number;
-  partners: Record<string, string>; // partner name -> HMAC secret
+  partners: Record<string, PartnerCredentials>; // partner name -> credentials
   // Operator deny list (hex felts): always blocked, in every mode — covers
   // upstream false negatives.
   additionalBlockedAddresses?: string[];
@@ -119,10 +129,26 @@ function validateConfig(raw: unknown): Config {
     throw new Error("config: partners must be a non-null object");
   }
   const partners = root.partners as Record<string, unknown>;
-  for (const [name, secret] of Object.entries(partners)) {
-    if (typeof secret !== "string" || secret.length === 0) {
-      throw new Error(`config: partners.${name} must be a non-empty string`);
+  const parsedPartners: Record<string, PartnerCredentials> = {};
+  for (const [name, value] of Object.entries(partners)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw new Error(`config: partners.${name} must be a non-null object`);
     }
+    const entry = value as Record<string, unknown>;
+    const requirePartnerField = (field: string): string => {
+      const fieldValue = entry[field];
+      if (typeof fieldValue !== "string" || fieldValue.length === 0) {
+        throw new Error(
+          `config: partners.${name}.${field} must be a non-empty string`
+        );
+      }
+      return fieldValue;
+    };
+    parsedPartners[name] = {
+      hmacSecret: requirePartnerField("hmacSecret"),
+      ellipticKey: requirePartnerField("ellipticKey"),
+      ellipticSecret: requirePartnerField("ellipticSecret"),
+    };
   }
 
   const ellipticUrl = requireString(elliptic, "url");
@@ -141,8 +167,6 @@ function validateConfig(raw: unknown): Config {
   return {
     elliptic: {
       url: ellipticUrl,
-      key: requireString(elliptic, "key"),
-      secret: requireString(elliptic, "secret"),
       timeoutMs: requirePositiveNumber(elliptic, "timeoutMs"),
     },
     rateLimitPerMinute: requirePositiveNumber(root, "rateLimitPerMinute"),
@@ -152,7 +176,7 @@ function validateConfig(raw: unknown): Config {
       root,
       "blockedCacheTtlSeconds"
     ),
-    partners: root.partners as Record<string, string>,
+    partners: parsedPartners,
     additionalBlockedAddresses: parseLowercaseHexList(
       root,
       "additionalBlockedAddresses"

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -219,8 +219,8 @@ export function createHandler(
     try {
       result = await forward({
         ellipticUrl: config.elliptic.url,
-        ellipticKey: config.elliptic.key,
-        ellipticSecret: config.elliptic.secret,
+        ellipticKey: config.partners[partnerName].ellipticKey,
+        ellipticSecret: config.partners[partnerName].ellipticSecret,
         ellipticTimeoutMs: config.elliptic.timeoutMs,
         address,
       });

--- a/elliptic-proxy/tests/auth.test.ts
+++ b/elliptic-proxy/tests/auth.test.ts
@@ -102,15 +102,19 @@ describe("authenticateRequest timestamp validation", () => {
   const config: Config = {
     elliptic: {
       url: "https://api.elliptic.co",
-      key: "key",
-      secret: "secret",
       timeoutMs: 10000,
     },
     rateLimitPerMinute: 100,
     maxBodyBytes: 10240,
     configCacheTtlSeconds: 300,
     blockedCacheTtlSeconds: 300,
-    partners: { "test-partner": partnerSecret },
+    partners: {
+      "test-partner": {
+        hmacSecret: partnerSecret,
+        ellipticKey: "key",
+        ellipticSecret: "secret",
+      },
+    },
   };
 
   function makeSignedRequest(timestamp: string): Request {

--- a/elliptic-proxy/tests/config.test.ts
+++ b/elliptic-proxy/tests/config.test.ts
@@ -235,6 +235,24 @@ describe("ConfigLoader", () => {
     expect(loaded.chainId).toBe(SN_MAIN_CHAIN_ID);
   });
 
+  it("defaults allowByok to false when absent", async () => {
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(VALID_CONFIG));
+    const loader = new ConfigLoader(fetcher);
+    expect((await loader.get()).allowByok).toBe(false);
+  });
+
+  it("honors allowByok only for the literal true", async () => {
+    const enabled = vi
+      .fn()
+      .mockResolvedValue(JSON.stringify({ ...VALID_CONFIG, allowByok: true }));
+    expect((await new ConfigLoader(enabled).get()).allowByok).toBe(true);
+    // A truthy non-boolean must not enable the path.
+    const truthy = vi
+      .fn()
+      .mockResolvedValue(JSON.stringify({ ...VALID_CONFIG, allowByok: "yes" }));
+    expect((await new ConfigLoader(truthy).get()).allowByok).toBe(false);
+  });
+
   it("throws when additionalBlockedAddresses is not a string array", async () => {
     const invalidConfig = {
       ...VALID_CONFIG,

--- a/elliptic-proxy/tests/config.test.ts
+++ b/elliptic-proxy/tests/config.test.ts
@@ -6,8 +6,6 @@ import { LIVE_CHAIN_ID, SN_MAIN_CHAIN_ID } from "./helpers.js";
 const VALID_CONFIG = {
   elliptic: {
     url: "https://api.elliptic.co",
-    key: "elliptic-key",
-    secret: btoa("elliptic-secret"),
     timeoutMs: 10000,
   },
   rateLimitPerMinute: 100,
@@ -15,8 +13,16 @@ const VALID_CONFIG = {
   configCacheTtlSeconds: 2,
   blockedCacheTtlSeconds: 300,
   partners: {
-    "prover-proxy": btoa("secret-aaa"),
-    "other-service": btoa("secret-bbb"),
+    "prover-proxy": {
+      hmacSecret: btoa("secret-aaa"),
+      ellipticKey: "prover-proxy-key",
+      ellipticSecret: btoa("prover-proxy-elliptic"),
+    },
+    "other-service": {
+      hmacSecret: btoa("secret-bbb"),
+      ellipticKey: "other-service-key",
+      ellipticSecret: btoa("other-service-elliptic"),
+    },
   },
   signingPrivateKey: "0x1234",
   chainId: LIVE_CHAIN_ID,
@@ -33,8 +39,14 @@ describe("ConfigLoader", () => {
     const fetcher = vi.fn().mockResolvedValue(JSON.stringify(VALID_CONFIG));
     const loader = new ConfigLoader(fetcher);
     const config = await loader.get();
-    expect(config.elliptic.key).toBe("elliptic-key");
-    expect(config.partners["prover-proxy"]).toBe(btoa("secret-aaa"));
+    expect(config.elliptic.url).toBe("https://api.elliptic.co");
+    expect(config.partners["prover-proxy"].hmacSecret).toBe(btoa("secret-aaa"));
+    expect(config.partners["prover-proxy"].ellipticKey).toBe(
+      "prover-proxy-key"
+    );
+    expect(config.partners["prover-proxy"].ellipticSecret).toBe(
+      btoa("prover-proxy-elliptic")
+    );
   });
 
   it("returns cached config within TTL", async () => {
@@ -105,15 +117,32 @@ describe("ConfigLoader", () => {
     );
   });
 
-  it("throws when a partner secret is not a string", async () => {
+  it("throws when a partner entry is not an object", async () => {
     const invalidConfig = {
       ...VALID_CONFIG,
-      partners: { "bad-partner": 123 },
+      partners: { "bad-partner": "just-a-secret" },
     };
     const fetcher = vi.fn().mockResolvedValue(JSON.stringify(invalidConfig));
     const loader = new ConfigLoader(fetcher);
     await expect(loader.get()).rejects.toThrow(
-      "partners.bad-partner must be a non-empty string"
+      "partners.bad-partner must be a non-null object"
+    );
+  });
+
+  it("throws when a partner is missing its Elliptic key", async () => {
+    const invalidConfig = {
+      ...VALID_CONFIG,
+      partners: {
+        "bad-partner": {
+          hmacSecret: btoa("secret"),
+          ellipticSecret: btoa("elliptic"),
+        },
+      },
+    };
+    const fetcher = vi.fn().mockResolvedValue(JSON.stringify(invalidConfig));
+    const loader = new ConfigLoader(fetcher);
+    await expect(loader.get()).rejects.toThrow(
+      "partners.bad-partner.ellipticKey must be a non-empty string"
     );
   });
 

--- a/elliptic-proxy/tests/helpers.ts
+++ b/elliptic-proxy/tests/helpers.ts
@@ -66,6 +66,7 @@ export function makeConfig(overrides: Partial<Config> = {}): Config {
     },
     signingPrivateKey: SIGNING_KEY,
     chainId: LIVE_CHAIN_ID,
+    allowByok: false,
     ...overrides,
   };
 }

--- a/elliptic-proxy/tests/helpers.ts
+++ b/elliptic-proxy/tests/helpers.ts
@@ -51,15 +51,19 @@ export function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
     elliptic: {
       url: "https://api.elliptic.co",
-      key: "elliptic-key",
-      secret: Buffer.from("elliptic-secret").toString("base64"),
       timeoutMs: 10000,
     },
     rateLimitPerMinute: 100,
     maxBodyBytes: 10240,
     configCacheTtlSeconds: 300,
     blockedCacheTtlSeconds: 300,
-    partners: { "test-partner": PARTNER_SECRET },
+    partners: {
+      "test-partner": {
+        hmacSecret: PARTNER_SECRET,
+        ellipticKey: "elliptic-key",
+        ellipticSecret: Buffer.from("elliptic-secret").toString("base64"),
+      },
+    },
     signingPrivateKey: SIGNING_KEY,
     chainId: LIVE_CHAIN_ID,
     ...overrides,

--- a/elliptic-proxy/tests/integration.test.ts
+++ b/elliptic-proxy/tests/integration.test.ts
@@ -9,19 +9,25 @@ import { LIVE_CHAIN_ID, SIGNING_KEY } from "./helpers.js";
 describe("integration: full request flow", () => {
   it("happy path — valid screen request returns blocked verdict", async () => {
     const partnerSecret = Buffer.from("integration-secret").toString("base64");
+    const ellipticKey = "real-key";
+    const ellipticSecret = Buffer.from("real-secret").toString("base64");
 
     const config: Config = {
       elliptic: {
         url: "https://api.elliptic.co",
-        key: "real-key",
-        secret: Buffer.from("real-secret").toString("base64"),
         timeoutMs: 10000,
       },
       rateLimitPerMinute: 100,
       maxBodyBytes: 10240,
       configCacheTtlSeconds: 300,
       blockedCacheTtlSeconds: 300,
-      partners: { "integration-partner": partnerSecret },
+      partners: {
+        "integration-partner": {
+          hmacSecret: partnerSecret,
+          ellipticKey,
+          ellipticSecret,
+        },
+      },
       signingPrivateKey: SIGNING_KEY,
       chainId: LIVE_CHAIN_ID,
     };
@@ -85,8 +91,13 @@ describe("integration: full request flow", () => {
     const allowed = JSON.parse(res.body);
     expect(allowed).toMatchObject({ blocked: false, source: "elliptic" });
     expect(allowed.signature).toBeDefined();
+    // The partner's own Elliptic credentials are used for the upstream call.
     expect(mockForward).toHaveBeenCalledWith(
-      expect.objectContaining({ address: "0xabc123" })
+      expect.objectContaining({
+        address: "0xabc123",
+        ellipticKey,
+        ellipticSecret,
+      })
     );
   });
 });

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -68,15 +68,22 @@ async function startEllipticProxy(): Promise<void> {
   const config: Config = {
     elliptic: {
       url: `http://127.0.0.1:${mockEllipticApiPort}`,
-      key: "elliptic-api-key",
-      secret: Buffer.from("elliptic-api-secret").toString("base64"),
       timeoutMs: 10000,
     },
     rateLimitPerMinute: 100,
     maxBodyBytes: 10240,
     configCacheTtlSeconds: 300,
     blockedCacheTtlSeconds: 300,
-    partners: { [PARTNER_NAME]: PARTNER_SECRET },
+    // Each partner carries its own Elliptic credentials; the proxy re-signs the
+    // upstream call with them. The mock API ignores the signature, so any
+    // non-empty key/secret works here.
+    partners: {
+      [PARTNER_NAME]: {
+        hmacSecret: PARTNER_SECRET,
+        ellipticKey: "elliptic-api-key",
+        ellipticSecret: Buffer.from("elliptic-api-secret").toString("base64"),
+      },
+    },
     // Deposits are screened (live Elliptic, against the mock API) and signed in
     // one /screen call.
     signingPrivateKey: SIGNING_KEY,


### PR DESCRIPTION
Adds an allowByok boolean to Config (default false, only the literal true
enables it). Gates the upcoming BYOK access path so the existing deployment is
unaffected until a deployment opts in. No behavior change yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/831)
<!-- Reviewable:end -->
