### PR TITLE
fix(demo): accept ACCEPTED_ON_L2/L1 as waitForTransaction success states

### DIFF
--- a/demo/src/hooks/useTransactionBuilder.ts
+++ b/demo/src/hooks/useTransactionBuilder.ts
@@ -1,7 +1,8 @@
 import { useState, useCallback, useRef, type RefObject } from "react";
-import { TransactionFinalityStatus, hash, type Account, type RpcProvider } from "starknet";
+import { hash, type Account, type RpcProvider } from "starknet";
 import type { PrivateTransfersInterface } from "starknet-sdk";
 import type { AppConfig } from "../config.ts";
+import { WAIT_OPTIONS } from "../starknet.ts";
 import { type TransactionStatus, waitForProvingBlock } from "./useTransactions.ts";
 import type { BuilderOperation } from "../components/TransactionBuilder.tsx";
 import { Timeline } from "../timeline.ts";
@@ -17,11 +18,6 @@ import {
   normalizeSignature,
   type PaymasterCall,
 } from "../paymaster.ts";
-
-const WAIT_OPTIONS = {
-  successStates: [TransactionFinalityStatus.PRE_CONFIRMED],
-  retryInterval: 100,
-};
 
 function getFeeMode(config: AppConfig): FeeMode {
   return { mode: "sponsored_private", pool_fee_token: config.paymasterFeeToken!, tip: "normal" };

--- a/demo/src/hooks/useTransactions.ts
+++ b/demo/src/hooks/useTransactions.ts
@@ -1,11 +1,11 @@
 import { useState, useCallback, useMemo, useRef, type RefObject } from "react";
-import { TransactionFinalityStatus, transaction, type Account, type RpcProvider } from "starknet";
+import { transaction, type Account, type RpcProvider } from "starknet";
 import { Open, type PrivateTransfersInterface, type PrivateTransfersBuilder } from "starknet-sdk";
 import { getQuotes, quoteToCalls } from "../avnu.ts";
 import { findEkuboPool, type AppConfig } from "../config.ts";
 import { Timeline } from "../timeline.ts";
 import { toRawAmount } from "../format.ts";
-import { previewRedeem, STRK_TOKEN_ADDRESS } from "../starknet.ts";
+import { previewRedeem, STRK_TOKEN_ADDRESS, WAIT_OPTIONS } from "../starknet.ts";
 import {
   type FeeAction,
   type FeeMode,
@@ -13,11 +13,6 @@ import {
   paymasterExecuteApplyAction,
   toPaymasterCall,
 } from "../paymaster.ts";
-
-const WAIT_OPTIONS = {
-  successStates: [TransactionFinalityStatus.PRE_CONFIRMED],
-  retryInterval: 100,
-};
 
 function getFeeMode(config: AppConfig): FeeMode {
   return { mode: "sponsored_private", pool_fee_token: config.paymasterFeeToken!, tip: "normal" };

--- a/demo/src/starknet.ts
+++ b/demo/src/starknet.ts
@@ -1,4 +1,9 @@
-import { Account, RpcProvider } from "starknet";
+import {
+  Account,
+  RpcProvider,
+  TransactionFinalityStatus,
+  type waitForTransactionOptions,
+} from "starknet";
 import {
   createPrivateTransfers,
   ProvingServiceProofProvider,
@@ -17,6 +22,16 @@ import { NoValidateProofProvider } from "./proof-provider.ts";
  */
 export const STRK_TOKEN_ADDRESS =
   "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d";
+
+/** Must include the ACCEPTED_ON_L* states, else a tx skipping PRE_CONFIRMED is polled forever. */
+export const WAIT_OPTIONS: waitForTransactionOptions = {
+  successStates: [
+    TransactionFinalityStatus.PRE_CONFIRMED,
+    TransactionFinalityStatus.ACCEPTED_ON_L2,
+    TransactionFinalityStatus.ACCEPTED_ON_L1,
+  ],
+  retryInterval: 100,
+};
 
 export function createDiscoveryProvider(
   config: AppConfig,


### PR DESCRIPTION
The demo's `WAIT_OPTIONS.successStates` only listed `PRE_CONFIRMED`. starknet.js's `waitForTransaction` exits its poll loop only on a `successStates` match, and its retries timeout is checked solely inside the `catch` block — so a tx that goes straight to `ACCEPTED_ON_L2` (skipping the PRE_CONFIRMED window) returns valid status forever, never throws, and is polled indefinitely despite succeeding.

Fix: add `ACCEPTED_ON_L2`/`ACCEPTED_ON_L1` to `successStates` (PRE_CONFIRMED stays for the fast path) and hoist the duplicated const into the shared `starknet.ts`. Verified with prettier/eslint/tsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/864)
<!-- Reviewable:end -->
