### PR TITLE
test: use deploy_mock_erc20_token util

### DIFF
--- a/packages/ekubo_swap_anonymizer/src/tests/test_utils.cairo
+++ b/packages/ekubo_swap_anonymizer/src/tests/test_utils.cairo
@@ -8,10 +8,10 @@ use ekubo_swap_anonymizer::ekubo_swap_anonymizer::{
 };
 use ekubo_swap_anonymizer::test_utils_contracts::mock_ekubo_amm::MockEkuboAMM::deploy_for_test as deploy_mock_ekubo_amm_for_test;
 use privacy::objects::OpenNoteDeposit;
-use snforge_std::{CustomToken, DeclareResultTrait, Token, declare};
+use snforge_std::{DeclareResultTrait, Token, declare};
 use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
-use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
+use starkware_utils_testing::test_utils::deploy_mock_erc20_token;
 
 pub fn deploy_mock_ekubo_amm() -> ContractAddress {
     let class_hash = declare(contract: "MockEkuboAMM").unwrap_syscall().contract_class().class_hash;
@@ -48,19 +48,12 @@ pub fn pool_key_for_tokens(token_a: ContractAddress, token_b: ContractAddress) -
 }
 
 pub fn new_token() -> Token {
-    let config = TokenConfig {
+    deploy_mock_erc20_token(
         name: "TestToken",
         symbol: "TT",
         decimals: 18,
         initial_supply: 1_000_000_000_000_000_000_000_000_000_000_u256,
         owner: 'TOKEN_OWNER'.try_into().unwrap(),
-    };
-    let token = config.deploy();
-    Token::Custom(
-        CustomToken {
-            contract_address: token.address,
-            balances_variable_selector: selector!("ERC20_balances"),
-        },
     )
 }
 

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -62,8 +62,8 @@ use snforge_std::signature::stark_curve::{
 };
 use snforge_std::signature::{KeyPairTrait, SignerTrait};
 use snforge_std::{
-    CheatSpan, CustomToken, DeclareResultTrait, MessageToL1, MessageToL1Spy, MessageToL1SpyTrait,
-    Token, TokenTrait, cheat_proof_facts, cheat_resource_bounds, declare, interact_with_state,
+    CheatSpan, DeclareResultTrait, MessageToL1, MessageToL1Spy, MessageToL1SpyTrait, Token,
+    TokenTrait, cheat_proof_facts, cheat_resource_bounds, declare, interact_with_state,
     map_entry_address, spy_messages_to_l1, store,
 };
 use starknet::account::Call;
@@ -79,7 +79,7 @@ use starkware_utils::components::roles::interface::{
     ICommonRolesDispatcher, ICommonRolesDispatcherTrait, Role,
 };
 use starkware_utils_testing::test_utils::{
-    Deployable, TokenConfig, TokenHelperTrait, cheat_caller_address_once, generic_load,
+    TokenHelperTrait, cheat_caller_address_once, deploy_mock_erc20_token, generic_load,
 };
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
@@ -1477,20 +1477,12 @@ pub(crate) impl TestImpl of TestTrait {
 
     fn new_token(ref self: Test) -> Token {
         self.nonce += 1;
-        let config = TokenConfig {
+        deploy_mock_erc20_token(
             name: format!("Token {}", self.nonce),
             symbol: format!("Token {}", self.nonce),
             decimals: constants::DECIMALS,
             initial_supply: constants::TOKEN_SUPPLY,
             owner: constants::TOKEN_OWNER,
-        };
-        let token = config.deploy();
-
-        Token::Custom(
-            CustomToken {
-                contract_address: token.address,
-                balances_variable_selector: selector!("ERC20_balances"),
-            },
         )
     }
 

--- a/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
+++ b/packages/vesu_lending_anonymizer/src/tests/test_utils.cairo
@@ -1,9 +1,9 @@
 use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use privacy::objects::OpenNoteDeposit;
-use snforge_std::{CustomToken, DeclareResultTrait, Token, TokenTrait, declare};
+use snforge_std::{DeclareResultTrait, Token, TokenTrait, declare};
 use starknet::deployment::DeploymentParams;
 use starknet::{ContractAddress, SyscallResultTrait};
-use starkware_utils_testing::test_utils::{Deployable, TokenConfig};
+use starkware_utils_testing::test_utils::deploy_mock_erc20_token;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVault::deploy_for_test as deploy_mock_vesu_vault_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultNoop::deploy_for_test as deploy_mock_vesu_vault_noop_for_test;
 use vesu_lending_anonymizer::test_utils_contracts::mock_vesu_vault::MockVesuVaultOverflow::deploy_for_test as deploy_mock_vesu_vault_overflow_for_test;
@@ -166,18 +166,11 @@ pub fn deploy_mock_vesu_vault_overflow(underlying_token: ContractAddress) -> Con
 }
 
 fn deploy_test_erc20_token() -> Token {
-    let config = TokenConfig {
+    deploy_mock_erc20_token(
         name: "VesuTestToken",
         symbol: "VTT",
         decimals: 18,
         initial_supply: 1_000_000_000_000_000_000_000_000_000_000_u256,
         owner: 'TOKEN_OWNER'.try_into().unwrap(),
-    };
-    let token = config.deploy();
-    Token::Custom(
-        CustomToken {
-            contract_address: token.address,
-            balances_variable_selector: selector!("ERC20_balances"),
-        },
     )
 }


### PR DESCRIPTION
## Summary

`privacy::new_token`, `vesu::deploy_test_erc20_token`, and `ekubo::new_token` each re-implemented what `starkware_utils_testing::test_utils::deploy_mock_erc20_token` already does (deploy the ERC20 mock + wrap into `Token::Custom { …, balances_variable_selector: selector!("ERC20_balances") }`).

This calls the shared util directly in all three and drops the now-unused `Deployable` / `TokenConfig` / `CustomToken` imports. Behavior is identical. (`sub_account_anonymizer::deploy_token` already used the util.)

## Verification

`snforge test`: privacy 271 passed, vesu 6 passed, ekubo 3 passed (0 failed). `scarb fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/846)
<!-- Reviewable:end -->
