### PR TITLE
feat(sub_account_anonymizer): add CollectPolicy for open notes

### DIFF
--- a/packages/privacy/src/tests/test_e2e.cairo
+++ b/packages/privacy/src/tests/test_e2e.cairo
@@ -21,7 +21,7 @@ use starknet::ContractAddress;
 use starknet::account::Call;
 use starkware_utils_testing::test_utils::TokenHelperTrait;
 use sub_account_anonymizer::sub_account_anonymizer::{
-    ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait,
+    CollectPolicy, ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait, OpenNote,
 };
 
 // Helper: Constants for e2e testing.
@@ -1941,7 +1941,10 @@ fn test_e2e_sub_account_anonymizer_compute_invoke() {
         calldata: array![token_addr.into(), amount.into(), 0].span(),
     };
     let calls: Array<Call> = array![transfer_to_caller];
-    let open_notes: Span<(felt252, ContractAddress)> = [(note_id, token_addr)].span();
+    let open_notes: Span<OpenNote> = [
+        OpenNote { note_id, token: token_addr, collect_policy: CollectPolicy::All },
+    ]
+        .span();
     let mut invoke_data: Array<felt252> = array![];
     calls.serialize(ref invoke_data);
     open_notes.serialize(ref invoke_data);

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -14,6 +14,17 @@ use starknet::{ClassHash, ContractAddress};
 /// The result of [`privacy_compute`]: an identity commitment that identifies a single sub-account.
 pub type IdentityCommitment = felt252;
 
