### PR TITLE
feat(sub_account_anonymizer): emit event on sub-account deployment

### DIFF
--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -168,6 +168,16 @@ pub mod SubAccountAnonymizer {
         sub_accounts: IterableMap<IdentityCommitment, ContractAddress>,
     }
 
+    #[derive(Serde, Copy, Debug, Drop, PartialEq, starknet::Event)]
+    pub struct SubAccountDeployed {
+        /// The identity commitment the sub-account is bound to.
+        #[key]
+        pub identity_commitment: IdentityCommitment,
+        /// The deployed sub-account address.
+        #[key]
+        pub sub_account: ContractAddress,
+    }
+
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
@@ -179,6 +189,7 @@ pub mod SubAccountAnonymizer {
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
         SRC5Event: SRC5Component::Event,
+        SubAccountDeployed: SubAccountDeployed,
     }
 
     #[constructor]
@@ -242,7 +253,7 @@ pub mod SubAccountAnonymizer {
             if let Some(sub_account_addr) = self.sub_accounts.read(identity_commitment) {
                 return ISubAccountDispatcher { contract_address: sub_account_addr };
             }
-            let (sub_account_addr, _) = deploy_syscall(
+            let (sub_account, _) = deploy_syscall(
                 class_hash: self.sub_account_class_hash.read(),
                 contract_address_salt: identity_commitment,
                 calldata: array![].span(),
@@ -250,9 +261,10 @@ pub mod SubAccountAnonymizer {
             )
                 .unwrap_syscall();
             // Sanity check: deployed address cannot be zero.
-            assert(sub_account_addr.is_non_zero(), errors::ZERO_ADDRESS);
-            self.sub_accounts.write(identity_commitment, sub_account_addr);
-            ISubAccountDispatcher { contract_address: sub_account_addr }
+            assert(sub_account.is_non_zero(), errors::ZERO_ADDRESS);
+            self.sub_accounts.write(identity_commitment, sub_account);
+            self.emit(SubAccountDeployed { identity_commitment, sub_account });
+            ISubAccountDispatcher { contract_address: sub_account }
         }
 
         /// Settles each note in `open_notes`, returning one [`OpenNoteDeposit`] per note.

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -2,13 +2,17 @@ use core::hash::HashStateTrait;
 use core::num::traits::{Bounded, Zero};
 use core::poseidon::PoseidonTrait;
 use privacy::objects::OpenNoteDeposit;
-use snforge_std::{DeclareResultTrait, TokenTrait, declare};
+use snforge_std::{
+    DeclareResultTrait, EventSpyTrait, EventsFilterTrait, TokenTrait, declare, spy_events,
+};
 use starknet::account::Call;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_accounts::sub_account::{ISubAccountDispatcher, ISubAccountDispatcherTrait};
 use starkware_utils_testing::test_utils::{
-    TokenHelperTrait, assert_panic_with_felt_error, cheat_caller_address_once,
+    TokenHelperTrait, assert_expected_event_emitted, assert_panic_with_felt_error,
+    cheat_caller_address_once,
 };
+use sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed;
 use sub_account_anonymizer::sub_account_anonymizer::{
     ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
     ISubAccountAnonymizerSafeDispatcherTrait, OpenNote, errors,
@@ -91,6 +95,33 @@ fn test_invoke_executes_and_collects_open_note() {
     assert_eq!(components.token.balance_of(sub_account), 0);
     assert_eq!(components.token.balance_of(components.anonymizer), AMOUNT.into());
     assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+}
+
+#[test]
+fn test_deploy_emits_sub_account_deployed_event() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let identity_commitment = anonymizer.privacy_compute('USER', 'DAPP', 1);
+
+    // The first invoke deploys the sub-account and emits the event.
+    let mut spy = spy_events();
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+    let sub_account = anonymizer.get_sub_account(identity_commitment);
+    let expected_event = SubAccountDeployed { identity_commitment, sub_account };
+    let events = spy.get_events().emitted_by(contract_address: components.anonymizer).events;
+    assert_eq!(events.len(), 1);
+    assert_expected_event_emitted(
+        spied_event: events[0],
+        :expected_event,
+        expected_event_selector: @selector!("SubAccountDeployed"),
+        expected_event_name: "SubAccountDeployed",
+    );
+
+    // A second invoke reuses the sub-account, so no new deployment event is emitted.
+    let mut spy = spy_events();
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+    let events = spy.get_events().emitted_by(contract_address: components.anonymizer).events;
+    assert_eq!(events.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## What

Add a `SubAccountDeployed` event to `SubAccountAnonymizer`, emitted when a sub-account is deployed for an identity commitment.

## Why

Sub-account deployment currently leaves no on-chain trace on the anonymizer itself, making off-chain indexing of which identity commitments have live sub-accounts awkward. The event exposes the binding directly.

## Details

- New `SubAccountDeployed` struct event with an indexed (`#[key]`) `identity_commitment` and the deployed `sub_account` address, following the repo's event convention.
- Emitted from `get_or_deploy_sub_account` right after the storage write, so it fires **only on first deployment** — reusing an existing sub-account emits nothing.

## Testing

- New `test_deploy_emits_sub_account_deployed_event`: asserts the event is emitted with the correct commitment/address on first invoke, and that a reuse invoke emits no new deployment event.
- `sub_account_anonymizer`: 17/17 pass; `scarb fmt --check` clean.

> Note: independent of #880 (IterableMap) — branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/881)
<!-- Reviewable:end -->
