### PR TITLE
docs(privacy): add comment explaining why compute_result is non empty

### DIFF
--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -562,7 +562,10 @@ pub mod Privacy {
                 calldata: compute_calldata.span(),
             )
                 .unwrap_or_else(|panic_data| propagate_external_panic(panic_data.span()));
+            // The compute result should be non-empty, as `privacy_compute` is assumed to bind the
+            // identity key to it.
             assert(!compute_result.is_empty(), errors::EMPTY_COMPUTE_RESULT);
+
             // The target's `privacy_invoke_with_computation` receives the compute result followed
             // by the caller-supplied invoke data as a single calldata span.
             let mut invoke_calldata = array![];


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/878)
<!-- Reviewable:end -->
