### PR TITLE
feat(sub-account-anonymizer): two-stage commitment + get_sub_accounts view

### DIFF
--- a/packages/privacy/src/tests/test_e2e.cairo
+++ b/packages/privacy/src/tests/test_e2e.cairo
@@ -22,6 +22,7 @@ use starknet::account::Call;
 use starkware_utils_testing::test_utils::TokenHelperTrait;
 use sub_account_anonymizer::sub_account_anonymizer::{
     CollectPolicy, ISubAccountAnonymizerDispatcher, ISubAccountAnonymizerDispatcherTrait, OpenNote,
+    partial_commitment,
 };
 
 // Helper: Constants for e2e testing.
@@ -1988,10 +1989,10 @@ fn test_e2e_sub_account_anonymizer_compute_invoke() {
     // A sub-account was deployed for the derived commitment and holds nothing after collection.
     let anonymizer_disp = ISubAccountAnonymizerDispatcher { contract_address: anonymizer };
     let identity_key = user.compute_identity_key(contract_address: anonymizer);
-    let identity_commitment = anonymizer_disp.privacy_compute(:identity_key, :dapp_name, :nonce);
-    let sub_account = anonymizer_disp.get_sub_account(:identity_commitment);
-    assert!(sub_account.is_non_zero());
-    assert_eq!(token.balance_of(address: sub_account), 0);
+    let sub_account_info = *anonymizer_disp
+        .get_sub_accounts(partial_commitment(:identity_key, :dapp_name), 0, 1)[0];
+    assert!(sub_account_info.is_deployed);
+    assert_eq!(token.balance_of(address: sub_account_info.address), 0);
 }
 
 /// E2E: two open notes on the *same* token in one sub-account interaction is unsupported and fails.

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -7,12 +7,27 @@
 //! pull them into open notes. Driving interactions is restricted to the configured privacy
 //! contract.
 
+use core::hash::HashStateTrait;
+use core::poseidon::PoseidonTrait;
 use privacy::objects::OpenNoteDeposit;
 use starknet::account::Call;
 use starknet::{ClassHash, ContractAddress};
 
 /// The result of [`privacy_compute`]: an identity commitment that identifies a single sub-account.
 pub type IdentityCommitment = felt252;
+
+/// The nonce-independent half of an identity commitment, `hash(identity_key, dapp_name)`.
+pub type PartialCommitment = felt252;
+
+/// A sub-account resolved by [`get_sub_accounts`]: its `nonce`, `address`, and whether it is
+/// deployed. When `is_deployed` is false, `address` is the deterministic address the sub-account
+/// *would* deploy to, computed the same way the deploy syscall derives it.
+#[derive(Serde, Copy, Drop, PartialEq, Debug)]
+pub struct SubAccountInfo {
+    pub nonce: u64,
+    pub address: ContractAddress,
+    pub is_deployed: bool,
+}
 
 /// How much of the sub-account's `token` balance to collect for an open note.
 #[derive(Serde, Copy, Drop, PartialEq, Debug)]
@@ -23,6 +38,22 @@ pub enum CollectPolicy {
     Diff,
     /// Collect this exact amount.
     Exact: u128,
+}
+
+/// Upper bound on the nonce range a single [`get_sub_accounts`] call may resolve, so a view call
+/// can never be driven into an unbounded loop by a caller-supplied range.
+pub const MAX_SCAN_RANGE: u64 = 1024;
+
+/// Computes the [`PartialCommitment`](PartialCommitment) `hash(identity_key, dapp_name)`.
+pub fn partial_commitment(identity_key: felt252, dapp_name: felt252) -> PartialCommitment {
+    PoseidonTrait::new().update(identity_key).update(dapp_name).finalize()
+}
+
+/// Computes the full identity commitment `hash(partial_commitment, nonce)`.
+pub fn commitment_from_partial(
+    partial_commitment: PartialCommitment, nonce: felt252,
+) -> IdentityCommitment {
+    PoseidonTrait::new().update(partial_commitment).update(nonce).finalize()
 }
 
 /// An open note to settle after an interaction.
