### PR TITLE
perf(sdk): reuse outgoing-channel count from recipient discovery (drop redundant total-only query)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- Opening a channel to a new recipient no longer issues a second
+  `discoverChannels("total-only")` request. The recipient-discovery walk already
+  runs to the sentinel, so it now returns the outgoing-channel count, and the
+  compiler reuses that count as the new channel's index — halving the outgoing
+  discovery work on that path. Providers whose targeted discovery stops short of
+  the sentinel (e.g. on-chain `ContractDiscovery`) still fall back to the
+  dedicated count query.
+
 ## 0.14.3-RC.1
 
 ### Added

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -521,7 +521,7 @@ export class ActionCompiler {
 
     // Discover channels for all recipients that need discovery in a single call
     // discoverChannels computes channel keys and returns current nonce state
-    const { channels } = await this.discoveryProvider.discoverChannels(
+    const { channels, total } = await this.discoveryProvider.discoverChannels(
       this.userAddress,
       this.userViewingKey,
       recipientsToDiscover,
@@ -533,14 +533,22 @@ export class ActionCompiler {
       return { channels, total: undefined };
     }
 
-    const { total } = await this.discoveryProvider.discoverChannels(
-      this.userAddress,
-      this.userViewingKey,
-      "total-only",
-      { blockIdentifier: options?.provingBlockId }
-    );
+    // Opening a new channel needs the sender's outgoing-channel count. The
+    // discovery above already walked to the sentinel for the indexer provider,
+    // so reuse its count; only providers whose targeted discovery stops short of
+    // the sentinel (e.g. on-chain ContractDiscovery) fall back to a count query.
+    const resolvedTotal =
+      total ??
+      (
+        await this.discoveryProvider.discoverChannels(
+          this.userAddress,
+          this.userViewingKey,
+          "total-only",
+          { blockIdentifier: options?.provingBlockId }
+        )
+      ).total;
 
-    return { channels, total };
+    return { channels, total: resolvedTotal };
   }
 
   /**

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -338,7 +338,10 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       }
     }
 
-    return { timestamp: blockRef!, channels };
+    // The loop above runs to the sentinel, so the final cursor carries the
+    // authoritative outgoing-channel count. Surface it so callers opening a new
+    // channel can reuse it instead of issuing a separate "total-only" query.
+    return { timestamp: blockRef!, channels, total: apiCursor.total_n_channels };
   }
 
   async discoverRequirement(

--- a/sdk/tests/internal/compiler-channel-count.test.ts
+++ b/sdk/tests/internal/compiler-channel-count.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ActionCompiler } from "../../src/internal/compiler.js";
+import { createEmptyRegistry, SetupRequirement } from "../../src/interfaces.js";
+import type { DiscoveryProviderInterface, Note } from "../../src/interfaces.js";
+import { AddressMap } from "../../src/utils/maps.js";
+import { Channel } from "../../src/internal/channel.js";
+
+const USER_ADDRESS = 0xa11cen;
+const VIEWING_KEY = 0xbeefn;
+const RECIPIENT_ADDR = 0xb0b1n;
+
+/** A discovered-but-not-yet-opened channel: public key known, no channel key. */
+function precomputedChannels() {
+  return new AddressMap<Channel>([[RECIPIENT_ADDR, new Channel(0xaa2n)]]);
+}
+
+function baseProvider(): DiscoveryProviderInterface {
+  return {
+    discoverNotes: vi.fn().mockResolvedValue({
+      timestamp: "0xblock",
+      notes: new AddressMap<Note[]>(),
+      cursor: { blockId: "0xblock", incomingChannels: new AddressMap() },
+    }),
+    discoverChannels: vi.fn(),
+    discoverRequirement: vi.fn().mockResolvedValue(SetupRequirement.SetupChannel),
+  };
+}
+
+function openChannelIndex(clientActions: { type: string; input: { index?: number } }[]) {
+  return clientActions.find((action) => action.type === "OpenChannel")?.input.index;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ActionCompiler outgoing channel count", () => {
+  it("reuses the total from recipient discovery and skips the total-only query", async () => {
+    const provider = baseProvider();
+    provider.discoverChannels = vi.fn().mockResolvedValue({
+      timestamp: "0xblock",
+      channels: precomputedChannels(),
+      total: 5,
+    });
+    const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, provider);
+
+    const result = await compiler.compile(
+      { openChannels: [{ recipient: RECIPIENT_ADDR }] },
+      { registry: createEmptyRegistry(), autoDiscover: { channels: "refresh" } }
+    );
+
+    // Single discovery round-trip: the recipient walk already carried the count.
+    expect(provider.discoverChannels).toHaveBeenCalledOnce();
+    // The reused count becomes the new channel's index.
+    expect(openChannelIndex(result.clientActions)).toBe(5);
+  });
+
+  it("falls back to a total-only query when discovery returns no total", async () => {
+    const provider = baseProvider();
+    provider.discoverChannels = vi
+      .fn()
+      .mockResolvedValueOnce({ timestamp: "0xblock", channels: precomputedChannels() })
+      .mockResolvedValueOnce({ timestamp: "0xblock", total: 7 });
+    const compiler = new ActionCompiler(USER_ADDRESS, VIEWING_KEY, provider);
+
+    const result = await compiler.compile(
+      { openChannels: [{ recipient: RECIPIENT_ADDR }] },
+      { registry: createEmptyRegistry(), autoDiscover: { channels: "refresh" } }
+    );
+
+    expect(provider.discoverChannels).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(provider.discoverChannels).mock.calls[1][2]).toBe("total-only");
+    expect(openChannelIndex(result.clientActions)).toBe(7);
+  });
+});

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -375,6 +375,35 @@ describe("IndexerDiscoveryProvider", () => {
       expect(result.channels).toBeUndefined();
     });
 