+/// How much of the sub-account's `token` balance to collect for an open note.
+#[derive(Serde, Copy, Drop, PartialEq, Debug)]
+pub enum CollectPolicy {
+    /// Collect the sub-account's entire `token` balance.
+    All,
+    /// Collect only the balance gained during this interaction.
+    Diff,
+    /// Collect this exact amount.
+    Exact: u128,
+}
+
 /// An open note to settle after an interaction.
 #[derive(Serde, Copy, Drop, PartialEq, Debug)]
 pub struct OpenNote {
@@ -21,6 +32,8 @@ pub struct OpenNote {
     pub note_id: felt252,
     /// The token to deposit.
     pub token: ContractAddress,
+    /// The policy selecting how much of the sub-account's `token` balance to collect for this note.
+    pub collect_policy: CollectPolicy,
 }
 
 #[starknet::interface]
@@ -53,9 +66,9 @@ pub trait ISubAccountAnonymizer<T> {
     /// sub-account; see [`privacy_compute`]. Preimage is off-chain only and unrecoverable from
     /// on-chain data.
     /// - `calls` (`Array<Call>`) - the dapp calls to run as the sub-account.
-    /// - `open_notes` ([`Span<OpenNote>`](OpenNote)) - the notes to settle; for each, the
-    ///   sub-account's entire `token` balance is swept into this anonymizer and recorded as a
-    ///   deposit.
+    /// - `open_notes` ([`Span<OpenNote>`](OpenNote)) - the notes to settle; for each, the amount
+    ///   selected by its [`collect_policy`](CollectPolicy) is collected from the sub-account into
+    ///   this anonymizer and recorded as a deposit.
     ///
     /// #### Returns
     /// - ([`Span<OpenNoteDeposit>`](privacy::objects::OpenNoteDeposit)) - one deposit per open
@@ -67,8 +80,12 @@ pub trait ISubAccountAnonymizer<T> {
     /// #### Reverts
     /// - [`UNAUTHORIZED_CALLER`](errors::UNAUTHORIZED_CALLER): Thrown if the caller is not the
     ///   configured privacy contract.
-    /// - [`ZERO_BALANCE`](errors::ZERO_BALANCE): Thrown if the sub-account holds no balance of an
-    ///   open note's `token` (all open notes must be deposited with amount > 0).
+    /// - [`ZERO_BALANCE`](errors::ZERO_BALANCE): Thrown if the amount collected for an open note is
+    ///   zero (all open notes must be deposited with amount > 0).
+    /// - [`NEGATIVE_DIFF`](errors::NEGATIVE_DIFF): Thrown for a `CollectPolicy::Diff` note
+    ///   if the interaction reduced the sub-account's `token` balance.
+    /// - [`INSUFFICIENT_BALANCE`](errors::INSUFFICIENT_BALANCE): Thrown for a
+    ///   `CollectPolicy::Exact` note if the amount exceeds the sub-account's `token` balance.
     /// - [`AMOUNT_OVERFLOW`](errors::AMOUNT_OVERFLOW): Thrown if the amount
     ///   collected for an open note exceeds `u128`.
     fn privacy_invoke_with_computation(
@@ -106,6 +123,8 @@ pub trait ISubAccountAnonymizer<T> {
 pub mod errors {
     pub const UNAUTHORIZED_CALLER: felt252 = 'UNAUTHORIZED_CALLER';
     pub const ZERO_BALANCE: felt252 = 'ZERO_BALANCE';
+    pub const NEGATIVE_DIFF: felt252 = 'NEGATIVE_DIFF';
+    pub const INSUFFICIENT_BALANCE: felt252 = 'INSUFFICIENT_BALANCE';
     pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
     /// Internal error.
     pub const ZERO_ADDRESS: felt252 = 'ZERO_ADDRESS';
@@ -114,7 +133,7 @@ pub mod errors {
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
     use core::hash::HashStateTrait;
-    use core::num::traits::Zero;
+    use core::num::traits::{CheckedSub, Zero};
     use core::poseidon::PoseidonTrait;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -137,7 +156,7 @@ pub mod SubAccountAnonymizer {
     use starkware_utils::storage::iterable_map::{
         IterableMap, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use super::{ISubAccountAnonymizer, IdentityCommitment, OpenNote, errors};
+    use super::{CollectPolicy, ISubAccountAnonymizer, IdentityCommitment, OpenNote, errors};
 
     component!(path: ReplaceabilityComponent, storage: replaceability, event: ReplaceabilityEvent);
     component!(path: CommonRolesComponent, storage: common_roles, event: CommonRolesEvent);
@@ -223,8 +242,12 @@ pub mod SubAccountAnonymizer {
                 get_caller_address() == self.privacy_contract.read(), errors::UNAUTHORIZED_CALLER,
             );
             let sub_account = self.get_or_deploy_sub_account(:identity_commitment);
+            // Pair note with its pre-interaction balance for `CollectPolicy::Diff` notes.
+            let note_balance_snapshots = snapshot_open_notes(
+                sub_account: sub_account.contract_address, :open_notes,
+            );
             sub_account.execute(calls);
-            self.collect_open_notes(:sub_account, :open_notes)
+            self.collect_open_notes(:sub_account, :note_balance_snapshots)
         }
 
         fn get_sub_account(
@@ -267,11 +290,13 @@ pub mod SubAccountAnonymizer {
             ISubAccountDispatcher { contract_address: sub_account }
         }
 
-        /// Settles each note in `open_notes`, returning one [`OpenNoteDeposit`] per note.
-        /// For each note, sweeps the sub-account's entire `token` balance into this anonymizer and
-        /// approves the privacy contract to pull that amount.
+        /// Settles each note, returning one [`OpenNoteDeposit`] per note.
+        /// For each note, collects the amount selected by its [`collect_policy`](CollectPolicy)
+        /// from the sub-account into this anonymizer and approves the privacy contract to pull it.
         fn collect_open_notes(
-            self: @ContractState, sub_account: ISubAccountDispatcher, open_notes: Span<OpenNote>,
+            self: @ContractState,
+            sub_account: ISubAccountDispatcher,
+            note_balance_snapshots: Array<(OpenNote, u256)>,
         ) -> Span<OpenNoteDeposit> {
             let anonymizer = get_contract_address();
             let privacy_contract = self.privacy_contract.read();
@@ -279,22 +304,49 @@ pub mod SubAccountAnonymizer {
             // `sub_account.execute`.
             let mut transfer_calls: Array<Call> = array![];
             let mut deposits: Array<OpenNoteDeposit> = array![];
-            for note in open_notes {
-                let OpenNote { note_id, token } = *note;
+            for (note, pre_balance) in note_balance_snapshots {
+                let OpenNote { note_id, token, collect_policy } = note;
                 let token_contract = IERC20Dispatcher { contract_address: token };
                 let balance = token_contract.balance_of(account: sub_account.contract_address);
-                // All open notes must be deposited with amount > 0.
-                assert(balance.is_non_zero(), errors::ZERO_BALANCE);
+                let collected = match collect_policy {
+                    CollectPolicy::All => balance,
+                    CollectPolicy::Diff => balance
+                        .checked_sub(pre_balance)
+                        .expect(errors::NEGATIVE_DIFF),
+                    CollectPolicy::Exact(exact) => {
+                        assert(balance >= exact.into(), errors::INSUFFICIENT_BALANCE);
+                        exact.into()
+                    },
+                };
+                // Every open note must be deposited with amount > 0.
+                assert(collected.is_non_zero(), errors::ZERO_BALANCE);
 
                 transfer_calls
-                    .append(build_transfer_call(:token, recipient: anonymizer, amount: balance));
-                token_contract.approve(spender: privacy_contract, amount: balance);
-                let amount: u128 = balance.try_into().expect(errors::AMOUNT_OVERFLOW);
+                    .append(build_transfer_call(:token, recipient: anonymizer, amount: collected));
+                token_contract.approve(spender: privacy_contract, amount: collected);
+                let amount: u128 = collected.try_into().expect(errors::AMOUNT_OVERFLOW);
                 deposits.append(OpenNoteDeposit { note_id, token, amount });
             }
             sub_account.execute(transfer_calls);
             deposits.span()
         }
+    }
+
+    /// Pairs `CollectPolicy::Diff` notes with the sub-account's `token` balance before the
+    /// interaction. Other policies are paired with (unused) zero.
+    fn snapshot_open_notes(
+        sub_account: ContractAddress, open_notes: Span<OpenNote>,
+    ) -> Array<(OpenNote, u256)> {
+        let mut note_balance_snapshots: Array<(OpenNote, u256)> = array![];
+        for note in open_notes {
+            let pre_balance = match *note.collect_policy {
+                CollectPolicy::Diff => IERC20Dispatcher { contract_address: *note.token }
+                    .balance_of(account: sub_account),
+                _ => 0,
+            };
+            note_balance_snapshots.append((*note, pre_balance));
+        }
+        note_balance_snapshots
     }
 
     /// Builds a `Call` that transfers `amount` of `token` to `recipient`.

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -14,7 +14,7 @@ use starkware_utils_testing::test_utils::{
 };
 use sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed;
 use sub_account_anonymizer::sub_account_anonymizer::{
-    ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
+    CollectPolicy, ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
     ISubAccountAnonymizerSafeDispatcherTrait, OpenNote, errors,
 };
 use sub_account_anonymizer::tests::test_utils::{
@@ -78,7 +78,10 @@ fn test_invoke_executes_and_collects_open_note() {
         .invoke(
             :identity_commitment,
             calls: array![transfer_to_caller_call(components.mock_dapp, token, AMOUNT)],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All },
+            ]
+                .span(),
         );
 
     // One deposit returned, matching the collected token/amount.
@@ -161,8 +164,8 @@ fn test_collects_multiple_open_notes() {
                 transfer_to_caller_call(components.mock_dapp, addr_b, amount_b),
             ],
             open_notes: array![
-                OpenNote { note_id: 'NOTE_A', token: addr_a },
-                OpenNote { note_id: 'NOTE_B', token: addr_b },
+                OpenNote { note_id: 'NOTE_A', token: addr_a, collect_policy: CollectPolicy::All },
+                OpenNote { note_id: 'NOTE_B', token: addr_b, collect_policy: CollectPolicy::All },
             ]
                 .span(),
         );
@@ -205,7 +208,10 @@ fn test_multiple_invokes_run_in_one_call() {
                 transfer_to_caller_call(components.mock_dapp, token, first),
                 transfer_to_caller_call(components.mock_dapp, token, second),
             ],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All },
+            ]
+                .span(),
         );
 
     let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
@@ -277,7 +283,7 @@ fn test_sub_account_is_reused_per_identity_commitment() {
 }
 
 #[test]
-fn test_sweeps_full_balance_including_preexisting() {
+fn test_collects_full_balance_including_preexisting() {
     let components = deploy_components();
     let token = components.token.contract_address();
     let identity_commitment = anonymizer_disp(components.anonymizer)
@@ -295,10 +301,13 @@ fn test_sweeps_full_balance_including_preexisting() {
         .invoke(
             :identity_commitment,
             calls: array![transfer_to_caller_call(components.mock_dapp, token, AMOUNT)],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All },
+            ]
+                .span(),
         );
 
-    // The full balance is swept: pre-existing plus the amount added by the interaction.
+    // The full balance is collected: pre-existing plus the amount added by the interaction.
     let total = preexisting + AMOUNT;
     assert_eq!(deposits.len(), 1);
     let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
@@ -313,27 +322,59 @@ fn test_sweeps_full_balance_including_preexisting() {
 
 #[test]
 #[feature("safe_dispatcher")]
-fn test_empty_balance_open_note_reverts() {
+fn test_zero_balance_reverts() {
     let components = deploy_components();
     let token = components.token.contract_address();
     let identity_commitment = anonymizer_disp(components.anonymizer)
         .privacy_compute('USER', 'DAPP', 1);
-
-    // No calls and no funds, so the sub-account's balance is zero. A zero-amount deposit would be
-    // rejected downstream, so collecting it reverts with `ZERO_BALANCE`.
-    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
     let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    let open_note_all = OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All };
+    let calls = array![];
+
+    // Deploy the sub-account (empty invoke) first.
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+
+    // All with zero balance.
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
     let result = safe
         .privacy_invoke_with_computation(
-            :identity_commitment,
-            calls: array![],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            :identity_commitment, :calls, open_notes: array![open_note_all].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_BALANCE);
+
+    // Diff with zero balance.
+    let open_note_diff = OpenNote { collect_policy: CollectPolicy::Diff, ..open_note_all };
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let result = safe
+        .privacy_invoke_with_computation(
+            :identity_commitment, calls: array![], open_notes: array![open_note_diff].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_BALANCE);
+
+    // Zero diff with non-zero balance.
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let preexisting: u128 = 500_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let result = safe
+        .privacy_invoke_with_computation(
+            :identity_commitment, calls: array![], open_notes: array![open_note_diff].span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::ZERO_BALANCE);
+
+    // Exact with zero balance.
+    let open_note_exact = OpenNote { collect_policy: CollectPolicy::Exact(0), ..open_note_all };
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let result = safe
+        .privacy_invoke_with_computation(
+            :identity_commitment, calls: array![], open_notes: array![open_note_exact].span(),
         );
     assert_panic_with_felt_error(:result, expected_error: errors::ZERO_BALANCE);
 }
 
 #[test]
-fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
+#[feature("safe_dispatcher")]
+fn test_collects_remaining_balance_after_invoke_transfers_out() {
     let components = deploy_components();
     let token = components.token.contract_address();
     let identity_commitment = anonymizer_disp(components.anonymizer)
@@ -345,7 +386,7 @@ fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
     let preexisting: u128 = 1_000_000;
     components.token.supply(address: sub_account, amount: preexisting);
 
-    // The invoke makes the sub-account send some tokens out; only the remainder is swept.
+    // The invoke makes the sub-account send some tokens out; only the remainder is collected.
     let sink: ContractAddress = 'SINK'.try_into().unwrap();
     let sent: u128 = 300_000;
     let transfer = Call {
@@ -357,10 +398,13 @@ fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
         .invoke(
             :identity_commitment,
             calls: array![transfer],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All },
+            ]
+                .span(),
         );
 
-    // The balance left after the outbound transfer is swept; funds sent out are not recovered.
+    // The balance left after the outbound transfer is collected; funds sent out are not recovered.
     let remaining = preexisting - sent;
     let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
     assert_eq!(note_id, NOTE_ID);
@@ -369,6 +413,145 @@ fn test_sweeps_remaining_balance_after_invoke_transfers_out() {
     assert_eq!(components.token.balance_of(sub_account), 0);
     assert_eq!(components.token.balance_of(components.anonymizer), remaining.into());
     assert_eq!(components.token.balance_of(sink), sent.into());
+
+    // Try to collect with diff policy.
+    components.token.supply(address: sub_account, amount: preexisting);
+    let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let result = safe
+        .privacy_invoke_with_computation(
+            :identity_commitment,
+            calls: array![transfer],
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::Diff },
+            ]
+                .span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::NEGATIVE_DIFF);
+}
+
+#[test]
+fn test_collect_diff_takes_only_interaction_gain() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
+
+    // When no pre-existing balance, `Diff` collects everything.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+    let deposits = components
+        .invoke(
+            :identity_commitment,
+            calls: array![transfer_to_caller_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::Diff },
+            ]
+                .span(),
+        );
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, AMOUNT);
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), AMOUNT.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+
+    // Fund the sub-account with a pre-existing balance that `Diff` must leave untouched.
+    let preexisting: u128 = 500_000;
+    components.token.supply(address: sub_account, amount: preexisting);
+
+    // The interaction adds `AMOUNT`; `Diff` collects only that gain.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+    let deposits = components
+        .invoke(
+            :identity_commitment,
+            calls: array![transfer_to_caller_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::Diff },
+            ]
+                .span(),
+        );
+
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, AMOUNT);
+    // Only the interaction gain is collected; the pre-existing balance stays in the sub-account.
+    assert_eq!(components.token.balance_of(sub_account), preexisting.into());
+    assert_eq!(components.token.balance_of(components.anonymizer), 2 * AMOUNT.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), AMOUNT.into());
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_collect_exact_policy() {
+    let components = deploy_components();
+    let token = components.token.contract_address();
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', 1);
+
+    // The interaction pays the sub-account `AMOUNT`; `Exact` collects only part of it.
+    components.token.supply(address: components.mock_dapp, amount: AMOUNT);
+    let exact: u128 = 400_000;
+    let deposits = components
+        .invoke(
+            :identity_commitment,
+            calls: array![transfer_to_caller_call(components.mock_dapp, token, AMOUNT)],
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::Exact(exact) },
+            ]
+                .span(),
+        );
+
+    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, exact);
+    // Only `exact` is collected; the rest of the interaction payout stays in the sub-account.
+    let remaining = AMOUNT - exact;
+    assert_eq!(components.token.balance_of(sub_account), remaining.into());
+    assert_eq!(components.token.balance_of(components.anonymizer), exact.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), exact.into());
+
+    // Test collect exact remaining balance.
+    let deposits = components
+        .invoke(
+            :identity_commitment,
+            calls: array![],
+            open_notes: array![
+                OpenNote {
+                    note_id: NOTE_ID, token, collect_policy: CollectPolicy::Exact(remaining),
+                },
+            ]
+                .span(),
+        );
+    assert_eq!(deposits.len(), 1);
+    let OpenNoteDeposit { note_id, token: deposit_token, amount } = *deposits[0];
+    assert_eq!(note_id, NOTE_ID);
+    assert_eq!(deposit_token, token);
+    assert_eq!(amount, remaining);
+    assert_eq!(components.token.balance_of(sub_account), 0);
+    assert_eq!(components.token.balance_of(components.anonymizer), remaining.into() + exact.into());
+    assert_eq!(components.token.allowance(components.anonymizer, PRIVACY), remaining.into());
+
+    // Try to collect exceeding balance.
+    cheat_caller_address_once(contract_address: components.anonymizer, caller_address: PRIVACY);
+    let safe = ISubAccountAnonymizerSafeDispatcher { contract_address: components.anonymizer };
+    let result = safe
+        .privacy_invoke_with_computation(
+            :identity_commitment,
+            calls: array![],
+            open_notes: array![
+                OpenNote {
+                    note_id: NOTE_ID, token, collect_policy: CollectPolicy::Exact(remaining),
+                },
+            ]
+                .span(),
+        );
+    assert_panic_with_felt_error(:result, expected_error: errors::INSUFFICIENT_BALANCE);
 }
 
 #[test]
