### PR TITLE
feat(sub-account-anonymizer): privacy_invoke_with_computation

### DIFF
--- a/packages/sub_account_anonymizer/Scarb.toml
+++ b/packages/sub_account_anonymizer/Scarb.toml
@@ -25,7 +25,9 @@ starkware_utils_testing.workspace = true
 [[test]]
 name = "sub_account_anonymizer_unittest"
 build-external-contracts = [
+    "starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock",
     "starkware_utils::contracts::sub_account::SubAccount",
+    "sub_account_anonymizer::test_utils_contracts::mock_dapp::MockDapp",
 ]
 
 [scripts]

--- a/packages/sub_account_anonymizer/src/lib.cairo
+++ b/packages/sub_account_anonymizer/src/lib.cairo
@@ -1,3 +1,5 @@
 pub mod sub_account_anonymizer;
 #[cfg(test)]
+pub mod test_utils_contracts;
+#[cfg(test)]
 pub mod tests;

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -1,6 +1,26 @@
 //! Sub-account anonymizer for privacy-preserving dapp interactions.
+//!
+//! Runs arbitrary dapp calls on behalf of the privacy contract through per-commitment
+//! [`SubAccount`](starkware_utils::contracts::sub_account::SubAccount) contracts. Each commitment
+//! maps to a dedicated sub-account that performs the dapp calls and holds the resulting funds; the
+//! anonymizer then collects those funds into itself and approves the privacy contract to pull
+//! them into open notes. Driving interactions is restricted to the configured privacy contract.
 
+use privacy::objects::OpenNoteDeposit;
+use starknet::account::Call;
 use starknet::{ClassHash, ContractAddress};
