### PR TITLE
feat(sub-account-anonymizer): privacy_compute

### DIFF
--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -4,19 +4,51 @@ use starknet::{ClassHash, ContractAddress};
 
 #[starknet::interface]
 pub trait ISubAccountAnonymizer<T> {
-    /// Returns the sub-account address bound to `commitment`, or zero if none has been deployed
-    /// yet.
+    /// Derives the commitment that identifies a sub-account.
+    ///
+    /// #### Parameters
+    /// - `identity_key` (`felt252`) - A unique handle derived by the privacy pool from a user
+    /// identity. It is linked to the user but cannot be traced back to them. Only the holder of the
+    /// underlying identity can reproduce it, making it a pseudonymous proof of ownership without
+    /// revealing who they are.
+    /// - `dapp_name` (`felt252`) - The dapp the sub-account interacts with, scoping commitments per
+    /// dapp.
+    /// - `nonce` (`felt252`) - A nonce that lets one identity derive multiple distinct sub-accounts
+    /// for the same dapp.
+    ///
+    /// #### Returns
+    /// - (`felt252`) - A commitment binding to a single sub-account.
+    fn privacy_compute(
+        self: @T, identity_key: felt252, dapp_name: felt252, nonce: felt252,
+    ) -> felt252;
+
+    /// Returns the sub-account address bound to `commitment`.
+    ///
+    /// #### Parameters
+    /// - `commitment` (`felt252`) - The commitment derived by `privacy_compute`.
+    ///
+    /// #### Returns
+    /// - (`ContractAddress`) - The deployed sub-account address, or zero if none has been deployed
+    /// for `commitment` yet.
     fn get_sub_account(self: @T, commitment: felt252) -> ContractAddress;
 
     /// Returns the privacy contract authorized to drive interactions.
+    ///
+    /// #### Returns
+    /// - (`ContractAddress`) - The address of the authorized privacy contract.
     fn get_privacy_contract(self: @T) -> ContractAddress;
 
     /// Returns the class hash of the `SubAccount` contract deployed per commitment.
+    ///
+    /// #### Returns
+    /// - (`ClassHash`) - The class hash used when deploying a sub-account.
     fn get_sub_account_class_hash(self: @T) -> ClassHash;
 }
 
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
+    use core::hash::HashStateTrait;
+    use core::poseidon::PoseidonTrait;
     use starknet::storage::{
         Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
@@ -46,6 +78,12 @@ pub mod SubAccountAnonymizer {
 
     #[abi(embed_v0)]
     pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
+        fn privacy_compute(
+            self: @ContractState, identity_key: felt252, dapp_name: felt252, nonce: felt252,
+        ) -> felt252 {
+            PoseidonTrait::new().update(identity_key).update(dapp_name).update(nonce).finalize()
+        }
+
         fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
             self.sub_accounts.read(commitment)
         }

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,4 +1,6 @@
+use core::hash::HashStateTrait;
 use core::num::traits::Zero;
+use core::poseidon::PoseidonTrait;
 use snforge_std::{DeclareResultTrait, declare};
 use starknet::SyscallResultTrait;
 use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
@@ -23,4 +25,24 @@ fn test_get_sub_account_class_hash() {
 fn test_get_sub_account_unknown_commitment_is_zero() {
     let anonymizer = deploy_sub_account_anonymizer();
     assert!(anonymizer_disp(anonymizer).get_sub_account('UNKNOWN').is_zero());
+}
+
+#[test]
+fn test_privacy_compute_matches_poseidon() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let commitment = anonymizer_disp(anonymizer).privacy_compute('USER', 'DAPP', 7);
+    let expected = PoseidonTrait::new().update('USER').update('DAPP').update(7).finalize();
+    assert_eq!(commitment, expected);
+}
+
+#[test]
+fn test_privacy_compute_is_deterministic_and_distinct() {
+    let anonymizer = anonymizer_disp(deploy_sub_account_anonymizer());
+    let base = anonymizer.privacy_compute('USER', 'DAPP', 1);
+    // Deterministic for the same inputs.
+    assert_eq!(base, anonymizer.privacy_compute('USER', 'DAPP', 1));
+    // Each input affects the commitment.
+    assert_ne!(base, anonymizer.privacy_compute('OTHER', 'DAPP', 1));
+    assert_ne!(base, anonymizer.privacy_compute('USER', 'OTHER', 1));
+    assert_ne!(base, anonymizer.privacy_compute('USER', 'DAPP', 2));
 }


### PR DESCRIPTION
Adds `privacy_compute(identity_key, dapp_name, seq_nonce) -> commitment`, the Poseidon hash that identifies the per-interaction sub-account, with tests for the hash value and its determinism/input-distinctness. Pure view; the invocation entrypoint that consumes the commitment follows in the next PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/838)
<!-- Reviewable:end -->
