### PR TITLE
feat(privacy): compute-and-invoke action with tests

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=f74a835454a692fbb1e4bc828ea896a3ee3d5c6a#f74a835454a692fbb1e4bc828ea896a3ee3d5c6a"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=72de622127788d66db2426b7af8c83fdffcc431b#72de622127788d66db2426b7af8c83fdffcc431b"
 dependencies = [
  "openzeppelin",
 ]
@@ -195,7 +195,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=f74a835454a692fbb1e4bc828ea896a3ee3d5c6a#f74a835454a692fbb1e4bc828ea896a3ee3d5c6a"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=72de622127788d66db2426b7af8c83fdffcc431b#72de622127788d66db2426b7af8c83fdffcc431b"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -203,6 +203,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sub_account_anonymizer"
+version = "0.1.0"
+dependencies = [
+ "openzeppelin",
+ "privacy",
+ "snforge_std",
+ "starkware_utils",
+ "starkware_utils_testing",
+]
+
+[[package]]
 name = "vesu_lending_anonymizer"
 version = "0.1.0"
 dependencies = [

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,6 +2,7 @@
 members = [
     "packages/ekubo_swap_anonymizer",
     "packages/privacy",
+    "packages/sub_account_anonymizer",
     "packages/vesu_lending_anonymizer",
 ]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -19,8 +19,8 @@ assert_macros = "2.17.0"
 # flags from CI workflows and sdk/package.json scripts
 openzeppelin = "3.0.0"
 ekubo = { git = "https://github.com/EkuboProtocol/starknet-contracts", rev = "8b4de8b5701d10b101c06b786740bf45b6cf15cb" }
-starkware_utils = { git ="https://github.com/starkware-libs/starkware-starknet-utils", rev="f74a835454a692fbb1e4bc828ea896a3ee3d5c6a" }
-starkware_utils_testing = { git="https://github.com/starkware-libs/starkware-starknet-utils", rev="f74a835454a692fbb1e4bc828ea896a3ee3d5c6a" }
+starkware_utils = { git ="https://github.com/starkware-libs/starkware-starknet-utils", rev="72de622127788d66db2426b7af8c83fdffcc431b" }
+starkware_utils_testing = { git="https://github.com/starkware-libs/starkware-starknet-utils", rev="72de622127788d66db2426b7af8c83fdffcc431b" }
 
 [workspace.tool.fmt]
 sort-module-level-items = true

--- a/packages/privacy/src/actions.cairo
+++ b/packages/privacy/src/actions.cairo
@@ -218,6 +218,25 @@ pub(crate) impl InvokeExternalInputValid of InputValidation<InvokeExternalInput>
     }
 }
 
+/// Input for the `ComputeAndInvoke` client action.
+#[derive(Serde, Copy, Drop, PartialEq, Debug)]
+pub struct ComputeAndInvokeInput {
+    /// The target contract address whose `privacy_compute` is queried and
+    /// `privacy_invoke_with_computation` is later invoked.
+    pub contract_address: ContractAddress,
+    /// Calldata forwarded after the derived `identity_key` when calling `privacy_compute`.
+    pub compute_data: Span<felt252>,
+    /// Calldata forwarded to the server-side `InvokeWithComputation` action.
+    pub invoke_data: Span<felt252>,
+}
+
+pub(crate) impl ComputeAndInvokeInputValid of InputValidation<ComputeAndInvokeInput> {
+    fn assert_valid(self: ComputeAndInvokeInput) {
+        let ComputeAndInvokeInput { contract_address, compute_data: _, invoke_data: _ } = self;
+        assert(contract_address.is_non_zero(), errors::ZERO_CONTRACT_ADDRESS);
+    }
+}
+
 /// An action to be executed by the client.
 #[derive(Serde, Copy, Drop, Debug, PartialEq)]
 pub enum ClientAction {
@@ -243,6 +262,9 @@ pub enum ClientAction {
     /// Invokes an external contract: forwards the contract address and calldata as a server-side
     /// Invoke action.
     InvokeExternal: InvokeExternalInput,
+    /// Runs `privacy_compute` on the client and forwards its result as a server-side
+    /// `InvokeWithComputation` action.
+    ComputeAndInvoke: ComputeAndInvokeInput,
 }
 
 #[generate_trait]
@@ -268,12 +290,14 @@ pub(crate) impl ClientActionImpl of ClientActionTrait {
             ClientAction::UseNote(_) => Self::USE_NOTES_PHASE,
             ClientAction::Withdraw(_) => Self::WITHDRAW_PHASE,
             ClientAction::InvokeExternal(_) => Self::INVOKE_PHASE,
+            ClientAction::ComputeAndInvoke(_) => Self::INVOKE_PHASE,
         }
     }
 
     /// Asserts action_phase >= curr_phase (ACTIONS_OUT_OF_ORDER) and update `curr_phase` to the
     /// phase to advance to.
