### PR TITLE
fix(discovery-service): default max_batch_size to 100

### DIFF
--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -31,7 +31,7 @@ max_concurrent_requests = 10
 connect_timeout = 60        # seconds
 request_timeout = 30        # seconds
 max_idle_per_host = 10
-max_batch_size = 256        # max storage slots per JSON-RPC batch request
+max_batch_size = 100        # max storage slots per JSON-RPC batch request
 event_page_size = 1024      # max events per starknet_getEvents page (spec max: 1024)
 
 [indexer]

--- a/crates/discovery-service/src/config.rs
+++ b/crates/discovery-service/src/config.rs
@@ -60,7 +60,7 @@ impl Default for RpcConfig {
             connect_timeout: Duration::from_secs(60),
             request_timeout: Duration::from_secs(30),
             max_idle_per_host: 10,
-            max_batch_size: 256,
+            max_batch_size: 100,
             event_page_size: 1024,
         }
     }

--- a/deploy/discovery-service/config.example.toml
+++ b/deploy/discovery-service/config.example.toml
@@ -12,7 +12,7 @@ max_concurrent_requests = 10
 connect_timeout = 60
 request_timeout = 30
 max_idle_per_host = 10
-max_batch_size = 256
+max_batch_size = 100
 event_page_size = 1024
 
 [indexer]


### PR DESCRIPTION
## Problem
Funded-account discovery syncs returned `503 STORAGE_ERROR` on `/v1/sync/incoming_state`, while empty/small accounts worked.

## Cause
The discovery service chunks `get_storage_at` reads at `[rpc] max_batch_size`, defaulting to 256. Pathfinder's default RPC batch-size limit (`--rpc.batch-size-limit`) is 100, so a sync reading >100 slots sent a batch the node rejected wholesale (`-32700 "array exceeds maximum length 100"`) → generic 503. Nothing "enforces" 100 specifically — it's just the node's default, and both it and `max_batch_size` are configurable.

## Fix
Default `RpcConfig.max_batch_size` 256 → 100 so a fresh deploy is consistent with the node's default out of the box (config.rs, example config, spec).

## Verification
`cargo fmt` / `cargo clippy --all-targets` clean; `cargo test -p discovery-service` green. Verified live: after setting `max_batch_size=100` on the testnet ConfigMap, a funded account (2772 notes) synced cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/847)
<!-- Reviewable:end -->
