### PR TITLE
fix(discovery-service): log storage backend errors at warn, not debug

### DIFF
--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -15,7 +15,7 @@ use discovery_core::sync::incoming_state::IncomingSubchannel;
 use discovery_core::sync::outgoing_state::OutgoingSubchannel;
 use serde::{Deserialize, Serialize};
 use starknet_core::types::{BlockId, Felt};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use super::block_id_serde;
 use crate::chain_state::ChainHead;
@@ -85,7 +85,7 @@ pub fn storage_error_to_response(
             ),
         ),
         other => {
-            debug!("Storage error: {}", other);
+            warn!("Storage error: {}", other);
             (
                 StatusCode::SERVICE_UNAVAILABLE,
                 ApiErrorResponse::new(error_codes::STORAGE_ERROR, "Storage backend error"),

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -7,7 +7,7 @@ use discovery_core::discovery::DiscoveryCursor;
 use discovery_core::history::types::HistoryCursor;
 use discovery_core::storage_backend::{StorageError, StorageSnapshot};
 use starknet_core::types::{BlockId, Felt};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::api::types::{error_codes, ApiErrorResponse};
 use crate::chain_state::{ChainState, ChainStateError};
@@ -216,7 +216,7 @@ pub async fn validate_viewing_key<S: StorageSnapshot>(
                     ),
                 ),
                 other => {
-                    debug!("Storage error fetching public key: {}", other);
+                    warn!("Storage error fetching public key: {}", other);
                     (
                         StatusCode::SERVICE_UNAVAILABLE,
                         ApiErrorResponse::new(error_codes::STORAGE_ERROR, "Storage backend error"),


### PR DESCRIPTION
## Problem
When a storage read failed (e.g. the recent batch-size 503), the underlying cause was logged only at `debug!` — off under the default `RUST_LOG=info` — so the generic `STORAGE_ERROR` / "Storage backend error" response left operators with nothing to diagnose.

## Change
Log the underlying storage error at `warn!` instead of `debug!` in both mapping sites (`storage_error_to_response` and the validator's public-key fetch). The API response is unchanged — internal error detail is deliberately kept out of client responses; operators read the cause from logs.

## Verification
`cargo fmt` / `cargo clippy --all-targets` clean; `cargo test -p discovery-service` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/848)
<!-- Reviewable:end -->
