### PR TITLE
refactor(sdk): use point-free .map(toBigInt)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -96,6 +96,11 @@ Apply these guidelines when writing or reviewing code in this codebase.
 - Inline directly in function arguments if it doesn't hurt readability
 - *Example:* `spawn(foo.clone(), bar.clone())` instead of `let foo = foo.clone(); let bar = bar.clone(); spawn(foo, bar)`
 
+### Pass functions point-free when the lambda only forwards arguments
+- A callback that does nothing but forward its single argument is redundant wrapping; pass the function directly
+- *Example:* `values.map(toBigInt)` instead of `values.map((value) => toBigInt(value))`
+- *Caveat:* Only safe when the function ignores the extra arguments `Array.map`/`forEach`/etc. pass (`element, index, array`). A function that reads a second parameter breaks — e.g. `["1","2"].map(parseInt)` feeds the index in as the radix and returns `[1, NaN]`. When in doubt, keep the explicit arrow
+
 ### Check for existing utilities before adding new ones
 - Before writing a local helper function, search the codebase for existing shared utilities
 - If similar code exists in multiple places, extract to a shared module (e.g., `test_fixtures.rs` for test helpers)

--- a/sdk/src/internal/compiler.ts
+++ b/sdk/src/internal/compiler.ts
@@ -468,7 +468,7 @@ export class ActionCompiler {
         withdrawals,
         poolAddress: this.poolAddress,
       });
-      const calldata = CallData.compile(call.calldata ?? []).map((value) => toBigInt(value));
+      const calldata = CallData.compile(call.calldata ?? []).map(toBigInt);
 
       const input = {
         type: "InvokeExternal",

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -142,7 +142,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
       blockIdentifier?: BlockIdentifier;
     }
   ): Promise<{ timestamp: BlockIdentifier; notes: AddressMap<Note[]>; cursor: NotesCursor }> {
-    const tokenFilter = params?.tokens ? new Set(params.tokens.map((t) => toBigInt(t))) : null;
+    const tokenFilter = params?.tokens ? new Set(params.tokens.map(toBigInt)) : null;
     const cursor = params?.cursor;
     let apiCursor: ApiDiscoveryCursor = cursor ? notesCursorToApiCursor(cursor, tokenFilter) : {};
 
@@ -332,7 +332,7 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     );
 
     if (recipients !== "all") {
-      const requested = new Set(recipients.map((r) => toBigInt(r)));
+      const requested = new Set(recipients.map(toBigInt));
       for (const key of [...channels.keys()]) {
         if (!requested.has(key)) channels.delete(key);
       }


### PR DESCRIPTION
## What

Replace the redundant single-argument lambda wrapper with a point-free function reference at the three `.map()` call sites that forwarded each element straight into `toBigInt`:

- `sdk/src/internal/compiler.ts` — `CallData.compile(...).map(toBigInt)`
- `sdk/src/internal/indexer-discovery.ts` — token filter set
- `sdk/src/internal/indexer-discovery.ts` — recipient filter set

This matches the existing point-free precedent already in the codebase (`proof-facts.ts`, `abstract-private-transfers.ts`).

## Why

`values.map((value) => toBigInt(value))` is just `values.map(toBigInt)`. `toBigInt` reads only its first parameter, so the extra `(index, array)` arguments `Array.map` passes are ignored — behavior is identical. Removing the wrapper trims boilerplate.

The conversion itself stays where it is: it's a boundary normalization (`CallData.compile` returns decimal-string felts; the SDK internals work in `bigint`), not duplication that can be pushed elsewhere.

## Guideline

Recorded the point-free principle — including the classic `.map(parseInt)` footgun caveat (only safe when the callback ignores the extra args) — under **Brevity** in `.claude/rules/code-style.md`.

## Verification

- `npm run lint` (prettier + eslint + `tsc --noEmit`) — clean. The clean type-check confirms `.map(toBigInt)` is type-safe at every site.
- `npm run test:fast` — 25 files / 246 tests pass.

No `CHANGELOG.md` entry: pure internal refactor with zero consumer-observable behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/862)
<!-- Reviewable:end -->
