### PR TITLE
docs(elliptic-proxy): document BYOK path and its trust implication

### DIFF
--- a/elliptic-proxy/README.md
+++ b/elliptic-proxy/README.md
@@ -43,7 +43,8 @@ The secret value must be a JSON string with this structure:
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
   "additionalBlockedAddresses": [],
-  "blockOverrideAddresses": []
+  "blockOverrideAddresses": [],
+  "allowByok": false
 }
 ```
 
@@ -60,6 +61,7 @@ The secret value must be a JSON string with this structure:
 | `blockOverrideAddresses` _(optional)_     | Operator allow list (hex felts): listed addresses always screen as allowed, winning over the deny list, the blocked cache, and the upstream verdict — rescues addresses the upstream wrongly flags (false positives).                                                                                                                            |
 | `signingPrivateKey` _(required)_          | STARK-curve private key (felt hex, `1 <= key < curve order`) signing screening attestations; the production key is FPI-managed.                                                                                                                                                                                                                  |
 | `chainId` _(required)_                    | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN combined with a mock `elliptic.url` is rejected at config load.                                                                                                                                                                                         |
+| `allowByok` _(optional)_                  | Enables the [BYOK](#byok-bring-your-own-key) path when set to the literal `true`; absent or any other value is `false`. Off by default — enabling it is a security decision (BYOK verdicts are signed with this deployment's key).                                                                                                                |
 
 ### Generating partner secrets
 
@@ -87,6 +89,32 @@ Required headers on every request:
 | `x-access-key`       | Partner name (matches a key in `config.partners`) |
 | `x-access-sign`      | Base64-encoded HMAC-SHA256 signature              |
 | `x-access-timestamp` | Unix timestamp in milliseconds                    |
+
+## BYOK (bring-your-own-key)
+
+When `allowByok` is enabled, a client that is **not** a registered partner can
+screen by supplying its own Elliptic credentials. Instead of `x-access-key`, send:
+
+| Header               | Value                                                            |
+| -------------------- | ---------------------------------------------------------------- |
+| `x-elliptic-key`     | The client's own Elliptic API key                                |
+| `x-elliptic-secret`  | The client's own Elliptic HMAC secret (base64)                   |
+| `x-access-sign`      | `HMAC-SHA256(x-elliptic-secret, ts + method + lowercase(path) + body)` |
+| `x-access-timestamp` | Unix timestamp in milliseconds                                   |
+
+The client self-signs with its own Elliptic secret (proving possession + body
+integrity, replay-bounded by the 5-minute window); the proxy forwards using the
+client's key + secret. Credentials are sent in headers only and never logged.
+Verdicts report `source: "byok"` and are rate-limited under a synthetic
+`byok:<hash>` id. A registered partner always takes the partner path.
+
+> **⚠️ Security:** a BYOK allowed verdict is signed with this deployment's
+> `signingPrivateKey`, and the on-chain verifier cannot distinguish it from a
+> vetted partner's attestation (the verdict `source` is not in the signed
+> struct). Enabling BYOK lets anyone with any Elliptic key obtain a pool-trusted
+> attestation. Enable deliberately; keep `allowByok` off unless that trade-off is
+> intended, and never reuse a mainnet-trusted signing key on a testnet/mock
+> deployment.
 
 ## Response shape
 

--- a/elliptic-proxy/design.md
+++ b/elliptic-proxy/design.md
@@ -52,7 +52,8 @@ re-reads it according to `configCacheTtlSeconds`.
   },
   "signingPrivateKey": "0x<stark-curve-private-key>",
   "chainId": "0x534e5f4d41494e",
-  "additionalBlockedAddresses": []
+  "additionalBlockedAddresses": [],
+  "allowByok": false
 }
 ```
 
