### PR TITLE
refactor(sub-account-anonymizer): rename commitment to identity_commitment

### DIFF
--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -1,17 +1,18 @@
 //! Sub-account anonymizer for privacy-preserving dapp interactions.
 //!
-//! Runs arbitrary dapp calls on behalf of the privacy contract through per-commitment
-//! [`SubAccount`](starkware_utils::contracts::sub_account::SubAccount) contracts. Each commitment
-//! maps to a dedicated sub-account that performs the dapp calls and holds the resulting funds; the
-//! anonymizer then collects those funds into itself and approves the privacy contract to pull
-//! them into open notes. Driving interactions is restricted to the configured privacy contract.
+//! Runs arbitrary dapp calls on behalf of the privacy contract through per-identity-commitment
+//! [`SubAccount`](starkware_utils::contracts::sub_account::SubAccount) contracts. Each identity
+//! commitment maps to a dedicated sub-account that performs the dapp calls and holds the resulting
+//! funds; the anonymizer then collects those funds into itself and approves the privacy contract to
+//! pull them into open notes. Driving interactions is restricted to the configured privacy
+//! contract.
 
 use privacy::objects::OpenNoteDeposit;
 use starknet::account::Call;
 use starknet::{ClassHash, ContractAddress};
 
-/// The result of [`privacy_compute`]: a commitment that identifies a single sub-account.
-pub type PrivacyComputeCommitment = felt252;
+/// The result of [`privacy_compute`]: an identity commitment that identifies a single sub-account.
+pub type IdentityCommitment = felt252;
 
 /// An open note to settle after an interaction.
 #[derive(Serde, Copy, Drop, PartialEq, Debug)]