@@ -52,7 +83,9 @@ pub trait ISubAccountAnonymizer<T> {
     ///
     /// #### Returns
     /// - ([`IdentityCommitment`](IdentityCommitment)) - An identity commitment binding to a
-    /// single sub-account.
+    /// single sub-account, computed in two stages as `hash(hash(identity_key, dapp_name), nonce)`.
+    /// The inner `hash(identity_key, dapp_name)` is the [`PartialCommitment`](PartialCommitment),
+    /// which the nonce-scanning views consume so a single off-chain derivation covers every nonce.
     fn privacy_compute(
         self: @T, identity_key: felt252, dapp_name: felt252, nonce: felt252,
     ) -> IdentityCommitment;
@@ -97,7 +130,31 @@ pub trait ISubAccountAnonymizer<T> {
         open_notes: Span<OpenNote>,
     ) -> Span<OpenNoteDeposit>;
 
-    /// Returns the sub-account address bound to `identity_commitment`.
+    /// Resolves the sub-accounts for nonces `[start_nonce, end_nonce)` under `partial_commitment`,
+    /// one [`SubAccountInfo`](SubAccountInfo) per nonce in ascending order. A deployed nonce
+    /// carries its stored address; an undeployed one carries the deterministic address it would
+    /// deploy to (so callers can address a sub-account before it exists). The commitment for each
+    /// nonce is `hash(partial_commitment, nonce)`.
+    ///
+    /// #### Parameters
+    /// - `partial_commitment` ([`PartialCommitment`](PartialCommitment)) - the user+dapp half of
+    /// the commitment, `hash(identity_key, dapp_name)`.
+    /// - `start_nonce` (`u64`) - the first nonce to resolve (inclusive).
+    /// - `end_nonce` (`u64`) - the upper bound (exclusive).
+    ///
+    /// #### Returns
+    /// - ([`Span<SubAccountInfo>`](SubAccountInfo)) - one entry per nonce in `[start_nonce,
+    /// end_nonce)`.
+    ///
+    /// #### Reverts
+    /// - [`INVALID_RANGE`](errors::INVALID_RANGE): Thrown if `end_nonce < start_nonce`.
+    /// - [`RANGE_TOO_LARGE`](errors::RANGE_TOO_LARGE): Thrown if `end_nonce - start_nonce` exceeds
+    ///   [`MAX_SCAN_RANGE`](MAX_SCAN_RANGE).
+    fn get_sub_accounts(
+        self: @T, partial_commitment: PartialCommitment, start_nonce: u64, end_nonce: u64,
+    ) -> Span<SubAccountInfo>;
+
+    /// Returns the deployed sub-account address bound to `identity_commitment`.
     ///
     /// #### Parameters
     /// - `identity_commitment` ([`IdentityCommitment`](IdentityCommitment)) - The identity
@@ -128,18 +185,19 @@ pub mod errors {
     pub const NEGATIVE_DIFF: felt252 = 'NEGATIVE_DIFF';
     pub const INSUFFICIENT_BALANCE: felt252 = 'INSUFFICIENT_BALANCE';
     pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
+    pub const RANGE_TOO_LARGE: felt252 = 'RANGE_TOO_LARGE';
+    pub const INVALID_RANGE: felt252 = 'INVALID_RANGE';
     /// Internal error.
     pub const ZERO_ADDRESS: felt252 = 'ZERO_ADDRESS';
 }
 
 #[starknet::contract]
 pub mod SubAccountAnonymizer {
-    use core::hash::HashStateTrait;
-    use core::num::traits::{CheckedSub, Zero};
-    use core::poseidon::PoseidonTrait;
+    use core::num::traits::{CheckedSub, SaturatingSub, Zero};
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::utils::deployments::calculate_contract_address_from_deploy_syscall;
     use privacy::objects::OpenNoteDeposit;
     use starknet::account::Call;
     use starknet::storage::{
@@ -158,7 +216,10 @@ pub mod SubAccountAnonymizer {
     use starkware_utils::storage::iterable_map::{
         IterableMap, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use super::{CollectPolicy, ISubAccountAnonymizer, IdentityCommitment, OpenNote, errors};
+    use super::{
+        CollectPolicy, ISubAccountAnonymizer, IdentityCommitment, MAX_SCAN_RANGE, OpenNote,
+        PartialCommitment, SubAccountInfo, commitment_from_partial, errors, partial_commitment,
+    };
 
     component!(path: ReplaceabilityComponent, storage: replaceability, event: ReplaceabilityEvent);
     component!(path: CommonRolesComponent, storage: common_roles, event: CommonRolesEvent);
@@ -231,7 +292,7 @@ pub mod SubAccountAnonymizer {
         fn privacy_compute(
             self: @ContractState, identity_key: felt252, dapp_name: felt252, nonce: felt252,
         ) -> IdentityCommitment {
-            PoseidonTrait::new().update(identity_key).update(dapp_name).update(nonce).finalize()
+            commitment_from_partial(partial_commitment(identity_key, dapp_name), nonce)
         }
 
         fn privacy_invoke_with_computation(
@@ -250,6 +311,39 @@ pub mod SubAccountAnonymizer {
             );
             sub_account.execute(calls);
             self.collect_open_notes(:sub_account, :note_balance_snapshots)
+        }
+
+        fn get_sub_accounts(
+            self: @ContractState,
+            partial_commitment: PartialCommitment,
+            start_nonce: u64,
+            end_nonce: u64,
+        ) -> Span<SubAccountInfo> {
+            assert(end_nonce >= start_nonce, errors::INVALID_RANGE);
+            assert(
+                end_nonce.saturating_sub(start_nonce) <= MAX_SCAN_RANGE, errors::RANGE_TOO_LARGE,
+            );
+            let class_hash = self.sub_account_class_hash.read();
+            let deployer_address = get_contract_address();
+            let mut sub_accounts: Array<SubAccountInfo> = array![];
+            for nonce in start_nonce..end_nonce {
+                let commitment = commitment_from_partial(partial_commitment, nonce.into());
+                let stored = self.get_sub_account(commitment);
+                let is_deployed = stored.is_non_zero();
+                // Undeployed sub-accounts resolve to the address the deploy syscall would derive.
+                let address = if is_deployed {
+                    stored
+                } else {
+                    calculate_contract_address_from_deploy_syscall(
+                        salt: commitment,
+                        :class_hash,
+                        constructor_calldata: array![].span(),
+                        :deployer_address,
+                    )
+                };
+                sub_accounts.append(SubAccountInfo { nonce, address, is_deployed });
+            }
+            sub_accounts.span()
         }
 
         fn get_sub_account(

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -15,15 +15,23 @@ use starkware_utils_testing::test_utils::{
 use sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed;
 use sub_account_anonymizer::sub_account_anonymizer::{
     CollectPolicy, ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
-    ISubAccountAnonymizerSafeDispatcherTrait, OpenNote, errors,
+    ISubAccountAnonymizerSafeDispatcherTrait, MAX_SCAN_RANGE, OpenNote, SubAccountInfo,
+    commitment_from_partial, errors, partial_commitment,
 };
 use sub_account_anonymizer::tests::test_utils::{
-    ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components, deploy_sub_account_anonymizer,
-    deploy_token, transfer_to_caller_call,
+    Components, ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components,
+    deploy_sub_account_anonymizer, deploy_token, transfer_to_caller_call,
 };
 
 const AMOUNT: u128 = 1_000_000;
 const NOTE_ID: felt252 = 'NOTE_ID';
+
+/// Resolves the `('USER', 'DAPP', nonce)` sub-account via the range view.
+fn sub_account_info(anonymizer: ContractAddress, nonce: u64) -> SubAccountInfo {
+    let infos = anonymizer_disp(anonymizer)
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), nonce, nonce + 1);
+    *infos[0]
+}
 
 #[test]
 fn test_get_privacy_contract() {
@@ -45,11 +53,25 @@ fn test_get_sub_account_unknown_identity_commitment_is_zero() {
 }
 
 #[test]
-fn test_privacy_compute_matches_poseidon() {
+fn test_undeployed_sub_account_resolves_to_computed_address() {
+    let anonymizer = deploy_sub_account_anonymizer();
+    let info = sub_account_info(anonymizer, 0);
+    // Undeployed, but still resolves to the deterministic address it would deploy to.
+    assert!(!info.is_deployed);
+    assert!(info.address.is_non_zero());
+}
+
+#[test]
+fn test_privacy_compute_is_two_stage_poseidon() {
     let anonymizer = deploy_sub_account_anonymizer();
     let identity_commitment = anonymizer_disp(anonymizer).privacy_compute('USER', 'DAPP', 7);
-    let expected = PoseidonTrait::new().update('USER').update('DAPP').update(7).finalize();
+    // Two-stage: hash(hash(identity_key, dapp_name), nonce).
+    let expected_partial = PoseidonTrait::new().update('USER').update('DAPP').finalize();
+    let expected = PoseidonTrait::new().update(expected_partial).update(7).finalize();
     assert_eq!(identity_commitment, expected);
+    // The exported helpers reproduce each stage.
+    assert_eq!(partial_commitment('USER', 'DAPP'), expected_partial);
+    assert_eq!(commitment_from_partial(expected_partial, 7), expected);
 }
 
 #[test]
@@ -91,7 +113,7 @@ fn test_invoke_executes_and_collects_open_note() {
     assert_eq!(deposit_token, token);
     assert_eq!(amount, AMOUNT);
 
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let sub_account = sub_account_info(components.anonymizer, 1).address;
     assert!(sub_account.is_non_zero());
     // Funds flowed dapp -> sub-account -> anonymizer, and the privacy contract is approved to pull.
     assert_eq!(components.token.balance_of(components.mock_dapp), 0);
@@ -238,7 +260,7 @@ fn test_invoke_but_not_collect() {
         );
     assert_eq!(deposits.len(), 0);
     assert_eq!(components.token.balance_of(components.anonymizer), 0);
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let sub_account = sub_account_info(components.anonymizer, 1).address;
     assert_eq!(components.token.balance_of(sub_account), AMOUNT.into());
 }
 
@@ -249,7 +271,7 @@ fn test_deployed_sub_account_owned_by_anonymizer() {
         .privacy_compute('USER', 'DAPP', 1);
     components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
 
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let sub_account = sub_account_info(components.anonymizer, 1).address;
     // The anonymizer is the sub-account's deployer, so it is the only authorized controller.
     assert_eq!(
         ISubAccountDispatcher { contract_address: sub_account }.owner(), components.anonymizer,
@@ -266,20 +288,20 @@ fn test_sub_account_is_reused_per_identity_commitment() {
 
     components
         .invoke(identity_commitment: identity_commitment_a, calls: array![], open_notes: no_notes);
-    let sub_account_a = anonymizer.get_sub_account(identity_commitment_a);
-    assert!(sub_account_a.is_non_zero());
+    let sub_account_a = sub_account_info(components.anonymizer, 1);
+    assert!(sub_account_a.is_deployed);
 
     // Same identity commitment reuses the same sub-account (no redeploy).
     components
         .invoke(identity_commitment: identity_commitment_a, calls: array![], open_notes: no_notes);
-    assert_eq!(anonymizer.get_sub_account(identity_commitment_a), sub_account_a);
+    assert_eq!(sub_account_info(components.anonymizer, 1).address, sub_account_a.address);
 
     // A different identity commitment gets a distinct sub-account.
     components
         .invoke(identity_commitment: identity_commitment_b, calls: array![], open_notes: no_notes);
-    let sub_account_b = anonymizer.get_sub_account(identity_commitment_b);
-    assert!(sub_account_b.is_non_zero());
-    assert!(sub_account_b != sub_account_a);
+    let sub_account_b = sub_account_info(components.anonymizer, 2);
+    assert!(sub_account_b.is_deployed);
+    assert!(sub_account_b.address != sub_account_a.address);
 }
 
 #[test]
@@ -291,7 +313,7 @@ fn test_collects_full_balance_including_preexisting() {
 
     // Deploy the sub-account (empty invoke) so we can give it a pre-existing balance.
     components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let sub_account = sub_account_info(components.anonymizer, 1).address;
     let preexisting: u128 = 500_000;
     components.token.supply(address: sub_account, amount: preexisting);
 
@@ -382,7 +404,7 @@ fn test_collects_remaining_balance_after_invoke_transfers_out() {
 
     // Deploy and pre-fund the sub-account.
     components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
-    let sub_account = anonymizer_disp(components.anonymizer).get_sub_account(identity_commitment);
+    let sub_account = sub_account_info(components.anonymizer, 1).address;
     let preexisting: u128 = 1_000_000;
     components.token.supply(address: sub_account, amount: preexisting);
 
@@ -582,3 +604,98 @@ fn test_collected_amount_overflow() {
         );
 }
 
+/// Deploys the sub-account for `('USER', 'DAPP', nonce)` via an empty invoke.
+fn deploy_nonce(components: Components, nonce: u64) {
+    let identity_commitment = anonymizer_disp(components.anonymizer)
+        .privacy_compute('USER', 'DAPP', nonce.into());
+    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
+}
+
+#[test]
+fn test_get_sub_accounts_resolves_deployed_and_undeployed() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let partial = partial_commitment('USER', 'DAPP');
+    deploy_nonce(components, 0);
+    deploy_nonce(components, 1);
+
+    // Nonce 2 is undeployed; the view resolves every nonce in range with an is_deployed flag.
+    let infos = anonymizer.get_sub_accounts(partial, 0, 3);
+    assert_eq!(infos.len(), 3);
+    assert_eq!((*infos[0]).nonce, 0);
+    assert!((*infos[0]).is_deployed);
+    assert!((*infos[1]).is_deployed);
+    let undeployed = *infos[2];
+    assert_eq!(undeployed.nonce, 2);
+    assert!(!undeployed.is_deployed);
+    // Even undeployed, it resolves to the deterministic address it would deploy to.
+    assert!(undeployed.address.is_non_zero());
+}
+
+#[test]
+fn test_get_sub_accounts_computed_address_matches_deploy() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let partial = partial_commitment('USER', 'DAPP');
+
+    let before = *anonymizer.get_sub_accounts(partial, 0, 1)[0];
+    assert!(!before.is_deployed);
+    deploy_nonce(components, 0);
+    let after = *anonymizer.get_sub_accounts(partial, 0, 1)[0];
+    assert!(after.is_deployed);
+    // The address computed before deployment matches the actual on-chain deploy address.
+    assert_eq!(before.address, after.address);
+}
+
+#[test]
+fn test_get_sub_accounts_scopes_by_dapp_and_nonce() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let dapp = anonymizer.get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, 2);
+    let nonce0 = *dapp[0];
+    let nonce1 = *dapp[1];
+    let other_dapp = *anonymizer.get_sub_accounts(partial_commitment('USER', 'OTHER'), 0, 1)[0];
+    assert!(nonce0.address != nonce1.address);
+    assert!(nonce0.address != other_dapp.address);
+}
+
+#[test]
+fn test_get_sub_accounts_from_start_nonce() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let partial = partial_commitment('USER', 'DAPP');
+    deploy_nonce(components, 0);
+    deploy_nonce(components, 1);
+
+    // Scanning from nonce 1 skips nonce 0; entries carry their own nonce.
+    let infos = anonymizer.get_sub_accounts(partial, 1, 3);
+    assert_eq!(infos.len(), 2);
+    assert_eq!((*infos[0]).nonce, 1);
+    assert!((*infos[0]).is_deployed);
+    assert_eq!((*infos[1]).nonce, 2);
+    assert!(!(*infos[1]).is_deployed);
+}
+
+#[test]
+fn test_get_sub_accounts_empty_range() {
+    let components = deploy_components();
+    let infos = anonymizer_disp(components.anonymizer)
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 5);
+    assert_eq!(infos.len(), 0);
+}
+
+#[test]
+#[should_panic(expected: 'RANGE_TOO_LARGE')]
+fn test_get_sub_accounts_range_too_large_reverts() {
+    let components = deploy_components();
+    anonymizer_disp(components.anonymizer)
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, MAX_SCAN_RANGE + 1);
+}
+
+#[test]
+#[should_panic(expected: 'INVALID_RANGE')]
+fn test_get_sub_accounts_inverted_range_reverts() {
+    let components = deploy_components();
+    anonymizer_disp(components.anonymizer)
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 3);
+}


### PR DESCRIPTION
privacy_compute becomes hash(hash(identity_key, dapp_name), nonce); the inner
hash is the PartialCommitment. get_sub_accounts(partial, start, end) resolves each
nonce in range to a SubAccountInfo { nonce, address, is_deployed } — a deployed
nonce carries its stored address, an undeployed one the deterministic address it
would deploy to (via OZ calculate_contract_address_from_deploy_syscall, matching
the deploy syscall). Range capped by MAX_SCAN_RANGE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/883)
<!-- Reviewable:end -->
