### PR TITLE
feat(elliptic-proxy): BYOK screening with client-supplied Elliptic creds

### DIFF
--- a/elliptic-proxy/src/auth.ts
+++ b/elliptic-proxy/src/auth.ts
@@ -1,5 +1,5 @@
 // src/auth.ts
-import { createHmac, timingSafeEqual } from "crypto";
+import { createHash, createHmac, timingSafeEqual } from "crypto";
 import type { Request } from "@google-cloud/functions-framework";
 import type { Config } from "./config.js";
 
@@ -8,6 +8,13 @@ const MAX_TIMESTAMP_DRIFT_MS = 5 * 60 * 1000;
 export interface AuthResult {
   partnerName: string;
   secret: string;
+  // Set for a BYOK request: the client is not a registered partner but supplied
+  // its own Elliptic credentials, which the proxy re-signs the upstream call
+  // with. partnerName is then a synthetic "byok:<hash>" id used only for
+  // rate-limiting and logging (never the raw key).
+  byok?: boolean;
+  ellipticKey?: string;
+  ellipticSecret?: string;
 }
 
 export function authenticateRequest(
@@ -17,8 +24,11 @@ export function authenticateRequest(
   const partnerName = firstValue(req.headers["x-access-key"]);
   const accessSign = firstValue(req.headers["x-access-sign"]);
   const accessTimestamp = firstValue(req.headers["x-access-timestamp"]);
+  const ellipticKey = firstValue(req.headers["x-elliptic-key"]);
+  const ellipticSecret = firstValue(req.headers["x-elliptic-secret"]);
 
-  if (!partnerName || !accessSign || !accessTimestamp) {
+  // Both the partner and BYOK paths authenticate with a timestamped HMAC.
+  if (!accessSign || !accessTimestamp) {
     return { error: "unauthorized", reason: "missing_headers", partnerName };
   }
 
@@ -30,34 +40,75 @@ export function authenticateRequest(
     return { error: "unauthorized", reason: "timestamp_expired", partnerName };
   }
 
-  if (!Object.hasOwn(config.partners, partnerName)) {
-    return { error: "unauthorized", reason: "unknown_partner", partnerName };
-  }
-
-  const partnerSecret = config.partners[partnerName]?.hmacSecret;
-  if (!partnerSecret) {
-    return { error: "unauthorized", reason: "unknown_partner", partnerName };
-  }
-
   const rawBody = req.rawBody?.toString() ?? "";
-  if (
-    !verifySignature(
-      partnerSecret,
-      accessSign,
-      accessTimestamp,
-      req.method,
-      req.path,
-      rawBody
-    )
-  ) {
+
+  // Registered partner: HMAC keyed by the partner's stored hmacSecret. A known
+  // partner always takes this path, so a BYOK header can never shadow one.
+  if (partnerName && Object.hasOwn(config.partners, partnerName)) {
+    const partnerSecret = config.partners[partnerName].hmacSecret;
+    if (
+      !verifySignature(
+        partnerSecret,
+        accessSign,
+        accessTimestamp,
+        req.method,
+        req.path,
+        rawBody
+      )
+    ) {
+      return {
+        error: "unauthorized",
+        reason: "invalid_signature",
+        partnerName,
+      };
+    }
+    return { partnerName, secret: partnerSecret };
+  }
+
+  // BYOK: the client supplies its own Elliptic key + secret and self-signs the
+  // request with that secret — proving possession and protecting body integrity
+  // (replay-bounded by the drift window above). The verdict is screened against
+  // the client's own Elliptic account but still signed with the proxy key, so
+  // the path is gated by allowByok (an explicit operator trust decision).
+  if (ellipticKey || ellipticSecret) {
+    if (!config.allowByok) {
+      return { error: "unauthorized", reason: "byok_disabled", partnerName };
+    }
+    if (!ellipticKey || !ellipticSecret) {
+      return { error: "unauthorized", reason: "byok_incomplete", partnerName };
+    }
+    if (
+      !verifySignature(
+        ellipticSecret,
+        accessSign,
+        accessTimestamp,
+        req.method,
+        req.path,
+        rawBody
+      )
+    ) {
+      return {
+        error: "unauthorized",
+        reason: "invalid_signature",
+        partnerName,
+      };
+    }
+    const byokId =
+      "byok:" +
+      createHash("sha256").update(ellipticKey).digest("hex").slice(0, 16);
     return {
-      error: "unauthorized",
-      reason: "invalid_signature",
-      partnerName,
+      partnerName: byokId,
+      secret: ellipticSecret,
+      byok: true,
+      ellipticKey,
+      ellipticSecret,
     };
   }
 
-  return { partnerName, secret: partnerSecret };
+  if (!partnerName) {
+    return { error: "unauthorized", reason: "missing_headers", partnerName };
+  }
+  return { error: "unauthorized", reason: "unknown_partner", partnerName };
 }
 
 export function computeHmacSignature(

--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -141,10 +141,13 @@ export function createHandler(
     const chainIdFelt = BigInt(config.chainId);
 
     // Verdicts are labeled with the upstream that produced them: "mock" when
-    // the mock Elliptic upstream is selected, "elliptic" otherwise.
+    // the mock Elliptic upstream is selected, "elliptic" otherwise. A BYOK
+    // request screened the client's own Elliptic account, so its upstream-
+    // derived verdicts are labeled "byok".
     const upstreamSource = isMockEllipticUrl(config.elliptic.url)
       ? "mock"
       : "elliptic";
+    const verdictSource = authResult.byok ? "byok" : upstreamSource;
 
     // Every allowed verdict is signed — the response IS the attestation the
     // caller relays on-chain. Signing runs after the verdict over a fresh
@@ -215,12 +218,21 @@ export function createHandler(
       return;
     }
 
+    // BYOK requests forward the client's own Elliptic credentials; registered
+    // partners forward the credentials stored under their name. The ?? only
+    // evaluates the partners lookup on the partner path, so a synthetic BYOK
+    // partnerName never indexes config.partners.
+    const ellipticKey =
+      authResult.ellipticKey ?? config.partners[partnerName].ellipticKey;
+    const ellipticSecret =
+      authResult.ellipticSecret ?? config.partners[partnerName].ellipticSecret;
+
     let result: ForwardResponse;
     try {
       result = await forward({
         ellipticUrl: config.elliptic.url,
-        ellipticKey: config.partners[partnerName].ellipticKey,
-        ellipticSecret: config.partners[partnerName].ellipticSecret,
+        ellipticKey,
+        ellipticSecret,
         ellipticTimeoutMs: config.elliptic.timeoutMs,
         address,
       });
@@ -262,7 +274,7 @@ export function createHandler(
     // blockchain" — e.g. a freshly derived StarkNet address with no on-chain
     // history. There is no exposure to score, so allow the address.
     if (result.status === 404) {
-      sendAllowed(upstreamSource, {
+      sendAllowed(verdictSource, {
         partner: partnerName,
         ellipticStatus: result.status,
         ellipticLatencyMs: result.durationMs,
@@ -313,13 +325,13 @@ export function createHandler(
       blockedCache.markBlocked(address);
       sendResponse(
         200,
-        JSON.stringify({ blocked: true, source: upstreamSource }),
+        JSON.stringify({ blocked: true, source: verdictSource }),
         {
           partner: partnerName,
           ellipticStatus: result.status,
           ellipticLatencyMs: result.durationMs,
           result: "blocked",
-          source: upstreamSource,
+          source: verdictSource,
           scoringReason: scoringResult.reason,
           triggeringRuleIds:
             scoringResult.triggeringRuleIds.length > 0
@@ -331,7 +343,7 @@ export function createHandler(
       return;
     }
 
-    sendAllowed(upstreamSource, {
+    sendAllowed(verdictSource, {
       partner: partnerName,
       ellipticStatus: result.status,
       ellipticLatencyMs: result.durationMs,

--- a/elliptic-proxy/tests/byok.test.ts
+++ b/elliptic-proxy/tests/byok.test.ts
@@ -1,0 +1,94 @@
+// tests/byok.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createHandler } from "../src/handler.js";
+import {
+  makeConfig,
+  makeByokRequest,
+  makeResponse,
+  BYOK_ELLIPTIC_KEY,
+  BYOK_ELLIPTIC_SECRET,
+} from "./helpers.js";
+
+// An upstream reply the handler treats as "not on chain" → allowed + signed.
+const NOT_ON_CHAIN = { status: 404, body: "", durationMs: 5 };
+
+function handlerFor(configOverrides = {}, forward = vi.fn()) {
+  const config = makeConfig({ allowByok: true, ...configOverrides });
+  const configLoader = { get: vi.fn().mockResolvedValue(config) };
+  return { handler: createHandler(configLoader, forward), forward };
+}
+
+describe("BYOK screening path", () => {
+  it("forwards the client's Elliptic credentials and signs the verdict", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue(NOT_ON_CHAIN);
+    const res = makeResponse();
+    await handler(makeByokRequest(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ellipticKey: BYOK_ELLIPTIC_KEY,
+        ellipticSecret: BYOK_ELLIPTIC_SECRET,
+        address: "0xabc123",
+      })
+    );
+    const verdict = JSON.parse(res.body);
+    expect(verdict).toMatchObject({ blocked: false, source: "byok" });
+    // BYOK verdicts are signed with the proxy key, exactly like partners.
+    expect(verdict.signature).toBeDefined();
+  });
+
+  it("returns 401 byok_disabled when the gate is off", async () => {
+    const { handler, forward } = handlerFor({ allowByok: false });
+    const res = makeResponse();
+    await handler(makeByokRequest(), res);
+    expect(res.statusCode).toBe(401);
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when only one Elliptic header is present", async () => {
+    const { handler, forward } = handlerFor();
+    const req = makeByokRequest({
+      headers: {
+        "x-elliptic-key": BYOK_ELLIPTIC_KEY,
+        "x-access-sign": "ignored",
+        "x-access-timestamp": Date.now().toString(),
+      },
+    });
+    const res = makeResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the self-signed HMAC is wrong", async () => {
+    const { handler, forward } = handlerFor();
+    const req = makeByokRequest();
+    (req.headers as Record<string, string>)["x-access-sign"] = "bad-signature";
+    const res = makeResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it("never leaks the client Elliptic secret in the response or logs", async () => {
+    const captured: string[] = [];
+    const sink = (...args: unknown[]) => captured.push(args.join(" "));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(sink);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(sink);
+
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue(NOT_ON_CHAIN);
+    const res = makeResponse();
+    await handler(makeByokRequest(), res);
+
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+
+    const haystack = res.body + "\n" + captured.join("\n");
+    expect(haystack).not.toContain(BYOK_ELLIPTIC_SECRET);
+    // The pre-base64 secret value must not appear either.
+    expect(haystack).not.toContain("client-elliptic-secret");
+  });
+});

--- a/elliptic-proxy/tests/helpers.ts
+++ b/elliptic-proxy/tests/helpers.ts
@@ -107,6 +107,46 @@ export function makeRequest(
   } as unknown as Request;
 }
 
+// A BYOK client's own Elliptic credentials. The raw pre-base64 secret string is
+// asserted-against in the no-leak test, so keep it recognizable.
+export const BYOK_ELLIPTIC_KEY = "client-elliptic-key";
+export const BYOK_ELLIPTIC_SECRET = Buffer.from(
+  "client-elliptic-secret"
+).toString("base64");
+
+// A BYOK request: no x-access-key, the client's Elliptic key + secret in
+// headers, and x-access-sign HMAC-signed with the client's own Elliptic secret.
+export function makeByokRequest(
+  overrides: Record<string, unknown> = {},
+  address = "0xabc123",
+  ellipticKey = BYOK_ELLIPTIC_KEY,
+  ellipticSecret = BYOK_ELLIPTIC_SECRET
+): Request {
+  const body = JSON.stringify({ address });
+  const timestamp = Date.now().toString();
+  const signature = computeHmacSignature(
+    ellipticSecret,
+    timestamp,
+    "POST",
+    "/screen",
+    body
+  );
+
+  return {
+    method: "POST",
+    path: "/screen",
+    headers: {
+      "x-elliptic-key": ellipticKey,
+      "x-elliptic-secret": ellipticSecret,
+      "x-access-sign": signature,
+      "x-access-timestamp": timestamp,
+    },
+    rawBody: Buffer.from(body),
+    body: { address },
+    ...overrides,
+  } as unknown as Request;
+}
+
 export function makeResponse(): Response & {
   statusCode: number;
   body: string;


### PR DESCRIPTION
When allowByok is enabled, a client that is not a registered partner may screen
by supplying its own Elliptic key + secret in x-elliptic-key / x-elliptic-secret
headers and self-signing the request (x-access-sign) with that secret. auth.ts
gates and verifies the BYOK request and returns a synthetic 'byok:<hash>'
rate-limit id (never the raw key); handler.ts sources the upstream creds from
the BYOK result (guarding the partners lookup) and labels the verdict
source 'byok'. The verdict is still signed with the proxy key, so the path is
off by default.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/832)
<!-- Reviewable:end -->
