### PR TITLE
feat(elliptic-proxy): map upstream 401/403 to a clear error for BYOK

### DIFF
--- a/elliptic-proxy/src/handler.ts
+++ b/elliptic-proxy/src/handler.ts
@@ -287,6 +287,24 @@ export function createHandler(
     // Only score successful Elliptic responses — non-2xx indicates an upstream
     // error and must not be interpreted as a screening result.
     if (result.status < 200 || result.status >= 300) {
+      // A BYOK client supplied its own Elliptic credentials, so a 401/403 from
+      // Elliptic means *its* credentials are bad — surface that distinctly
+      // instead of the generic 502 a BYOK client would otherwise read as
+      // "Elliptic is down". Partner credentials are operator-managed, so the
+      // partner path keeps the 502.
+      if (authResult.byok && (result.status === 401 || result.status === 403)) {
+        sendResponse(
+          401,
+          JSON.stringify({ error: "elliptic rejected credentials" }),
+          {
+            partner: partnerName,
+            result: "error",
+            errorType: "byok_elliptic_auth",
+            ellipticStatus: result.status,
+          }
+        );
+        return;
+      }
       console.error(
         JSON.stringify({
           error: "upstream_error",

--- a/elliptic-proxy/tests/byok.test.ts
+++ b/elliptic-proxy/tests/byok.test.ts
@@ -72,6 +72,15 @@ describe("BYOK screening path", () => {
     expect(forward).not.toHaveBeenCalled();
   });
 
+  it("maps an upstream 401 to 'elliptic rejected credentials' (not 502)", async () => {
+    const { handler, forward } = handlerFor();
+    forward.mockResolvedValue({ status: 401, body: "{}", durationMs: 5 });
+    const res = makeResponse();
+    await handler(makeByokRequest(), res);
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).error).toBe("elliptic rejected credentials");
+  });
+
   it("never leaks the client Elliptic secret in the response or logs", async () => {
     const captured: string[] = [];
     const sink = (...args: unknown[]) => captured.push(args.join(" "));


### PR DESCRIPTION
When a BYOK request's own Elliptic credentials are rejected upstream (401/403),
return 401 'elliptic rejected credentials' instead of the generic 502, so a
BYOK client can distinguish bad credentials from an Elliptic outage. The
operator-managed partner path keeps the 502.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/834)
<!-- Reviewable:end -->