+    it("returns total alongside channels for an explicit recipients filter", async () => {
+      const provider = createProvider();
+      mockFetchJson({
+        body: outgoingSyncResponse({
+          channels: [channelEntry(RECIPIENT_ADDR, PUBLIC_KEY_1, CHANNEL_KEY_1)],
+          cursor: {
+            channel_discovery_complete: true,
+            total_n_channels: 9,
+            channels: {
+              [RECIPIENT_ADDR]: {
+                channel_key: CHANNEL_KEY_1,
+                subchannel_discovery_complete: true,
+                subchannels: {},
+              },
+            },
+          },
+        }),
+      });
+
+      const result = await provider.discoverChannels(USER_ADDRESS, VIEWING_KEY, [
+        BigInt(RECIPIENT_ADDR),
+      ]);
+
+      // The recipient walk reaches the sentinel, so the count comes back without
+      // a separate total-only request.
+      expect(result.total).toBe(9);
+      expect(result.channels!.has(BigInt(RECIPIENT_ADDR))).toBe(true);
+    });
+
     it("prefers real channels over precomputed channels for the same recipient", async () => {
       const provider = createProvider();
       const PRECOMPUTED_KEY = "0xdd1";


### PR DESCRIPTION
## Summary

Removes the redundant `discoverChannels("total-only")` round-trip when opening a channel to a new recipient. Follow-up to #858 (off `main`, **not** stacked).

When the compiler opens a channel to a recipient with no existing on-chain channel, it needs the sender's current outgoing-channel count to assign the new channel's index. It fetched that with a **second** `discoverChannels("total-only")` call (`compiler.ts`) — a full redundant walk of the sender's outgoing channels, because the recipient-discovery call right before it already paginates to the sentinel and therefore already knows the count.

This PR threads that count through:

- **`IndexerDiscoveryProvider.discoverChannels`** now returns `total` (the final cursor's `total_n_channels`) for the explicit-recipients and `"all"` paths — the pagination loop already runs to the sentinel, so the value is in hand. Additive; `total?: number` is already in the return type, and `"all"` callers ignore it.
- **The compiler** reuses that `total` and only falls back to the `total-only` query when a provider doesn't supply one.

Net: **one outgoing-state walk per new-recipient transfer instead of two** (plus the subchannel/note processing that walk entails). For the indexer provider the fallback never fires.

## Why the fallback (not an unconditional drop)

The compiler is provider-agnostic. `ContractDiscoveryProvider`'s explicit-recipients path probes only the requested recipients' channel markers — it does **not** walk to the sentinel, so it can't return a count. Dropping the second call unconditionally would make it return `undefined` → channel index `0` → a `NON_ZERO_VALUE` collision. The `total ?? (total-only)` form keeps that provider correct (it takes the fallback) while the indexer skips the extra walk.

## Relationship to #858

Complementary, independent:
- **#858** makes the `total-only` query itself correct (paginates to the sentinel) — the correctness floor and defense for any direct caller.
- **This PR** avoids invoking `total-only` on the indexer path at all, reusing the count the recipient walk already produced.

For the indexer path this PR alone also resolves the 257th-recipient `NON_ZERO_VALUE` (the buggy single-request `total-only` is no longer reached via the compiler). They touch overlapping files; whichever merges second will need a trivial `CHANGELOG.md` `## Unreleased` resolution (#858 adds `### Fixed`, this adds `### Changed`). I'd suggest landing #858 first so the `total-only` fallback stays correct on its own.

## Tests

- `indexer-discovery.test.ts`: `discoverChannels` with an explicit recipients filter returns `total` from the completed walk.
- `compiler-channel-count.test.ts` (new): the compiler makes a **single** discovery call when the count is supplied (and uses it as the new channel's index), and falls back to `total-only` when it isn't.

## Verification

- `npm run lint`: clean
- `npm run test:fast`: 249/249 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/861)
<!-- Reviewable:end -->