@@ -70,6 +71,7 @@ re-reads it according to `configCacheTtlSeconds`.
 | `additionalBlockedAddresses` _(opt.)_ | Test-only deny list consumed by the mock upstream — listed addresses screen as sanctioned. Ignored when screening live (load-time warning).                              |
 | `signingPrivateKey` _(required)_      | STARK-curve private key (felt hex) signing screening attestations; production key is FPI-managed.                                                                        |
 | `chainId` _(required)_                | Hex felt of the network the deployment signs for, bound into the SNIP-12 domain. SN_MAIN + mock `elliptic.url` is rejected at config load.                               |
+| `allowByok` _(opt.)_                  | Enables the BYOK path when the literal `true`; absent/any other value is `false`. See [BYOK](#byok-bring-your-own-key). Off by default.                                  |
 
 ### Verdict precedence
 
@@ -102,6 +104,50 @@ The proxy:
    `x-access-sign`
 3. Re-signs the request with that partner's own Elliptic key and secret
 4. Forwards with the new `x-access-key`, `x-access-sign`, `x-access-timestamp`
+
+## BYOK (bring-your-own-key)
+
+When `allowByok` is `true`, a client that is **not** a registered partner may
+screen by supplying its own Elliptic credentials. It is detected when the
+request carries no known `x-access-key` but both BYOK headers are present:
+
+- `x-elliptic-key` — the client's Elliptic API key (sent upstream as `x-access-key`)
+- `x-elliptic-secret` — the client's Elliptic HMAC secret (base64), used to re-sign
+  the upstream call
+
+The client signs the request the same way a partner does — `x-access-sign` =
+`HMAC-SHA256(x-elliptic-secret, timestamp + method + lowercase(path) + body)` —
+but with its **own** Elliptic secret. The proxy verifies that HMAC with the
+supplied secret (proving possession + body integrity, replay-bounded by the same
+5-minute window) and forwards using the client's key + secret. There is no
+pre-registration: the client's Elliptic account pays for the screening call.
+
+Credentials travel in headers only — never in the body or any signed payload —
+and never appear in logs. BYOK requests are rate-limited and logged under a
+synthetic `byok:<sha256(key)[..16]>` id, never the raw key. Verdicts report
+`source: "byok"`.
+
+Precedence: a known partner always takes the partner path (a BYOK header can
+never shadow a registered partner). Errors: `byok_disabled` (gate off),
+`byok_incomplete` (only one BYOK header), `invalid_signature` (bad self-signed
+HMAC) — all `401`.
+
+### ⚠️ Trust implication
+
+A BYOK allowed verdict is **signed with this deployment's `signingPrivateKey`**,
+exactly like a partner's. The on-chain verifier hashes only `{depositor,
+issued_at}` with `chain_id` — the `source` is **not** in the signed struct — so a
+BYOK attestation is **indistinguishable on-chain from a vetted partner's**.
+Enabling BYOK therefore lets anyone holding any Elliptic key (including a
+permissive tenant, or via the `404 → allowed` path for fresh addresses) obtain a
+pool-trusted attestation. This is an explicit operator decision, contained by:
+
+- `allowByok` defaults `false` (opt-in per deployment).
+- The SNIP-12 domain binds `chain_id`, so a testnet-chain BYOK signature cannot be
+  relayed on mainnet — **provided the deployment's `chainId` matches its network**.
+- The existing config guard still rejects a `mock:` upstream with `SN_MAIN`.
+- Operators must not reuse a mainnet-trusted `signingPrivateKey` on a testnet/mock
+  deployment.
 
 ## Rate Limiting
 


### PR DESCRIPTION
Documents the BYOK header contract (x-elliptic-key / x-elliptic-secret +
self-signed x-access-sign), the allowByok gate, the synthetic byok:<hash> id,
and a prominent security note: BYOK verdicts are signed with the deployment's
key and are indistinguishable on-chain from a vetted partner's attestation, so
the path is off by default and must be enabled deliberately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/833)
<!-- Reviewable:end -->