-    /// InvokeExternal is only allowed once per Tx.
+    /// At most one of the invoke-phase actions (InvokeExternal, ComputeAndInvoke) is allowed per
+    /// Tx.
     fn assert_and_advance_phase(self: @ClientAction, ref curr_phase: u8) {
         let action_phase = self.phase();
         assert(action_phase >= curr_phase, errors::ACTIONS_OUT_OF_ORDER);
@@ -361,4 +385,8 @@ pub enum ServerAction {
     /// Invoke an external contract via the
     /// [`INVOKE_SELECTOR`](privacy::utils::constants::INVOKE_SELECTOR) selector.
     Invoke: InvokeInput,
+    /// Invoke an external contract via the
+    /// [`INVOKE_WITH_COMPUTATION_SELECTOR`](privacy::utils::constants::INVOKE_WITH_COMPUTATION_SELECTOR)
+    /// selector.
+    InvokeWithComputation: InvokeInput,
 }

--- a/packages/privacy/src/hashes.cairo
+++ b/packages/privacy/src/hashes.cairo
@@ -43,6 +43,17 @@ pub(crate) fn hash(data: Span<felt252>) -> felt252 {
     poseidon_hash_span(data)
 }
 
+/// Computes the identity key bound to a user and contract_address, forwarded to the contract's
+/// `privacy_compute` by a `ComputeAndInvoke` action.
+///
+/// Returns `h(user_addr, user_private_key, contract_address)`.
+// TODO: Consider adding a domain-separation tag.
+pub(crate) fn compute_identity_key(
+    user_addr: ContractAddress, user_private_key: felt252, contract_address: ContractAddress,
+) -> felt252 {
+    hash([user_addr.into(), user_private_key, contract_address.into()].span())
+}
+
 /// Computes the hash used to encrypt the private key in `EncPrivateKey`.
 ///
 /// Returns `h(ENC_PRIVATE_KEY_TAG, shared_x)`

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -829,26 +829,12 @@ pub mod Privacy {
                     },
                     ServerAction::TransferTo(input) => self._apply_transfer_to(:input),
                     ServerAction::Invoke(input) => {
-                        let open_note_deposits = self._apply_invoke(:input);
-                        if !open_note_deposits.is_empty() {
-                            // As we set the input.contract_address as the open_note depositor,
-                            // there can be only one open_note depositor address.
-                            let open_note_depositor = input.contract_address;
-                            assert(
-                                !self.blocked_open_note_depositors.read(open_note_depositor),
-                                errors::OPEN_NOTE_DEPOSITOR_BLOCKED,
+                        self
+                            ._apply_invoke_and_deposits(
+                                :input,
+                                selector: INVOKE_SELECTOR,
+                                ref :undeposited_open_notes,
                             );
-                            // Apply deposits to open notes returned by Invoke.
-                            for deposit in open_note_deposits {
-                                self
-                                    ._deposit_to_open_note(
-                                        depositor: open_note_depositor, deposit: *deposit,
-                                    );
-                            }
-                            undeposited_open_notes = undeposited_open_notes
-                                .checked_sub(open_note_deposits.len())
-                                .expect(internal_errors::TOO_MANY_OPEN_NOTES_DEPOSITED);
-                        }
                     },
                     ServerAction::EmitViewingKeySet(event) => self.emit(event),
                     ServerAction::EmitWithdrawal(event) => self.emit(event),
@@ -928,17 +914,46 @@ pub mod Privacy {
             checked_transfer(token_address: token, recipient: to_addr, amount: amount.into());
         }
 
-        fn _apply_invoke(ref self: ContractState, input: InvokeInput) -> Span<OpenNoteDeposit> {
+        fn _apply_invoke_and_deposits(
+            ref self: ContractState,
+            input: InvokeInput,
+            selector: felt252,
+            ref undeposited_open_notes: usize,
+        ) {
             let InvokeInput { contract_address, calldata } = input;
             let mut return_data = call_contract_syscall(
-                address: contract_address, entry_point_selector: INVOKE_SELECTOR, :calldata,
+                address: contract_address, entry_point_selector: selector, :calldata,
             )
                 .unwrap_syscall();
 
             let deposits: Span<OpenNoteDeposit> = Serde::deserialize(ref return_data)
                 .expect(errors::INVALID_INVOKE_RETURN_DATA);
             assert(return_data.is_empty(), errors::INVALID_INVOKE_RETURN_DATA);
-            deposits
+            self
+                ._apply_open_note_deposits(
+                    :deposits, depositor: contract_address, ref :undeposited_open_notes,
+                );
+        }
+
+        fn _apply_open_note_deposits(
+            ref self: ContractState,
+            deposits: Span<OpenNoteDeposit>,
+            depositor: ContractAddress,
+            ref undeposited_open_notes: usize,
+        ) {
+            if !deposits.is_empty() {
+                assert(
+                    !self.blocked_open_note_depositors.read(depositor),
+                    errors::OPEN_NOTE_DEPOSITOR_BLOCKED,
+                );
+                // Apply deposits to open notes returned by Invoke.
+                for deposit in deposits {
+                    self._deposit_to_open_note(:depositor, deposit: *deposit);
+                }
+                undeposited_open_notes = undeposited_open_notes
+                    .checked_sub(deposits.len())
+                    .expect(internal_errors::TOO_MANY_OPEN_NOTES_DEPOSITED);
+            }
         }
 
         /// Applies a single deposit to an open note. Used when applying the span returned by an

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -7,15 +7,16 @@ pub mod Privacy {
     use openzeppelin::introspection::src5::SRC5Component;
     use openzeppelin::security::ReentrancyGuardComponent;
     use privacy::actions::{
-        AppendInput, ClientAction, ClientActionTrait, CreateEncNoteInput, CreateOpenNoteInput,
-        DepositInput, InputValidation, InvokeExternalInput, InvokeInput, OpenChannelInput,
-        OpenSubchannelInput, ServerAction, SetViewingKeyInput, TransferFromInput, TransferToInput,
-        UseNoteInput, WithdrawInput, WriteOnceInput,
+        AppendInput, ClientAction, ClientActionTrait, ComputeAndInvokeInput, CreateEncNoteInput,
+        CreateOpenNoteInput, DepositInput, InputValidation, InvokeExternalInput, InvokeInput,
+        OpenChannelInput, OpenSubchannelInput, ServerAction, SetViewingKeyInput, TransferFromInput,
+        TransferToInput, UseNoteInput, WithdrawInput, WriteOnceInput,
     };
     use privacy::errors::internal_errors;
     use privacy::hashes::{
-        compute_channel_key, compute_channel_marker, compute_note_id, compute_nullifier,
-        compute_outgoing_channel_id, compute_subchannel_id, compute_subchannel_marker,
+        compute_channel_key, compute_channel_marker, compute_identity_key, compute_note_id,
+        compute_nullifier, compute_outgoing_channel_id, compute_subchannel_id,
+        compute_subchannel_marker,
     };
     use privacy::interface::{IAdmin, IClient, IServer, IViews};
     use privacy::objects::{
@@ -25,7 +26,8 @@ pub mod Privacy {
     use privacy::snip12::{ScreeningAttestation, is_screening_attestation_valid};
     use privacy::utils::constants::{
         CONTRACT_VERSION, DEPOSITOR_VALIDATION_MAX_AGE, DEPOSITOR_VALIDATION_MAX_FUTURE,
-        INVOKE_SELECTOR, OPEN_NOTE_SALT, STRK_TOKEN_ADDRESS, VIRTUAL_SNOS, VIRTUAL_SNOS0,
+        INVOKE_SELECTOR, INVOKE_WITH_COMPUTATION_SELECTOR, OPEN_NOTE_SALT, PRIVACY_COMPUTE_SELECTOR,
+        STRK_TOKEN_ADDRESS, VIRTUAL_SNOS, VIRTUAL_SNOS0,
     };
     use privacy::utils::{
         ProofFacts, assert_valid_os_call, assert_valid_signature, compute_message_hash,
@@ -33,8 +35,8 @@ pub mod Privacy {
         encrypt_outgoing_channel_info, encrypt_private_key, encrypt_subchannel_info,
         encrypt_user_addr, extract_compile_actions_inputs,
         extract_server_actions_from_compile_and_panic, is_canonical_key, open_note, pack,
-        panic_with_server_actions, send_message_to_server, storage_path_to_felt252,
-        to_write_once_action, unpack,
+        panic_with_server_actions, propagate_external_panic, send_message_to_server,
+        storage_path_to_felt252, to_write_once_action, unpack,
     };
     use privacy::{errors, events};
     use starknet::account::Call;
@@ -295,6 +297,8 @@ pub mod Privacy {
                     ClientAction::Withdraw(input) => self
                         .withdraw(:user_addr, :input, ref :token_balances),
                     ClientAction::InvokeExternal(input) => self.invoke_external(:input),
+                    ClientAction::ComputeAndInvoke(input) => self
+                        .compute_and_invoke(:user_addr, :user_private_key, :input),
                 };
                 self._client_apply_actions(actions: actions.span(), ref :has_replay_protection);
                 server_actions.extend(actions);
@@ -533,6 +537,43 @@ pub mod Privacy {
             array![ServerAction::Invoke(InvokeInput { contract_address, calldata })]
         }
 
+        /// Calls the given contract's `privacy_compute` with `[identity_key] ++ compute_data` and
+        /// forwards its result as a server-side `InvokeWithComputation` action.
+        /// A panic from `privacy_compute` is re-raised via `propagate_external_panic`.
+        fn compute_and_invoke(
+            self: @ContractState,
+            user_addr: ContractAddress,
+            user_private_key: felt252,
+            input: ComputeAndInvokeInput,
+        ) -> Array<ServerAction> {
+            input.assert_valid();
+            let ComputeAndInvokeInput { contract_address, compute_data, invoke_data } = input;
+            let identity_key = compute_identity_key(
+                :user_addr, :user_private_key, :contract_address,
+            );
+            let mut compute_calldata = array![identity_key];
+            compute_calldata.append_span(compute_data);
+            let computed_data =
+                match call_contract_syscall(
+                    address: contract_address,
+                    entry_point_selector: PRIVACY_COMPUTE_SELECTOR,
+                    calldata: compute_calldata.span(),
+                ) {
+                Ok(computed_data) => computed_data,
+                Err(panic_data) => propagate_external_panic(panic_data.span()),
+            };
+            // The target's `privacy_invoke_with_computation` receives the compute result followed
+            // by the caller-supplied invoke data as a single calldata span.
+            let mut calldata = array![];
+            calldata.append_span(computed_data);
+            calldata.append_span(invoke_data);
+            array![
+                ServerAction::InvokeWithComputation(
+                    InvokeInput { contract_address, calldata: calldata.span() },
+                ),
+            ]
+        }
+
         /// Returns the server actions to use a note.
         /// Assumes `owner_addr` is non-zero and `owner_private_key` is non-zero and canonical
         /// (checked in `main`).
@@ -719,6 +760,7 @@ pub mod Privacy {
                     ServerAction::TransferFrom(_) => {},
                     ServerAction::TransferTo(_) => {},
                     ServerAction::Invoke(_) => {},
+                    ServerAction::InvokeWithComputation(_) => {},
                     ServerAction::EmitViewingKeySet(_) => {},
                     ServerAction::EmitWithdrawal(_) => {},
                     ServerAction::EmitDeposit(_) => {},
@@ -831,8 +873,14 @@ pub mod Privacy {
                     ServerAction::Invoke(input) => {
                         self
                             ._apply_invoke_and_deposits(
+                                :input, selector: INVOKE_SELECTOR, ref :undeposited_open_notes,
+                            );
+                    },
+                    ServerAction::InvokeWithComputation(input) => {
+                        self
+                            ._apply_invoke_and_deposits(
                                 :input,
-                                selector: INVOKE_SELECTOR,
+                                selector: INVOKE_WITH_COMPUTATION_SELECTOR,
                                 ref :undeposited_open_notes,
                             );
                     },

--- a/packages/privacy/src/tests/mock_invoke_returns.cairo
+++ b/packages/privacy/src/tests/mock_invoke_returns.cairo
@@ -6,6 +6,12 @@ use privacy::objects::OpenNoteDeposit;
 pub trait IMockEcho<T> {
     /// Returns the given deposits as-is (calldata is deserialized as Span<OpenNoteDeposit>).
     fn privacy_invoke(ref self: T, deposits: Span<OpenNoteDeposit>) -> Span<OpenNoteDeposit>;
+    /// Same echo behavior as `privacy_invoke`, reached via the `InvokeWithComputation` server
+    /// action's selector. The forwarded `computed_data ++ invoke_data` is deserialized as the
+    /// deposits to echo.
+    fn privacy_invoke_with_computation(
+        ref self: T, deposits: Span<OpenNoteDeposit>,
+    ) -> Span<OpenNoteDeposit>;
 }
 
 #[starknet::contract]
@@ -26,12 +32,102 @@ pub mod MockEcho {
         ) -> Span<OpenNoteDeposit> {
             deposits
         }
+
+        fn privacy_invoke_with_computation(
+            ref self: ContractState, deposits: Span<OpenNoteDeposit>,
+        ) -> Span<OpenNoteDeposit> {
+            deposits
+        }
     }
 }
 
+/// Mock target for the `ComputeAndInvoke` client / `InvokeWithComputation` server path.
+#[starknet::interface]
+pub trait IMockCompute<T> {
+    fn privacy_compute(self: @T, identity_key: felt252, payload: felt252) -> felt252;
+    fn privacy_invoke_with_computation(
+        ref self: T, commitment: felt252, deposits: Span<OpenNoteDeposit>,
+    ) -> Span<OpenNoteDeposit>;
+}
+
+#[starknet::contract]
+pub mod MockCompute {
+    use privacy::hashes::hash;
+    use privacy::objects::OpenNoteDeposit;
+    use starknet::storage::{
+        Map, StorageMapWriteAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use super::IMockCompute;
+
+    pub const COMPUTE_PANIC: felt252 = 'MOCK_COMPUTE_PANIC';
+    pub const INVOKE_PANIC: felt252 = 'MOCK_INVOKE_PANIC';
+
+    #[storage]
+    struct Storage {
+        panic_on_compute: bool,
+        panic_on_invoke: bool,
+        commitments: Map<felt252, bool>,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, panic_on_compute: bool, panic_on_invoke: bool) {
+        self.panic_on_compute.write(panic_on_compute);
+        self.panic_on_invoke.write(panic_on_invoke);
+    }
+
+    #[abi(embed_v0)]
+    pub impl MockComputeImpl of IMockCompute<ContractState> {
+        fn privacy_compute(
+            self: @ContractState, identity_key: felt252, payload: felt252,
+        ) -> felt252 {
+            assert(!self.panic_on_compute.read(), COMPUTE_PANIC);
+            hash([identity_key, payload].span())
+        }
+
+        fn privacy_invoke_with_computation(
+            ref self: ContractState, commitment: felt252, deposits: Span<OpenNoteDeposit>,
+        ) -> Span<OpenNoteDeposit> {
+            assert(!self.panic_on_invoke.read(), INVOKE_PANIC);
+            self.commitments.write(commitment, true);
+            deposits
+        }
+    }
+}
+
+/// Mock whose `privacy_compute` takes no `compute_data` (only the `identity_key`) and returns a
+/// two-felt `computed_data`. Used to exercise `compute_and_invoke`'s assembly with empty
+/// `compute_data` and a multi-felt `computed_data`.
+#[starknet::interface]
+pub trait IMockComputeMultiFelt<T> {
+    fn privacy_compute(self: @T, identity_key: felt252) -> (felt252, felt252);
+}
+
+#[starknet::contract]
+pub mod MockComputeMultiFelt {
+    use super::IMockComputeMultiFelt;
+
+    pub const COMPUTED_MARKER: felt252 = 'COMPUTED_MARKER';
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {}
+
+    #[abi(embed_v0)]
+    pub impl MockComputeMultiFeltImpl of IMockComputeMultiFelt<ContractState> {
+        fn privacy_compute(self: @ContractState, identity_key: felt252) -> (felt252, felt252) {
+            (identity_key, COMPUTED_MARKER)
+        }
+    }
+}
+
+/// Returns garbage (a bare felt that cannot deserialize as `Span<OpenNoteDeposit>`) from both the
+/// `Invoke` and `InvokeWithComputation` entry points.
 #[starknet::interface]
 pub trait IMockReturnGarbage<T> {
     fn privacy_invoke(ref self: T) -> felt252;
+    fn privacy_invoke_with_computation(ref self: T) -> felt252;
 }
 
 #[starknet::contract]
@@ -49,12 +145,19 @@ pub mod MockReturnGarbage {
         fn privacy_invoke(ref self: ContractState) -> felt252 {
             1
         }
+
+        fn privacy_invoke_with_computation(ref self: ContractState) -> felt252 {
+            1
+        }
     }
 }
 
+/// Returns valid deposits followed by trailing garbage (extra felt) from both the `Invoke` and
+/// `InvokeWithComputation` entry points.
 #[starknet::interface]
 pub trait IMockReturnTrailingGarbage<T> {
     fn privacy_invoke(ref self: T) -> (Span<OpenNoteDeposit>, felt252);
+    fn privacy_invoke_with_computation(ref self: T) -> (Span<OpenNoteDeposit>, felt252);
 }
 
 #[starknet::contract]
@@ -71,6 +174,12 @@ pub mod MockReturnTrailingGarbage {
     #[abi(embed_v0)]
     pub impl MockReturnTrailingGarbageImpl of IMockReturnTrailingGarbage<ContractState> {
         fn privacy_invoke(ref self: ContractState) -> (Span<OpenNoteDeposit>, felt252) {
+            ([].span(), 1)
+        }
+
+        fn privacy_invoke_with_computation(
+            ref self: ContractState,
+        ) -> (Span<OpenNoteDeposit>, felt252) {
             ([].span(), 1)
         }
     }

--- a/packages/privacy/src/tests/mock_reentrancy.cairo
+++ b/packages/privacy/src/tests/mock_reentrancy.cairo
@@ -9,6 +9,13 @@ pub trait IReentrancyMock<T> {
     /// Called by the privacy contract via INVOKE_SELECTOR. Attempts to call
     /// `apply_actions` on the caller (privacy contract) with empty actions.
     fn privacy_invoke(ref self: T);
+    /// Called by the privacy contract via INVOKE_WITH_COMPUTATION_SELECTOR. Attempts to call
+    /// `apply_actions` on the caller (privacy contract) with empty actions.
+    fn privacy_invoke_with_computation(ref self: T);
+    /// Called by the privacy contract via PRIVACY_COMPUTE_SELECTOR during `__execute__` (client
+    /// side). Attempts to reenter `apply_actions` on the caller (privacy contract) with empty
+    /// actions.
+    fn privacy_compute(ref self: T, identity_key: felt252) -> felt252;
 }
 
 #[starknet::contract]
@@ -26,8 +33,21 @@ pub mod MockReentrancy {
     #[abi(embed_v0)]
     impl ReentrancyMockImpl of IReentrancyMock<ContractState> {
         fn privacy_invoke(ref self: ContractState) {
-            let privacy_addr = get_caller_address();
-            IServerDispatcher { contract_address: privacy_addr }.apply_actions([].span(), None);
+            call_apply_actions();
         }
+
+        fn privacy_invoke_with_computation(ref self: ContractState) {
+            call_apply_actions();
+        }
+
+        fn privacy_compute(ref self: ContractState, identity_key: felt252) -> felt252 {
+            call_apply_actions();
+            identity_key
+        }
+    }
+
+    fn call_apply_actions() {
+        let privacy_addr = get_caller_address();
+        IServerDispatcher { contract_address: privacy_addr }.apply_actions([].span(), None);
     }
 }

--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -1,19 +1,30 @@
 use core::num::traits::Zero;
 use core::poseidon::poseidon_hash_span;
+use openzeppelin::security::ReentrancyGuardComponent::Errors as ReentrancyGuardErrors;
 use privacy::actions::{
-    AppendInput, ClientAction, CreateEncNoteInput, CreateOpenNoteInput, DepositInput,
-    InvokeExternalInput, OpenChannelInput, OpenSubchannelInput, ServerAction, SetViewingKeyInput,
-    TransferFromInput, TransferToInput, UseNoteInput, WithdrawInput,
+    AppendInput, ClientAction, ComputeAndInvokeInput, CreateEncNoteInput, CreateOpenNoteInput,
+    DepositInput, InvokeExternalInput, InvokeInput, OpenChannelInput, OpenSubchannelInput,
+    ServerAction, SetViewingKeyInput, TransferFromInput, TransferToInput, UseNoteInput,
+    WithdrawInput,
 };
-use privacy::hashes::{compute_note_id, compute_nullifier, compute_subchannel_id};
+use privacy::hashes::{
+    compute_identity_key, compute_note_id, compute_nullifier, compute_subchannel_id,
+};
 use privacy::objects::{EncSubchannelInfo, EncUserAddr, OpenNoteDeposit};
 use privacy::test_contracts::mock_swap_executor::errors as mock_swap_executor_errors;
+use privacy::tests::mock_invoke_returns::MockCompute::COMPUTE_PANIC;
+use privacy::tests::mock_invoke_returns::MockComputeMultiFelt::COMPUTED_MARKER;
+use privacy::tests::mock_invoke_returns::{IMockComputeDispatcher, IMockComputeDispatcherTrait};
 use privacy::tests::utils_for_tests::{
     AuditorTrait, CreateEncNoteInputIntoServerActionTrait, CreateOpenNoteInputIntoServerActionTrait,
     InvokeExternalInputIntoServerActionTrait, NoteZero, PrivacyCfgTrait, Test, TestTrait, UserTrait,
     constants, decrypt_channel_info, decrypt_outgoing_channel_info, decrypt_subchannel_token,
+    deploy_mock_compute, deploy_mock_compute_multi_felt, deploy_mock_reentrancy,
+    deploy_mock_return_garbage,
 };
-use privacy::utils::constants::{ESTIMATION_BASE_TX_VERSION, OPEN_NOTE_SALT, TWO_POW_120, TX_V3};
+use privacy::utils::constants::{
+    ERR_WRAPPER, ESTIMATION_BASE_TX_VERSION, OPEN_NOTE_SALT, TWO_POW_120, TX_V3,
+};
 use privacy::utils::{
     compute_message_hash, decode_note_amount, encrypt_channel_info, encrypt_user_addr,
     is_canonical_key, to_write_once_action, unpack,
@@ -4263,6 +4274,25 @@ fn test_internal_actions() {
     // Expected: Invoke.
     let expected_actions = invoke_external_input.into_server_actions();
     assert_eq!(actions, expected_actions);
+
+    // Compute and invoke action.
+    let mock_compute = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock_compute, compute_data: ['X'].span(), invoke_data: ['Y'].span(),
+    };
+    let actions = user_1.internal_compute_and_invoke(input: compute_and_invoke_input);
+    let user_identity_key = user_1.compute_identity_key(contract_address: mock_compute);
+    let expected_computed_data = IMockComputeDispatcher { contract_address: mock_compute }
+        .privacy_compute(identity_key: user_identity_key, payload: 'X');
+    let expected_actions = [
+        ServerAction::InvokeWithComputation(
+            InvokeInput {
+                contract_address: mock_compute, calldata: [expected_computed_data, 'Y'].span(),
+            },
+        ),
+    ]
+        .span();
+    assert_eq!(actions, expected_actions);
 }
 
 #[test]
@@ -4970,6 +5000,23 @@ fn test_actions_out_of_order() {
     let result = user.safe_compile_and_panic(:client_actions);
     assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
 
+    // Catch ACTIONS_OUT_OF_ORDER (compute and invoke -> set viewing key).
+    let mock_compute = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock_compute, compute_data: ['X'].span(), invoke_data: ['Y'].span(),
+    };
+    let client_actions = [
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+    ]
+        .span();
+    let result = user.safe_execute(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+    let result = user.safe_compile_actions(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+    let result = user.safe_compile_and_panic(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+
     // Catch ACTIONS_OUT_OF_ORDER (invoke -> open channel).
     let client_actions = [
         ClientAction::Deposit(DepositInput { token: token_addr, amount }),
@@ -5079,17 +5126,7 @@ fn test_actions_out_of_order() {
     assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
     let result = user.safe_compile_and_panic(:client_actions);
     assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
-
-    // Catch ACTIONS_OUT_OF_ORDER (invoke -> second invoke).
-    let client_actions = [
-        ClientAction::InvokeExternal(invoke_external_input),
-        ClientAction::InvokeExternal(invoke_external_input),
-    ]
-        .span();
-    let result = user.safe_execute(:client_actions);
-    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
-    let result = user.safe_compile_actions(:client_actions);
-    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+    // Two invoke-phase actions in one tx are covered by `test_multiple_invoke_reverts`.
 }
 
 #[test]
@@ -5531,6 +5568,50 @@ fn test_no_replay_protection() {
     let result = user
         .safe_compile_actions(
             client_actions: [deposit_action, withdraw_action, invoke_action].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+
+    // InvokeAndCompute only.
+    let mock_compute = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock_compute, compute_data: ['X'].span(), invoke_data: ['Y'].span(),
+    };
+    let compute_and_invoke_action = ClientAction::ComputeAndInvoke(compute_and_invoke_input);
+    let result = user
+        .safe_execute(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_and_panic(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_actions(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+
+    // Deposit, InvokeAndCompute.
+    let result = user
+        .safe_execute(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_and_panic(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_actions(client_actions: [deposit_action, compute_and_invoke_action].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+
+    // Deposit, Withdraw, ComputeAndInvoke.
+    let result = user
+        .safe_execute(
+            client_actions: [deposit_action, withdraw_action, compute_and_invoke_action].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_and_panic(
+            client_actions: [deposit_action, withdraw_action, compute_and_invoke_action].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user
+        .safe_compile_actions(
+            client_actions: [deposit_action, withdraw_action, compute_and_invoke_action].span(),
         );
     assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
 }
@@ -6140,24 +6221,40 @@ fn test_swap_without_withdraw_fails() {
 }
 
 #[test]
-fn test_multiple_invoke_external_reverts() {
+fn test_multiple_invoke_reverts() {
+    // At most one invoke-phase action (InvokeExternal / ComputeAndInvoke) is allowed per tx, so
+    // any pair of invoke-phase actions reverts with ACTIONS_OUT_OF_ORDER — regardless of order or
+    // which variant each is.
     let mut test: Test = Default::default();
     let mut user = test.new_user();
 
-    let dummy_invoke = InvokeExternalInput {
-        contract_address: test.privacy.swap_executor.address, calldata: [].span(),
-    };
-    let client_actions = [
-        ClientAction::InvokeExternal(dummy_invoke), ClientAction::InvokeExternal(dummy_invoke),
+    let mock = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let invoke = ClientAction::InvokeExternal(
+        InvokeExternalInput {
+            contract_address: test.privacy.swap_executor.address, calldata: [].span(),
+        },
+    );
+    let compute_invoke = ClientAction::ComputeAndInvoke(
+        ComputeAndInvokeInput {
+            contract_address: mock, compute_data: ['X'].span(), invoke_data: [].span(),
+        },
+    );
+
+    // invoke-invoke, compute_invoke-invoke, invoke-compute_invoke, compute_invoke-compute_invoke.
+    let cases = [
+        [invoke, invoke].span(), [compute_invoke, invoke].span(), [invoke, compute_invoke].span(),
+        [compute_invoke, compute_invoke].span(),
     ]
         .span();
-
-    let result = user.safe_execute(:client_actions);
-    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
-    let result = user.safe_compile_and_panic(:client_actions);
-    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
-    let result = user.safe_compile_actions(:client_actions);
-    assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+    for client_actions in cases {
+        let client_actions = *client_actions;
+        let result = user.safe_execute(:client_actions);
+        assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+        let result = user.safe_compile_and_panic(:client_actions);
+        assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+        let result = user.safe_compile_actions(:client_actions);
+        assert_panic_with_felt_error(:result, expected_error: errors::ACTIONS_OUT_OF_ORDER);
+    }
 }
 
 #[test]
@@ -6191,6 +6288,297 @@ fn test_invoke_external_client_action_assertions() {
     assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
     let result = user.safe_compile_actions(:client_actions);
     assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+}
+
+#[test]
+fn test_compute_and_invoke_client_action_assertions() {
+    // ComputeAndInvoke validation: zero target address is rejected before any external call.
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+
+    let input = ComputeAndInvokeInput {
+        contract_address: Zero::zero(), compute_data: ['X'].span(), invoke_data: [].span(),
+    };
+    let client_actions = [ClientAction::ComputeAndInvoke(input)].span();
+    let result = user.safe_execute(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_CONTRACT_ADDRESS);
+    let result = user.safe_compile_and_panic(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_CONTRACT_ADDRESS);
+    let result = user.safe_compile_actions(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_CONTRACT_ADDRESS);
+
+    // ComputeAndInvoke alone (no privacy actions) - has should_execute=false, so without a
+    // privacy action like UseNote, the transaction fails.
+    let mock_compute = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let valid_input = ComputeAndInvokeInput {
+        contract_address: mock_compute, compute_data: ['X'].span(), invoke_data: [].span(),
+    };
+    let client_actions = [ClientAction::ComputeAndInvoke(valid_input)].span();
+    let result = user.safe_execute(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user.safe_compile_and_panic(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+    let result = user.safe_compile_actions(:client_actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::NO_REPLAY_PROTECTION);
+}
+
+#[test]
+fn test_compute_and_invoke_builds_invoke_with_computation() {
+    // The core of compute_and_invoke: it calls `privacy_compute` with `[identity_key] ++
+    // compute_data`, then forwards `computed_data ++ invoke_data` (target preserved) as the
+    // `InvokeWithComputation` server action. The mock echoes `identity_key` as the computed_data.
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let mock = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+    let invoke_data = ['INVOKE_A', 'INVOKE_B'].span();
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock, compute_data: ['PAYLOAD'].span(), invoke_data,
+    };
+    // Pair with a replay-protecting action so execute() succeeds.
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    let actions = user.execute(:client_actions);
+
+    let identity_key = user.compute_identity_key(contract_address: mock);
+    let computed_data = IMockComputeDispatcher { contract_address: mock }
+        .privacy_compute(:identity_key, payload: 'PAYLOAD');
+    let mut expected_calldata = array![computed_data];
+    expected_calldata.append_span(invoke_data);
+    let expected = ServerAction::InvokeWithComputation(
+        InvokeInput { contract_address: mock, calldata: expected_calldata.span() },
+    );
+    // compute_and_invoke emits the single InvokeWithComputation action last.
+    assert_eq!(*actions[actions.len() - 1], expected);
+}
+
+#[test]
+fn test_compute_and_invoke_propagates_compute_panic() {
+    // `privacy_compute` runs during execute(); its panic is re-raised, bracketed by ERR_WRAPPER.
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let mock = deploy_mock_compute(panic_on_compute: true, panic_on_invoke: false);
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock, compute_data: ['X'].span(), invoke_data: [].span(),
+    };
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    match user.safe_execute(:client_actions) {
+        Result::Ok(_) => panic!("expected privacy_compute panic to propagate"),
+        Result::Err(panic_data) => {
+            // propagate_external_panic brackets the forwarded callee panic with ERR_WRAPPER.
+            assert_eq!(
+                panic_data,
+                array![
+                    ERR_WRAPPER, COMPUTE_PANIC, 'ENTRYPOINT_FAILED', ERR_WRAPPER,
+                    'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED',
+                ],
+            );
+        },
+    }
+}
+
+#[test]
+fn test_compute_and_invoke_missing_selector() {
+    // The target lacks `privacy_compute`, so the client-side compute call during execute() fails
+    // with ENTRYPOINT_NOT_FOUND, re-raised (bracketed by ERR_WRAPPER) via propagate_external_panic.
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let target = deploy_mock_return_garbage();
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: target, compute_data: ['X'].span(), invoke_data: [].span(),
+    };
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    match user.safe_execute(:client_actions) {
+        Result::Ok(_) => panic!("expected missing privacy_compute selector to panic"),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data[0], ERR_WRAPPER);
+            assert_eq!(*panic_data[1], 'ENTRYPOINT_NOT_FOUND');
+        },
+    }
+}
+
+#[test]
+fn test_compute_and_invoke_reentrancy_locked() {
+    // privacy_compute runs during __execute__, which holds the reentrancy lock. A target whose
+    // privacy_compute reenters the privacy contract is rejected with REENTRANT_CALL, re-raised
+    // through compute_and_invoke's propagate_external_panic (hence bracketed by ERR_WRAPPER).
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let reentrancy_mock = deploy_mock_reentrancy();
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: reentrancy_mock, compute_data: [].span(), invoke_data: [].span(),
+    };
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    match user.safe_execute(:client_actions) {
+        Result::Ok(_) => panic!("expected reentrant privacy_compute to be rejected"),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data[0], ERR_WRAPPER);
+            assert_eq!(*panic_data[1], ReentrancyGuardErrors::REENTRANT_CALL);
+        },
+    }
+}
+
+#[test]
+fn test_compute_and_invoke_defers_invoke() {
+    // Unlike the compute call, the invoke is deferred to apply_actions: a target whose
+    // `privacy_invoke_with_computation` would panic still lets execute() succeed.
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let mock = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: true);
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock, compute_data: ['X'].span(), invoke_data: [].span(),
+    };
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    // Succeeds: the panicking invoke was never called during execute().
+    user.execute(:client_actions);
+}
+
+#[test]
+fn test_compute_and_invoke_assembles_empty_compute_and_multi_felt_result() {
+    // Edge cases for the calldata assembly: empty `compute_data` (privacy_compute gets just
+    // `[identity_key]`) and a multi-felt `computed_data` (prepended ahead of `invoke_data`).
+    let mut test: Test = Default::default();
+    let mut user = test.new_user();
+    let random = user.get_random();
+
+    let mock = deploy_mock_compute_multi_felt();
+    let invoke_data = ['INVOKE'].span();
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock, compute_data: [].span(), invoke_data,
+    };
+    let client_actions = [
+        ClientAction::SetViewingKey(SetViewingKeyInput { random }),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    let actions = user.execute(:client_actions);
+
+    // The mock returns `[identity_key, COMPUTED_MARKER]` as computed_data.
+    let identity_key = compute_identity_key(
+        user_addr: user.address, user_private_key: user.private_key, contract_address: mock,
+    );
+    let expected = ServerAction::InvokeWithComputation(
+        InvokeInput {
+            contract_address: mock, calldata: [identity_key, COMPUTED_MARKER, 'INVOKE'].span(),
+        },
+    );
+    assert_eq!(*actions[actions.len() - 1], expected);
+}
+
+#[test]
+fn test_compute_and_invoke_e2e_with_mock_deposits_to_open_note() {
+    // Full client -> server flow against a mock: execute() runs privacy_compute and builds the
+    // InvokeWithComputation action; apply_actions() calls privacy_invoke_with_computation, whose
+    // echoed deposit lands in the open note created in the same tx.
+    let mut test: Test = Default::default();
+    let token = test.new_token();
+    let token_addr = token.contract_address();
+    let amount = constants::DEFAULT_AMOUNT;
+    let mut user = test.new_user();
+
+    let mock = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: false);
+
+    user.set_viewing_key_e2e();
+    user.open_channel_with_token_e2e(recipient: user, :token_addr, outgoing_channel_index: 0);
+
+    let create_note_input = user
+        .new_open_note_with_generated_random(recipient: user, :token_addr, index: 0);
+    let (note_id, _) = user.compute_open_note(:create_note_input);
+
+    // The invoke target is the depositor: fund it so the deposit can be pulled into the open note.
+    token.supply(address: mock, :amount);
+    token.approve(owner: mock, spender: test.privacy.address, amount: amount.into());
+
+    // invoke_data carries the deposits the mock echoes back (after the leading computed_data felt
+    // it consumes).
+    let deposits: Span<OpenNoteDeposit> = [OpenNoteDeposit { note_id, token: token_addr, amount }]
+        .span();
+    let mut invoke_data: Array<felt252> = array![];
+    deposits.serialize(ref invoke_data);
+
+    let compute_and_invoke_input = ComputeAndInvokeInput {
+        contract_address: mock, compute_data: ['X'].span(), invoke_data: invoke_data.span(),
+    };
+    let client_actions = [
+        ClientAction::CreateOpenNote(create_note_input),
+        ClientAction::ComputeAndInvoke(compute_and_invoke_input),
+    ]
+        .span();
+
+    let server_actions = user.execute(:client_actions);
+    let mut spy = spy_events();
+    test.privacy.apply_actions(actions: server_actions);
+
+    let stored_note = test.privacy.get_note(:note_id);
+    let (salt, stored_amount) = unpack(packed_value: stored_note.packed_value);
+    assert_eq!(salt, OPEN_NOTE_SALT);
+    assert_eq!(stored_amount, amount);
+    assert_eq!(stored_note.token, token_addr);
+    assert_eq!(token.balance_of(address: mock), Zero::zero());
+    assert_eq!(token.balance_of(address: test.privacy.address), amount.into());
+
+    // apply_actions emits OpenNoteCreated (from CreateOpenNote) then OpenNoteDeposited (from the
+    // InvokeWithComputation deposit, with the invoke target as depositor).
+    let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
+    assert_eq!(emitted_events.len(), 2);
+    let expected_create_event = events::OpenNoteCreated {
+        enc_recipient_addr: encrypt_user_addr(
+            ephemeral_secret: create_note_input.random,
+            auditor_public_key: test.privacy.get_auditor_public_key(),
+            user_addr: user.address,
+        ),
+        token: token_addr,
+        note_id,
+    };
+    assert_expected_event_emitted(
+        spied_event: emitted_events[0],
+        expected_event: expected_create_event,
+        expected_event_selector: @selector!("OpenNoteCreated"),
+        expected_event_name: "OpenNoteCreated",
+    );
+    let expected_deposit_event = events::OpenNoteDeposited {
+        depositor: mock, token: token_addr, note_id, amount,
+    };
+    assert_expected_event_emitted(
+        spied_event: emitted_events[1],
+        expected_event: expected_deposit_event,
+        expected_event_selector: @selector!("OpenNoteDeposited"),
+        expected_event_name: "OpenNoteDeposited",
+    );
 }
 
 #[test]

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -7,12 +7,13 @@ use privacy::actions::{
 use privacy::errors::internal_errors;
 use privacy::objects::{EncOutgoingChannelInfo, Note, OpenNoteDeposit};
 use privacy::test_contracts::mock_swap_executor::errors as mock_swap_executor_errors;
+use privacy::tests::mock_invoke_returns::MockCompute::INVOKE_PANIC;
 use privacy::tests::utils_for_tests::{
     CreateOpenNoteInputIntoServerActionTrait, InvokeExternalInputIntoServerActionTrait, NoteZero,
-    PrivacyCfgTrait, Test, TestTrait, UserTrait, VesuTrait, constants, deploy_mock_reentrancy,
-    deploy_mock_return_garbage, deploy_mock_return_trailing_garbage, deploy_mock_swap_executor,
-    deploy_mock_vesu_vault_noop, invoke_mock_swap_executor_input, sign_screening_attestation,
-    sign_screening_attestation_with,
+    PrivacyCfgTrait, Test, TestTrait, UserTrait, VesuTrait, constants, deploy_mock_compute,
+    deploy_mock_reentrancy, deploy_mock_return_garbage, deploy_mock_return_trailing_garbage,
+    deploy_mock_swap_executor, deploy_mock_vesu_vault_noop, invoke_mock_swap_executor_input,
+    sign_screening_attestation, sign_screening_attestation_with,
 };
 use privacy::utils::constants::{
     DEPOSITOR_VALIDATION_MAX_AGE, DEPOSITOR_VALIDATION_MAX_FUTURE, OPEN_NOTE_SALT,
@@ -562,6 +563,114 @@ fn test_apply_emit_deposit() {
 }
 
 #[test]
+fn test_apply_invoke_with_computation_deposit() {
+    let mut test: Test = Default::default();
+    let token = test.new_token();
+    let token_addr = token.contract_address();
+    let echo_executor_addr = test.privacy.echo_executor;
+    let enc_recipient_addr = test.mock_new_enc_address();
+    let amount = constants::DEFAULT_AMOUNT;
+    let (note_id, _) = test.mock_new_note(:amount);
+
+    // Plant an empty open note in storage so the deposit can find it.
+    let empty_note = open_note(token: token_addr);
+    test.privacy.cheat_create_note(:note_id, note: empty_note);
+
+    // Fund depositor (the InvokeWithComputation target).
+    token.supply(address: echo_executor_addr, :amount);
+    token.approve(owner: echo_executor_addr, spender: test.privacy.address, amount: amount.into());
+
+    let expected_create_event = events::OpenNoteCreated {
+        enc_recipient_addr, token: token_addr, note_id,
+    };
+    let expected_deposit_event = events::OpenNoteDeposited {
+        depositor: echo_executor_addr, token: token_addr, note_id, amount,
+    };
+    let deposit = OpenNoteDeposit { note_id, token: token_addr, amount };
+    let actions: Array<ServerAction> = array![
+        ServerAction::EmitOpenNoteCreated(expected_create_event),
+        test.privacy.invoke_with_computation_echo_deposits([deposit].span()),
+    ];
+    let mut spy = spy_events();
+    test.privacy.apply_actions(actions.span());
+
+    // Verify the deposit landed in the open note.
+    let deposited_note = test.privacy.get_note(:note_id);
+    let (salt, stored_amount) = unpack(packed_value: deposited_note.packed_value);
+    assert_eq!(salt, OPEN_NOTE_SALT);
+    assert_eq!(stored_amount, amount);
+    assert_eq!(deposited_note.token, token_addr);
+
+    let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
+    assert_eq!(events.len(), 2);
+    assert_expected_event_emitted(
+        spied_event: events[0],
+        expected_event: expected_create_event,
+        expected_event_selector: @selector!("OpenNoteCreated"),
+        expected_event_name: "OpenNoteCreated",
+    );
+    assert_expected_event_emitted(
+        spied_event: events[1],
+        expected_event: expected_deposit_event,
+        expected_event_selector: @selector!("OpenNoteDeposited"),
+        expected_event_name: "OpenNoteDeposited",
+    );
+}
+
+#[test]
+fn test_apply_invoke_with_computation_missing_selector() {
+    let mut test: Test = Default::default();
+
+    // The swap executor implements `privacy_invoke` but not `privacy_invoke_with_computation`. The
+    // arm must route to the with-computation selector, so the call fails with ENTRYPOINT_NOT_FOUND
+    // rather than reaching `privacy_invoke`.
+    let target = test.privacy.swap_executor.address;
+    let action = ServerAction::InvokeWithComputation(
+        InvokeInput { contract_address: target, calldata: [].span() },
+    );
+    let result = test.privacy.safe_apply_actions([action].span());
+    assert_panic_with_felt_error(:result, expected_error: 'ENTRYPOINT_NOT_FOUND');
+}
+
+#[test]
+fn test_apply_invoke_with_computation_blocked_depositor() {
+    let mut test: Test = Default::default();
+    let token = test.new_token();
+    let token_addr = token.contract_address();
+    let echo_executor_addr = test.privacy.echo_executor;
+    let enc_recipient_addr = test.mock_new_enc_address();
+    let amount = constants::DEFAULT_AMOUNT;
+    let (note_id, _) = test.mock_new_note(:amount);
+
+    let empty_note = open_note(token: token_addr);
+    test.privacy.cheat_create_note(:note_id, note: empty_note);
+    token.supply(address: echo_executor_addr, :amount);
+    token.approve(owner: echo_executor_addr, spender: test.privacy.address, amount: amount.into());
+
+    let deposit = OpenNoteDeposit { note_id, token: token_addr, amount };
+    let actions = [
+        ServerAction::EmitOpenNoteCreated(
+            events::OpenNoteCreated { enc_recipient_addr, token: token_addr, note_id },
+        ),
+        test.privacy.invoke_with_computation_echo_deposits([deposit].span()),
+    ]
+        .span();
+
+    // The depositor is the InvokeWithComputation target (echo executor); blocking it reverts.
+    test.privacy.set_open_note_depositor_blocked(depositor: echo_executor_addr, blocked: true);
+    let result = test.privacy.safe_apply_actions(:actions);
+    assert_panic_with_felt_error(:result, expected_error: errors::OPEN_NOTE_DEPOSITOR_BLOCKED);
+
+    // Unblocking lets the same deposit land.
+    test.privacy.set_open_note_depositor_blocked(depositor: echo_executor_addr, blocked: false);
+    test.privacy.apply_actions(:actions);
+    let deposited_note = test.privacy.get_note(:note_id);
+    let (salt, stored_amount) = unpack(packed_value: deposited_note.packed_value);
+    assert_eq!(salt, OPEN_NOTE_SALT);
+    assert_eq!(stored_amount, amount);
+}
+
+#[test]
 fn test_apply_emit_open_note_created() {
     let mut test: Test = Default::default();
     let token = test.new_token();
@@ -663,6 +772,12 @@ fn test_apply_actions_reentrancy_locked() {
     let reentrancy_mock = deploy_mock_reentrancy();
     let invoke_input = InvokeInput { contract_address: reentrancy_mock, calldata: [].span() };
     let result = test.privacy.safe_apply_actions([ServerAction::Invoke(invoke_input)].span());
+    assert_panic_with_felt_error(:result, expected_error: ReentrancyGuardErrors::REENTRANT_CALL);
+
+    // The InvokeWithComputation path holds the same lock: a reentrant apply_actions is rejected.
+    let result = test
+        .privacy
+        .safe_apply_actions([ServerAction::InvokeWithComputation(invoke_input)].span());
     assert_panic_with_felt_error(:result, expected_error: ReentrancyGuardErrors::REENTRANT_CALL);
 }
 
@@ -945,6 +1060,11 @@ fn test_invoke_from_blocked_address_without_open_note_deposit_is_allowed() {
     // The block list is only consulted when an Invoke yields open-note deposits. With none, the tx
     // succeeds even though the Invoke target is blocked (no `OPEN_NOTE_DEPOSITOR_BLOCKED` revert).
     test.privacy.apply_actions(:actions);
+
+    // Same for the compute-invoke path: an InvokeWithComputation that yields no deposits succeeds
+    // even though the (blocked) target is the would-be depositor.
+    let compute_actions = [test.privacy.invoke_with_computation_echo_deposits(no_deposits)].span();
+    test.privacy.apply_actions(actions: compute_actions);
 }
 
 #[test]
@@ -973,17 +1093,33 @@ fn test_deposit_to_open_note_assertions() {
             create_actions, note_id, token_addr: Zero::zero(), :amount,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_TOKEN);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(
+            create_actions, note_id, token_addr: Zero::zero(), :amount,
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_TOKEN);
 
     // Catch ZERO_AMOUNT - create valid note, deposit with zero amount.
     let result = test
         .privacy
         .safe_create_open_note_and_invoke(create_actions, :note_id, :token_addr, amount: 0);
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_AMOUNT);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(create_actions, :note_id, :token_addr, amount: 0);
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_AMOUNT);
 
     // Catch NOTE_NOT_FOUND - create note A, deposit targeting non-existent note B.
     let result = test
         .privacy
         .safe_create_open_note_and_invoke(
+            create_actions, note_id: 'NONEXISTENT', :token_addr, :amount,
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_FOUND);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(
             create_actions, note_id: 'NONEXISTENT', :token_addr, :amount,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_FOUND);
@@ -999,11 +1135,23 @@ fn test_deposit_to_open_note_assertions() {
             create_actions, note_id: note_id_enc, :token_addr, :amount,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_OPEN);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(
+            create_actions, note_id: note_id_enc, :token_addr, :amount,
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NOTE_NOT_OPEN);
 
     // Catch TOKEN_MISMATCH - create open note for token A, deposit with token B.
     let result = test
         .privacy
         .safe_create_open_note_and_invoke(
+            create_actions, :note_id, token_addr: test.mock_new_token(), :amount,
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::TOKEN_MISMATCH);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(
             create_actions, :note_id, token_addr: test.mock_new_token(), :amount,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::TOKEN_MISMATCH);
@@ -1018,6 +1166,12 @@ fn test_deposit_to_open_note_assertions() {
     let result = test
         .privacy
         .safe_create_open_note_and_invoke(
+            create_actions_b, note_id: note_id_deposited, :token_addr, :amount,
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NOTE_ALREADY_DEPOSITED);
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(
             create_actions_b, note_id: note_id_deposited, :token_addr, :amount,
         );
     assert_panic_with_felt_error(:result, expected_error: errors::NOTE_ALREADY_DEPOSITED);
@@ -1046,6 +1200,10 @@ fn test_deposit_to_open_note_transfer_assertions() {
         .privacy
         .safe_create_open_note_and_invoke(create_actions, :note_id, :token_addr, :amount);
     assert_panic_with_error(:result, expected_error: Erc20Error::INSUFFICIENT_BALANCE.describe());
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(create_actions, :note_id, :token_addr, :amount);
+    assert_panic_with_error(:result, expected_error: Erc20Error::INSUFFICIENT_BALANCE.describe());
 
     // Test 2: INSUFFICIENT_ALLOWANCE - Echo executor has tokens but no approval.
     // Reuse the same note since Test 1 failed and didn't modify the note state.
@@ -1054,6 +1212,10 @@ fn test_deposit_to_open_note_transfer_assertions() {
     let result = test
         .privacy
         .safe_create_open_note_and_invoke(create_actions, :note_id, :token_addr, :amount);
+    assert_panic_with_error(:result, expected_error: Erc20Error::INSUFFICIENT_ALLOWANCE.describe());
+    let result = test
+        .privacy
+        .safe_create_open_note_and_compute_invoke(create_actions, :note_id, :token_addr, :amount);
     assert_panic_with_error(:result, expected_error: Erc20Error::INSUFFICIENT_ALLOWANCE.describe());
 }
 
@@ -1186,6 +1348,13 @@ fn test_apply_invoke_return_deserialize_error() {
     };
     let result = test.privacy.safe_apply_actions([ServerAction::Invoke(invoke_input)].span());
     assert_panic_with_felt_error(:result, expected_error: errors::INVALID_INVOKE_RETURN_DATA);
+
+    // Same non-deserializable return via the InvokeWithComputation path (the mock returns the same
+    // garbage from its `privacy_invoke_with_computation` entry point).
+    let result = test
+        .privacy
+        .safe_apply_actions([ServerAction::InvokeWithComputation(invoke_input)].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::INVALID_INVOKE_RETURN_DATA);
 }
 
 #[test]
@@ -1196,6 +1365,13 @@ fn test_apply_invoke_return_extra_data() {
         contract_address: mock_return_trailing_garbage_addr, calldata: [].span(),
     };
     let result = test.privacy.safe_apply_actions([ServerAction::Invoke(invoke_input)].span());
+    assert_panic_with_felt_error(:result, expected_error: errors::INVALID_INVOKE_RETURN_DATA);
+
+    // Same trailing-garbage return via the InvokeWithComputation path (the mock returns the same
+    // valid-deposits-plus-trailing-felt from its `privacy_invoke_with_computation` entry point).
+    let result = test
+        .privacy
+        .safe_apply_actions([ServerAction::InvokeWithComputation(invoke_input)].span());
     assert_panic_with_felt_error(:result, expected_error: errors::INVALID_INVOKE_RETURN_DATA);
 }
 
@@ -1219,6 +1395,21 @@ fn test_apply_invoke_propagates_panic() {
     assert_panic_with_felt_error(
         :result, expected_error: mock_swap_executor_errors::INSUFFICIENT_BALANCE,
     );
+}
+
+#[test]
+fn test_apply_invoke_with_computation_propagates_panic() {
+    let mut test: Test = Default::default();
+    let mock = deploy_mock_compute(panic_on_compute: false, panic_on_invoke: true);
+
+    let mut calldata = array![0];
+    let deposits: Span<OpenNoteDeposit> = [].span();
+    deposits.serialize(ref calldata);
+    let action = ServerAction::InvokeWithComputation(
+        InvokeInput { contract_address: mock, calldata: calldata.span() },
+    );
+    let result = test.privacy.safe_apply_actions([action].span());
+    assert_panic_with_felt_error(:result, expected_error: INVOKE_PANIC);
 }
 
 #[test]
@@ -1561,6 +1752,13 @@ fn test_undeposited_open_notes() {
     let result = test.privacy.safe_apply_actions(:actions);
     assert_panic_with_felt_error(:result, expected_error: errors::UNDEPOSITED_OPEN_NOTES);
 
+    // Same UNDEPOSITED_OPEN_NOTES via the compute-invoke path.
+    let no_deposits: Span<OpenNoteDeposit> = array![].span();
+    let mut actions: Array<ServerAction> = create_input.into_server_actions(:user).into();
+    actions.append(test.privacy.invoke_with_computation_echo_deposits(no_deposits));
+    let result = test.privacy.safe_apply_actions(actions.span());
+    assert_panic_with_felt_error(:result, expected_error: errors::UNDEPOSITED_OPEN_NOTES);
+
     // Catch TOO_MANY_OPEN_NOTES_DEPOSITED: Invoke deposit without a matching EmitOpenNoteCreated.
     let create_input = user
         .new_open_note_with_generated_random(recipient: user, :token_addr, index: 0);
@@ -1574,6 +1772,14 @@ fn test_undeposited_open_notes() {
         .invoke_external_echo_deposits([deposit].span())
         .into_server_actions();
     let result = test.privacy.safe_apply_actions(:actions);
+    assert_panic_with_felt_error(
+        :result, expected_error: internal_errors::TOO_MANY_OPEN_NOTES_DEPOSITED,
+    );
+
+    // Same TOO_MANY_OPEN_NOTES_DEPOSITED via the compute-invoke path.
+    let compute_actions = [test.privacy.invoke_with_computation_echo_deposits([deposit].span())]
+        .span();
+    let result = test.privacy.safe_apply_actions(actions: compute_actions);
     assert_panic_with_felt_error(
         :result, expected_error: internal_errors::TOO_MANY_OPEN_NOTES_DEPOSITED,
     );

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -12,16 +12,18 @@ use ekubo_swap_anonymizer::ekubo_swap_anonymizer::{
 use ekubo_swap_anonymizer::test_utils_contracts::mock_ekubo_amm::MockEkuboAMM::deploy_for_test as deploy_mock_ekubo_amm_for_test;
 use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use privacy::actions::{
-    AppendInput, ClientAction, CreateEncNoteInput, CreateOpenNoteInput, DepositInput,
-    InvokeExternalInput, InvokeInput, OpenChannelInput, OpenSubchannelInput, ServerAction,
-    SetViewingKeyInput, TransferFromInput, TransferToInput, UseNoteInput, WithdrawInput,
+    AppendInput, ClientAction, ComputeAndInvokeInput, CreateEncNoteInput, CreateOpenNoteInput,
+    DepositInput, InvokeExternalInput, InvokeInput, OpenChannelInput, OpenSubchannelInput,
+    ServerAction, SetViewingKeyInput, TransferFromInput, TransferToInput, UseNoteInput,
+    WithdrawInput,
 };
 use privacy::events;
 use privacy::hashes::{
     compute_channel_key, compute_channel_marker, compute_enc_channel_key_hash,
     compute_enc_private_key_hash, compute_enc_recipient_addr_hash, compute_enc_sender_addr_hash,
-    compute_enc_token_hash, compute_enc_user_addr_hash, compute_note_id, compute_nullifier,
-    compute_outgoing_channel_id, compute_subchannel_id, compute_subchannel_marker, hash,
+    compute_enc_token_hash, compute_enc_user_addr_hash, compute_identity_key, compute_note_id,
+    compute_nullifier, compute_outgoing_channel_id, compute_subchannel_id,
+    compute_subchannel_marker, hash,
 };
 use privacy::interface::{
     IAdminDispatcher, IAdminDispatcherTrait, IAdminSafeDispatcher, IAdminSafeDispatcherTrait,
@@ -46,6 +48,8 @@ use privacy::test_contracts::mock_swap_executor::{
     ISwapExecutorSafeDispatcherTrait,
 };
 use privacy::tests::mock_account::MockAccount::deploy_for_test as deploy_mock_account_for_test;
+use privacy::tests::mock_invoke_returns::MockCompute::deploy_for_test as deploy_mock_compute_for_test;
+use privacy::tests::mock_invoke_returns::MockComputeMultiFelt::deploy_for_test as deploy_mock_compute_multi_felt_for_test;
 use privacy::tests::mock_invoke_returns::MockEcho::deploy_for_test as deploy_mock_echo_for_test;
 use privacy::tests::mock_invoke_returns::MockReturnGarbage::deploy_for_test as deploy_mock_return_garbage_for_test;
 use privacy::tests::mock_invoke_returns::MockReturnTrailingGarbage::deploy_for_test as deploy_mock_return_trailing_garbage_for_test;
@@ -394,6 +398,22 @@ pub(crate) impl UserImpl of UserTrait {
             || {
                 let mut state = Privacy::contract_state_for_testing();
                 state.invoke_external(:input)
+            },
+        )
+            .span()
+    }
+
+    fn internal_compute_and_invoke(
+        self: @User, input: ComputeAndInvokeInput,
+    ) -> Span<ServerAction> {
+        interact_with_state(
+            *self.privacy.address,
+            || {
+                let mut state = Privacy::contract_state_for_testing();
+                state
+                    .compute_and_invoke(
+                        user_addr: *self.address, user_private_key: *self.private_key, :input,
+                    )
             },
         )
             .span()
@@ -905,6 +925,12 @@ pub(crate) impl UserImpl of UserTrait {
             ephemeral_secret: random,
             auditor_public_key: self.privacy.get_auditor_public_key(),
             user_addr: *self.address,
+        )
+    }
+
+    fn compute_identity_key(self: @User, contract_address: ContractAddress) -> felt252 {
+        compute_identity_key(
+            user_addr: *self.address, user_private_key: *self.private_key, :contract_address,
         )
     }
 
@@ -1748,6 +1774,20 @@ pub(crate) impl PrivacyCfgImpl of PrivacyCfgTrait {
         self.safe_apply_actions(actions.span())
     }
 
+    #[feature("safe_dispatcher")]
+    fn safe_create_open_note_and_compute_invoke(
+        self: @PrivacyCfg,
+        create_actions: Span<ServerAction>,
+        note_id: felt252,
+        token_addr: ContractAddress,
+        amount: u128,
+    ) -> Result<(), Array<felt252>> {
+        let deposit = OpenNoteDeposit { note_id, token: token_addr, amount };
+        let mut actions: Array<ServerAction> = create_actions.into();
+        actions.append(self.invoke_with_computation_echo_deposits([deposit].span()));
+        self.safe_apply_actions(actions.span())
+    }
+
     fn pause(self: @PrivacyCfg) {
         cheat_caller_address_once(
             contract_address: *self.address, caller_address: *self.roles.security_agent,
@@ -2092,6 +2132,18 @@ pub(crate) impl PrivacyCfgImpl of PrivacyCfgTrait {
         deposits.serialize(ref calldata);
         InvokeExternalInput { contract_address: executor, calldata: calldata.span() }
     }
+
+    /// Build an `InvokeWithComputation` server action targeting the echo executor, with the given
+    /// deposits serialized as the forwarded calldata.
+    fn invoke_with_computation_echo_deposits(
+        self: @PrivacyCfg, deposits: Span<OpenNoteDeposit>,
+    ) -> ServerAction {
+        let mut calldata: Array<felt252> = array![];
+        deposits.serialize(ref calldata);
+        ServerAction::InvokeWithComputation(
+            InvokeInput { contract_address: *self.echo_executor, calldata: calldata.span() },
+        )
+    }
 }
 
 impl DefaultTestImpl of Default<Test> {
@@ -2341,6 +2393,36 @@ fn deploy_mock_amm() -> ContractAddress {
         class_hash: *class_hash, :deployment_params,
     )
         .expect('MockAMM deployment failed');
+    contract_address
+}
+
+/// Deploys a `MockCompute` target for the `ComputeAndInvoke` / `InvokeWithComputation` path. The
+/// flags make `privacy_compute` / `privacy_invoke_with_computation` panic, to exercise
+/// panic-propagation and call-deferral.
+pub(crate) fn deploy_mock_compute(
+    panic_on_compute: bool, panic_on_invoke: bool,
+) -> ContractAddress {
+    let class_hash = declare(contract: "MockCompute").unwrap_syscall().contract_class().class_hash;
+    let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
+    let (contract_address, _) = deploy_mock_compute_for_test(
+        class_hash: *class_hash, :deployment_params, :panic_on_compute, :panic_on_invoke,
+    )
+        .expect('MOCK_COMPUTE_DEPLOY_FAIL');
+    contract_address
+}
+
+/// Deploys a `MockComputeMultiFelt` target, whose `privacy_compute` takes no `compute_data` and
+/// returns a two-felt `computed_data`.
+pub(crate) fn deploy_mock_compute_multi_felt() -> ContractAddress {
+    let class_hash = declare(contract: "MockComputeMultiFelt")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
+    let (contract_address, _) = deploy_mock_compute_multi_felt_for_test(
+        class_hash: *class_hash, :deployment_params,
+    )
+        .expect('MOCK_COMPUTE_MULTI_DEPLOY_FAIL');
     contract_address
 }
 

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -18,7 +18,8 @@ use privacy::objects::{
     EncChannelInfo, EncOutgoingChannelInfo, EncPrivateKey, EncSubchannelInfo, EncUserAddr, Note,
 };
 use privacy::utils::constants::{
-    ENTRYPOINT_FAILED, HALF_ORDER, OK_WRAPPER, OPEN_NOTE_PACKED_VALUE, OPEN_NOTE_SALT, TWO_POW_120,
+    ENTRYPOINT_FAILED, ERR_WRAPPER, HALF_ORDER, OK_WRAPPER, OPEN_NOTE_PACKED_VALUE, OPEN_NOTE_SALT,
+    TWO_POW_120,
 };
 use starknet::account::Call;
 use starknet::storage::{StorageAsPointer, StoragePath};
@@ -45,6 +46,10 @@ pub mod constants {
     pub const TWO_POW_120: u128 = 2_u128.pow(120);
     pub const ENTRYPOINT_FAILED: felt252 = 'ENTRYPOINT_FAILED';
     pub const OK_WRAPPER: felt252 = 'PRIVACY_OK_WRAPPER';
+    /// Brackets panic data propagated from an external contract call made during client
+    /// compilation. Distinct from `OK_WRAPPER` so that a panicking external contract cannot forge
+    /// server actions by emitting `OK_WRAPPER`-bracketed panic data.
+    pub const ERR_WRAPPER: felt252 = 'PRIVACY_ERR_WRAPPER';
     pub const TX_V3: felt252 = 3;
     /// The offset of simulated transactions.
     pub const ESTIMATION_BASE_TX_VERSION: felt252 = TWO_POW_128.try_into().unwrap();
@@ -58,6 +63,14 @@ pub mod constants {
     pub const VIRTUAL_SNOS0: felt252 = 'VIRTUAL_SNOS0';
     /// Selector called with the [`Invoke`](privacy::actions::ServerAction::Invoke) action.
     pub const INVOKE_SELECTOR: felt252 = selector!("privacy_invoke");
+    /// Selector called during client compilation to derive the computation result forwarded by a
+    /// [`ComputeAndInvoke`](privacy::actions::ClientAction::ComputeAndInvoke) action.
+    pub const PRIVACY_COMPUTE_SELECTOR: felt252 = selector!("privacy_compute");
+    /// Selector called with the
+    /// [`InvokeWithComputation`](privacy::actions::ServerAction::InvokeWithComputation) action.
+    pub const INVOKE_WITH_COMPUTATION_SELECTOR: felt252 = selector!(
+        "privacy_invoke_with_computation",
+    );
     /// STRK fee token address — same on all Starknet networks (mainnet, sepolia, devnet).
     pub const STRK_TOKEN_ADDRESS: ContractAddress =
         0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
@@ -394,6 +407,17 @@ pub(crate) fn panic_with_server_actions(server_actions: Span<ServerAction>) -> n
     server_actions.serialize(ref panic_data);
     panic_data.append(OK_WRAPPER);
     panic(panic_data);
+}
+
+/// Re-panics with an external call's `panic_data` (captured during client compilation), prefixed
+/// with `ERR_WRAPPER`. The prefix guarantees the head differs from `OK_WRAPPER`, so
+/// `extract_server_actions_from_compile_and_panic` treats it as a propagated error rather than
+/// decoding the callee-controlled `panic_data` as forged server actions.
+pub(crate) fn propagate_external_panic(panic_data: Span<felt252>) -> never {
+    let mut wrapped = array![ERR_WRAPPER];
+    wrapped.append_span(panic_data);
+    wrapped.append(ERR_WRAPPER);
+    panic(wrapped);
 }
 
 /// IMPORTANT: This function only works for types whose serialization format

--- a/packages/sub_account_anonymizer/README.md
+++ b/packages/sub_account_anonymizer/README.md
@@ -1,0 +1,9 @@
+# Sub-Account Anonymizer
+
+Lets the privacy pool run arbitrary dapp interactions on behalf of its users without linking those
+interactions back to a user.
+
+Each user interaction is identified by a commitment. The anonymizer keeps a registry mapping every
+commitment to a dedicated sub-account contract that performs the dapp calls and holds the resulting
+funds, which are then settled back into the privacy pool's open notes. Driving interactions is
+restricted to the privacy contract the anonymizer is configured for.

--- a/packages/sub_account_anonymizer/Scarb.toml
+++ b/packages/sub_account_anonymizer/Scarb.toml
@@ -1,0 +1,42 @@
+[package]
+name = "sub_account_anonymizer"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[tool]
+fmt.workspace = true
+scarb.workspace = true
+
+[dependencies]
+starknet.workspace = true
+openzeppelin.workspace = true
+starkware_utils.workspace = true
+privacy = { path = "../privacy" }
+
+[dev-dependencies]
+assert_macros.workspace = true
+snforge_std.workspace = true
+starkware_utils_testing.workspace = true
+
+[lib]
+
+[[test]]
+name = "sub_account_anonymizer_unittest"
+build-external-contracts = [
+    "starkware_utils::contracts::sub_account::SubAccount",
+]
+
+[scripts]
+test = "snforge test"
+
+[[target.starknet-contract]]
+sierra = true
+casm = true
+casm-add-pythonic-hints = true
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+inlining-strategy = "avoid"

--- a/packages/sub_account_anonymizer/Scarb.toml
+++ b/packages/sub_account_anonymizer/Scarb.toml
@@ -25,7 +25,9 @@ starkware_utils_testing.workspace = true
 [[test]]
 name = "sub_account_anonymizer_unittest"
 build-external-contracts = [
+    "starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock",
     "starkware_utils::contracts::sub_account::SubAccount",
+    "sub_account_anonymizer::test_utils_contracts::mock_dapp::MockDapp",
 ]
 
 [scripts]

--- a/packages/sub_account_anonymizer/src/lib.cairo
+++ b/packages/sub_account_anonymizer/src/lib.cairo
@@ -1,0 +1,3 @@
+pub mod sub_account_anonymizer;
+#[cfg(test)]
+pub mod tests;

--- a/packages/sub_account_anonymizer/src/lib.cairo
+++ b/packages/sub_account_anonymizer/src/lib.cairo
@@ -1,3 +1,5 @@
 pub mod sub_account_anonymizer;
 #[cfg(test)]
+pub mod test_utils_contracts;
+#[cfg(test)]
 pub mod tests;

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -4,6 +4,12 @@ use starknet::{ClassHash, ContractAddress};
 
 #[starknet::interface]
 pub trait ISubAccountAnonymizer<T> {
+    /// Derives the commitment identifying the sub-account: the Poseidon hash of the
+    /// `(identity_key, dapp_name, seq_nonce)` triple.
+    fn privacy_compute(
+        self: @T, identity_key: felt252, dapp_name: felt252, seq_nonce: felt252,
+    ) -> felt252;
+
     /// Returns the sub-account address bound to `commitment`, or zero if none has been deployed
     /// yet.
     fn get_sub_account(self: @T, commitment: felt252) -> ContractAddress;
@@ -17,6 +23,8 @@ pub trait ISubAccountAnonymizer<T> {
 
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
+    use core::hash::HashStateTrait;
+    use core::poseidon::PoseidonTrait;
     use starknet::storage::{
         Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
@@ -46,6 +54,12 @@ pub mod SubAccountAnonymizer {
 
     #[abi(embed_v0)]
     pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
+        fn privacy_compute(
+            self: @ContractState, identity_key: felt252, dapp_name: felt252, seq_nonce: felt252,
+        ) -> felt252 {
+            PoseidonTrait::new().update(identity_key).update(dapp_name).update(seq_nonce).finalize()
+        }
+
         fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
             self.sub_accounts.read(commitment)
         }

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -1,5 +1,13 @@
 //! Sub-account anonymizer for privacy-preserving dapp interactions.
+//!
+//! Runs arbitrary dapp calls on behalf of the privacy contract through per-commitment
+//! [`SubAccount`](starkware_utils::contracts::sub_account::SubAccount) contracts. Each commitment
+//! maps to a dedicated sub-account that performs the dapp calls and holds the resulting funds; the
+//! anonymizer then collects those funds into itself and approves the privacy contract to pull
+//! them into open notes. Driving interactions is restricted to the configured privacy contract.
 
+use privacy::objects::OpenNoteDeposit;
+use starknet::account::Call;
 use starknet::{ClassHash, ContractAddress};
 
 #[starknet::interface]
@@ -9,6 +17,31 @@ pub trait ISubAccountAnonymizer<T> {
     fn privacy_compute(
         self: @T, identity_key: felt252, dapp_name: felt252, seq_nonce: felt252,
     ) -> felt252;
+
+    /// Executes `invokes` through the sub-account bound to `commitment` (deploying it on first
+    /// use), then collects each requested open-note token from the sub-account and into this
+    /// anonymizer, approving the privacy contract to pull the collected amount.
+    ///
+    /// #### Parameters
+    /// - `commitment` (`felt252`) - identifies the sub-account; see [`privacy_compute`].
+    /// - `invokes` (`Array<Call>`) - the dapp calls to run as the sub-account.
+    /// - `open_notes` (`Span<(felt252, ContractAddress)>`) - `(note_id, token)` pairs to settle;
+    ///   for each, the amount the interaction added to the sub-account's `token` balance is
+    ///   collected and recorded as a deposit.
+    ///
+    /// #### Returns
+    /// - ([`Span<OpenNoteDeposit>`](privacy::objects::OpenNoteDeposit)) - one deposit per open
+    /// note,
+    ///   for the privacy contract to apply.
+    ///
+    /// #### Preconditions
+    /// - Caller must be the configured privacy contract.
+    fn privacy_invoke_with_computation(
+        ref self: T,
+        commitment: felt252,
+        invokes: Array<Call>,
+        open_notes: Span<(felt252, ContractAddress)>,
+    ) -> Span<OpenNoteDeposit>;
 
     /// Returns the sub-account address bound to `commitment`, or zero if none has been deployed
     /// yet.
@@ -21,15 +54,32 @@ pub trait ISubAccountAnonymizer<T> {
     fn get_sub_account_class_hash(self: @T) -> ClassHash;
 }
 
+/// Error codes for sub-account anonymizer operations.
+pub mod errors {
+    pub const CALLER_NOT_PRIVACY: felt252 = 'CALLER_NOT_PRIVACY';
+    pub const COLLECTED_AMOUNT_OVERFLOW: felt252 = 'COLLECTED_AMOUNT_OVERFLOW';
+}
+
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
     use core::hash::HashStateTrait;
+    use core::num::traits::Zero;
     use core::poseidon::PoseidonTrait;
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use privacy::objects::OpenNoteDeposit;
+    use starknet::account::Call;
     use starknet::storage::{
-        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
     };
-    use starknet::{ClassHash, ContractAddress};
-    use super::ISubAccountAnonymizer;
+    use starknet::syscalls::deploy_syscall;
+    use starknet::{
+        ClassHash, ContractAddress, SyscallResultTrait, get_caller_address, get_contract_address,
+    };
+    use starkware_utils::contracts::sub_account::{
+        ISubAccountDispatcher, ISubAccountDispatcherTrait,
+    };
+    use super::{ISubAccountAnonymizer, errors};
 
     #[storage]
     struct Storage {
@@ -60,6 +110,21 @@ pub mod SubAccountAnonymizer {
             PoseidonTrait::new().update(identity_key).update(dapp_name).update(seq_nonce).finalize()
         }
 
+        fn privacy_invoke_with_computation(
+            ref self: ContractState,
+            commitment: felt252,
+            invokes: Array<Call>,
+            open_notes: Span<(felt252, ContractAddress)>,
+        ) -> Span<OpenNoteDeposit> {
+            assert(
+                get_caller_address() == self.privacy_contract.read(), errors::CALLER_NOT_PRIVACY,
+            );
+            let sub_account = self.get_or_deploy_sub_account(:commitment);
+            let notes = record_pre_balances(sub_account, open_notes);
+            sub_account.execute(invokes);
+            self.collect_open_notes(:sub_account, :notes)
+        }
+
         fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
             self.sub_accounts.read(commitment)
         }
@@ -71,5 +136,89 @@ pub mod SubAccountAnonymizer {
         fn get_sub_account_class_hash(self: @ContractState) -> ClassHash {
             self.sub_account_class_hash.read()
         }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        /// Returns the sub-account bound to `commitment`, deploying a fresh one on first use. The
+        /// commitment is the deployment salt, so each commitment maps to a deterministic address,
+        /// and the deployed `SubAccount` records this anonymizer (its deployer) as owner.
+        fn get_or_deploy_sub_account(
+            ref self: ContractState, commitment: felt252,
+        ) -> ISubAccountDispatcher {
+            let existing = self.sub_accounts.read(commitment);
+            if existing.is_non_zero() {
+                return ISubAccountDispatcher { contract_address: existing };
+            }
+            let (sub_account_addr, _) = deploy_syscall(
+                class_hash: self.sub_account_class_hash.read(),
+                contract_address_salt: commitment,
+                calldata: array![].span(),
+                deploy_from_zero: false,
+            )
+                .unwrap_syscall();
+            self.sub_accounts.write(commitment, sub_account_addr);
+            ISubAccountDispatcher { contract_address: sub_account_addr }
+        }
+
+        /// Collects, for each `(note_id, token, pre_balance)` in `notes`, the balance the
+        /// interaction added to `sub_account` (its current balance minus `pre_balance`) into this
+        /// anonymizer, approves the privacy contract to pull it, and returns one deposit per note.
+        /// Only the sub-account can move its own funds, so each transfer is routed through it.
+        fn collect_open_notes(
+            self: @ContractState,
+            sub_account: ISubAccountDispatcher,
+            notes: Span<(felt252, ContractAddress, u256)>,
+        ) -> Span<OpenNoteDeposit> {
+            let anonymizer = get_contract_address();
+            let privacy_contract = self.privacy_contract.read();
+            let mut deposits: Array<OpenNoteDeposit> = array![];
+            for note in notes {
+                let (note_id, token, pre_balance) = *note;
+                let erc20 = IERC20Dispatcher { contract_address: token };
+                // Collect only what the interaction added; clamp so a decrease yields zero.
+                let post_balance = erc20.balance_of(account: sub_account.contract_address);
+                let amount = if post_balance > pre_balance {
+                    post_balance - pre_balance
+                } else {
+                    0
+                };
+
+                let transfer_calldata = array![
+                    anonymizer.into(), amount.low.into(), amount.high.into(),
+                ];
+                sub_account
+                    .execute(
+                        array![
+                            Call {
+                                to: token,
+                                selector: selector!("transfer"),
+                                calldata: transfer_calldata.span(),
+                            },
+                        ],
+                    );
+
+                erc20.approve(spender: privacy_contract, :amount);
+                let amount: u128 = amount.try_into().expect(errors::COLLECTED_AMOUNT_OVERFLOW);
+                deposits.append(OpenNoteDeposit { note_id, token, amount });
+            }
+            deposits.span()
+        }
+    }
+
+    /// Records each open note's token together with the sub-account's current balance of it, so
+    /// `collect_open_notes` can later credit only the delta the interaction adds. Each returned
+    /// entry is `(note_id, token, pre_balance)`.
+    fn record_pre_balances(
+        sub_account: ISubAccountDispatcher, open_notes: Span<(felt252, ContractAddress)>,
+    ) -> Span<(felt252, ContractAddress, u256)> {
+        let mut notes: Array<(felt252, ContractAddress, u256)> = array![];
+        for note in open_notes {
+            let (note_id, token) = *note;
+            let pre_balance = IERC20Dispatcher { contract_address: token }
+                .balance_of(account: sub_account.contract_address);
+            notes.append((note_id, token, pre_balance));
+        }
+        notes.span()
     }
 }

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -1,0 +1,61 @@
+//! Sub-account anonymizer for privacy-preserving dapp interactions.
+
+use starknet::{ClassHash, ContractAddress};
+
+#[starknet::interface]
+pub trait ISubAccountAnonymizer<T> {
+    /// Returns the sub-account address bound to `commitment`, or zero if none has been deployed
+    /// yet.
+    fn get_sub_account(self: @T, commitment: felt252) -> ContractAddress;
+
+    /// Returns the privacy contract authorized to drive interactions.
+    fn get_privacy_contract(self: @T) -> ContractAddress;
+
+    /// Returns the class hash of the `SubAccount` contract deployed per commitment.
+    fn get_sub_account_class_hash(self: @T) -> ClassHash;
+}
+
+#[starknet::contract]
+pub mod SubAccountAnonymizer {
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StoragePointerReadAccess, StoragePointerWriteAccess,
+    };
+    use starknet::{ClassHash, ContractAddress};
+    use super::ISubAccountAnonymizer;
+
+    #[storage]
+    struct Storage {
+        /// Address of the authorized privacy contract.
+        privacy_contract: ContractAddress,
+        /// Class hash of the `SubAccount` contract deployed per commitment.
+        // TODO: Consider making this a constant.
+        sub_account_class_hash: ClassHash,
+        /// Maps a commitment to the sub-account deployed for it.
+        sub_accounts: Map<felt252, ContractAddress>,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        privacy_contract: ContractAddress,
+        sub_account_class_hash: ClassHash,
+    ) {
+        self.privacy_contract.write(privacy_contract);
+        self.sub_account_class_hash.write(sub_account_class_hash);
+    }
+
+    #[abi(embed_v0)]
+    pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
+        fn get_sub_account(self: @ContractState, commitment: felt252) -> ContractAddress {
+            self.sub_accounts.read(commitment)
+        }
+
+        fn get_privacy_contract(self: @ContractState) -> ContractAddress {
+            self.privacy_contract.read()
+        }
+
+        fn get_sub_account_class_hash(self: @ContractState) -> ClassHash {
+            self.sub_account_class_hash.read()
+        }
+    }
+}

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -4,7 +4,8 @@
 //! [`SubAccount`](starkware_utils::contracts::sub_account::SubAccount) contracts. Each commitment
 //! maps to a dedicated sub-account that performs the dapp calls and holds the resulting funds; the
 //! anonymizer then collects those funds into itself and approves the privacy contract to pull
-//! them into open notes. Driving interactions is restricted to the configured privacy contract.
+//! them into open notes. Driving interactions is restricted to the configured privacy contract,
+//! while upgrading the contract class is restricted to the owner.
 
 use privacy::objects::OpenNoteDeposit;
 use starknet::account::Call;
@@ -65,7 +66,10 @@ pub mod SubAccountAnonymizer {
     use core::hash::HashStateTrait;
     use core::num::traits::Zero;
     use core::poseidon::PoseidonTrait;
+    use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::interfaces::upgrades::IUpgradeable;
+    use openzeppelin::upgrades::UpgradeableComponent;
     use privacy::objects::OpenNoteDeposit;
     use starknet::account::Call;
     use starknet::storage::{
@@ -81,8 +85,20 @@ pub mod SubAccountAnonymizer {
     };
     use super::{ISubAccountAnonymizer, errors};
 
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
+
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
+
     #[storage]
     struct Storage {
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        upgradeable: UpgradeableComponent::Storage,
         /// Address of the authorized privacy contract.
         privacy_contract: ContractAddress,
         /// Class hash of the `SubAccount` contract deployed per commitment.
@@ -92,14 +108,25 @@ pub mod SubAccountAnonymizer {
         sub_accounts: Map<felt252, ContractAddress>,
     }
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        UpgradeableEvent: UpgradeableComponent::Event,
+    }
+
     #[constructor]
     fn constructor(
         ref self: ContractState,
         privacy_contract: ContractAddress,
         sub_account_class_hash: ClassHash,
+        owner: ContractAddress,
     ) {
         self.privacy_contract.write(privacy_contract);
         self.sub_account_class_hash.write(sub_account_class_hash);
+        self.ownable.initializer(owner);
     }
 
     #[abi(embed_v0)]
@@ -135,6 +162,15 @@ pub mod SubAccountAnonymizer {
 
         fn get_sub_account_class_hash(self: @ContractState) -> ClassHash {
             self.sub_account_class_hash.read()
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl UpgradeableImpl of IUpgradeable<ContractState> {
+        /// Replaces the contract class hash with `new_class_hash`. Owner-only.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            self.ownable.assert_only_owner();
+            self.upgradeable.upgrade(new_class_hash);
         }
     }
 

--- a/packages/sub_account_anonymizer/src/test_utils_contracts.cairo
+++ b/packages/sub_account_anonymizer/src/test_utils_contracts.cairo
@@ -1,0 +1,1 @@
+pub mod mock_dapp;

--- a/packages/sub_account_anonymizer/src/test_utils_contracts/mock_dapp.cairo
+++ b/packages/sub_account_anonymizer/src/test_utils_contracts/mock_dapp.cairo
@@ -1,0 +1,29 @@
+//! Minimal dapp used to exercise sub_account-driven interactions: `pay_out` transfers a previously
+//! funded token balance to whoever calls it (the sub_account), modelling a dapp that returns funds
+//! to the calling account.
+
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait IMockDapp<T> {
+    /// Transfers `amount` of `token` from this contract to the caller.
+    fn pay_out(ref self: T, token: ContractAddress, amount: u256);
+}
+
+#[starknet::contract]
+pub mod MockDapp {
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use starknet::{ContractAddress, get_caller_address};
+    use super::IMockDapp;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl MockDappImpl of IMockDapp<ContractState> {
+        fn pay_out(ref self: ContractState, token: ContractAddress, amount: u256) {
+            IERC20Dispatcher { contract_address: token }
+                .transfer(recipient: get_caller_address(), :amount);
+        }
+    }
+}

--- a/packages/sub_account_anonymizer/src/tests.cairo
+++ b/packages/sub_account_anonymizer/src/tests.cairo
@@ -1,0 +1,2 @@
+pub mod test_sub_account_anonymizer;
+pub mod test_utils;

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,0 +1,26 @@
+use core::num::traits::Zero;
+use snforge_std::{DeclareResultTrait, declare};
+use starknet::SyscallResultTrait;
+use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
+use sub_account_anonymizer::tests::test_utils::{
+    PRIVACY, anonymizer_disp, deploy_sub_account_anonymizer,
+};
+
+#[test]
+fn test_get_privacy_contract() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    assert_eq!(anonymizer_disp(anonymizer).get_privacy_contract(), PRIVACY);
+}
+
+#[test]
+fn test_get_sub_account_class_hash() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let expected = *declare("SubAccount").unwrap_syscall().contract_class().class_hash;
+    assert_eq!(anonymizer_disp(anonymizer).get_sub_account_class_hash(), expected);
+}
+
+#[test]
+fn test_get_sub_account_unknown_commitment_is_zero() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    assert!(anonymizer_disp(anonymizer).get_sub_account('UNKNOWN').is_zero());
+}

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,19 +1,25 @@
 use core::hash::HashStateTrait;
 use core::num::traits::{Bounded, Zero};
 use core::poseidon::PoseidonTrait;
+use openzeppelin::interfaces::ownable::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use openzeppelin::interfaces::upgrades::{
+    IUpgradeableSafeDispatcher, IUpgradeableSafeDispatcherTrait,
+};
 use privacy::objects::OpenNoteDeposit;
-use snforge_std::{DeclareResultTrait, TokenTrait, declare};
+use snforge_std::{DeclareResultTrait, TokenTrait, declare, get_class_hash};
 use starknet::account::Call;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::contracts::sub_account::{ISubAccountDispatcher, ISubAccountDispatcherTrait};
-use starkware_utils_testing::test_utils::{TokenHelperTrait, assert_panic_with_felt_error};
+use starkware_utils_testing::test_utils::{
+    TokenHelperTrait, assert_panic_with_felt_error, cheat_caller_address_once,
+};
 use sub_account_anonymizer::sub_account_anonymizer::{
     ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
     ISubAccountAnonymizerSafeDispatcherTrait, errors,
 };
 use sub_account_anonymizer::tests::test_utils::{
-    ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components, deploy_sub_account_anonymizer,
-    deploy_token, pay_out_call,
+    ComponentsTrait, OWNER, PRIVACY, anonymizer_disp, deploy_components,
+    deploy_sub_account_anonymizer, deploy_token, pay_out_call,
 };
 
 const AMOUNT: u128 = 1_000_000;
@@ -341,4 +347,25 @@ fn test_collected_amount_overflow() {
             ],
             open_notes: array![(NOTE_ID, token)].span(),
         );
+}
+
+#[test]
+fn test_owner_is_configured() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    assert_eq!(IOwnableDispatcher { contract_address: anonymizer }.owner(), OWNER);
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_upgrade_rejects_non_owner_and_allows_owner() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let new_class_hash = *declare("SubAccount").unwrap_syscall().contract_class().class_hash;
+    let safe = IUpgradeableSafeDispatcher { contract_address: anonymizer };
+
+    let result = safe.upgrade(new_class_hash);
+    assert_panic_with_felt_error(:result, expected_error: 'Caller is not the owner');
+
+    cheat_caller_address_once(contract_address: anonymizer, caller_address: OWNER);
+    assert!(safe.upgrade(new_class_hash).is_ok());
+    assert_eq!(get_class_hash(anonymizer), new_class_hash);
 }

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,12 +1,23 @@
 use core::hash::HashStateTrait;
-use core::num::traits::Zero;
+use core::num::traits::{Bounded, Zero};
 use core::poseidon::PoseidonTrait;
-use snforge_std::{DeclareResultTrait, declare};
-use starknet::SyscallResultTrait;
-use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
-use sub_account_anonymizer::tests::test_utils::{
-    PRIVACY, anonymizer_disp, deploy_sub_account_anonymizer,
+use privacy::objects::OpenNoteDeposit;
+use snforge_std::{DeclareResultTrait, TokenTrait, declare};
+use starknet::account::Call;
+use starknet::{ContractAddress, SyscallResultTrait};
+use starkware_utils::contracts::sub_account::{ISubAccountDispatcher, ISubAccountDispatcherTrait};
+use starkware_utils_testing::test_utils::{TokenHelperTrait, assert_panic_with_felt_error};
+use sub_account_anonymizer::sub_account_anonymizer::{
+    ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
+    ISubAccountAnonymizerSafeDispatcherTrait, errors,
 };
+use sub_account_anonymizer::tests::test_utils::{
+    ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components, deploy_sub_account_anonymizer,
+    deploy_token, pay_out_call,
+};
+
+const AMOUNT: u128 = 1_000_000;
+const NOTE_ID: felt252 = 'NOTE_ID';
 
 #[test]
 fn test_get_privacy_contract() {
@@ -45,4 +56,289 @@ fn test_privacy_compute_is_deterministic_and_distinct() {
     assert_ne!(base, anonymizer.privacy_compute('OTHER', 'DAPP', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'OTHER', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'DAPP', 2));
+}
+
+#[test]
+fn test_invoke_executes_and_collects_open_note() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Fund the dapp so the sub-account-driven call pays the sub-account `AMOUNT`.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            invokes: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![(NOTE_ID, token)].span(),
+        );
+
+    // One deposit returned, matching the collected token/amount.
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, AMOUNT);
+
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    assert!(sub_account.is_non_zero());
+    // Funds flowed dapp -> sub-account -> anonymizer, and the privacy contract is approved to pull.
+    assert_eq!(components.token.balance_of(components.mock_dapp), 0);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), AMOUNT.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_invoke_only_privacy_contract() {
+    let components = deploy_components();
+    // No caller cheat: the caller is the test contract, not the privacy contract.
+    let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    let result = safe
+        .privacy_invoke_with_computation(
+            commitment: 0, invokes: array![], open_notes: array![].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::CALLER_NOT_PRIVACY);
+}
+
+#[test]
+fn test_collects_multiple_open_notes() {
+    let components = deploy_components();
+    let token_a = components.token;
+    let token_b = deploy_token();
+    let addr_a = token_a.contract_address();
+    let addr_b = token_b.contract_address();
+    assert!(addr_a != addr_b);
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    let amount_a: u128 = 1_000_000;
+    let amount_b: u128 = 2_500_000;
+    token_a.supply(address: components.mock_dapp, amount: amount_a);
+    token_b.supply(address: components.mock_dapp, amount: amount_b);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            invokes: array![
+                pay_out_call(components.mock_dapp, addr_a, amount_a),
+                pay_out_call(components.mock_dapp, addr_b, amount_b),
+            ],
+            open_notes: array![('NOTE_A', addr_a), ('NOTE_B', addr_b)].span(),
+        );
+
+    // One deposit per note, each carrying its own token/amount.
+    assert_eq!(deposits.len(), 2);
+    let OpenNoteDeposit { note_id: id_a, token: tok_a, amount: amt_a } = *deposits[0];
+    assert_eq!(id_a, 'NOTE_A');
+    assert_eq!(tok_a, addr_a);
+    assert_eq!(amt_a, amount_a);
+    let OpenNoteDeposit { note_id: id_b, token: tok_b, amount: amt_b } = *deposits[1];
+    assert_eq!(id_b, 'NOTE_B');
+    assert_eq!(tok_b, addr_b);
+    assert_eq!(amt_b, amount_b);
+
+    assert_eq!(token_a.balance_of(components.mock_dapp), 0);
+    assert_eq!(token_b.balance_of(components.mock_dapp), 0);
+    assert_eq!(token_a.balance_of(components.anonymizer), amount_a.into());
+    assert_eq!(token_b.balance_of(components.anonymizer), amount_b.into());
+    assert_eq!(token_a.allowance(components.anonymizer, PRIVACY), amount_a.into());
+    assert_eq!(token_b.allowance(components.anonymizer, PRIVACY), amount_b.into());
+}
+
+#[test]
+fn test_multiple_invokes_run_in_one_call() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    let first: u128 = 700_000;
+    let second: u128 = 300_000;
+    components.token.supply(address: components.mock_dapp, amount: first + second);
+
+    // Two calls in one interaction; both run as the sub-account and their output is combined.
+    let deposits = components
+        .invoke(
+            :commitment,
+            invokes: array![
+                pay_out_call(components.mock_dapp, token, first),
+                pay_out_call(components.mock_dapp, token, second),
+            ],
+            open_notes: array![(NOTE_ID, token)].span(),
+        );
+
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, first + second);
+    assert_eq!(components.token.balance_of(components.anonymizer), (first + second).into());
+}
+
+#[test]
+fn test_invoke_but_not_collect() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    let first: u128 = 1_000_000;
+    let second: u128 = 400_000;
+    components.token.supply(address: components.mock_dapp, amount: first + second);
+
+    let deposits = components
+        .invoke(
+            :commitment,
+            invokes: array![pay_out_call(components.mock_dapp, token, first)],
+            open_notes: array![].span(),
+        );
+    assert_eq!(deposits.len(), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), 0);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    assert_eq!(components.token.balance_of(sub_account), first.into());
+}
+
+#[test]
+fn test_deployed_sub_account_owned_by_anonymizer() {
+    let components = deploy_components();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    components.invoke(:commitment, invokes: array![], open_notes: array![].span());
+
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    // The anonymizer is the sub-account's deployer, so it is the only authorized controller.
+    assert_eq!(
+        ISubAccountDispatcher { contract_address: sub_account }.owner(), components.anonymizer,
+    );
+}
+
+#[test]
+fn test_sub_account_is_reused_per_commitment() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let commitment_a = anonymizer.privacy_compute('USER', 'DAPP', 1);
+    let commitment_b = anonymizer.privacy_compute('USER', 'DAPP', 2);
+    let no_notes = array![].span();
+
+    components.invoke(commitment: commitment_a, invokes: array![], open_notes: no_notes);
+    let sub_account_a = anonymizer.get_sub_account(commitment_a);
+    assert!(sub_account_a.is_non_zero());
+
+    // Same commitment reuses the same sub-account (no redeploy).
+    components.invoke(commitment: commitment_a, invokes: array![], open_notes: no_notes);
+    assert_eq!(anonymizer.get_sub_account(commitment_a), sub_account_a);
+
+    // A different commitment gets a distinct sub-account.
+    components.invoke(commitment: commitment_b, invokes: array![], open_notes: no_notes);
+    let sub_account_b = anonymizer.get_sub_account(commitment_b);
+    assert!(sub_account_b.is_non_zero());
+    assert!(sub_account_b != sub_account_a);
+}
+
+#[test]
+fn test_collects_only_funds_added_by_invoke() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Deploy the sub-account (empty invoke) so we can give it a pre-existing balance.
+    components.invoke(:commitment, invokes: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let preexisting: u128 = 500_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+
+    // The interaction adds `AMOUNT` on top of the pre-existing balance.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+    let deposits = components
+        .invoke(
+            :commitment,
+            invokes: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![(NOTE_ID, token)].span(),
+        );
+
+    // Only the added `AMOUNT` is collected; the pre-existing balance stays in the sub-account.
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, AMOUNT);
+    assert_eq!(components.token.balance_of(components.mock_dapp), 0);
+    assert_eq!(components.token.balance_of(sub_account), preexisting.into());
+    assert_eq!(components.token.balance_of(components.anonymizer), AMOUNT.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+}
+
+#[test]
+fn test_zero_delta_open_note_collects_nothing() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // No invokes, so the open-note token's balance is unchanged → zero delta.
+    let deposits = components
+        .invoke(:commitment, invokes: array![], open_notes: array![(NOTE_ID, token)].span());
+
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), 0);
+}
+
+#[test]
+fn test_decreased_balance_collects_nothing() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Deploy and pre-fund the sub-account.
+    components.invoke(:commitment, invokes: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let preexisting: u128 = 1_000_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+
+    // The invoke makes the sub-account send tokens out, decreasing its balance.
+    let sink: ContractAddress = 'SINK'.try_into().unwrap();
+    let sent: u128 = 300_000;
+    let transfer = Call {
+        to: token,
+        selector: selector!("transfer"),
+        calldata: array![sink.into(), sent.into(), 0].span(),
+    };
+    let deposits = components
+        .invoke(
+            :commitment, invokes: array![transfer], open_notes: array![(NOTE_ID, token)].span(),
+        );
+
+    // Delta is negative, so it clamps to zero — nothing collected.
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, 0);
+    assert_eq!(components.token.balance_of(sub_account), (preexisting - sent).into());
+    assert_eq!(components.token.balance_of(components.anonymizer), 0);
+    assert_eq!(components.token.balance_of(sink), sent.into());
+}
+
+#[test]
+#[should_panic(expected: 'COLLECTED_AMOUNT_OVERFLOW')]
+fn test_collected_amount_overflow() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+
+    // Fund the dapp with `u128::MAX + 1` (two supplies, since `supply` takes a u128).
+    let max = Bounded::<u128>::MAX;
+    components.token.supply(address: components.mock_dapp, amount: max);
+    components.token.supply(address: components.mock_dapp, amount: 1);
+
+    // Two pay-outs add `u128::MAX + 1` to the sub-account, so the collected delta overflows u128.
+    components
+        .invoke(
+            :commitment,
+            invokes: array![
+                pay_out_call(components.mock_dapp, token, max),
+                pay_out_call(components.mock_dapp, token, 1),
+            ],
+            open_notes: array![(NOTE_ID, token)].span(),
+        );
 }

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -1,4 +1,6 @@
+use core::hash::HashStateTrait;
 use core::num::traits::Zero;
+use core::poseidon::PoseidonTrait;
 use snforge_std::{DeclareResultTrait, declare};
 use starknet::SyscallResultTrait;
 use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcherTrait;
@@ -23,4 +25,24 @@ fn test_get_sub_account_class_hash() {
 fn test_get_sub_account_unknown_commitment_is_zero() {
     let anonymizer = deploy_sub_account_anonymizer();
     assert!(anonymizer_disp(anonymizer).get_sub_account('UNKNOWN').is_zero());
+}
+
+#[test]
+fn test_privacy_compute_matches_poseidon() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let commitment = anonymizer_disp(anonymizer).privacy_compute('USER', 'DAPP', 7);
+    let expected = PoseidonTrait::new().update('USER').update('DAPP').update(7).finalize();
+    assert_eq!(commitment, expected);
+}
+
+#[test]
+fn test_privacy_compute_is_deterministic_and_distinct() {
+    let anonymizer = anonymizer_disp(deploy_sub_account_anonymizer());
+    let base = anonymizer.privacy_compute('USER', 'DAPP', 1);
+    // Deterministic for the same inputs.
+    assert_eq!(base, anonymizer.privacy_compute('USER', 'DAPP', 1));
+    // Each input affects the commitment.
+    assert_ne!(base, anonymizer.privacy_compute('OTHER', 'DAPP', 1));
+    assert_ne!(base, anonymizer.privacy_compute('USER', 'OTHER', 1));
+    assert_ne!(base, anonymizer.privacy_compute('USER', 'DAPP', 2));
 }

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -1,12 +1,57 @@
-use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use privacy::objects::OpenNoteDeposit;
+use snforge_std::{ContractClassTrait, DeclareResultTrait, Token, declare};
+use starknet::account::Call;
 use starknet::{ContractAddress, SyscallResultTrait};
-use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcher;
+use starkware_utils_testing::test_utils::{cheat_caller_address_once, deploy_mock_erc20_token};
+use sub_account_anonymizer::sub_account_anonymizer::{
+    ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait,
+};
 
 /// The address configured as the privacy contract; the only authorized caller.
 pub const PRIVACY: ContractAddress = 'PRIVACY'.try_into().unwrap();
 
 pub fn anonymizer_disp(anonymizer: ContractAddress) -> ISubAccountAnonymizerDispatcher {
     ISubAccountAnonymizerDispatcher { contract_address: anonymizer }
+}
+
+/// A deployed anonymizer together with a funding-capable token and a mock dapp, for exercising the
+/// full invoke-and-collect flow.
+#[derive(Drop, Copy)]
+pub struct Components {
+    pub token: Token,
+    pub mock_dapp: ContractAddress,
+    pub anonymizer: ContractAddress,
+}
+
+#[generate_trait]
+pub impl ComponentsImpl of ComponentsTrait {
+    /// Calls `privacy_invoke_with_computation` cheating the caller to be the privacy contract.
+    fn invoke(
+        self: @Components,
+        commitment: felt252,
+        invokes: Array<Call>,
+        open_notes: Span<(felt252, ContractAddress)>,
+    ) -> Span<OpenNoteDeposit> {
+        cheat_caller_address_once(contract_address: *self.anonymizer, caller_address: PRIVACY);
+        anonymizer_disp(*self.anonymizer)
+            .privacy_invoke_with_computation(:commitment, :invokes, :open_notes)
+    }
+}
+
+pub fn deploy_components() -> Components {
+    let token = deploy_token();
+    let mock_dapp = deploy_mock_dapp();
+    let anonymizer = deploy_sub_account_anonymizer();
+    Components { token, mock_dapp, anonymizer }
+}
+
+/// Builds a `pay_out(token, amount)` call on the mock dapp, which transfers `amount` to its caller.
+pub fn pay_out_call(mock_dapp: ContractAddress, token: ContractAddress, amount: u128) -> Call {
+    Call {
+        to: mock_dapp,
+        selector: selector!("pay_out"),
+        calldata: array![token.into(), amount.into(), 0].span(),
+    }
 }
 
 pub fn deploy_sub_account_anonymizer() -> ContractAddress {
@@ -18,5 +63,23 @@ pub fn deploy_sub_account_anonymizer() -> ContractAddress {
     let (address, _) = contract
         .deploy(@array![PRIVACY.into(), sub_account_class_hash.into()])
         .unwrap_syscall();
+    address
+}
+
+pub fn deploy_token() -> Token {
+    // Snforge deploys each contract to a fresh address per deploy() call regardless of identical
+    // class/calldata.
+    deploy_mock_erc20_token(
+        name: "SubAccTestToken",
+        symbol: "SAT",
+        decimals: 18,
+        initial_supply: 1_000_000_000_000_000_000_000_000_u256,
+        owner: 'TOKEN_OWNER'.try_into().unwrap(),
+    )
+}
+
+fn deploy_mock_dapp() -> ContractAddress {
+    let contract = declare("MockDapp").unwrap_syscall().contract_class();
+    let (address, _) = contract.deploy(@array![]).unwrap_syscall();
     address
 }

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -1,0 +1,22 @@
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use starknet::{ContractAddress, SyscallResultTrait};
+use sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizerDispatcher;
+
+/// The address configured as the privacy contract; the only authorized caller.
+pub const PRIVACY: ContractAddress = 'PRIVACY'.try_into().unwrap();
+
+pub fn anonymizer_disp(anonymizer: ContractAddress) -> ISubAccountAnonymizerDispatcher {
+    ISubAccountAnonymizerDispatcher { contract_address: anonymizer }
+}
+
+pub fn deploy_sub_account_anonymizer() -> ContractAddress {
+    let sub_account_class_hash = *declare("SubAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let contract = declare("SubAccountAnonymizer").unwrap_syscall().contract_class();
+    let (address, _) = contract
+        .deploy(@array![PRIVACY.into(), sub_account_class_hash.into()])
+        .unwrap_syscall();
+    address
+}

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -10,6 +10,9 @@ use sub_account_anonymizer::sub_account_anonymizer::{
 /// The address configured as the privacy contract; the only authorized caller.
 pub const PRIVACY: ContractAddress = 'PRIVACY'.try_into().unwrap();
 
+/// The address configured as the contract owner; authorized to upgrade and transfer ownership.
+pub const OWNER: ContractAddress = 'OWNER'.try_into().unwrap();
+
 pub fn anonymizer_disp(anonymizer: ContractAddress) -> ISubAccountAnonymizerDispatcher {
     ISubAccountAnonymizerDispatcher { contract_address: anonymizer }
 }
@@ -61,7 +64,7 @@ pub fn deploy_sub_account_anonymizer() -> ContractAddress {
         .class_hash;
     let contract = declare("SubAccountAnonymizer").unwrap_syscall().contract_class();
     let (address, _) = contract
-        .deploy(@array![PRIVACY.into(), sub_account_class_hash.into()])
+        .deploy(@array![PRIVACY.into(), sub_account_class_hash.into(), OWNER.into()])
         .unwrap_syscall();
     address
 }


### PR DESCRIPTION
## Summary

Adds the **compute-and-invoke** flow to the privacy pool:

- **`ComputeAndInvoke`** client action — during `execute()`, calls the target's `privacy_compute` (passing the derived identity key + caller `compute_data`) and forwards the result, compiling to an **`InvokeWithComputation`** server action.
- **`InvokeWithComputation`** server action — at `apply_actions`, routes to the target's `privacy_invoke_with_computation` (commitment ++ invoke data) and applies any returned open-note deposits, sharing the existing `_apply_invoke_and_deposits` path with `Invoke`.
- Identity-key / commitment derivation (`hashes.cairo`) and `propagate_external_panic` handling (`utils.cairo`).
- Enforces the single invoke-phase-action-per-tx rule (any pair of `InvokeExternal`/`ComputeAndInvoke` reverts `ACTIONS_OUT_OF_ORDER`).

## Tests

Full parity with the existing `Invoke` path:
- **Client:** validation, calldata assembly (empty + multi-felt), defer-during-execute, missing `privacy_compute` selector, client-side reentrancy, panic propagation, e2e deposit-to-open-note (with create + deposit events).
- **Server:** missing selector, return-data validation (deserialize / trailing garbage), panic propagation, blocked depositor, deposit-error matrix (NOTE_NOT_FOUND / NOT_OPEN / ALREADY_DEPOSITED / TOKEN_MISMATCH / ZERO_*), and the `UNDEPOSITED` / `TOO_MANY_OPEN_NOTES_DEPOSITED` invariants.
- Consolidated the garbage-return mocks (`MockReturnGarbage` / `MockReturnTrailingGarbage` now serve both entry points) and merged the multiple-invoke revert tests into one parametrized test.

All privacy tests pass (`snforge test --package privacy`): 283 passed, 0 failed, 3 ignored. `scarb fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/843)
<!-- Reviewable:end -->