+
+/// The result of [`privacy_compute`]: a commitment that identifies a single sub-account.
+pub type PrivacyComputeCommitment = felt252;
+
+/// An open note to settle after an interaction.
+#[derive(Serde, Copy, Drop, PartialEq, Debug)]
+pub struct OpenNote {
+    /// The identifier of the open note to deposit to.
+    pub note_id: felt252,
+    /// The token to deposit.
+    pub token: ContractAddress,
+}
 
 #[starknet::interface]
 pub trait ISubAccountAnonymizer<T> {
@@ -17,20 +37,56 @@ pub trait ISubAccountAnonymizer<T> {
     /// for the same dapp.
     ///
     /// #### Returns
-    /// - (`felt252`) - A commitment binding to a single sub-account.
+    /// - ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - A commitment binding to a
+    /// single sub-account.
     fn privacy_compute(
         self: @T, identity_key: felt252, dapp_name: felt252, nonce: felt252,
-    ) -> felt252;
+    ) -> PrivacyComputeCommitment;
+
+    /// Executes `calls` through the sub-account bound to `commitment` (deploying it on first
+    /// use), then collects each requested open-note token from the sub-account and into this
+    /// anonymizer, approving the privacy contract to pull the collected amount.
+    ///
+    /// #### Parameters
+    /// - `commitment` ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - identifies the
+    /// sub-account; see [`privacy_compute`]. Preimage is off-chain only and unrecoverable from
+    /// on-chain data.
+    /// - `calls` (`Array<Call>`) - the dapp calls to run as the sub-account.
+    /// - `open_notes` ([`Span<OpenNote>`](OpenNote)) - the notes to settle; for each, the
+    ///   sub-account's entire `token` balance is swept into this anonymizer and recorded as a
+    ///   deposit.
+    ///
+    /// #### Returns
+    /// - ([`Span<OpenNoteDeposit>`](privacy::objects::OpenNoteDeposit)) - one deposit per open
+    ///   note, for the privacy contract to apply.
+    ///
+    /// #### Preconditions
+    /// - Caller must be the configured privacy contract.
+    ///
+    /// #### Reverts
+    /// - [`UNAUTHORIZED_CALLER`](errors::UNAUTHORIZED_CALLER): Thrown if the caller is not the
+    ///   configured privacy contract.
+    /// - [`ZERO_BALANCE`](errors::ZERO_BALANCE): Thrown if the sub-account holds no balance of an
+    ///   open note's `token` (all open notes must be deposited with amount > 0).
+    /// - [`AMOUNT_OVERFLOW`](errors::AMOUNT_OVERFLOW): Thrown if the amount
+    ///   collected for an open note exceeds `u128`.
+    fn privacy_invoke_with_computation(
+        ref self: T,
+        commitment: PrivacyComputeCommitment,
+        calls: Array<Call>,
+        open_notes: Span<OpenNote>,
+    ) -> Span<OpenNoteDeposit>;
 
     /// Returns the sub-account address bound to `commitment`.
     ///
     /// #### Parameters
-    /// - `commitment` (`felt252`) - The commitment derived by `privacy_compute`.
+    /// - `commitment` ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - The commitment
+    /// derived by `privacy_compute`.
     ///
     /// #### Returns
     /// - (`ContractAddress`) - The deployed sub-account address, or zero if none has been deployed
     /// for `commitment` yet.
-    fn get_sub_account(self: @T, commitment: felt252) -> ContractAddress;
+    fn get_sub_account(self: @T, commitment: PrivacyComputeCommitment) -> ContractAddress;
 
     /// Returns the privacy contract authorized to drive interactions.
     ///
@@ -45,15 +101,33 @@ pub trait ISubAccountAnonymizer<T> {
     fn get_sub_account_class_hash(self: @T) -> ClassHash;
 }
 
+/// Error codes for sub-account anonymizer operations.
+pub mod errors {
+    pub const UNAUTHORIZED_CALLER: felt252 = 'UNAUTHORIZED_CALLER';
+    pub const ZERO_BALANCE: felt252 = 'ZERO_BALANCE';
+    pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
+}
+
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
     use core::hash::HashStateTrait;
+    use core::num::traits::Zero;
     use core::poseidon::PoseidonTrait;
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use privacy::objects::OpenNoteDeposit;
+    use starknet::account::Call;
     use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
-    use starknet::{ClassHash, ContractAddress};
-    use super::ISubAccountAnonymizer;
+    use starknet::syscalls::deploy_syscall;
+    use starknet::{
+        ClassHash, ContractAddress, SyscallResultTrait, get_caller_address, get_contract_address,
+    };
+    use starkware_utils::contracts::sub_account::{
+        ISubAccountDispatcher, ISubAccountDispatcherTrait,
+    };
+    use super::{ISubAccountAnonymizer, OpenNote, PrivacyComputeCommitment, errors};
 
     #[storage]
     struct Storage {
@@ -63,7 +137,7 @@ pub mod SubAccountAnonymizer {
         // TODO: Consider making this a constant.
         sub_account_class_hash: ClassHash,
         /// Maps a commitment to the sub-account deployed for it.
-        sub_accounts: Map<felt252, ContractAddress>,
+        sub_accounts: Map<PrivacyComputeCommitment, ContractAddress>,
     }
 
     #[constructor]
@@ -80,11 +154,27 @@ pub mod SubAccountAnonymizer {
     pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
         fn privacy_compute(
             self: @ContractState, identity_key: felt252, dapp_name: felt252, nonce: felt252,
-        ) -> felt252 {
+        ) -> PrivacyComputeCommitment {
             PoseidonTrait::new().update(identity_key).update(dapp_name).update(nonce).finalize()
         }
 
-        fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
+        fn privacy_invoke_with_computation(
+            ref self: ContractState,
+            commitment: PrivacyComputeCommitment,
+            calls: Array<Call>,
+            open_notes: Span<OpenNote>,
+        ) -> Span<OpenNoteDeposit> {
+            assert(
+                get_caller_address() == self.privacy_contract.read(), errors::UNAUTHORIZED_CALLER,
+            );
+            let sub_account = self.get_or_deploy_sub_account(:commitment);
+            sub_account.execute(calls);
+            self.collect_open_notes(:sub_account, :open_notes)
+        }
+
+        fn get_sub_account(
+            self: @ContractState, commitment: PrivacyComputeCommitment,
+        ) -> ContractAddress {
             self.sub_accounts.read(commitment)
         }
 
@@ -95,5 +185,67 @@ pub mod SubAccountAnonymizer {
         fn get_sub_account_class_hash(self: @ContractState) -> ClassHash {
             self.sub_account_class_hash.read()
         }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        /// Returns the sub-account bound to `commitment`, deploying a fresh one on first use. The
+        /// commitment is the deployment salt, so each commitment maps to a deterministic address,
+        /// and the deployed `SubAccount` records this anonymizer (its deployer) as owner.
+        fn get_or_deploy_sub_account(
+            ref self: ContractState, commitment: PrivacyComputeCommitment,
+        ) -> ISubAccountDispatcher {
+            let existing = self.sub_accounts.read(commitment);
+            if existing.is_non_zero() {
+                return ISubAccountDispatcher { contract_address: existing };
+            }
+            let (sub_account_addr, _) = deploy_syscall(
+                class_hash: self.sub_account_class_hash.read(),
+                contract_address_salt: commitment,
+                calldata: array![].span(),
+                deploy_from_zero: false,
+            )
+                .unwrap_syscall();
+            self.sub_accounts.write(commitment, sub_account_addr);
+            ISubAccountDispatcher { contract_address: sub_account_addr }
+        }
+
+        /// Settles each note in `open_notes`, returning one [`OpenNoteDeposit`] per note.
+        /// For each note, sweeps the sub-account's entire `token` balance into this anonymizer and
+        /// approves the privacy contract to pull that amount.
+        fn collect_open_notes(
+            self: @ContractState, sub_account: ISubAccountDispatcher, open_notes: Span<OpenNote>,
+        ) -> Span<OpenNoteDeposit> {
+            let anonymizer = get_contract_address();
+            let privacy_contract = self.privacy_contract.read();
+            // Transfers are collected into one batch and run through a single
+            // `sub_account.execute`.
+            let mut transfer_calls: Array<Call> = array![];
+            let mut deposits: Array<OpenNoteDeposit> = array![];
+            for note in open_notes {
+                let OpenNote { note_id, token } = *note;
+                let token_contract = IERC20Dispatcher { contract_address: token };
+                let balance = token_contract.balance_of(account: sub_account.contract_address);
+                // All open notes must be deposited with amount > 0.
+                assert(balance.is_non_zero(), errors::ZERO_BALANCE);
+
+                transfer_calls
+                    .append(build_transfer_call(:token, recipient: anonymizer, amount: balance));
+                token_contract.approve(spender: privacy_contract, amount: balance);
+                let amount: u128 = balance.try_into().expect(errors::AMOUNT_OVERFLOW);
+                deposits.append(OpenNoteDeposit { note_id, token, amount });
+            }
+            sub_account.execute(transfer_calls);
+            deposits.span()
+        }
+    }
+
+    /// Builds a `Call` that transfers `amount` of `token` to `recipient`.
+    fn build_transfer_call(
+        token: ContractAddress, recipient: ContractAddress, amount: u256,
+    ) -> Call {
+        let mut calldata = array![recipient.into()];
+        amount.serialize(ref calldata);
+        Call { to: token, selector: selector!("transfer"), calldata: calldata.span() }
     }
 }

--- a/packages/sub_account_anonymizer/src/test_utils_contracts.cairo
+++ b/packages/sub_account_anonymizer/src/test_utils_contracts.cairo
@@ -1,0 +1,1 @@
+pub mod mock_dapp;

--- a/packages/sub_account_anonymizer/src/test_utils_contracts/mock_dapp.cairo
+++ b/packages/sub_account_anonymizer/src/test_utils_contracts/mock_dapp.cairo
@@ -1,0 +1,29 @@
+//! Minimal dapp used to exercise sub_account-driven interactions: `pay_out` transfers a previously
+//! funded token balance to whoever calls it (the sub_account), modelling a dapp that returns funds
+//! to the calling account.
+
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockDapp<T> {
+    /// Transfers `amount` of `token` from this contract to the caller.
+    fn pay_out(ref self: T, token: ContractAddress, amount: u256);
+}
+
+#[starknet::contract]
+pub mod MockDapp {
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::{ContractAddress, get_caller_address};
+    use super::IMockDapp;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl MockDappImpl of IMockDapp<ContractState> {
+        fn pay_out(ref self: ContractState, token: ContractAddress, amount: u256) {
+            IERC20Dispatcher { contract_address: token }
+                .transfer(recipient: get_caller_address(), :amount);
+        }
+    }
+}

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,12 +1,25 @@
 use core::hash::HashStateTrait;
-use core::num::traits::Zero;
+use core::num::traits::{Bounded, Zero};
 use core::poseidon::PoseidonTrait;
-use snforge_std::{DeclareResultTrait, declare};
-use starknet::SyscallResultTrait;
-use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
-use sub_account_anonymizer::tests::test_utils::{
-    PRIVACY, anonymizer_disp, deploy_sub_account_anonymizer,
+use privacy::objects::OpenNoteDeposit;
+use snforge_std::{DeclareResultTrait, TokenTrait, declare};
+use starknet::account::Call;
+use starknet::{ContractAddress, SyscallResultTrait};
+use starkware_utils::contracts::sub_account::{ISubAccountDispatcher, ISubAccountDispatcherTrait};
+use starkware_utils_testing::test_utils::{
+    TokenHelperTrait, assert_panic_with_felt_error, cheat_caller_address_once,
 };
+use sub_account_anonymizer::sub_account_anonymizer::{
+    ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
+    ISubAccountAnonymizerSafeDispatcherTrait, OpenNote, errors,
+};
+use sub_account_anonymizer::tests::test_utils::{
+    ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components, deploy_sub_account_anonymizer,
+    deploy_token, pay_out_call,
+};
+
+const AMOUNT: u128 = 1_000_000;
+const NOTE_ID: felt252 = 'NOTE_ID';
 
 #[test]
 fn test_get_privacy_contract() {
@@ -45,4 +58,297 @@ fn test_privacy_compute_is_deterministic_and_distinct() {
     assert_ne!(base, anonymizer.privacy_compute('OTHER', 'DAPP', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'OTHER', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'DAPP', 2));
+}
+
+#[test]
+fn test_invoke_executes_and_collects_open_note() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Fund the dapp so the sub-account-driven call pays the sub-account `AMOUNT`.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
+
+    // One deposit returned, matching the collected token/amount.
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, AMOUNT);
+
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    assert!(sub_account.is_non_zero());
+    // Funds flowed dapp -> sub-account -> anonymizer, and the privacy contract is approved to pull.
+    assert_eq!(components.token.balance_of(components.mock_dapp), 0);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), AMOUNT.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_invoke_only_privacy_contract() {
+    let components = deploy_components();
+    // No caller cheat: the caller is the test contract, not the privacy contract.
+    let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    let result = safe
+        .privacy_invoke_with_computation(
+            commitment: 0, calls: array![], open_notes: array![].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::UNAUTHORIZED_CALLER);
+}
+
+#[test]
+fn test_collects_multiple_open_notes() {
+    let components = deploy_components();
+    let token_a = components.token;
+    let token_b = deploy_token();
+    let addr_a = token_a.contract_address();
+    let addr_b = token_b.contract_address();
+    assert!(addr_a != addr_b);
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    let amount_a: u128 = 1_000_000;
+    let amount_b: u128 = 2_500_000;
+    token_a.supply(address: components.mock_dapp, amount: amount_a);
+    token_b.supply(address: components.mock_dapp, amount: amount_b);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![
+                pay_out_call(components.mock_dapp, addr_a, amount_a),
+                pay_out_call(components.mock_dapp, addr_b, amount_b),
+            ],
+            open_notes: array![
+                OpenNote { note_id: 'NOTE_A', token: addr_a },
+                OpenNote { note_id: 'NOTE_B', token: addr_b },
+            ]
+                .span(),
+        );
+
+    // One deposit per note, each carrying its own token/amount.
+    assert_eq!(deposits.len(), 2);
+    let OpenNoteDeposit { note_id: id_a, token: tok_a, amount: amt_a } = *deposits[0];
+    assert_eq!(id_a, 'NOTE_A');
+    assert_eq!(tok_a, addr_a);
+    assert_eq!(amt_a, amount_a);
+    let OpenNoteDeposit { note_id: id_b, token: tok_b, amount: amt_b } = *deposits[1];
+    assert_eq!(id_b, 'NOTE_B');
+    assert_eq!(tok_b, addr_b);
+    assert_eq!(amt_b, amount_b);
+
+    assert_eq!(token_a.balance_of(components.mock_dapp), 0);
+    assert_eq!(token_b.balance_of(components.mock_dapp), 0);
+    assert_eq!(token_a.balance_of(components.anonymizer), amount_a.into());
+    assert_eq!(token_b.balance_of(components.anonymizer), amount_b.into());
+    assert_eq!(token_a.allowance(components.anonymizer, PRIVACY), amount_a.into());
+    assert_eq!(token_b.allowance(components.anonymizer, PRIVACY), amount_b.into());
+}
+
+#[test]
+fn test_multiple_invokes_run_in_one_call() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    let first: u128 = 700_000;
+    let second: u128 = 300_000;
+    components.token.supply(address: components.mock_dapp, amount: first + second);
+
+    // Two calls in one interaction; both run as the sub-account and their output is combined.
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![
+                pay_out_call(components.mock_dapp, token, first),
+                pay_out_call(components.mock_dapp, token, second),
+            ],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
+
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, first + second);
+    assert_eq!(components.token.balance_of(components.anonymizer), (first + second).into());
+}
+
+#[test]
+fn test_invoke_but_not_collect() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![].span(),
+        );
+    assert_eq!(deposits.len(), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), 0);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    assert_eq!(components.token.balance_of(sub_account), AMOUNT.into());
+}
+
+#[test]
+fn test_deployed_sub_account_owned_by_anonymizer() {
+    let components = deploy_components();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    components.invoke(:commitment, calls: array![], open_notes: array![].span());
+
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    // The anonymizer is the sub-account's deployer, so it is the only authorized controller.
+    assert_eq!(
+        ISubAccountDispatcher { contract_address: sub_account }.owner(), components.anonymizer,
+    );
+}
+
+#[test]
+fn test_sub_account_is_reused_per_commitment() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let commitment_a = anonymizer.privacy_compute('USER', 'DAPP', 1);
+    let commitment_b = anonymizer.privacy_compute('USER', 'DAPP', 2);
+    let no_notes = array![].span();
+
+    components.invoke(commitment: commitment_a, calls: array![], open_notes: no_notes);
+    let sub_account_a = anonymizer.get_sub_account(commitment_a);
+    assert!(sub_account_a.is_non_zero());
+
+    // Same commitment reuses the same sub-account (no redeploy).
+    components.invoke(commitment: commitment_a, calls: array![], open_notes: no_notes);
+    assert_eq!(anonymizer.get_sub_account(commitment_a), sub_account_a);
+
+    // A different commitment gets a distinct sub-account.
+    components.invoke(commitment: commitment_b, calls: array![], open_notes: no_notes);
+    let sub_account_b = anonymizer.get_sub_account(commitment_b);
+    assert!(sub_account_b.is_non_zero());
+    assert!(sub_account_b != sub_account_a);
+}
+
+#[test]
+fn test_sweeps_full_balance_including_preexisting() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Deploy the sub-account (empty invoke) so we can give it a pre-existing balance.
+    components.invoke(:commitment, calls: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let preexisting: u128 = 500_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+
+    // The interaction adds `AMOUNT` on top of the pre-existing balance.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
+
+    // The full balance is swept: pre-existing plus the amount added by the interaction.
+    let total = preexisting + AMOUNT;
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, total);
+    assert_eq!(components.token.balance_of(components.mock_dapp), 0);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), total.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), total.into());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_empty_balance_open_note_reverts() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // No calls and no funds, so the sub-account's balance is zero. A zero-amount deposit would be
+    // rejected downstream, so collecting it reverts with `ZERO_BALANCE`.
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    let result = safe
+        .privacy_invoke_with_computation(
+            :commitment,
+            calls: array![],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_BALANCE);
+}
+
+#[test]
+fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Deploy and pre-fund the sub-account.
+    components.invoke(:commitment, calls: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let preexisting: u128 = 1_000_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+
+    // The invoke makes the sub-account send some tokens out; only the remainder is swept.
+    let sink: ContractAddress = 'SINK'.try_into().unwrap();
+    let sent: u128 = 300_000;
+    let transfer = Call {
+        to: token,
+        selector: selector!("transfer"),
+        calldata: array![sink.into(), sent.into(), 0].span(),
+    };
+    let deposits = components
+        .invoke(
+            :commitment,
+            calls: array![transfer],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
+
+    // The balance left after the outbound transfer is swept; funds sent out are not recovered.
+    let remaining = preexisting - sent;
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, remaining);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), remaining.into());
+    assert_eq!(components.token.balance_of(sink), sent.into());
+}
+
+#[test]
+#[should_panic(expected: 'AMOUNT_OVERFLOW')]
+fn test_collected_amount_overflow() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Fund the dapp with `u128::MAX + 1` (two supplies, since `supply` takes a u128).
+    let max = Bounded::<u128>::MAX;
+    components.token.supply(address: components.mock_dapp, amount: max);
+    components.token.supply(address: components.mock_dapp, amount: 1);
+
+    // Two pay-outs add `u128::MAX + 1` to the sub-account, so the collected delta overflows u128.
+    components
+        .invoke(
+            :commitment,
+            calls: array![
+                pay_out_call(components.mock_dapp, token, max),
+                pay_out_call(components.mock_dapp, token, 1),
+            ],
+            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+        );
 }

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -1,12 +1,54 @@
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use privacy::objects::OpenNoteDeposit;
+use snforge_std::{ContractClassTrait, DeclareResultTrait, Token, declare};
+use starknet::account::Call;
 use starknet::{ContractAddress, SyscallResultTrait};
