### PR TITLE
feat(privacy): add domain-separation tag to compute_identity_key

### DIFF
--- a/packages/privacy/src/hashes.cairo
+++ b/packages/privacy/src/hashes.cairo
@@ -35,6 +35,8 @@ pub mod domain_separation {
     pub const ENC_RECIPIENT_ADDR_TAG: felt252 = 'ENC_RECIPIENT_ADDR_TAG:V1';
     /// Tag for `outgoing_channel_id`.
     pub const OUTGOING_CHANNEL_ID_TAG: felt252 = 'OUTGOING_CHANNEL_ID_TAG:V1';
+    /// Tag for `identity_key`.
+    pub const IDENTITY_KEY_TAG: felt252 = 'IDENTITY_KEY_TAG:V1';
 }
 
 
@@ -51,12 +53,11 @@ pub(crate) fn hash(data: Span<felt252>) -> felt252 {
 /// them, and it can be reproduced only by the user. It serves as a pseudonymous proof of
 /// ownership the target can derive sub-accounts from without learning who the user is.
 ///
-/// Returns `h(user_addr, user_private_key, contract_address)`.
-// TODO: Consider adding a domain-separation tag.
+/// Returns `h(IDENTITY_KEY_TAG, user_addr, user_private_key, contract_address)`.
 pub(crate) fn compute_identity_key(
     user_addr: ContractAddress, user_private_key: felt252, contract_address: ContractAddress,
 ) -> felt252 {
-    hash([user_addr.into(), user_private_key, contract_address.into()].span())
+    hash([IDENTITY_KEY_TAG, user_addr.into(), user_private_key, contract_address.into()].span())
 }
 
 /// Computes the hash used to encrypt the private key in `EncPrivateKey`.

--- a/packages/privacy/src/tests/test_hashes.cairo
+++ b/packages/privacy/src/tests/test_hashes.cairo
@@ -1,8 +1,35 @@
 use privacy::hashes::{
-    compute_channel_key, compute_channel_marker, compute_note_id, compute_nullifier,
-    compute_outgoing_channel_id, compute_subchannel_id, compute_subchannel_marker, hash,
+    compute_channel_key, compute_channel_marker, compute_identity_key, compute_note_id,
+    compute_nullifier, compute_outgoing_channel_id, compute_subchannel_id,
+    compute_subchannel_marker, hash,
 };
 use starkware_utils::constants::MAX_U32;
+
+#[test]
+fn test_compute_identity_key_different_inputs() {
+    let user_addr = hash(['USER_ADDR'].span()).try_into().unwrap();
+    let user_private_key = hash(['USER_PRIVATE_KEY'].span());
+    let contract_address = hash(['CONTRACT_ADDRESS'].span()).try_into().unwrap();
+    let identity_key = compute_identity_key(:user_addr, :user_private_key, :contract_address);
+    let other_user_addr = hash(['OTHER_USER_ADDR'].span()).try_into().unwrap();
+    let other_user_private_key = hash(['OTHER_USER_PRIVATE_KEY'].span());
+    let other_contract_address = hash(['OTHER_CONTRACT_ADDRESS'].span()).try_into().unwrap();
+    assert_ne!(user_addr, other_user_addr);
+    assert_ne!(user_private_key, other_user_private_key);
+    assert_ne!(contract_address, other_contract_address);
+    let identity_key_diff_user_addr = compute_identity_key(
+        user_addr: other_user_addr, :user_private_key, :contract_address,
+    );
+    let identity_key_diff_user_private_key = compute_identity_key(
+        :user_addr, user_private_key: other_user_private_key, :contract_address,
+    );
+    let identity_key_diff_contract_address = compute_identity_key(
+        :user_addr, :user_private_key, contract_address: other_contract_address,
+    );
+    assert_ne!(identity_key, identity_key_diff_user_addr);
+    assert_ne!(identity_key, identity_key_diff_user_private_key);
+    assert_ne!(identity_key, identity_key_diff_contract_address);
+}
 
 #[test]
 fn test_compute_channel_key_different_inputs() {


### PR DESCRIPTION
## What

Implements the standing TODO on `compute_identity_key` in [`hashes.cairo`](packages/privacy/src/hashes.cairo): adds a domain-separation tag to its Poseidon hash input.

- Adds `IDENTITY_KEY_TAG: felt252 = 'IDENTITY_KEY_TAG:V1'` to the `domain_separation` module, following the existing `<VAR_NAME>:V<VERSION>` template.
- Prepends the tag so the hash is now `h(IDENTITY_KEY_TAG, user_addr, user_private_key, contract_address)`, and updates the doc comment to match.
- Adds `test_compute_identity_key_different_inputs` mirroring the existing per-input divergence tests in `test_hashes.cairo`.

## Why

`compute_identity_key` was the only hash in the module without a domain-separation tag, making its output collidable in principle with any other unprefixed 3-felt Poseidon hash over the same domain. Tagging it removes that cross-context collision risk and matches the convention used by every sibling hash.

## Notes

- **Breaking change** for identity-key values: the hash output changes. Within this repo nothing persists the value across a boundary (contract and tests recompute through the same function), but any externally deployed contract or stored identity commitment would need to migrate.
- No SDK/Rust mirror and no spec documents this hash — Cairo is the source of truth, and only it needed updating.

## Verification

- `snforge test --package privacy`: 293 passed, 0 failed (3 pre-existing ignores), including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/863)
<!-- Reviewable:end -->
