### PR TITLE
refactor(privacy): rename extract_server_actions_from_compile_and_panic

### DIFF
--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -33,10 +33,9 @@ pub mod Privacy {
         ProofFacts, assert_valid_os_call, assert_valid_signature, compute_message_hash,
         decode_note_amount, derive_public_key, enc_note_packed_value, encrypt_channel_info,
         encrypt_outgoing_channel_info, encrypt_private_key, encrypt_subchannel_info,
-        encrypt_user_addr, extract_compile_actions_inputs,
-        extract_server_actions_from_compile_and_panic, is_canonical_key, open_note, pack,
-        panic_with_server_actions, propagate_external_panic, send_message_to_server,
-        storage_path_to_felt252, to_write_once_action, unpack,
+        encrypt_user_addr, extract_compile_actions_inputs, extract_server_actions_from_panic,
+        is_canonical_key, open_note, pack, panic_with_server_actions, propagate_external_panic,
+        send_message_to_server, storage_path_to_felt252, to_write_once_action, unpack,
     };
     use privacy::{errors, events};
     use starknet::account::Call;
@@ -227,7 +226,7 @@ pub mod Privacy {
                 calldata: calldata.span(),
             );
 
-            extract_server_actions_from_compile_and_panic(:syscall_result)
+            extract_server_actions_from_panic(:syscall_result)
         }
 
         /// Panics directly for internal errors; external calls should be wrapped via syscall

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -422,7 +422,7 @@ pub(crate) fn send_message_to_server(
 
 /// Gets the result from `compile_and_panic` and returns the server actions on success.
 /// Panics on failure with the result's panic data.
-pub(crate) fn extract_server_actions_from_compile_and_panic(
+pub(crate) fn extract_server_actions_from_panic(
     syscall_result: Result<Span<felt252>, Array<felt252>>,
 ) -> Span<ServerAction> {
     let origin_panic_data = syscall_result.expect_err(internal_errors::EXPECTED_PANIC).span();


### PR DESCRIPTION
## What

Renames `extract_server_actions_from_compile_and_panic` → `extract_server_actions_from_panic` in the privacy package (definition in `utils.cairo`, import + call site in `privacy.cairo`).

## Why

The function extracts server actions from panic data returned by a syscall; the `compile_and_` prefix added length without clarifying what it does. The shorter name reads better at the call site.

## Verification

- `scarb build` passes for the privacy package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/871)
<!-- Reviewable:end -->