@@ -24,31 +25,31 @@ pub struct OpenNote {
 
 #[starknet::interface]
 pub trait ISubAccountAnonymizer<T> {
-    /// Derives the commitment that identifies a sub-account.
+    /// Derives the identity commitment that identifies a sub-account.
     ///
     /// #### Parameters
     /// - `identity_key` (`felt252`) - A unique handle derived by the privacy pool from a user
     /// identity. It is linked to the user but cannot be traced back to them. Only the holder of the
     /// underlying identity can reproduce it, making it a pseudonymous proof of ownership without
     /// revealing who they are.
-    /// - `dapp_name` (`felt252`) - The dapp the sub-account interacts with, scoping commitments per
-    /// dapp.
+    /// - `dapp_name` (`felt252`) - The dapp the sub-account interacts with, scoping identity
+    /// commitments per dapp.
     /// - `nonce` (`felt252`) - A nonce that lets one identity derive multiple distinct sub-accounts
     /// for the same dapp.
     ///
     /// #### Returns
-    /// - ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - A commitment binding to a
+    /// - ([`IdentityCommitment`](IdentityCommitment)) - An identity commitment binding to a
     /// single sub-account.
     fn privacy_compute(
         self: @T, identity_key: felt252, dapp_name: felt252, nonce: felt252,
-    ) -> PrivacyComputeCommitment;
+    ) -> IdentityCommitment;
 
-    /// Executes `calls` through the sub-account bound to `commitment` (deploying it on first
-    /// use), then collects each requested open-note token from the sub-account and into this
+    /// Executes `calls` through the sub-account bound to `identity_commitment` (deploying it on
+    /// first use), then collects each requested open-note token from the sub-account and into this
     /// anonymizer, approving the privacy contract to pull the collected amount.
     ///
     /// #### Parameters
-    /// - `commitment` ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - identifies the
+    /// - `identity_commitment` ([`IdentityCommitment`](IdentityCommitment)) - identifies the
     /// sub-account; see [`privacy_compute`]. Preimage is off-chain only and unrecoverable from
     /// on-chain data.
     /// - `calls` (`Array<Call>`) - the dapp calls to run as the sub-account.
@@ -72,21 +73,21 @@ pub trait ISubAccountAnonymizer<T> {
     ///   collected for an open note exceeds `u128`.
     fn privacy_invoke_with_computation(
         ref self: T,
-        commitment: PrivacyComputeCommitment,
+        identity_commitment: IdentityCommitment,
         calls: Array<Call>,
         open_notes: Span<OpenNote>,
     ) -> Span<OpenNoteDeposit>;
 
-    /// Returns the sub-account address bound to `commitment`.
+    /// Returns the sub-account address bound to `identity_commitment`.
     ///
     /// #### Parameters
-    /// - `commitment` ([`PrivacyComputeCommitment`](PrivacyComputeCommitment)) - The commitment
-    /// derived by `privacy_compute`.
+    /// - `identity_commitment` ([`IdentityCommitment`](IdentityCommitment)) - The identity
+    /// commitment derived by `privacy_compute`.
     ///
     /// #### Returns
     /// - (`ContractAddress`) - The deployed sub-account address, or zero if none has been deployed
-    /// for `commitment` yet.
-    fn get_sub_account(self: @T, commitment: PrivacyComputeCommitment) -> ContractAddress;
+    /// for `identity_commitment` yet.
+    fn get_sub_account(self: @T, identity_commitment: IdentityCommitment) -> ContractAddress;
 
     /// Returns the privacy contract authorized to drive interactions.
     ///
@@ -94,7 +95,7 @@ pub trait ISubAccountAnonymizer<T> {
     /// - (`ContractAddress`) - The address of the authorized privacy contract.
     fn get_privacy_contract(self: @T) -> ContractAddress;
 
-    /// Returns the class hash of the `SubAccount` contract deployed per commitment.
+    /// Returns the class hash of the `SubAccount` contract deployed per identity commitment.
     ///
     /// #### Returns
     /// - (`ClassHash`) - The class hash used when deploying a sub-account.
@@ -133,7 +134,7 @@ pub mod SubAccountAnonymizer {
     use starkware_utils::contracts::sub_account::{
         ISubAccountDispatcher, ISubAccountDispatcherTrait,
     };
-    use super::{ISubAccountAnonymizer, OpenNote, PrivacyComputeCommitment, errors};
+    use super::{ISubAccountAnonymizer, IdentityCommitment, OpenNote, errors};
 
     component!(path: ReplaceabilityComponent, storage: replaceability, event: ReplaceabilityEvent);
     component!(path: CommonRolesComponent, storage: common_roles, event: CommonRolesEvent);
@@ -158,11 +159,11 @@ pub mod SubAccountAnonymizer {
         src5: SRC5Component::Storage,
         /// Address of the authorized privacy contract.
         privacy_contract: ContractAddress,
-        /// Class hash of the `SubAccount` contract deployed per commitment.
+        /// Class hash of the `SubAccount` contract deployed per identity commitment.
         // TODO: Consider making this a constant.
         sub_account_class_hash: ClassHash,
-        /// Maps a commitment to the sub-account deployed for it.
-        sub_accounts: Map<PrivacyComputeCommitment, ContractAddress>,
+        /// Maps an identity commitment to the sub-account deployed for it.
+        sub_accounts: Map<IdentityCommitment, ContractAddress>,
     }
 
     #[event]
@@ -195,28 +196,28 @@ pub mod SubAccountAnonymizer {
     pub impl SubAccountAnonymizerImpl of ISubAccountAnonymizer<ContractState> {
         fn privacy_compute(
             self: @ContractState, identity_key: felt252, dapp_name: felt252, nonce: felt252,
-        ) -> PrivacyComputeCommitment {
+        ) -> IdentityCommitment {
             PoseidonTrait::new().update(identity_key).update(dapp_name).update(nonce).finalize()
         }
 
         fn privacy_invoke_with_computation(
             ref self: ContractState,
-            commitment: PrivacyComputeCommitment,
+            identity_commitment: IdentityCommitment,
             calls: Array<Call>,
             open_notes: Span<OpenNote>,
         ) -> Span<OpenNoteDeposit> {
             assert(
                 get_caller_address() == self.privacy_contract.read(), errors::UNAUTHORIZED_CALLER,
             );
-            let sub_account = self.get_or_deploy_sub_account(:commitment);
+            let sub_account = self.get_or_deploy_sub_account(:identity_commitment);
             sub_account.execute(calls);
             self.collect_open_notes(:sub_account, :open_notes)
         }
 
         fn get_sub_account(
-            self: @ContractState, commitment: PrivacyComputeCommitment,
+            self: @ContractState, identity_commitment: IdentityCommitment,
         ) -> ContractAddress {
-            self.sub_accounts.read(commitment)
+            self.sub_accounts.read(identity_commitment)
         }
 
         fn get_privacy_contract(self: @ContractState) -> ContractAddress {
@@ -230,24 +231,24 @@ pub mod SubAccountAnonymizer {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        /// Returns the sub-account bound to `commitment`, deploying a fresh one on first use. The
-        /// commitment is the deployment salt, so each commitment maps to a deterministic address,
+        /// Returns the sub-account bound to `identity_commitment`, deploying a fresh one on first
+        /// use. The commitment is the deployment salt, so each one maps to a deterministic address,
         /// and the deployed `SubAccount` records this anonymizer (its deployer) as owner.
         fn get_or_deploy_sub_account(
-            ref self: ContractState, commitment: PrivacyComputeCommitment,
+            ref self: ContractState, identity_commitment: IdentityCommitment,
         ) -> ISubAccountDispatcher {
-            let existing = self.sub_accounts.read(commitment);
+            let existing = self.sub_accounts.read(identity_commitment);
             if existing.is_non_zero() {
                 return ISubAccountDispatcher { contract_address: existing };
             }
             let (sub_account_addr, _) = deploy_syscall(
                 class_hash: self.sub_account_class_hash.read(),
-                contract_address_salt: commitment,
+                contract_address_salt: identity_commitment,
                 calldata: array![].span(),
                 deploy_from_zero: false,
             )
                 .unwrap_syscall();
-            self.sub_accounts.write(commitment, sub_account_addr);
+            self.sub_accounts.write(identity_commitment, sub_account_addr);
             ISubAccountDispatcher { contract_address: sub_account_addr }
         }
 

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -35,7 +35,7 @@ fn test_get_sub_account_class_hash() {
 }
 
 #[test]
-fn test_get_sub_account_unknown_commitment_is_zero() {
+fn test_get_sub_account_unknown_identity_commitment_is_zero() {
     let anonymizer = deploy_sub_account_anonymizer();
     assert!(anonymizer_disp(anonymizer).get_sub_account('UNKNOWN').is_zero());
 }
@@ -43,9 +43,9 @@ fn test_get_sub_account_unknown_commitment_is_zero() {
 #[test]
 fn test_privacy_compute_matches_poseidon() {
     let anonymizer = deploy_sub_account_anonymizer();
-    let commitment = anonymizer_disp(anonymizer).privacy_compute('USER', 'DAPP', 7);
+    let identity_commitment = anonymizer_disp(anonymizer).privacy_compute('USER', 'DAPP', 7);
     let expected = PoseidonTrait::new().update('USER').update('DAPP').update(7).finalize();
-    assert_eq!(commitment, expected);
+    assert_eq!(identity_commitment, expected);
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_privacy_compute_is_deterministic_and_distinct() {
     let base = anonymizer.privacy_compute('USER', 'DAPP', 1);
     // Deterministic for the same inputs.
     assert_eq!(base, anonymizer.privacy_compute('USER', 'DAPP', 1));
-    // Each input affects the commitment.
+    // Each input affects the identity commitment.
     assert_ne!(base, anonymizer.privacy_compute('OTHER', 'DAPP', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'OTHER', 1));
     assert_ne!(base, anonymizer.privacy_compute('USER', 'DAPP', 2));
@@ -64,14 +64,15 @@ fn test_privacy_compute_is_deterministic_and_distinct() {
 fn test_invoke_executes_and_collects_open_note() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     // Fund the dapp so the sub-account-driven call pays the sub-account `AMOUNT`.
     components.token.supply(address: components.mock_dapp, amount: AMOUNT);
 
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
             open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
         );
@@ -83,7 +84,7 @@ fn test_invoke_executes_and_collects_open_note() {
     assert_eq!(deposit_token, token);
     assert_eq!(amount, AMOUNT);
 
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
     assert!(sub_account.is_non_zero());
     // Funds flowed dapp -> sub-account -> anonymizer, and the privacy contract is approved to pull.
     assert_eq!(components.token.balance_of(components.mock_dapp), 0);
@@ -100,7 +101,7 @@ fn test_invoke_only_privacy_contract() {
     let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
     let result = safe
         .privacy_invoke_with_computation(
-            commitment: 0, calls: array![], open_notes: array![].span(),
+            identity_commitment: 0, calls: array![], open_notes: array![].span(),
         );
     assert_panic_with_felt_error(:result, expected_error: errors::UNAUTHORIZED_CALLER);
 }
@@ -113,7 +114,8 @@ fn test_collects_multiple_open_notes() {
     let addr_a = token_a.contract_address();
     let addr_b = token_b.contract_address();
     assert!(addr_a != addr_b);
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     let amount_a: u128 = 1_000_000;
     let amount_b: u128 = 2_500_000;
@@ -122,7 +124,7 @@ fn test_collects_multiple_open_notes() {
 
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![
                 pay_out_call(components.mock_dapp, addr_a, amount_a),
                 pay_out_call(components.mock_dapp, addr_b, amount_b),
@@ -157,7 +159,8 @@ fn test_collects_multiple_open_notes() {
 fn test_multiple_invokes_run_in_one_call() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     let first: u128 = 700_000;
     let second: u128 = 300_000;
@@ -166,7 +169,7 @@ fn test_multiple_invokes_run_in_one_call() {
     // Two calls in one interaction; both run as the sub-account and their output is combined.
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![
                 pay_out_call(components.mock_dapp, token, first),
                 pay_out_call(components.mock_dapp, token, second),
@@ -185,29 +188,31 @@ fn test_multiple_invokes_run_in_one_call() {
 fn test_invoke_but_not_collect() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     components.token.supply(address: components.mock_dapp, amount: AMOUNT);
 
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
             open_notes: array![].span(),
         );
     assert_eq!(deposits.len(), 0);
     assert_eq!(components.token.balance_of(components.anonymizer), 0);
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
     assert_eq!(components.token.balance_of(sub_account), AMOUNT.into());
 }
 
 #[test]
 fn test_deployed_sub_account_owned_by_anonymizer() {
     let components = deploy_components();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
-    components.invoke(:commitment, calls: array![], open_notes: array![].span());
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
 
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
     // The anonymizer is the sub-account's deployer, so it is the only authorized controller.
     assert_eq!(
         ISubAccountDispatcher { contract_address: sub_account }.owner(), components.anonymizer,
@@ -215,24 +220,27 @@ fn test_deployed_sub_account_owned_by_anonymizer() {
 }
 
 #[test]
-fn test_sub_account_is_reused_per_commitment() {
+fn test_sub_account_is_reused_per_identity_commitment() {
     let components = deploy_components();
     let anonymizer = anonymizer_disp(components.anonymizer);
-    let commitment_a = anonymizer.privacy_compute('USER', 'DAPP', 1);
-    let commitment_b = anonymizer.privacy_compute('USER', 'DAPP', 2);
+    let identity_commitment_a = anonymizer.privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment_b = anonymizer.privacy_compute('USER', 'DAPP', 2);
     let no_notes = array![].span();
 
-    components.invoke(commitment: commitment_a, calls: array![], open_notes: no_notes);
-    let sub_account_a = anonymizer.get_sub_account(commitment_a);
+    components
+        .invoke(identity_commitment: identity_commitment_a, calls: array![], open_notes: no_notes);
+    let sub_account_a = anonymizer.get_sub_account(identity_commitment_a);
     assert!(sub_account_a.is_non_zero());
 
-    // Same commitment reuses the same sub-account (no redeploy).
-    components.invoke(commitment: commitment_a, calls: array![], open_notes: no_notes);
-    assert_eq!(anonymizer.get_sub_account(commitment_a), sub_account_a);
+    // Same identity commitment reuses the same sub-account (no redeploy).
+    components
+        .invoke(identity_commitment: identity_commitment_a, calls: array![], open_notes: no_notes);
+    assert_eq!(anonymizer.get_sub_account(identity_commitment_a), sub_account_a);
 
-    // A different commitment gets a distinct sub-account.
-    components.invoke(commitment: commitment_b, calls: array![], open_notes: no_notes);
-    let sub_account_b = anonymizer.get_sub_account(commitment_b);
+    // A different identity commitment gets a distinct sub-account.
+    components
+        .invoke(identity_commitment: identity_commitment_b, calls: array![], open_notes: no_notes);
+    let sub_account_b = anonymizer.get_sub_account(identity_commitment_b);
     assert!(sub_account_b.is_non_zero());
     assert!(sub_account_b != sub_account_a);
 }
@@ -241,11 +249,12 @@ fn test_sub_account_is_reused_per_commitment() {
 fn test_sweeps_full_balance_including_preexisting() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     // Deploy the sub-account (empty invoke) so we can give it a pre-existing balance.
-    components.invoke(:commitment, calls: array![], open_notes: array![].span());
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
     let preexisting: u128 = 500_000;
     components.token.supply(address: sub_account, amount: preexisting);
 
@@ -253,7 +262,7 @@ fn test_sweeps_full_balance_including_preexisting() {
     components.token.supply(address: components.mock_dapp, amount: AMOUNT);
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![pay_out_call(components.mock_dapp, token, AMOUNT)],
             open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
         );
@@ -276,7 +285,8 @@ fn test_sweeps_full_balance_including_preexisting() {
 fn test_empty_balance_open_note_reverts() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     // No calls and no funds, so the sub-account's balance is zero. A zero-amount deposit would be
     // rejected downstream, so collecting it reverts with `ZERO_BALANCE`.
@@ -284,7 +294,7 @@ fn test_empty_balance_open_note_reverts() {
     let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
     let result = safe
         .privacy_invoke_with_computation(
-            :commitment,
+            :identity_commitment,
             calls: array![],
             open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
         );
@@ -295,11 +305,12 @@ fn test_empty_balance_open_note_reverts() {
 fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     // Deploy and pre-fund the sub-account.
-    components.invoke(:commitment, calls: array![], open_notes: array![].span());
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(commitment);
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
     let preexisting: u128 = 1_000_000;
     components.token.supply(address: sub_account, amount: preexisting);
 
@@ -313,7 +324,7 @@ fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
     };
     let deposits = components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![transfer],
             open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
         );
@@ -334,7 +345,8 @@ fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
 fn test_collected_amount_overflow() {
     let components = deploy_components();
     let token = components.token.contract_address();
-    let commitment = anonymizer_disp(components.anonymizer).privacy_compute('USER', 'DAPP', 1);
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
 
     // Fund the dapp with `u128::MAX + 1` (two supplies, since `supply` takes a u128).
     let max = Bounded::<u128>::MAX;
@@ -344,7 +356,7 @@ fn test_collected_amount_overflow() {
     // Two pay-outs add `u128::MAX + 1` to the sub-account, so the collected delta overflows u128.
     components
         .invoke(
-            :commitment,
+            :identity_commitment,
             calls: array![
                 pay_out_call(components.mock_dapp, token, max),
                 pay_out_call(components.mock_dapp, token, 1),

--- a/packages/sub_account_anonymizer/src/tests/test_utils.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_utils.cairo
@@ -30,11 +30,14 @@ pub struct Components {
 pub impl ComponentsImpl of ComponentsTrait {
     /// Calls `privacy_invoke_with_computation` cheating the caller to be the privacy contract.
     fn invoke(
-        self: @Components, commitment: felt252, calls: Array<Call>, open_notes: Span<OpenNote>,
+        self: @Components,
+        identity_commitment: felt252,
+        calls: Array<Call>,
+        open_notes: Span<OpenNote>,
     ) -> Span<OpenNoteDeposit> {
         cheat_caller_address_once(contract_address: *self.anonymizer, caller_address: PRIVACY);
         anonymizer_disp(*self.anonymizer)
-            .privacy_invoke_with_computation(:commitment, :calls, :open_notes)
+            .privacy_invoke_with_computation(:identity_commitment, :calls, :open_notes)
     }
 }
 


### PR DESCRIPTION
Rename the per-sub-account commitment value and its PrivacyComputeCommitment type to identity_commitment / IdentityCommitment.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/851)
<!-- Reviewable:end -->
