### PR TITLE
test(privacy): e2e for sub-account anonymizer compute-invoke

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -166,6 +166,7 @@ dependencies = [
  "snforge_std",
  "starkware_utils",
  "starkware_utils_testing",
+ "sub_account_anonymizer",
  "vesu_lending_anonymizer",
 ]
 

--- a/packages/privacy/Scarb.toml
+++ b/packages/privacy/Scarb.toml
@@ -20,14 +20,18 @@ ekubo.workspace = true
 ekubo_swap_anonymizer = { path = "../ekubo_swap_anonymizer", features = ["test_utils"] }
 snforge_std.workspace = true
 starkware_utils_testing.workspace = true
+sub_account_anonymizer = { path = "../sub_account_anonymizer", features = ["test_utils"] }
 vesu_lending_anonymizer = { path = "../vesu_lending_anonymizer", features = ["test_utils"] }
 
 [[test]]
 name = "privacy_unittest"
 build-external-contracts = [
     "starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock",
+    "starkware_utils::contracts::sub_account::SubAccount",
     "ekubo_swap_anonymizer::ekubo_swap_anonymizer::EkuboSwapAnonymizer",
     "ekubo_swap_anonymizer::test_utils_contracts::mock_ekubo_amm::MockEkuboAMM",
+    "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer",
+    "sub_account_anonymizer::test_utils_contracts::mock_dapp::MockDapp",
     "vesu_lending_anonymizer::vesu_lending_anonymizer::VesuLendingAnonymizer",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault",
     "vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop",

--- a/packages/privacy/src/tests/test_e2e.cairo
+++ b/packages/privacy/src/tests/test_e2e.cairo
@@ -5,19 +5,24 @@ use core::num::traits::Zero;
 use ekubo::interfaces::router::TokenAmount;
 use ekubo::types::i129::i129;
 use privacy::actions::{
-    ClientAction, CreateEncNoteInput, DepositInput, InvokeExternalInput, OpenChannelInput,
-    OpenSubchannelInput, SetViewingKeyInput, UseNoteInput, WithdrawInput,
+    ClientAction, ComputeAndInvokeInput, CreateEncNoteInput, DepositInput, InvokeExternalInput,
+    OpenChannelInput, OpenSubchannelInput, SetViewingKeyInput, UseNoteInput, WithdrawInput,
 };
 use privacy::objects::OpenNoteDeposit;
 use privacy::tests::utils_for_tests::{
     PrivacyCfgTrait, Test, TestTrait, User, UserTrait, VesuTrait,
-    build_ekubo_swap_anonymizer_calldata, pool_key_for_tokens,
+    build_ekubo_swap_anonymizer_calldata, deploy_sub_account_anonymizer,
+    deploy_sub_account_mock_dapp, pool_key_for_tokens,
 };
 use privacy::utils::constants::OPEN_NOTE_SALT;
 use privacy::utils::{encrypt_channel_info, unpack};
 use snforge_std::TokenTrait;
 use starknet::ContractAddress;
+use starknet::account::Call;
 use starkware_utils_testing::test_utils::TokenHelperTrait;
+use sub_account_anonymizer::sub_account_anonymizer::{
+    ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait,
+};
 
 // Helper: Constants for e2e testing.
 const RANDOM: felt252 = 0x24a7f3e2b1c9d8e6f5a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e;
@@ -1900,4 +1905,88 @@ fn test_e2e_ekubo_invoke() {
     assert_eq!(filled_salt, OPEN_NOTE_SALT);
     assert_eq!(filled_amount, amount);
     assert_eq!(filled_note.token, output_token_addr);
+}
+
+/// E2E: drive the sub-account anonymizer through the compute-and-invoke flow. execute() runs the
+/// anonymizer's `privacy_compute` to derive the per-commitment sub-account; apply_actions then runs
+/// `privacy_invoke_with_computation`, which deploys the sub-account, has it call the dapp (funds
+/// land in the sub-account), collects them into the anonymizer, and settles them into the open note
+/// created in the same tx.
+#[test]
+fn test_e2e_sub_account_anonymizer_compute_invoke() {
+    let mut test: Test = Default::default();
+    let token = test.new_token();
+    let token_addr = token.contract_address();
+    let amount = 100_u128;
+    let mut user = test.new_user();
+
+    let anonymizer = deploy_sub_account_anonymizer(privacy_address: test.privacy.address);
+    let mock_dapp = deploy_sub_account_mock_dapp();
+    // Fund the dapp so its `pay_out` can transfer `amount` to the sub-account.
+    token.supply(address: mock_dapp, :amount);
+
+    // Open note that the collected funds settle into (created in the same tx as the invoke).
+    let create_open_note = user
+        .new_open_note_with_generated_random(recipient: user, :token_addr, index: 0);
+    let (note_id, _) = user.compute_open_note(create_note_input: create_open_note);
+
+    // compute_data feeds `privacy_compute(identity_key, dapp_name, seq_nonce)`.
+    let dapp_name = 'DAPP';
+    let nonce = 0;
+    let compute_data = [dapp_name, nonce].span();
+    // invoke_data carries `(invokes, open_notes)` forwarded to `privacy_invoke_with_computation`.
+    let pay_out = Call {
+        to: mock_dapp,
+        selector: selector!("pay_out"),
+        calldata: array![token_addr.into(), amount.into(), 0].span(),
+    };
+    let invokes: Array<Call> = array![pay_out];
+    let open_notes: Span<(felt252, ContractAddress)> = [(note_id, token_addr)].span();
+    let mut invoke_data: Array<felt252> = array![];
+    invokes.serialize(ref invoke_data);
+    open_notes.serialize(ref invoke_data);
+    let compute_and_invoke = ClientAction::ComputeAndInvoke(
+        ComputeAndInvokeInput {
+            contract_address: anonymizer,
+            compute_additional_data: compute_data,
+            invoke_additional_data: invoke_data.span(),
+        },
+    );
+
+    // Test balance before.
+    assert_eq!(token.balance_of(address: test.privacy.address), 0);
+    assert_eq!(token.balance_of(address: mock_dapp), amount.into());
+    assert_eq!(token.balance_of(address: anonymizer), 0);
+
+    test
+        .privacy
+        .execute_actions_e2e(
+            :user,
+            client_actions: [
+                set_viewing_key_action(), open_channel_action(from: user, to: user, index: 0),
+                open_subchannel_action(from: user, to: user, :token_addr, index: 0),
+                ClientAction::CreateOpenNote(create_open_note), compute_and_invoke,
+            ]
+                .span(),
+        );
+
+    // The dapp payout, collected via the sub-account and anonymizer, settled into the open note.
+    let filled_note = test.privacy.get_note(:note_id);
+    let (salt, filled_amount) = unpack(packed_value: filled_note.packed_value);
+    assert_eq!(salt, OPEN_NOTE_SALT);
+    assert_eq!(filled_amount, amount);
+    assert_eq!(filled_note.token, token_addr);
+
+    // Funds ended in the privacy contract; the dapp and anonymizer hold nothing.
+    assert_eq!(token.balance_of(address: test.privacy.address), amount.into());
+    assert_eq!(token.balance_of(address: mock_dapp), 0);
+    assert_eq!(token.balance_of(address: anonymizer), 0);
+
+    // A sub-account was deployed for the derived commitment and holds nothing after collection.
+    let anonymizer_disp = ISubAccountAnonymizerDispatcher { contract_address: anonymizer };
+    let identity_key = user.compute_identity_key(contract_address: anonymizer);
+    let identity_commitment = anonymizer_disp.privacy_compute(:identity_key, :dapp_name, :nonce);
+    let sub_account = anonymizer_disp.get_sub_account(:identity_commitment);
+    assert!(sub_account.is_non_zero());
+    assert_eq!(token.balance_of(address: sub_account), 0);
 }

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -66,15 +66,15 @@ use snforge_std::signature::stark_curve::{
 };
 use snforge_std::signature::{KeyPairTrait, SignerTrait};
 use snforge_std::{
-    CheatSpan, DeclareResultTrait, MessageToL1, MessageToL1Spy, MessageToL1SpyTrait, Token,
-    TokenTrait, cheat_proof_facts, cheat_resource_bounds, declare, interact_with_state,
-    map_entry_address, spy_messages_to_l1, store,
+    CheatSpan, ContractClassTrait, DeclareResultTrait, MessageToL1, MessageToL1Spy,
+    MessageToL1SpyTrait, Token, TokenTrait, cheat_proof_facts, cheat_resource_bounds, declare,
+    interact_with_state, map_entry_address, spy_messages_to_l1, store,
 };
 use starknet::account::Call;
 use starknet::deployment::DeploymentParams;
 use starknet::storage::StorableStoragePointerReadAccess;
 use starknet::{
-    ContractAddress, ResourcesBounds, SyscallResultTrait, VALIDATED, get_block_timestamp,
+    ClassHash, ContractAddress, ResourcesBounds, SyscallResultTrait, VALIDATED, get_block_timestamp,
 };
 use starkware_utils::components::pausable::interface::{
     IPausableDispatcher, IPausableDispatcherTrait,
@@ -85,6 +85,7 @@ use starkware_utils::components::roles::interface::{
 use starkware_utils_testing::test_utils::{
     TokenHelperTrait, cheat_caller_address_once, deploy_mock_erc20_token, generic_load,
 };
+use sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::deploy_for_test as deploy_sub_account_anonymizer_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow::deploy_for_test as deploy_mock_vesu_vault_overflow_for_test;
@@ -2265,6 +2266,37 @@ fn deploy_privacy(
         echo_executor,
         mock_amm,
     }
+}
+
+/// Deploys a `SubAccountAnonymizer` authorized to be driven by `privacy_address`, declaring the
+/// `SubAccount` class it deploys per commitment.
+pub(crate) fn deploy_sub_account_anonymizer(privacy_address: ContractAddress) -> ContractAddress {
+    let sub_account_class_hash: ClassHash = *declare(contract: "SubAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let class_hash = declare(contract: "SubAccountAnonymizer")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    let deployment_params = DeploymentParams { salt: 0, deploy_from_zero: true };
+    let (address, _) = deploy_sub_account_anonymizer_for_test(
+        class_hash: *class_hash,
+        :deployment_params,
+        privacy_contract: privacy_address,
+        :sub_account_class_hash,
+        governance_admin: 'GOVERNANCE_ADMIN'.try_into().unwrap(),
+    )
+        .expect('SUB_ACCT_ANON_DEPLOY_FAIL');
+    address
+}
+
+/// Deploys the `MockDapp` used by sub-account interactions (its `pay_out` transfers a funded token
+/// balance to the calling sub-account).
+pub(crate) fn deploy_sub_account_mock_dapp() -> ContractAddress {
+    let contract = declare(contract: "MockDapp").unwrap_syscall().contract_class();
+    let (address, _) = contract.deploy(constructor_calldata: @array![]).unwrap_syscall();
+    address
 }
 
 fn deploy_vesu_lending_anonymizer() -> ContractAddress {

--- a/packages/sub_account_anonymizer/Scarb.toml
+++ b/packages/sub_account_anonymizer/Scarb.toml
@@ -20,6 +20,9 @@ assert_macros.workspace = true
 snforge_std.workspace = true
 starkware_utils_testing.workspace = true
 
+[features]
+test_utils = []
+
 [lib]
 
 [[test]]

--- a/packages/sub_account_anonymizer/src/lib.cairo
+++ b/packages/sub_account_anonymizer/src/lib.cairo
@@ -1,5 +1,7 @@
 pub mod sub_account_anonymizer;
 #[cfg(test)]
 pub mod test_utils_contracts;
+#[cfg(feature: 'test_utils')]
+pub mod test_utils_contracts;
 #[cfg(test)]
 pub mod tests;


### PR DESCRIPTION
## Summary

Stacked on #844. Adds one end-to-end test driving the **real** `SubAccountAnonymizer` through the compute-and-invoke flow:

- `execute()` runs the anonymizer's `privacy_compute(identity_key, dapp_name, seq_nonce)` to derive the per-commitment sub-account.
- `apply_actions()` runs `privacy_invoke_with_computation`, which deploys the sub-account, has it call `MockDapp.pay_out` (funds land in the sub-account), collects them into the anonymizer, and settles them into the open note created in the same tx.
- Asserts the open note is filled, funds end in the privacy contract (dapp/anonymizer/sub-account all zero), and a sub-account was deployed for the derived commitment.

## Plumbing (mirrors the ekubo/vesu pattern)

- `sub_account_anonymizer`: added a `test_utils` feature exposing `test_utils_contracts` (so `MockDapp` is consumable externally).
- `privacy/Scarb.toml`: `sub_account_anonymizer` dev-dep with `test_utils`, plus `SubAccountAnonymizer`/`MockDapp`/`SubAccount` in `build-external-contracts`.
- `utils_for_tests.cairo`: `deploy_sub_account_anonymizer` / `deploy_sub_account_mock_dapp` helpers.

## Verification

`snforge test --package privacy`: 284 passed, 0 failed, 3 ignored. `sub_account_anonymizer`: 18 passed. `scarb fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/845)
<!-- Reviewable:end -->
