### PR TITLE
fix(e2e): drive in-repo screening pool in screening mode

### DIFF
--- a/e2e/scripts/batch-operations.ts
+++ b/e2e/scripts/batch-operations.ts
@@ -266,8 +266,8 @@ async function runDeposit() {
   }
   console.log("Approve tx:", approveTx.transaction_hash);
 
-  // Source-built pool: its class hash is never pinned, so force compatibility
-  // calldata until the in-repo contract accepts the screening suffix.
+  // Source-built pool: unpinned class hash, so set the mode explicitly. The pool
+  // screens deposits, so use the provider that signs each deposit's attestation.
   const transfers = createPrivateTransfers({
     account: aliceAccount,
     viewingKeyProvider: { getViewingKey: async () => BigInt(alice.viewingKey) },
@@ -277,7 +277,7 @@ async function runDeposit() {
     ),
     discoveryProvider: discovery,
     poolContractAddress: POOL_ADDRESS,
-    poolMode: "compatibility",
+    poolMode: "screening",
   });
 
   const depositInputs = Array.from({ length: chunkSize }, () => ({
@@ -406,7 +406,7 @@ async function runTransfer() {
     discoveryProvider: discovery,
     poolContractAddress: POOL_ADDRESS,
     // Unpinned source-built pool — see the deposit-flow comment above.
-    poolMode: "compatibility",
+    poolMode: "screening",
   });
 
   const transferOutputs = Array.from({ length: chunkSize }, () => ({

--- a/e2e/scripts/generate-dump.ts
+++ b/e2e/scripts/generate-dump.ts
@@ -19,7 +19,7 @@ import { createPrivateTransfers } from "@starkware-libs/starknet-privacy-sdk";
 import {
   Devnet,
   type DevnetEnvironment,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   ContractDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 
@@ -42,24 +42,24 @@ const devnet = new Devnet();
 const env = await devnet.initialize();
 const chainId = constants.StarknetChainId.SN_SEPOLIA;
 
-// Source-built pool: its class hash is never pinned, so force compatibility
-// calldata until the in-repo contract accepts the screening suffix.
+// Source-built pool: unpinned class hash, so set the mode explicitly. The pool
+// screens deposits, so use the provider that signs each deposit's attestation.
 const transfers = {
   alice: createPrivateTransfers({
     account: env.alice,
     viewingKeyProvider: { getViewingKey: async () => ALICE_VIEWING_KEY },
-    provingProvider: new CallMockProofProvider(env.provider, chainId),
+    provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
-    poolMode: "compatibility",
+    poolMode: "screening",
   }),
   bob: createPrivateTransfers({
     account: env.bob,
     viewingKeyProvider: { getViewingKey: async () => BOB_VIEWING_KEY },
-    provingProvider: new CallMockProofProvider(env.provider, chainId),
+    provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
-    poolMode: "compatibility",
+    poolMode: "screening",
   }),
 };
 

--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -5,7 +5,7 @@ import { repoRoot } from "./utils.js";
 import {
   Devnet,
   type DevnetEnvironment,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
@@ -125,30 +125,36 @@ export async function createE2eTestEnv(
   });
   await indexer.waitUntilReady(devnet.url);
 
-  // Source-built pool: its class hash is never pinned, so force compatibility
-  // calldata until the in-repo contract accepts the screening suffix.
+  // Source-built pool: unpinned class hash, so set the mode explicitly. The pool
+  // screens deposits, so use the provider that signs each deposit's attestation.
   const transfers = {
     alice: createPrivateTransfers({
       account: env.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(
+        env.provider,
+        chainId,
+      ),
       discoveryProvider: new IndexerDiscoveryProvider(
         indexer.apiUrl,
         env.privacy.address,
       ),
       poolContractAddress: env.privacy.address,
-      poolMode: "compatibility",
+      poolMode: "screening",
     }),
     bob: createPrivateTransfers({
       account: env.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(
+        env.provider,
+        chainId,
+      ),
       discoveryProvider: new IndexerDiscoveryProvider(
         indexer.apiUrl,
         env.privacy.address,
       ),
       poolContractAddress: env.privacy.address,
-      poolMode: "compatibility",
+      poolMode: "screening",
     }),
   };
 

--- a/e2e/tests/devnet/ohttp-relay.test.ts
+++ b/e2e/tests/devnet/ohttp-relay.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { constants } from "starknet";
 import {
   Devnet,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
@@ -83,14 +83,14 @@ describe("E2E OHTTP via relay", () => {
     const aliceOhttp = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     // Discover notes via relay — validates full client → relay → gateway pipeline
@@ -122,14 +122,14 @@ describe("E2E OHTTP via relay", () => {
     const bobOhttp = createPrivateTransfers({
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes: bobNotes } = await bobOhttp.discoverNotes();

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { constants } from "starknet";
 import {
   Devnet,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
@@ -79,14 +79,14 @@ describe("E2E OHTTP", () => {
     const aliceOhttp = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     // Discover notes via OHTTP — if this works, the full encrypt/decrypt pipeline is correct
@@ -115,14 +115,14 @@ describe("E2E OHTTP", () => {
     const bobOhttp = createPrivateTransfers({
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes: bobNotes } = await bobOhttp.discoverNotes();

--- a/e2e/tests/devnet/pagination-discovery.test.ts
+++ b/e2e/tests/devnet/pagination-discovery.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { constants } from "starknet";
 import {
   Devnet,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import { createPrivateTransfers } from "@starkware-libs/starknet-privacy-sdk";
@@ -70,14 +70,14 @@ describe("Discovery pagination with small budget", () => {
     const aliceTransfers = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     // total-only: exercises total_n_channels
@@ -106,14 +106,14 @@ describe("Discovery pagination with small budget", () => {
     const aliceTransfers = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes } = await aliceTransfers.discoverNotes();
@@ -125,14 +125,14 @@ describe("Discovery pagination with small budget", () => {
     const bobTransfers = createPrivateTransfers({
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes: bobNotes } = await bobTransfers.discoverNotes();

--- a/e2e/tests/devnet/payment-service-discovery.test.ts
+++ b/e2e/tests/devnet/payment-service-discovery.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import {
   Devnet,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
@@ -55,11 +55,14 @@ describe("Payment Service Discovery", () => {
       createPrivateTransfers({
         account,
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new CallMockProofProvider(de.provider, chainId),
+        provingProvider: new ScreeningCallMockProofProvider(
+          de.provider,
+          chainId,
+        ),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
-        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-        poolMode: "compatibility",
+        // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+        poolMode: "screening",
       }),
     );
 
@@ -229,11 +232,11 @@ describe("Payment Service Discovery", () => {
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => ALICE_KEY },
-      provingProvider: new CallMockProofProvider(de.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(de.provider, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes } = await aliceDiscover.discoverNotes();
@@ -260,11 +263,11 @@ describe("Payment Service Discovery", () => {
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => ALICE_KEY },
-      provingProvider: new CallMockProofProvider(de.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(de.provider, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const allAddresses = [de.alice.address, ...users.map((u) => u.address)];
@@ -290,11 +293,14 @@ describe("Payment Service Discovery", () => {
       const userDiscover = createPrivateTransfers({
         account: users[i],
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new CallMockProofProvider(de.provider, chainId),
+        provingProvider: new ScreeningCallMockProofProvider(
+          de.provider,
+          chainId,
+        ),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
-        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-        poolMode: "compatibility",
+        // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+        poolMode: "screening",
       });
 
       const { notes } = await userDiscover.discoverNotes();
@@ -319,11 +325,14 @@ describe("Payment Service Discovery", () => {
       const userDiscover = createPrivateTransfers({
         account: users[i],
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new CallMockProofProvider(de.provider, chainId),
+        provingProvider: new ScreeningCallMockProofProvider(
+          de.provider,
+          chainId,
+        ),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
-        // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-        poolMode: "compatibility",
+        // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+        poolMode: "screening",
       });
 
       const { channels } = await userDiscover.discoverChannels([

--- a/e2e/tests/devnet/smoke.test.ts
+++ b/e2e/tests/devnet/smoke.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { constants } from "starknet";
 import {
   Devnet,
-  CallMockProofProvider,
+  ScreeningCallMockProofProvider,
   IndexerDiscoveryProvider,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
@@ -68,14 +68,14 @@ describe("E2E Smoke", () => {
     const aliceIndexer = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     const { notes } = await aliceIndexer.discoverNotes();
@@ -101,14 +101,14 @@ describe("E2E Smoke", () => {
     const bobIndexer = createPrivateTransfers({
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new CallMockProofProvider(
+      provingProvider: new ScreeningCallMockProofProvider(
         de.provider,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     // Bob should discover 1 incoming note: 50 STRK from Alice

--- a/e2e/tests/integration/privacy-starknet-integration.test.ts
+++ b/e2e/tests/integration/privacy-starknet-integration.test.ts
@@ -165,8 +165,8 @@ describe("Privacy StarkNet integration", () => {
       ),
       discoveryProvider: discovery,
       poolContractAddress: poolAddress,
-      // Source-built devnet pool — unpinned class hash; force compatibility calldata.
-      poolMode: "compatibility",
+      // Source-built devnet pool screens deposits — drive it in screening mode with signed attestations.
+      poolMode: "screening",
     });
 
     // Mint tokens to Alice (admin is the minter)

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Testing: exported `ScreeningCallMockProofProvider` from the `/testing` entry
+  point. It extends `CallMockProofProvider` to sign each deposit's screening
+  attestation with the canonical test screener key, so integration suites can
+  drive a screening-capable pool's deposit path end to end.
+
 ### Breaking
 
 - Privacy pool role-management ABI changed (`PrivacyPoolABI` regenerated). The

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -28,6 +28,7 @@ export {
   compute_enc_sender_addr_hash,
 } from "../utils/hashes.js";
 export { CallMockProofProvider } from "./mock-proving.js";
+export { ScreeningCallMockProofProvider } from "./screening-mock-proving.js";
 export { ProvingServiceProofProvider } from "../internal/proving-service-provider.js";
 export { TracingRpcProvider, TracedRpcError, type DecodedError } from "./tracing-provider.js";
 export {


### PR DESCRIPTION
## Summary

Fixes the **E2E Devnet** failure where all 10 devnet test files revert with `Failed to deserialize param #2`.

### Root cause

The in-repo privacy pool's `apply_actions` now **unconditionally** takes a second parameter `screening: Option<ScreeningAttestation>` (introduced with the screening work), so the calldata must always encode that `Option`. But `e2e/src/harness.ts` and several devnet tests still drove the pool with `poolMode: "compatibility"` + the plain `CallMockProofProvider` — a stale workaround (its own comment: *"force compatibility calldata until the in-repo contract accepts the screening suffix"*). Compatibility mode omits param #2 entirely, so every deposit/`apply_actions` reverted with `Failed to deserialize param #2`.

This was latent on `main` (its last E2E Devnet run predates the screening contract change), so it surfaced on every PR branched after it — not on `main` itself.

### Fix

Bring the e2e side in line with the SDK's own `createDevnetTestEnv`, which already drives the same pool correctly:

- **Mock-proving devnet tests** (`harness.ts` + `smoke`, `ohttp`, `ohttp-relay`, `pagination-discovery`, `payment-service-discovery`): swap `CallMockProofProvider` → `ScreeningCallMockProofProvider` (signs each deposit's attestation with the canonical screener key the pool is deployed with) and `poolMode: "compatibility"` → `"screening"`.
- **Real-proving integration test + `batch-operations`/`generate-dump` scripts**: only the `poolMode` flip — the real `ProvingServiceProofProvider` supplies the attestation in `additional_data`.
- Export `ScreeningCallMockProofProvider` from the SDK `/testing` entry point so the harness can import it.

No production contract or SDK runtime code changes — only test/harness wiring and one test-helper export.

## Verification

- SDK: `npm run build` + `npm run lint` (prettier + eslint + tsc) — pass.
- e2e: `prettier --check` + `eslint` on all changed files — pass.
- E2E Devnet suite validated by CI on this PR (full devnet run); a local smoke run was also performed.

Note: this is the fix for the pre-existing E2E Devnet breakage discussed on #835 (removing `SCARB_IGNORE_CAIRO_VERSION`). #835 stays red on E2E Devnet until this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/840)
<!-- Reviewable:end -->