-use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcher;
+use starkware_utils_testing::test_utils::{cheat_caller_address_once, deploy_mock_erc20_token};
+use sub_account_anonymizer::sub_account_anonymizer::{
+    ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait, OpenNote,
+};
 
 /// The address configured as the privacy contract; the only authorized caller.
 pub const PRIVACY: ContractAddress = 'PRIVACY'.try_into().unwrap();
 
 pub fn anonymizer_disp(anonymizer: ContractAddress) -> ISubAccountAnonymizerDispatcher {
     ISubAccountAnonymizerDispatcher { contract_address: anonymizer }
+}
+
+/// A deployed anonymizer together with a funding-capable token and a mock dapp, for exercising the
+/// full invoke-and-collect flow.
+#[derive(Drop, Copy)]
+pub struct Components {
+    pub token: Token,
+    pub mock_dapp: ContractAddress,
+    pub anonymizer: ContractAddress,
+}
+
+#[generate_trait]
+pub impl ComponentsImpl of ComponentsTrait {
+    /// Calls `privacy_invoke_with_computation` cheating the caller to be the privacy contract.
+    fn invoke(
+        self: @Components, commitment: felt252, calls: Array<Call>, open_notes: Span<OpenNote>,
+    ) -> Span<OpenNoteDeposit> {
+        cheat_caller_address_once(contract_address: *self.anonymizer, caller_address: PRIVACY);
+        anonymizer_disp(*self.anonymizer)
+            .privacy_invoke_with_computation(:commitment, :calls, :open_notes)
+    }
+}
+
+pub fn deploy_components() -> Components {
+    let token = deploy_token();
+    let mock_dapp = deploy_mock_dapp();
+    let anonymizer = deploy_sub_account_anonymizer();
+    Components { token, mock_dapp, anonymizer }
+}
+
+/// Builds a `pay_out(token, amount)` call on the mock dapp, which transfers `amount` to its caller.
+pub fn pay_out_call(mock_dapp: ContractAddress, token: ContractAddress, amount: u128) -> Call {
+    Call {
+        to: mock_dapp,
+        selector: selector!("pay_out"),
+        calldata: array![token.into(), amount.into(), 0].span(),
+    }
 }
 
 pub fn deploy_sub_account_anonymizer() -> ContractAddress {
@@ -18,5 +60,23 @@ pub fn deploy_sub_account_anonymizer() -> ContractAddress {
     let (address, _) = contract
         .deploy(@array![PRIVACY.into(), sub_account_class_hash.into()])
         .unwrap_syscall();
+    address
+}
+
+pub fn deploy_token() -> Token {
+    // Snforge deploys each contract to a fresh address per deploy() call regardless of identical
+    // class/calldata.
+    deploy_mock_erc20_token(
+        name: "SubAccTestToken",
+        symbol: "SAT",
+        decimals: 18,
+        initial_supply: 1_000_000_000_000_000_000_000_000_u256,
+        owner: 'TOKEN_OWNER'.try_into().unwrap(),
+    )
+}
+
+fn deploy_mock_dapp() -> ContractAddress {
+    let contract = declare("MockDapp").unwrap_syscall().contract_class();
+    let (address, _) = contract.deploy(@array![]).unwrap_syscall();
     address
 }


### PR DESCRIPTION
Runs the supplied calls through the commitment's SubAccount (deployed lazily and owned by the anonymizer), then collects the SubAccount's balance to the requested open-note tokens and approves the privacy contract to pull it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/839)
<!-- Reviewable:end -->
