### PR TITLE
feat(privacy): emit ExternalInvoke event on external invoke

### DIFF
--- a/packages/privacy/src/events.cairo
+++ b/packages/privacy/src/events.cairo
@@ -79,6 +79,18 @@ pub struct OpenNoteDeposited {
 }
 
 #[derive(Serde, Copy, Debug, Drop, PartialEq, starknet::Event)]
+pub struct ExternalContractInvoked {
+    /// The external contract the pool invoked.
+    #[key]
+    pub contract_address: ContractAddress,
+    /// The entry point selector the pool called: `privacy_invoke` for a plain invoke,
+    /// `privacy_invoke_with_computation` for a compute-and-invoke. Lets consumers tell the
+    /// two apart (the private computation itself is not observable). Calldata is not emitted.
+    #[key]
+    pub selector: felt252,
+}
+
+#[derive(Serde, Copy, Debug, Drop, PartialEq, starknet::Event)]
 pub struct EncNoteCreated {
     /// The note ID.
     #[key]

--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -466,7 +466,9 @@ pub trait IServer<T> {
     /// ([`TransferFrom`](privacy::actions::ServerAction::TransferFrom))
     /// must be accompanied by a fresh, valid `screening` attestation for its depositor, and all
     /// deposits in one tx must share a single depositor.
-    /// - The open-note depositor (the [`Invoke`](privacy::actions::ServerAction::Invoke) target
+    /// - The open-note depositor (the target of the
+    /// [`Invoke`](privacy::actions::ServerAction::Invoke) or
+    /// [`InvokeWithComputation`](privacy::actions::ServerAction::InvokeWithComputation) action
     /// that funds the deposit) must not be on the block list.
     ///
     /// #### Events Emitted
@@ -486,7 +488,11 @@ pub trait IServer<T> {
     /// - [`NoteUsed`](privacy::events::NoteUsed): Emitted when
     /// [`EmitNoteUsed`](privacy::actions::ServerAction::EmitNoteUsed) action is executed.
     /// - [`OpenNoteDeposited`](privacy::events::OpenNoteDeposited): Emitted for each
-    /// `OpenNoteDeposit` returned by an [`Invoke`](privacy::actions::ServerAction::Invoke) action.
+    /// `OpenNoteDeposit` returned by an [`Invoke`](privacy::actions::ServerAction::Invoke) or
+    /// [`InvokeWithComputation`](privacy::actions::ServerAction::InvokeWithComputation) action.
+    /// - [`ExternalContractInvoked`](privacy::events::ExternalContractInvoked): Emitted for each
+    /// [`Invoke`](privacy::actions::ServerAction::Invoke) or
+    /// [`InvokeWithComputation`](privacy::actions::ServerAction::InvokeWithComputation) action.
     ///
     /// #### Reverts
     /// **Context validation (before applying actions):**

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -139,6 +139,7 @@ pub mod Privacy {
         OpenNoteCreated: events::OpenNoteCreated,
         EncNoteCreated: events::EncNoteCreated,
         OpenNoteDeposited: events::OpenNoteDeposited,
+        ExternalContractInvoked: events::ExternalContractInvoked,
         NoteUsed: events::NoteUsed,
         FeeAmountSet: events::FeeAmountSet,
         FeeCollectorSet: events::FeeCollectorSet,
@@ -966,6 +967,11 @@ pub mod Privacy {
             checked_transfer(token_address: token, recipient: to_addr, amount: amount.into());
         }
 
+        /// Executes the external invoke on `contract_address` with `selector`, emits an
+        /// [`ExternalContractInvoked`](events::ExternalContractInvoked) event, and deposits the
+        /// returned open notes.
+        /// `selector` distinguishes a plain invoke from a compute-and-invoke; calldata is
+        /// intentionally not emitted, as it is already visible in the public call trace.
         fn _apply_invoke_and_deposits(
             ref self: ContractState,
             input: InvokeInput,
@@ -977,6 +983,7 @@ pub mod Privacy {
                 address: contract_address, entry_point_selector: selector, :calldata,
             )
                 .unwrap_syscall();
+            self.emit(events::ExternalContractInvoked { contract_address, selector });
 
             let deposits: Span<OpenNoteDeposit> = Serde::deserialize(ref return_data)
                 .expect(errors::INVALID_INVOKE_RETURN_DATA);

--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -3105,8 +3105,9 @@ fn test_create_open_note_decrypt_recipient_addr() {
     // Auditor should be able to decrypt the sender address from the OpenNoteCreated event.
     let events = spy_events.get_events().emitted_by(contract_address: test.privacy.address).events;
     // events[0]: OpenNoteCreated from apply_actions.
-    // events[1]: OpenNoteDeposited from apply_actions.
-    assert_eq!(events.len(), 2);
+    // events[1]: ExternalContractInvoked from the invoke that fills the open note.
+    // events[2]: OpenNoteDeposited from apply_actions.
+    assert_eq!(events.len(), 3);
     let (_, event) = events[0];
     let enc_recipient_addr = EncUserAddr {
         auditor_public_key: *event.data[0],
@@ -3680,7 +3681,7 @@ fn test_execute_use_note_swap() {
     assert_eq!(token.balance_of(address: test.privacy.swap_executor.address), Zero::zero());
     assert_eq!(token.balance_of(address: test.privacy.mock_amm), amount.into());
     let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(events.len(), 4);
+    assert_eq!(events.len(), 5);
     assert_expected_event_emitted(
         spied_event: events[0],
         expected_event: events::NoteUsed { nullifier },
@@ -3710,11 +3711,20 @@ fn test_execute_use_note_swap() {
         expected_event_selector: @selector!("Withdrawal"),
         expected_event_name: "Withdrawal",
     );
+    let expected_event_external_invoke = events::ExternalContractInvoked {
+        contract_address: test.privacy.swap_executor.address, selector: selector!("privacy_invoke"),
+    };
+    assert_expected_event_emitted(
+        spied_event: events[3],
+        expected_event: expected_event_external_invoke,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
     let expected_event_deposit_to_open_note = events::OpenNoteDeposited {
         depositor: test.privacy.swap_executor.address, token: out_token_addr, note_id, amount,
     };
     assert_expected_event_emitted(
-        spied_event: events[3],
+        spied_event: events[4],
         expected_event: expected_event_deposit_to_open_note,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -5127,7 +5137,7 @@ fn test_execute_create_open_note() {
     test.privacy.apply_actions(:actions);
     assert_eq!(test.privacy.get_note(:note_id), expected_note);
     let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     let expected_event = events::OpenNoteCreated {
         enc_recipient_addr: user_2.compute_enc_user_addr(random: random.into()),
         token: token_addr,
@@ -5139,12 +5149,21 @@ fn test_execute_create_open_note() {
         expected_event_selector: @selector!("OpenNoteCreated"),
         expected_event_name: "OpenNoteCreated",
     );
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: test.privacy.echo_executor, selector: selector!("privacy_invoke"),
+    };
+    assert_expected_event_emitted(
+        spied_event: events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
     // Assert that the other event was OpenNoteFilled.
     let expected_deposited_event = events::OpenNoteDeposited {
         depositor: test.privacy.echo_executor, token: token_addr, note_id, amount,
     };
     assert_expected_event_emitted(
-        spied_event: events[1],
+        spied_event: events[2],
         expected_event: expected_deposited_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -5539,7 +5558,7 @@ fn test_swap_client_action() {
 
     // Verify events were properly emitted.
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 4);
+    assert_eq!(emitted_events.len(), 5);
 
     // Verify NoteUsed event (nullifier recorded).
     let nullifier = user.compute_nullifier(sender: user, token_addr: in_token_addr, index: 0);
@@ -5584,6 +5603,17 @@ fn test_swap_client_action() {
         expected_event_name: "Withdrawal",
     );
 
+    // Verify ExternalContractInvoked event (the pool invoked the swap executor via privacy_invoke).
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: swap_executor_addr, selector: selector!("privacy_invoke"),
+    };
+    assert_expected_event_emitted(
+        spied_event: emitted_events[3],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+
     // Verify OpenNoteDeposited event (output tokens deposited to open note).
     let expected_deposit_event = events::OpenNoteDeposited {
         depositor: swap_executor_addr,
@@ -5592,7 +5622,7 @@ fn test_swap_client_action() {
         amount: swap_amount,
     };
     assert_expected_event_emitted(
-        spied_event: emitted_events[3],
+        spied_event: emitted_events[4],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -6054,10 +6084,10 @@ fn test_compute_and_invoke_e2e_with_mock_deposits_to_open_note() {
     assert_eq!(token.balance_of(address: mock), Zero::zero());
     assert_eq!(token.balance_of(address: test.privacy.address), amount.into());
 
-    // apply_actions emits OpenNoteCreated (from CreateOpenNote) then OpenNoteDeposited (from the
-    // InvokeWithComputation deposit, with the invoke target as depositor).
+    // apply_actions emits OpenNoteCreated (from CreateOpenNote), then ExternalContractInvoked and
+    // OpenNoteDeposited (from the InvokeWithComputation, with the invoke target as depositor).
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 2);
+    assert_eq!(emitted_events.len(), 3);
     let expected_create_event = events::OpenNoteCreated {
         enc_recipient_addr: encrypt_user_addr(
             ephemeral_secret: create_note_input.random,
@@ -6073,11 +6103,20 @@ fn test_compute_and_invoke_e2e_with_mock_deposits_to_open_note() {
         expected_event_selector: @selector!("OpenNoteCreated"),
         expected_event_name: "OpenNoteCreated",
     );
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: mock, selector: selector!("privacy_invoke_with_computation"),
+    };
+    assert_expected_event_emitted(
+        spied_event: emitted_events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
     let expected_deposit_event = events::OpenNoteDeposited {
         depositor: mock, token: token_addr, note_id, amount,
     };
     assert_expected_event_emitted(
-        spied_event: emitted_events[1],
+        spied_event: emitted_events[2],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -6446,7 +6485,7 @@ fn test_invoke_external_swap_doesnt_execute_during_execute() {
         .get_events()
         .emitted_by(contract_address: test.privacy.address)
         .events;
-    assert_eq!(events_after.len(), 4);
+    assert_eq!(events_after.len(), 5);
     assert_expected_event_emitted(
         spied_event: events_after[0],
         expected_event: events::NoteUsed { nullifier },
@@ -6473,6 +6512,15 @@ fn test_invoke_external_swap_doesnt_execute_during_execute() {
         expected_event_selector: @selector!("Withdrawal"),
         expected_event_name: "Withdrawal",
     );
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: swap_executor_addr, selector: selector!("privacy_invoke"),
+    };
+    assert_expected_event_emitted(
+        spied_event: events_after[3],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
     let expected_deposit_event = events::OpenNoteDeposited {
         depositor: swap_executor_addr,
         token: out_token_addr,
@@ -6480,7 +6528,7 @@ fn test_invoke_external_swap_doesnt_execute_during_execute() {
         amount: swap_amount,
     };
     assert_expected_event_emitted(
-        spied_event: events_after[3],
+        spied_event: events_after[4],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -601,8 +601,12 @@ fn test_apply_invoke_with_computation_deposit() {
     assert_eq!(stored_amount, amount);
     assert_eq!(deposited_note.token, token_addr);
 
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: echo_executor_addr,
+        selector: selector!("privacy_invoke_with_computation"),
+    };
     let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     assert_expected_event_emitted(
         spied_event: events[0],
         expected_event: expected_create_event,
@@ -611,6 +615,12 @@ fn test_apply_invoke_with_computation_deposit() {
     );
     assert_expected_event_emitted(
         spied_event: events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: events[2],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -705,8 +715,11 @@ fn test_apply_emit_open_note_created() {
     actions.append_span(deposit_actions);
     let mut spy = spy_events();
     test.privacy.apply_actions(actions.span());
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: echo_executor_addr, selector: selector!("privacy_invoke"),
+    };
     let events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(events.len(), 2);
+    assert_eq!(events.len(), 3);
     assert_expected_event_emitted(
         spied_event: events[0],
         expected_event: expected_create_event,
@@ -715,6 +728,12 @@ fn test_apply_emit_open_note_created() {
     );
     assert_expected_event_emitted(
         spied_event: events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: events[2],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -989,8 +1008,11 @@ fn test_deposit_to_open_note() {
     let expected_deposit_event = events::OpenNoteDeposited {
         depositor: echo_executor, token: token_addr, note_id, amount,
     };
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: echo_executor, selector: selector!("privacy_invoke"),
+    };
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 2);
+    assert_eq!(emitted_events.len(), 3);
     assert_expected_event_emitted(
         spied_event: emitted_events[0],
         expected_event: expected_create_event,
@@ -999,6 +1021,12 @@ fn test_deposit_to_open_note() {
     );
     assert_expected_event_emitted(
         spied_event: emitted_events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: emitted_events[2],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -1305,8 +1333,11 @@ fn test_apply_invoke_swap() {
         note_id,
         amount: swap_amount,
     };
+    let expected_external_invoke_event = events::ExternalContractInvoked {
+        contract_address: executor_addr, selector: selector!("privacy_invoke"),
+    };
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 2);
+    assert_eq!(emitted_events.len(), 3);
     assert_expected_event_emitted(
         spied_event: emitted_events[0],
         expected_event: expected_create_event,
@@ -1315,6 +1346,12 @@ fn test_apply_invoke_swap() {
     );
     assert_expected_event_emitted(
         spied_event: emitted_events[1],
+        expected_event: expected_external_invoke_event,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: emitted_events[2],
         expected_event: expected_deposit_event,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -1852,8 +1889,11 @@ fn test_apply_invoke_vesu_deposit() {
     let expected_event_deposit = events::OpenNoteDeposited {
         depositor: anonymizer_addr, token: vault_addr, note_id, amount: deposit_amount,
     };
+    let expected_event_external_invoke = events::ExternalContractInvoked {
+        contract_address: anonymizer_addr, selector: selector!("privacy_invoke"),
+    };
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 2);
+    assert_eq!(emitted_events.len(), 3);
     assert_expected_event_emitted(
         spied_event: emitted_events[0],
         expected_event: expected_event_created,
@@ -1862,6 +1902,12 @@ fn test_apply_invoke_vesu_deposit() {
     );
     assert_expected_event_emitted(
         spied_event: emitted_events[1],
+        expected_event: expected_event_external_invoke,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: emitted_events[2],
         expected_event: expected_event_deposit,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",
@@ -1968,8 +2014,11 @@ fn test_apply_invoke_vesu_withdraw() {
     let expected_event_deposit = events::OpenNoteDeposited {
         depositor: anonymizer_addr, token: underlying_token_addr, note_id, amount: deposit_amount,
     };
+    let expected_event_external_invoke = events::ExternalContractInvoked {
+        contract_address: anonymizer_addr, selector: selector!("privacy_invoke"),
+    };
     let emitted_events = spy.get_events().emitted_by(contract_address: test.privacy.address).events;
-    assert_eq!(emitted_events.len(), 2);
+    assert_eq!(emitted_events.len(), 3);
     assert_expected_event_emitted(
         spied_event: emitted_events[0],
         expected_event: expected_event_created,
@@ -1978,6 +2027,12 @@ fn test_apply_invoke_vesu_withdraw() {
     );
     assert_expected_event_emitted(
         spied_event: emitted_events[1],
+        expected_event: expected_event_external_invoke,
+        expected_event_selector: @selector!("ExternalContractInvoked"),
+        expected_event_name: "ExternalContractInvoked",
+    );
+    assert_expected_event_emitted(
+        spied_event: emitted_events[2],
         expected_event: expected_event_deposit,
         expected_event_selector: @selector!("OpenNoteDeposited"),
         expected_event_name: "OpenNoteDeposited",

--- a/sdk/src/internal/abi.ts
+++ b/sdk/src/internal/abi.ts
@@ -1908,6 +1908,23 @@ export const PrivacyPoolABI = [
   },
   {
     "type": "event",
+    "name": "privacy::events::ExternalContractInvoked",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "contract_address",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "selector",
+        "type": "core::felt252",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "privacy::events::NoteUsed",
     "kind": "struct",
     "members": [
@@ -2044,6 +2061,11 @@ export const PrivacyPoolABI = [
       {
         "name": "OpenNoteDeposited",
         "type": "privacy::events::OpenNoteDeposited",
+        "kind": "nested"
+      },
+      {
+        "name": "ExternalContractInvoked",
+        "type": "privacy::events::ExternalContractInvoked",
         "kind": "nested"
       },
       {


### PR DESCRIPTION
Emit an ExternalInvoke event from _apply_invoke_and_deposits, keyed on
contract_address + selector, covering both privacy_invoke and
privacy_invoke_with_computation. Calldata is intentionally not emitted; the
selector distinguishes the two paths, and both target and selector are already
visible in the public call trace, so this leaks nothing new.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/855)
<!-- Reviewable:end -->
