### PR TITLE
feat(sdk): subaccounts(dappName).invoke + generated anonymizer ABI

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- Sub-accounts: `transfers.subaccounts(dappName)` returns a `SubAccountsBuilder`. `invoke(nonce, { calls })`
+  queues a `ComputeAndInvoke` against the sub-account anonymizer — `computeAdditionalData = [dappName, nonce]`
+  and `invokeAdditionalData` compiled from the dapp `calls` via the generated anonymizer ABI — and returns the
+  builder so the caller can add the open-note creation and `.execute()`. `dappName` accepts a felt or
+  a short string. Requires the new `subAccountAnonymizerAddress` field on the `createPrivateTransfers`
+  config; calling `subaccounts(...)` without it throws. `identify()` and `deployed()` on the builder
+  are declared but not yet implemented.
+
 ## 0.14.3-RC.3
 
 ### Breaking

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -41,11 +41,12 @@
   "scripts": {
     "scarb:build": "cd .. && scarb cache clean && scarb build --features test_contracts",
     "generate:abi": "npx tsx scripts/generate-abi.ts",
+    "generate:anonymizer-abi": "npx tsx scripts/generate-anonymizer-abi.ts",
     "generate:client-actions": "npx tsx scripts/generate-client-actions.ts",
     "generate:cairo-hashes": "npx tsx scripts/generate-hashes.ts && prettier --write src/utils/hashes.ts",
     "generate:pool-interface": "npx tsx scripts/generate-pool-interface.ts",
     "generate:cairo-refs": "cd .. && scarb test -p privacy -- --color always generate_reference --include-ignored 2>&1 | tee target/cairo-refs-output.txt && cd sdk && npx tsx scripts/generate-cairo-refs.ts ../target/cairo-refs-output.txt",
-    "generate": "npm run scarb:build && npm run generate:abi && npm run generate:client-actions && npm run generate:cairo-hashes && npm run generate:pool-interface && npm run generate:cairo-refs",
+    "generate": "npm run scarb:build && npm run generate:abi && npm run generate:anonymizer-abi && npm run generate:client-actions && npm run generate:cairo-hashes && npm run generate:pool-interface && npm run generate:cairo-refs",
     "build": "tsc -p tsconfig.build.json",
     "build:browser": "npx tsx scripts/build-browser.ts",
     "lint": "prettier --check src/ tests/ && eslint src/ tests/ && tsc --noEmit -p tsconfig.build.json",

--- a/sdk/scripts/generate-abi.ts
+++ b/sdk/scripts/generate-abi.ts
@@ -4,46 +4,19 @@
  * This replaces the need for abi-wan-kanabi dependency.
  */
 
-import { readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
-import { execSync } from "child_process";
-import { fileURLToPath } from "url";
+import { generateContractAbi } from "./generate-contract-abi.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const inputPath = join(__dirname, "../../target/dev/privacy_Privacy.contract_class.json");
-const outputPath = join(__dirname, "../src/internal/abi.ts");
-
-interface ContractClass {
-  abi: unknown[];
-}
-
-try {
-  // Read the contract class JSON
-  const contractClass: ContractClass = JSON.parse(readFileSync(inputPath, "utf-8"));
-
-  // Generate TypeScript file with ABI as const
-  const output = `/**
- * Privacy Pool Contract ABI
- *
- * This file is auto-generated from Cairo build artifacts.
- * Do not edit manually - run 'npm run generate:abi' to regenerate.
- *
- * The 'as const' assertion enables TypeScript to infer exact literal types,
- * which allows starknet.js's .typedv2() to provide full autocomplete
- * and type checking for contract methods.
- */
-
-export const PrivacyPoolABI = ${JSON.stringify(contractClass.abi, null, 2)} as const;
-`;
-
-  writeFileSync(outputPath, output);
-  console.log("✅ Successfully generated", outputPath);
-
-  // Run prettier to ensure consistent formatting
-  execSync(`prettier --write ${outputPath}`, { stdio: "inherit" });
-} catch (error) {
-  console.error("❌ Error generating ABI:", (error as Error).message);
-  process.exit(1);
-}
+generateContractAbi({
+  scriptUrl: import.meta.url,
+  inputPathFromScriptsDir: "../../target/dev/privacy_Privacy.contract_class.json",
+  outputPathFromScriptsDir: "../src/internal/abi.ts",
+  contractName: "Privacy Pool",
+  exportName: "PrivacyPoolABI",
+  regenerateCommand: "npm run generate:abi",
+  errorLabel: "ABI",
+  extraHeaderLines: [
+    "The 'as const' assertion enables TypeScript to infer exact literal types,",
+    "which allows starknet.js's .typedv2() to provide full autocomplete",
+    "and type checking for contract methods.",
+  ],
+});

--- a/sdk/scripts/generate-anonymizer-abi.ts
+++ b/sdk/scripts/generate-anonymizer-abi.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env npx tsx
+/**
+ * Extracts the SubAccountAnonymizer ABI from its Cairo build artifact into a TypeScript file,
+ * mirroring generate-abi.ts. Used by the SDK to compile `privacy_invoke_with_computation` calldata.
+ */
+
+import { generateContractAbi } from "./generate-contract-abi.js";
+
+generateContractAbi({
+  scriptUrl: import.meta.url,
+  inputPathFromScriptsDir:
+    "../../target/dev/sub_account_anonymizer_SubAccountAnonymizer.contract_class.json",
+  outputPathFromScriptsDir: "../src/internal/anonymizer-abi.ts",
+  contractName: "SubAccountAnonymizer",
+  exportName: "SubAccountAnonymizerABI",
+  regenerateCommand: "npm run generate:anonymizer-abi",
+  errorLabel: "anonymizer ABI",
+});

--- a/sdk/scripts/generate-contract-abi.ts
+++ b/sdk/scripts/generate-contract-abi.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+interface ContractClass {
+  abi: unknown[];
+}
+
+interface GenerateContractAbiOptions {
+  scriptUrl: string;
+  inputPathFromScriptsDir: string;
+  outputPathFromScriptsDir: string;
+  contractName: string;
+  exportName: string;
+  regenerateCommand: string;
+  errorLabel: string;
+  extraHeaderLines?: string[];
+}
+
+export function generateContractAbi({
+  scriptUrl,
+  inputPathFromScriptsDir,
+  outputPathFromScriptsDir,
+  contractName,
+  exportName,
+  regenerateCommand,
+  errorLabel,
+  extraHeaderLines,
+}: GenerateContractAbiOptions): void {
+  const scriptsDir = dirname(fileURLToPath(scriptUrl));
+  const inputPath = join(scriptsDir, inputPathFromScriptsDir);
+  const outputPath = join(scriptsDir, outputPathFromScriptsDir);
+
+  try {
+    const contractClass: ContractClass = JSON.parse(readFileSync(inputPath, "utf-8"));
+    const headerLines = [
+      `${contractName} Contract ABI`,
+      "",
+      "This file is auto-generated from Cairo build artifacts.",
+      `Do not edit manually - run '${regenerateCommand}' to regenerate.`,
+    ];
+    if (extraHeaderLines !== undefined) {
+      headerLines.push("", ...extraHeaderLines);
+    }
+
+    const output = `/**
+${headerLines.map((line) => (line === "" ? " *" : ` * ${line}`)).join("\n")}
+ */
+
+export const ${exportName} = ${JSON.stringify(contractClass.abi, null, 2)} as const;
+`;
+
+    writeFileSync(outputPath, output);
+    console.log("Successfully generated", outputPath);
+
+    execFileSync("prettier", ["--write", outputPath], { stdio: "inherit" });
+  } catch (error) {
+    console.error(`Error generating ${errorLabel}:`, (error as Error).message);
+    process.exit(1);
+  }
+}

--- a/sdk/src/factory.ts
+++ b/sdk/src/factory.ts
@@ -47,6 +47,11 @@ export interface CreatePrivateTransfersParams {
   provingProvider: ProofProviderInterface | ProofProviderConfig;
   discoveryProvider: DiscoveryProviderInterface | DiscoveryProviderConfig;
   poolContractAddress: StarknetAddress;
+  /**
+   * Sub-account anonymizer contract address. Required for `subaccounts(...)`: the contract the
+   * `ComputeAndInvoke` flow targets and whose views resolve sub-account addresses.
+   */
+  subAccountAnonymizerAddress?: StarknetAddress;
 }
 
 /**
@@ -110,5 +115,6 @@ export function createPrivateTransfers(
     discoveryProvider,
     proofInvocationFactory: params.proofInvocationFactory ?? new ProofInvocationFactory(),
     poolContractAddress: params.poolContractAddress,
+    subAccountAnonymizerAddress: params.subAccountAnonymizerAddress,
   });
 }

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -514,6 +514,44 @@ export interface PrivateTransfersInterface {
 
   /** Create a builder for batching multiple operations */
   build(options?: ExecuteOptions): PrivateTransfersBuilder;
+
+  /**
+   * Sub-account operations scoped to a single dapp.
+   *
+   * `dappName` scopes the derived sub-accounts to one dapp (a felt; a plain string is encoded as a
+   * Cairo short string). Requires `subAccountAnonymizerAddress` in the factory config; throws
+   * otherwise.
+   */
+  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder;
+}
+
+/** A sub-account: its `nonce` for the dapp and the deployed `address`. */
+export type SubAccount = { nonce: number; address: StarknetAddressBigint };
+
+/**
+ * Sub-account operations for one user + dapp, driven through the sub-account anonymizer contract.
+ * Each `nonce` maps to a distinct, deterministic sub-account address.
+ */
+export interface SubAccountsBuilder {
+  /**
+   * The deterministic sub-account address for `nonce` (deployed or not). Resolved through the
+   * anonymizer's on-chain views; see the discovery provider.
+   */
+  identify(nonce: BigNumberish): Promise<StarknetAddressBigint>;
+
+  /**
+   * The sub-accounts already deployed for this dapp, scanning consecutive nonces from `startNonce`
+   * (default 0) and stopping at the first undeployed one or `maxNonce`.
+   */
+  deployed(opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]>;
+
+  /**
+   * Queue a `computeAndInvoke` against the sub-account for `nonce`: run `calls` through it and
+   * settle the proceeds into the open notes created in the same transaction. Returns the builder so
+   * the caller can add the open-note creation (e.g. `.with(token).transfer({ recipient, amount: Open })`)
+   * and `.execute()`.
+   */
+  invoke(nonce: BigNumberish, options: { calls: Call[] }): PrivateTransfersBuilder;
 }
 
 // ============ Builder Types ============

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -20,13 +20,16 @@ import type {
   SimulateOptions,
   StarknetAddress,
   StarknetAddressBigint,
+  SubAccountsBuilder,
   ViewingKey,
   ViewingKeyProvider,
 } from "../interfaces.js";
+import type { BigNumberish } from "starknet";
 import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { toBigInt } from "../utils/crypto.js";
 import { PrivateTransfersBuilderImpl } from "./builders.js";
+import { SubAccountsBuilderImpl } from "./sub-accounts.js";
 import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
 
 /**
@@ -42,7 +45,8 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
   constructor(
     userAddress: StarknetAddress,
     protected readonly viewingKeyProvider: ViewingKeyProvider,
-    protected readonly discoveryProvider: DiscoveryProviderInterface
+    protected readonly discoveryProvider: DiscoveryProviderInterface,
+    protected readonly subAccountAnonymizerAddress?: StarknetAddress
   ) {
     this.user = toBigInt(userAddress);
   }
@@ -100,6 +104,19 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
    */
   build(options?: ExecuteOptions): PrivateTransfersBuilder {
     return new PrivateTransfersBuilderImpl(this, this.user, options);
+  }
+
+  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder {
+    if (this.subAccountAnonymizerAddress === undefined) {
+      throw new Error(
+        "subaccounts(...) requires `subAccountAnonymizerAddress` in the createPrivateTransfers config."
+      );
+    }
+    return new SubAccountsBuilderImpl({
+      transfers: this,
+      dappName,
+      subAccountAnonymizerAddress: this.subAccountAnonymizerAddress,
+    });
   }
 
   /**

--- a/sdk/src/internal/anonymizer-abi.ts
+++ b/sdk/src/internal/anonymizer-abi.ts
@@ -1,0 +1,789 @@
+/**
+ * SubAccountAnonymizer Contract ABI
+ *
+ * This file is auto-generated from Cairo build artifacts.
+ * Do not edit manually - run 'npm run generate:anonymizer-abi' to regenerate.
+ */
+
+export const SubAccountAnonymizerABI = [
+  {
+    type: "impl",
+    name: "SubAccountAnonymizerImpl",
+    interface_name: "sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizer",
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<core::felt252>",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<core::felt252>",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::starknet::account::Call",
+    members: [
+      {
+        name: "to",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "selector",
+        type: "core::felt252",
+      },
+      {
+        name: "calldata",
+        type: "core::array::Span::<core::felt252>",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "sub_account_anonymizer::sub_account_anonymizer::OpenNote",
+    members: [
+      {
+        name: "note_id",
+        type: "core::felt252",
+      },
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<sub_account_anonymizer::sub_account_anonymizer::OpenNote>",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<sub_account_anonymizer::sub_account_anonymizer::OpenNote>",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "privacy::objects::OpenNoteDeposit",
+    members: [
+      {
+        name: "note_id",
+        type: "core::felt252",
+      },
+      {
+        name: "token",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "amount",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<privacy::objects::OpenNoteDeposit>",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<privacy::objects::OpenNoteDeposit>",
+      },
+    ],
+  },
+  {
+    type: "enum",
+    name: "core::bool",
+    variants: [
+      {
+        name: "False",
+        type: "()",
+      },
+      {
+        name: "True",
+        type: "()",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "sub_account_anonymizer::sub_account_anonymizer::SubAccountInfo",
+    members: [
+      {
+        name: "nonce",
+        type: "core::integer::u64",
+      },
+      {
+        name: "address",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "is_deployed",
+        type: "core::bool",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<sub_account_anonymizer::sub_account_anonymizer::SubAccountInfo>",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<sub_account_anonymizer::sub_account_anonymizer::SubAccountInfo>",
+      },
+    ],
+  },
+  {
+    type: "interface",
+    name: "sub_account_anonymizer::sub_account_anonymizer::ISubAccountAnonymizer",
+    items: [
+      {
+        type: "function",
+        name: "privacy_compute",
+        inputs: [
+          {
+            name: "identity_key",
+            type: "core::felt252",
+          },
+          {
+            name: "dapp_name",
+            type: "core::felt252",
+          },
+          {
+            name: "nonce",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::felt252",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "privacy_invoke_with_computation",
+        inputs: [
+          {
+            name: "identity_commitment",
+            type: "core::felt252",
+          },
+          {
+            name: "calls",
+            type: "core::array::Array::<core::starknet::account::Call>",
+          },
+          {
+            name: "open_notes",
+            type: "core::array::Span::<sub_account_anonymizer::sub_account_anonymizer::OpenNote>",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::array::Span::<privacy::objects::OpenNoteDeposit>",
+          },
+        ],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "get_sub_accounts",
+        inputs: [
+          {
+            name: "partial_commitment",
+            type: "core::felt252",
+          },
+          {
+            name: "start_nonce",
+            type: "core::integer::u64",
+          },
+          {
+            name: "end_nonce",
+            type: "core::integer::u64",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::array::Span::<sub_account_anonymizer::sub_account_anonymizer::SubAccountInfo>",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_privacy_contract",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_sub_account_class_hash",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::starknet::class_hash::ClassHash",
+          },
+        ],
+        state_mutability: "view",
+      },
+    ],
+  },
+  {
+    type: "impl",
+    name: "ReplaceabilityImpl",
+    interface_name: "starkware_utils::components::replaceability::interface::IReplaceable",
+  },
+  {
+    type: "struct",
+    name: "starkware_utils::components::replaceability::interface::EICData",
+    members: [
+      {
+        name: "eic_hash",
+        type: "core::starknet::class_hash::ClassHash",
+      },
+      {
+        name: "eic_init_data",
+        type: "core::array::Span::<core::felt252>",
+      },
+    ],
+  },
+  {
+    type: "enum",
+    name: "core::option::Option::<starkware_utils::components::replaceability::interface::EICData>",
+    variants: [
+      {
+        name: "Some",
+        type: "starkware_utils::components::replaceability::interface::EICData",
+      },
+      {
+        name: "None",
+        type: "()",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "starkware_utils::components::replaceability::interface::ImplementationData",
+    members: [
+      {
+        name: "impl_hash",
+        type: "core::starknet::class_hash::ClassHash",
+      },
+      {
+        name: "eic_data",
+        type: "core::option::Option::<starkware_utils::components::replaceability::interface::EICData>",
+      },
+      {
+        name: "final",
+        type: "core::bool",
+      },
+    ],
+  },
+  {
+    type: "interface",
+    name: "starkware_utils::components::replaceability::interface::IReplaceable",
+    items: [
+      {
+        type: "function",
+        name: "get_upgrade_delay",
+        inputs: [],
+        outputs: [
+          {
+            type: "core::integer::u64",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_impl_activation_time",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::integer::u64",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "add_new_implementation",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "add_new_implementation_unsafe",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "remove_implementation",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "replace_to",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "validate_upgradeability",
+        inputs: [
+          {
+            name: "implementation_data",
+            type: "starkware_utils::components::replaceability::interface::ImplementationData",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    type: "impl",
+    name: "CommonRolesImpl",
+    interface_name: "starkware_utils::components::roles::interface::ICommonRoles",
+  },
+  {
+    type: "enum",
+    name: "starkware_utils::components::roles::interface::Role",
+    variants: [
+      {
+        name: "AppGovernor",
+        type: "()",
+      },
+      {
+        name: "AppRoleAdmin",
+        type: "()",
+      },
+      {
+        name: "GovernanceAdmin",
+        type: "()",
+      },
+      {
+        name: "Operator",
+        type: "()",
+      },
+      {
+        name: "TokenAdmin",
+        type: "()",
+      },
+      {
+        name: "UpgradeAgent",
+        type: "()",
+      },
+      {
+        name: "UpgradeGovernor",
+        type: "()",
+      },
+      {
+        name: "SecurityAdmin",
+        type: "()",
+      },
+      {
+        name: "SecurityAgent",
+        type: "()",
+      },
+      {
+        name: "SecurityGovernor",
+        type: "()",
+      },
+    ],
+  },
+  {
+    type: "struct",
+    name: "core::array::Span::<core::starknet::contract_address::ContractAddress>",
+    members: [
+      {
+        name: "snapshot",
+        type: "@core::array::Array::<core::starknet::contract_address::ContractAddress>",
+      },
+    ],
+  },
+  {
+    type: "interface",
+    name: "starkware_utils::components::roles::interface::ICommonRoles",
+    items: [
+      {
+        type: "function",
+        name: "grant_role",
+        inputs: [
+          {
+            name: "role",
+            type: "starkware_utils::components::roles::interface::Role",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "revoke_role",
+        inputs: [
+          {
+            name: "role",
+            type: "starkware_utils::components::roles::interface::Role",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "has_role",
+        inputs: [
+          {
+            name: "role",
+            type: "starkware_utils::components::roles::interface::Role",
+          },
+          {
+            name: "account",
+            type: "core::starknet::contract_address::ContractAddress",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::bool",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "renounce",
+        inputs: [
+          {
+            name: "role",
+            type: "starkware_utils::components::roles::interface::Role",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "reclaim_legacy_roles",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "reclaim_legacy_roles_for_accounts",
+        inputs: [
+          {
+            name: "accounts",
+            type: "core::array::Span::<core::starknet::contract_address::ContractAddress>",
+          },
+        ],
+        outputs: [],
+        state_mutability: "external",
+      },
+      {
+        type: "function",
+        name: "disable_legacy_role_reclaim",
+        inputs: [],
+        outputs: [],
+        state_mutability: "external",
+      },
+    ],
+  },
+  {
+    type: "constructor",
+    name: "constructor",
+    inputs: [
+      {
+        name: "privacy_contract",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "sub_account_class_hash",
+        type: "core::starknet::class_hash::ClassHash",
+      },
+      {
+        name: "governance_admin",
+        type: "core::starknet::contract_address::ContractAddress",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::replaceability::interface::ImplementationAdded",
+    kind: "struct",
+    members: [
+      {
+        name: "implementation_data",
+        type: "starkware_utils::components::replaceability::interface::ImplementationData",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::replaceability::interface::ImplementationRemoved",
+    kind: "struct",
+    members: [
+      {
+        name: "implementation_data",
+        type: "starkware_utils::components::replaceability::interface::ImplementationData",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::replaceability::interface::ImplementationReplaced",
+    kind: "struct",
+    members: [
+      {
+        name: "implementation_data",
+        type: "starkware_utils::components::replaceability::interface::ImplementationData",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::replaceability::interface::ImplementationFinalized",
+    kind: "struct",
+    members: [
+      {
+        name: "impl_hash",
+        type: "core::starknet::class_hash::ClassHash",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::replaceability::replaceability::ReplaceabilityComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "ImplementationAdded",
+        type: "starkware_utils::components::replaceability::interface::ImplementationAdded",
+        kind: "nested",
+      },
+      {
+        name: "ImplementationRemoved",
+        type: "starkware_utils::components::replaceability::interface::ImplementationRemoved",
+        kind: "nested",
+      },
+      {
+        name: "ImplementationReplaced",
+        type: "starkware_utils::components::replaceability::interface::ImplementationReplaced",
+        kind: "nested",
+      },
+      {
+        name: "ImplementationFinalized",
+        type: "starkware_utils::components::replaceability::interface::ImplementationFinalized",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "starkware_utils::components::common_roles::common_roles::CommonRolesComponent::Event",
+    kind: "enum",
+    variants: [],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+    kind: "struct",
+    members: [
+      {
+        name: "role",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGrantedWithDelay",
+    kind: "struct",
+    members: [
+      {
+        name: "role",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+      {
+        name: "delay",
+        type: "core::integer::u64",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+    kind: "struct",
+    members: [
+      {
+        name: "role",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+      {
+        name: "sender",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+    kind: "struct",
+    members: [
+      {
+        name: "role",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "previous_admin_role",
+        type: "core::felt252",
+        kind: "data",
+      },
+      {
+        name: "new_admin_role",
+        type: "core::felt252",
+        kind: "data",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "RoleGranted",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+        kind: "nested",
+      },
+      {
+        name: "RoleGrantedWithDelay",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGrantedWithDelay",
+        kind: "nested",
+      },
+      {
+        name: "RoleRevoked",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+        kind: "nested",
+      },
+      {
+        name: "RoleAdminChanged",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+        kind: "nested",
+      },
+    ],
+  },
+  {
+    type: "event",
+    name: "openzeppelin_introspection::src5::SRC5Component::Event",
+    kind: "enum",
+    variants: [],
+  },
+  {
+    type: "event",
+    name: "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::Event",
+    kind: "enum",
+    variants: [
+      {
+        name: "ReplaceabilityEvent",
+        type: "starkware_utils::components::replaceability::replaceability::ReplaceabilityComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "CommonRolesEvent",
+        type: "starkware_utils::components::common_roles::common_roles::CommonRolesComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "AccessControlEvent",
+        type: "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+        kind: "flat",
+      },
+      {
+        name: "SRC5Event",
+        type: "openzeppelin_introspection::src5::SRC5Component::Event",
+        kind: "flat",
+      },
+    ],
+  },
+] as const;

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -38,9 +38,15 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
       discoveryProvider: DiscoveryProviderInterface;
       proofInvocationFactory: ProofInvocationFactoryInterface;
       poolContractAddress: StarknetAddress;
+      subAccountAnonymizerAddress?: StarknetAddress;
     }
   ) {
-    super(params.account.address, params.viewingKeyProvider, params.discoveryProvider);
+    super(
+      params.account.address,
+      params.viewingKeyProvider,
+      params.discoveryProvider,
+      params.subAccountAnonymizerAddress
+    );
   }
 
   private async getCompiler(): Promise<ActionCompiler> {

--- a/sdk/src/internal/sub-accounts.ts
+++ b/sdk/src/internal/sub-accounts.ts
@@ -1,0 +1,75 @@
+import { BigNumberish, Call, CallData, hash, shortString } from "starknet";
+import type {
+  ComputeAndInvokeDetails,
+  InvokeCalldataBuilderArgs,
+  PrivateTransfersBuilder,
+  PrivateTransfersInterface,
+  StarknetAddress,
+  StarknetAddressBigint,
+  SubAccount,
+  SubAccountsBuilder,
+} from "../interfaces.js";
+import { SubAccountAnonymizerABI } from "./anonymizer-abi.js";
+import { toBigInt, toHex } from "../utils/index.js";
+
+/** Encodes a dapp name to a felt: a string is a Cairo short string, a felt passes through. */
+function encodeDappName(dappName: string | BigNumberish): bigint {
+  return typeof dappName === "string"
+    ? toBigInt(shortString.encodeShortString(dappName))
+    : toBigInt(dappName);
+}
+
+export class SubAccountsBuilderImpl implements SubAccountsBuilder {
+  private readonly dappName: bigint;
+  private readonly subAccountAnonymizerAddress: bigint;
+
+  constructor(
+    private readonly params: {
+      transfers: PrivateTransfersInterface;
+      dappName: string | BigNumberish;
+      subAccountAnonymizerAddress: StarknetAddress;
+    }
+  ) {
+    this.dappName = encodeDappName(params.dappName);
+    this.subAccountAnonymizerAddress = toBigInt(params.subAccountAnonymizerAddress);
+  }
+
+  invoke(nonce: BigNumberish, options: { calls: Call[] }): PrivateTransfersBuilder {
+    const { dappName, subAccountAnonymizerAddress } = this;
+    const nonceFelt = toBigInt(nonce);
+    // The anonymizer's `privacy_invoke_with_computation` takes Cairo `Call`s (to/selector/calldata).
+    const anonymizerCalls = options.calls.map((call) => ({
+      to: call.contractAddress,
+      selector: hash.getSelectorFromName(call.entrypoint),
+      calldata: CallData.compile(call.calldata ?? []),
+    }));
+
+    return this.params.transfers
+      .build()
+      .computeAndInvoke((args: InvokeCalldataBuilderArgs): ComputeAndInvokeDetails => {
+        const openNotes = args.openNotes.map((note) => ({
+          note_id: note.noteId,
+          token: note.token,
+        }));
+        // Compile (calls, open_notes) via the ABI and drop the leading identity_commitment felt,
+        // which the pool prepends from the privacy_compute result.
+        const invokeAdditionalData = new CallData(SubAccountAnonymizerABI)
+          .compile("privacy_invoke_with_computation", [0n, anonymizerCalls, openNotes])
+          .slice(1)
+          .map(toBigInt);
+        return {
+          contractAddress: toHex(subAccountAnonymizerAddress),
+          computeAdditionalData: [dappName, nonceFelt],
+          invokeAdditionalData,
+        };
+      });
+  }
+
+  async identify(_nonce: BigNumberish): Promise<StarknetAddressBigint> {
+    throw new Error("SubAccountsBuilder.identify() is not implemented yet.");
+  }
+
+  async deployed(_opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]> {
+    throw new Error("SubAccountsBuilder.deployed() is not implemented yet.");
+  }
+}

--- a/sdk/src/testing/mocknet.ts
+++ b/sdk/src/testing/mocknet.ts
@@ -6,7 +6,7 @@
  */
 
 import type { SignerInterface } from "starknet";
-import type { ExecuteResult, PrivateRegistry, ViewingKey } from "../interfaces.js";
+import type { ExecuteResult, PrivateRegistry, StarknetAddress, ViewingKey } from "../interfaces.js";
 import { PrivateTransfers } from "../internal/private-transfers.js";
 import { MockContracts } from "./contracts.js";
 import { MockPoolContract } from "./mock-pool-contract.js";
@@ -132,7 +132,11 @@ export class Mocknet {
    * @param userAddress - The user's Starknet address
    * @param viewingKey - The user's viewing key (private key)
    */
-  createPrivateTransfers(userAddress: bigint, viewingKey: ViewingKey): PrivateTransfers {
+  createPrivateTransfers(
+    userAddress: bigint,
+    viewingKey: ViewingKey,
+    options?: { subAccountAnonymizerAddress?: StarknetAddress }
+  ): PrivateTransfers {
     const pool = this.pool;
 
     return new PrivateTransfers({
@@ -146,6 +150,7 @@ export class Mocknet {
       discoveryProvider: new ContractDiscoveryProvider(pool),
       proofInvocationFactory: new MockProofInvocationFactory(),
       poolContractAddress: `0x${this.poolAddress.toString(16)}`,
+      subAccountAnonymizerAddress: options?.subAccountAnonymizerAddress,
     });
   }
 

--- a/sdk/tests/internal/sub-accounts.test.ts
+++ b/sdk/tests/internal/sub-accounts.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for SubAccountsBuilder.invoke: it builds a `computeAndInvoke` against the anonymizer with
+ * `computeAdditionalData = [dappName, nonce]` and `invokeAdditionalData` compiled from the dapp calls via the anonymizer
+ * ABI. The MockPoolContract simulate flow forwards these to the target's `privacy_compute` /
+ * `privacy_invoke_with_computation`, mirroring Cairo.
+ */
+import { describe, expect, it } from "vitest";
+import { CallData, hash, shortString } from "starknet";
+import { Mocknet } from "../../src/testing/mocknet.js";
+import { MockContract } from "../../src/testing/contracts.js";
+import { compute_identity_key } from "../../src/utils/hashes.js";
+import { SubAccountAnonymizerABI } from "../../src/internal/anonymizer-abi.js";
+import { toBigInt } from "../../src/utils/index.js";
+import { StarknetAddress } from "../../src/interfaces.js";
+
+const COMPUTED_MARKER = 0xc0ffeen;
+const ANONYMIZER = "0xab0a";
+
+class MockComputeContract implements MockContract {
+  [key: string]: unknown;
+  public computeCalls: bigint[][] = [];
+  public invokeCalls: bigint[][] = [];
+
+  constructor(public address: StarknetAddress) {}
+
+  // MockContracts.call spreads the flat calldata span as positional args.
+  privacy_compute(...calldata: bigint[]): bigint {
+    this.computeCalls.push(calldata);
+    return COMPUTED_MARKER;
+  }
+
+  privacy_invoke_with_computation(...calldata: bigint[]): void {
+    this.invokeCalls.push(calldata);
+  }
+}
+
+describe("SubAccountsBuilder.invoke", () => {
+  it("queues a computeAndInvoke with [dappName, nonce] and ABI-compiled calls", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const anonymizer = new MockComputeContract(ANONYMIZER);
+    mocknet.contracts.register(anonymizer);
+
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+    mocknet.executeOutside(await transfers.build().register().execute());
+
+    const dappName = "DAPP";
+    const nonce = 3n;
+    const calls = [{ contractAddress: "0xda99", entrypoint: "pay_out", calldata: [0x1234n, 0n] }];
+    mocknet.executeOutside(
+      await transfers.subaccounts(dappName).invoke(nonce, { calls }).execute()
+    );
+
+    const identityKey = compute_identity_key(
+      toBigInt(env.alice.address),
+      toBigInt(env.alice.privateKey),
+      toBigInt(ANONYMIZER)
+    );
+    const dappFelt = toBigInt(shortString.encodeShortString(dappName));
+    expect(anonymizer.computeCalls).toEqual([[identityKey, dappFelt, nonce]]);
+
+    // No open note was created, so open_notes is empty and invokeAdditionalData is fully determined by calls.
+    const expectedInvokeData = new CallData(SubAccountAnonymizerABI)
+      .compile("privacy_invoke_with_computation", [
+        0n,
+        [
+          {
+            to: "0xda99",
+            selector: hash.getSelectorFromName("pay_out"),
+            calldata: CallData.compile([0x1234n, 0n]),
+          },
+        ],
+        [],
+      ])
+      .slice(1)
+      .map(toBigInt);
+    expect(anonymizer.invokeCalls).toEqual([[COMPUTED_MARKER, ...expectedInvokeData]]);
+  });
+
+  it("encodes a felt dapp name equivalently to its short-string form", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const anonymizer = new MockComputeContract(ANONYMIZER);
+    mocknet.contracts.register(anonymizer);
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+    mocknet.executeOutside(await transfers.build().register().execute());
+
+    const dappFelt = toBigInt(shortString.encodeShortString("DAPP"));
+    mocknet.executeOutside(
+      await transfers.subaccounts(dappFelt).invoke(0n, { calls: [] }).execute()
+    );
+
+    expect(anonymizer.computeCalls[0]?.slice(1)).toEqual([dappFelt, 0n]);
+  });
+
+  it("throws when sub-account config is missing", () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey);
+    expect(() => transfers.subaccounts("DAPP")).toThrow(/subAccountAnonymizerAddress/);
+  });
+});


### PR DESCRIPTION
Adds subAccountAnonymizerAddress to the createPrivateTransfers config and a
SubAccountsBuilder via transfers.subaccounts(dappName). invoke(nonce, { calls })
queues a ComputeAndInvoke against the anonymizer (computeData=[dappName, nonce];
invokeData compiled from the dapp calls via the generated anonymizer ABI) and
returns the builder for chaining open-note creation + execute. identify/deployed
are stubbed until the discovery PRs. New generate:anonymizer-abi target, chained
into npm run generate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/884)
<!-- Reviewable:end -->
