### PR TITLE
refactor(elliptic-proxy): default proxy-screen.mjs to /screen, add path arg

### DIFF
--- a/elliptic-proxy/scripts/proxy-screen.mjs
+++ b/elliptic-proxy/scripts/proxy-screen.mjs
@@ -2,19 +2,19 @@
 // Call the deployed elliptic-proxy Cloud Function for a single address.
 // Signs the request as a partner using the same HMAC scheme the proxy verifies.
 //
-// Usage:
+// Usage (path defaults to "/screen", matching the proof-interceptor):
 //   PARTNER_NAME=acme PARTNER_SECRET=<base64> \
-//     node scripts/proxy-screen.mjs <proxy-url> <address>
+//     node scripts/proxy-screen.mjs <proxy-url> <address> [path]
 //   PARTNER_NAME=acme PARTNER_SECRET_HEX=<hex> \
-//     node scripts/proxy-screen.mjs <proxy-url> <address>
+//     node scripts/proxy-screen.mjs <proxy-url> <address> [path]
 //
 // Build first: `npm run build` (imports computeHmacSignature from dist/).
 
 import { computeHmacSignature } from "../dist/auth.js";
 
-const [, , proxyUrlArg, address] = process.argv;
+const [, , proxyUrlArg, address, pathArg] = process.argv;
 if (!proxyUrlArg || !address) {
-  console.error("usage: proxy-screen.mjs <proxy-url> <address>");
+  console.error("usage: proxy-screen.mjs <proxy-url> <address> [path]");
   process.exit(2);
 }
 
@@ -30,11 +30,10 @@ if (!partnerName || !partnerSecret) {
   process.exit(2);
 }
 
-const proxyUrl = new URL(proxyUrlArg);
-// Cloud Functions (cloudfunctions.net/<name>) strips the function-name segment
-// before dispatching to the container, so the server always sees req.path="/".
-// Override with PROXY_SIGN_PATH if you deploy behind a path-preserving gateway.
-const path = process.env.PROXY_SIGN_PATH ?? "/";
+// Append the path to the base URL and sign it, like the proof-interceptor.
+// Defaults to "/screen"; pass the optional path arg (leading "/") to override.
+const path = pathArg ?? "/screen";
+const proxyUrl = new URL(proxyUrlArg.replace(/\/+$/, "") + path);
 const body = JSON.stringify({ address });
 const timestamp = Date.now().toString();
 const signature = computeHmacSignature(


### PR DESCRIPTION
## What
`proxy-screen.mjs` now posts to `<proxy-url>/screen` and signs `/screen` by
default — the exact request the proof-interceptor makes — with an optional
positional `[path]` argument to override it.

## Why
Previously the smoke-test script POSTed the bare URL and signed only
`PROXY_SIGN_PATH` (default `/`). Reproducing the interceptor's call therefore
meant appending `/screen` to the URL **and** setting `PROXY_SIGN_PATH=/screen`
in tandem — two coupled knobs that had to agree. Defaulting to `/screen` makes
the script mirror the interceptor out of the box; the `[path]` arg is both
appended to the URL and signed, so the POSTed path and the signed path stay
consistent by construction.

## Behavior
- `node scripts/proxy-screen.mjs <url> <addr>` → POST `<url>/screen`, sign `/screen`
- `node scripts/proxy-screen.mjs <url> <addr> <path>` → POST `<url><path>`, sign `<path>`

Works for both a path-preserving gateway (`/screen` routes directly) and a Cloud
Function (name segment stripped, so the server still sees `/screen`), since the
HMAC is verified over the server-reconstructed `req.path` (`src/auth.ts`).

## Test
Verified against the deployed proxy: default → `HTTP 200` with a signature; an
override path (`/nonexistent`) → `403`, confirming the argument redirects the
request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/867)
<!-- Reviewable:end -->