@@ -392,7 +575,10 @@ fn test_collected_amount_overflow() {
                 transfer_to_caller_call(components.mock_dapp, token, max),
                 transfer_to_caller_call(components.mock_dapp, token, 1),
             ],
-            open_notes: array![OpenNote { note_id: NOTE_ID, token }].span(),
+            open_notes: array![
+                OpenNote { note_id: NOTE_ID, token, collect_policy: CollectPolicy::All },
+            ]
+                .span(),
         );
 }
 


### PR DESCRIPTION
## What

Adds a `CollectPolicy` enum on `OpenNote` so callers can choose how much of a sub-account's `token` balance is collected when settling each open note:

- **`All`** — collect the sub-account's entire `token` balance (previous, and only, behavior).
- **`Diff`** — collect only the balance *gained* during this interaction, leaving any pre-existing balance untouched.
- **`Exact(amount)`** — collect an exact `u128` amount; reverts if the sub-account doesn't have it.

## Why

Previously every open note swept the sub-account's full token balance. That conflates pre-existing funds with funds earned in the current interaction and gives callers no way to deposit a precise amount. `Diff` and `Exact` make settlement intent explicit.

## How

- `snapshot_open_notes` records each `Diff` note's pre-interaction `token` balance *before* the dapp calls run; other policies snapshot an (unused) zero.
- `collect_open_notes` computes the collected amount per policy after execution.
- New errors: `NEGATIVE_DIFF` (a `Diff` note where the interaction reduced the balance) and `INSUFFICIENT_BALANCE` (an `Exact` note exceeding the balance). `ZERO_BALANCE` still rejects any zero-amount collection.

## Testing

- `snforge test -p sub_account_anonymizer` — 18 passed, added coverage for `Diff`, `Exact`, zero-amount reverts across all policies, `NEGATIVE_DIFF`, and `INSUFFICIENT_BALANCE`.
- `snforge test -p privacy test_e2e_sub_account_anonymizer_compute_invoke` — passing (updated for the new `OpenNote` shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/882)
<!-- Reviewable:end -->
