### PR TITLE
fix(sdk): paginate total-only outgoing discovery (fixes 257th-recipient NON_ZERO_VALUE)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -114,6 +114,12 @@ Apply these guidelines when writing or reviewing code in this codebase.
 - Add comments where the reasoning isn't obvious from context
 - Focus on decisions, constraints, and non-obvious requirements
 
+### Describe the present, not the history
+- A comment explains how the code behaves now, not what it used to do or which bug it fixed
+- Don't narrate past errors, prior implementations, or the diff — that belongs in commit messages / PR descriptions
+- *Bad:* `// previously returned undefined, which the caller turned into index 0 and a collision`
+- *Good:* `// the service sets the total only once discovery reaches the sentinel, so paginate to completion`
+
 ### No visual separator comments
 - Don't use decorative comment lines to delineate sections (e.g., `// -----------`, `// =========`, `// ***`)
 - If a file needs visual structure, that's a signal to split into separate modules or use doc comments on items

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -12,6 +12,17 @@
   the sentinel (e.g. on-chain `ContractDiscovery`) still fall back to the
   dedicated count query.
 
+### Fixed
+
+- `discoverChannels("total-only")` now paginates outgoing channel discovery to
+  the sentinel instead of issuing a single request. A sender with at least
+  `max_channels` (default 256) outgoing channels caps the first page before the
+  sentinel, so the service returned no `total_n_channels`; the count surfaced as
+  `undefined` and the compiler turned it into channel index `0`, producing a
+  `NON_ZERO_VALUE` write-once collision when opening a channel to the next
+  (e.g. 257th) recipient. The count is now derived once discovery completes, and
+  a missing total after completion throws instead of being silently coerced.
+
 ## 0.14.3-RC.1
 
 ### Added

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -225,20 +225,37 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     total?: number;
   }> {
     if (recipients === "total-only") {
-      // For total-only, do a minimal outgoing sync to get the total channel count
-      const body: Record<string, unknown> = {
-        contract_address: toHex(this.contractAddress),
-        sender_address: toHex(address),
-        viewing_key: toHex(viewingKey),
-        cursor: { channel_discovery_complete: false },
-      };
-      if (params?.blockIdentifier !== undefined) {
-        body.block_ref = params.blockIdentifier;
+      // The service sets `total_n_channels` only once channel discovery reaches
+      // the sentinel, and a single request discovers at most `max_channels`.
+      // Paginate to completion — pruning complete channels each round frees
+      // cursor slots so discovery advances past the cap — then the count is final.
+      let apiCursor: ApiDiscoveryCursor = { channel_discovery_complete: false };
+      let blockRef: BlockIdentifier | undefined;
+      let complete = false;
+      do {
+        const body: Record<string, unknown> = {
+          contract_address: toHex(this.contractAddress),
+          sender_address: toHex(address),
+          viewing_key: toHex(viewingKey),
+          cursor: apiCursor,
+        };
+        if (blockRef) {
+          body.block_ref = blockRef;
+        } else if (params?.blockIdentifier !== undefined) {
+          body.block_ref = params.blockIdentifier;
+        }
+        const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
+        blockRef = resp.block_ref;
+        apiCursor = resp.cursor;
+        complete = isApiCursorComplete(resp.cursor);
+        if (!complete) pruneCompleteCursor(apiCursor);
+      } while (!complete);
+      if (apiCursor.total_n_channels === undefined) {
+        throw new Error("outgoing_state reported complete without total_n_channels");
       }
-      const resp = await this.post<ApiOutgoingSyncResponse>("/v1/sync/outgoing_state", body);
       return {
-        timestamp: resp.block_ref,
-        total: resp.cursor.total_n_channels!,
+        timestamp: blockRef!,
+        total: apiCursor.total_n_channels,
       };
     }
 

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -404,6 +404,69 @@ describe("IndexerDiscoveryProvider", () => {
       expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
     });
 
+    // Regression: a sender with >= max_channels (256) outgoing channels caps the
+    // first page before the sentinel, so the service returns no total_n_channels.
+    // 'total-only' must paginate to the sentinel rather than return undefined,
+    // which the compiler would turn into channel index 0 -> NON_ZERO_VALUE.
+    it("paginates 'total-only' to the sentinel when the first page caps before the count is known", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson(
+        {
+          // Page 1: cap hit at max_channels, sentinel not yet reached -> no total.
+          body: outgoingSyncResponse({
+            cursor: { channel_discovery_complete: false, last_channel_index: 255, channels: {} },
+          }),
+        },
+        {
+          // Page 2: sentinel reached -> total_n_channels is now authoritative.
+          body: outgoingSyncResponse({
+            cursor: {
+              channel_discovery_complete: true,
+              last_channel_index: 256,
+              total_n_channels: 257,
+              channels: {},
+            },
+          }),
+        }
+      );
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.total).toBe(257);
+
+      // Second request resumes from the first page (block_ref pinned, cursor advanced).
+      const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(secondBody.block_ref).toBe(BLOCK_REF);
+      expect(secondBody.cursor.last_channel_index).toBe(255);
+    });
+
+    it("returns total 0 for a brand-new sender (sentinel at index 0) without throwing", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          cursor: { channel_discovery_complete: true, total_n_channels: 0, channels: {} },
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only");
+
+      expect(result.total).toBe(0);
+    });
+
+    it("throws if 'total-only' completes without a total_n_channels (service contract violation)", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          cursor: { channel_discovery_complete: true, channels: {} },
+        }),
+      });
+
+      await expect(
+        provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, "total-only")
+      ).rejects.toThrow(/total_n_channels/);
+    });
+
     it("prefers real channels over precomputed channels for the same recipient", async () => {
       const provider = createProvider();
       const PRECOMPUTED_KEY = "0xdd1";


### PR DESCRIPTION
## Summary

Fixes a real off-by-one that makes **a private transfer to the 257th distinct recipient fail with `NON_ZERO_VALUE`** (while the first 256 work) — the "shield rush" finding against private-payroll, which uses this SDK.

When the SDK opens a channel to a **new** recipient it needs the sender's current outgoing-channel count, which it reads via `discoverChannels("total-only")`. That path did a **single** `/v1/sync/outgoing_state` request. But the discovery service caps a single request at `max_channels` (default **256**, `discovery-core/.../cursor.rs:34`) and only sets `total_n_channels` once it reaches the **sentinel** (`outgoing_channels.rs:140-143`). So for a sender with ≥256 existing channels the request breaks at the cap with `has_more=true` and returns **no total**.

That `undefined` total then propagated:

- `compiler.ts:128` → `createPool(..., total)` → `new PoolSimulator(..., totalChannels ?? 0)` (`compiler.ts:191`) — the `?? 0` turns it into `nextChannelIndex = 0`
- `compiler.ts:296` → the OpenChannel action gets `index: 0`
- on-chain, opening a channel at index 0 hits the **write-once** guard on the already-occupied slot 0 → `errors::NON_ZERO_VALUE` (`privacy.cairo:902`)

**Boundary, confirmed from code:** a sender with `N=255` channels (indices 0–254) discovers all 255 + sentinel in one request → `total=255` → 256th channel opens at index 255 ✅. With `N=256` (indices 0–255) the request caps before the sentinel → `total=undefined` → index 0 → collision on the 257th ❌. Existing recipients keep working because re-paying them skips the count query (`allOpen` short-circuit, `compiler.ts:531-533`).

## Fix

Make `total-only` **paginate to the sentinel** in a `do/while` loop, pruning complete channels each round (so the cursor frees slots and discovery advances past the cap) — exactly mirroring the existing `discoverChannels("all")` / `discoverNotes` loops. The count is then authoritative regardless of channel count. If the service ever reports `channel_discovery_complete` without a `total_n_channels`, we now **throw** instead of silently coercing to 0.

A brand-new sender still correctly returns `total = 0` (sentinel at index 0 → service sets `Some(0)`, verified by the Rust test `test_paginated_zero_channels_sets_total`), so the throw guard never false-positives.

## Tests

`sdk/tests/internal/indexer-discovery.test.ts` (29 pass):
- **≥256 pagination**: incomplete first page (no total) → sentinel page → `total=257`, asserts 2 requests + block_ref/cursor handoff. Fails against the old single-request code (1 request, `undefined`).
- **new-sender `total=0`** without throwing.
- **contract-violation throw** when complete-but-no-total.

## Verification

- `npm run lint` (prettier + eslint + tsc): clean
- `npm run test:fast`: 240/240 pass
- CHANGELOG updated under `## Unreleased` → `### Fixed`

An independent adversarial review (subagent) confirmed: the bug is real with the exact 256/257 boundary, the fix is correct/terminating with no stall, the regression test is meaningful (verified failing on old code, passing on fix), and there are no must-fix issues.

## Note / follow-up

The root cause is SDK-side, but `total-only` now walks all of the sender's channels (and the service processes their subchannels/notes) just to get a count. A cheaper follow-up would be to return `total` from the main `discoverChannels` walk (it already reaches the sentinel) and drop the second query, and/or add a dedicated outgoing channel-count view server-side. Out of scope here to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/858)
<!-- Reviewable:end -->
