### PR TITLE
feat(sub-account-anonymizer): initial contract

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sub_account_anonymizer"
+version = "0.1.0"
+dependencies = [
+ "openzeppelin",
+ "privacy",
+ "snforge_std",
+ "starkware_utils",
+ "starkware_utils_testing",
+]
+
+[[package]]
 name = "vesu_lending_anonymizer"
 version = "0.1.0"
 dependencies = [

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,6 +2,7 @@
 members = [
     "packages/ekubo_swap_anonymizer",
     "packages/privacy",
+    "packages/sub_account_anonymizer",
     "packages/vesu_lending_anonymizer",
 ]
 

--- a/packages/sub_account_anonymizer/README.md
+++ b/packages/sub_account_anonymizer/README.md
@@ -1,0 +1,9 @@
+# Sub-Account Anonymizer
+
+Lets the privacy pool run arbitrary dapp interactions on behalf of its users without linking those
+interactions back to a user.
+
+Each user interaction is identified by a commitment. The anonymizer keeps a registry mapping every
+commitment to a dedicated sub-account contract that performs the dapp calls and holds the resulting
+funds, which are then settled back into the privacy pool's open notes. Driving interactions is
+restricted to the privacy contract the anonymizer is configured for.

--- a/packages/sub_account_anonymizer/Scarb.toml
+++ b/packages/sub_account_anonymizer/Scarb.toml
@@ -1,0 +1,42 @@
+[package]
+name = "sub_account_anonymizer"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[tool]
+fmt.workspace = true
+scarb.workspace = true
+
+[dependencies]
+starknet.workspace = true
+openzeppelin.workspace = true
+starkware_utils.workspace = true
+privacy = { path = "../privacy" }
+
+[dev-dependencies]
+assert_macros.workspace = true
+snforge_std.workspace = true
+starkware_utils_testing.workspace = true
+
+[lib]
+
+[[test]]
+name = "sub_account_anonymizer_unittest"
+build-external-contracts = [
+    "starkware_utils::contracts::sub_account::SubAccount",
+]
+
+[scripts]
+test = "snforge test"
+
+[[target.starknet-contract]]
+sierra = true
+casm = true
+casm-add-pythonic-hints = true
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+inlining-strategy = "avoid"

--- a/packages/sub_account_anonymizer/src/lib.cairo
+++ b/packages/sub_account_anonymizer/src/lib.cairo
@@ -1,0 +1,3 @@
+pub mod sub_account_anonymizer;
+#[cfg(test)]
+pub mod tests;

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -1,0 +1,61 @@
+//! Sub-account anonymizer for privacy-preserving dapp interactions.
+
+use starknet::{ClassHash, ContractAddress};
+
+#[starknet::interface]
+pub trait ISubAccountAnonymizer<T> {
+    /// Returns the sub-account address bound to `commitment`, or zero if none has been deployed
+    /// yet.
+    fn get_sub_account(self: @T, commitment: felt252) -> ContractAddress;
+
+    /// Returns the privacy contract authorized to drive interactions.
+    fn get_privacy_contract(self: @T) -> ContractAddress;
+
+    /// Returns the class hash of the `SubAccount` contract deployed per commitment.
+    fn get_sub_account_class_hash(self: @T) -> ClassHash;
+}
+
+#[starknet::contract]
+pub mod SubAccountAnonymizer {
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use starknet::{ClassHash, ContractAddress};
+    use super::ISubAccountAnonymizer;
+
+    #[storage]
+    struct Storage {
+        /// Address of the authorized privacy contract.
+        privacy_contract: ContractAddress,
+        /// Class hash of the `SubAccount` contract deployed per commitment.
+        // TODO: Consider making this a constant.
+        sub_account_class_hash: ClassHash,
+        /// Maps a commitment to the sub-account deployed for it.
+        sub_accounts: Map<felt252, ContractAddress>,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        privacy_contract: ContractAddress,
+        sub_account_class_hash: ClassHash,
+    ) {
+        self.privacy_contract.write(privacy_contract);
+        self.sub_account_class_hash.write(sub_account_class_hash);
+    }
+
+    #[abi(embed_v0)]
+    pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
+        fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
+            self.sub_accounts.read(commitment)
+        }
+
+        fn get_privacy_contract(self: @ContractState) -> ContractAddress {
+            self.privacy_contract.read()
+        }
+
+        fn get_sub_account_class_hash(self: @ContractState) -> ClassHash {
+            self.sub_account_class_hash.read()
+        }
+    }
+}

--- a/packages/sub_account_anonymizer/src/tests.cairo
+++ b/packages/sub_account_anonymizer/src/tests.cairo
@@ -1,0 +1,2 @@
+pub mod test_sub_account_anonymizer;
+pub mod test_utils;

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,0 +1,26 @@
+use core::num::traits::Zero;
+use snforge_std::{DeclareResultTrait, declare};
+use starknet::SyscallResultTrait;
+use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
+use sub_account_anonymizer::tests::test_utils::{
+    PRIVACY, anonymizer_disp, deploy_sub_account_anonymizer,
+};
+
+#[test]
+fn test_get_privacy_contract() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    assert_eq!(anonymizer_disp(anonymizer).get_privacy_contract(), PRIVACY);
+}
+
+#[test]
+fn test_get_sub_account_class_hash() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let expected = *declare("SubAccount").unwrap_syscall().contract_class().class_hash;
+    assert_eq!(anonymizer_disp(anonymizer).get_sub_account_class_hash(), expected);
+}
+
+#[test]
+fn test_get_sub_account_unknown_commitment_is_zero() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    assert!(anonymizer_disp(anonymizer).get_sub_account('UNKNOWN').is_zero());
+}

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -1,0 +1,22 @@
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use starknet::{ContractAddress, SyscallResultTrait};
+use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcher;
+
+/// The address configured as the privacy contract; the only authorized caller.
+pub const PRIVACY: ContractAddress = 'PRIVACY'.try_into().unwrap();
+
+pub fn anonymizer_disp(anonymizer: ContractAddress) -> ISubAccountAnonymizerDispatcher {
+    ISubAccountAnonymizerDispatcher { contract_address: anonymizer }
+}
+
+pub fn deploy_sub_account_anonymizer() -> ContractAddress {
+    let sub_account_class_hash = *declare("SubAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let contract = declare("SubAccountAnonymizer").unwrap_syscall().contract_class();
+    let (address, _) = contract
+        .deploy(@array![PRIVACY.into(), sub_account_class_hash.into()])
+        .unwrap_syscall();
+    address
+}


### PR DESCRIPTION
Introduces the executor_anonymizer package with the storage layout
(privacy_contract, executor_class_hash, and the per-commitment executors
registry) and read accessors. Commitment derivation and the interaction
entrypoints are added in later PRs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/836)
<!-- Reviewable:end -->
