### PR TITLE
feat(discovery-service): /v1/sub_accounts view-proxy endpoint

### DIFF
--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -358,3 +358,59 @@ Retrieves paginated transaction history by scanning backward through note subcha
 - `409 BLOCK_REORGED` — `last_known_block` was reorged out.
 - `503 SERVICE_UNAVAILABLE` — No indexed head available yet.
 - Standard `DiscoveryError` mapping for storage and event errors.
+
+## 6.9 Sub-Accounts Endpoint
+
+`POST /v1/sub_accounts`
+
+Discovers the sub-accounts deployed for a user + dapp through a sub-account anonymizer. Unlike the
+sync endpoints, this is a **thin proxy over the anonymizer's on-chain views** — the contract owns the
+commitment derivation and nonce iteration. No viewing key is sent: the client derives the
+`partial_commitment = hash(identity_key, dapp_name)` off-chain (a Poseidon hash that reveals neither
+the identity key nor the dapp) and passes it in.
+
+**Request:**
+
+```json
+{
+  "contract_address": "0x...",       // the sub-account anonymizer
+  "partial_commitment": "0x...",     // hash(identity_key, dapp_name)
+  "start_nonce": 0,                  // optional, default 0
+  "end_nonce": 64,                   // exclusive upper bound (scan cap)
+  "last_known_block": "0x...",       // optional, reorg detection
+  "block_ref": "0x..."               // optional, pins reads
+}
+```
+
+**Behavior:**
+
+- Resolves `block_ref` (same rules as §6.2), then calls the anonymizer's
+  `get_sub_accounts(partial_commitment, start_nonce, end_nonce)` view. The contract resolves **every**
+  nonce in the range to a `{ nonce, address, is_deployed }`: a deployed nonce carries its stored
+  address, an undeployed one the deterministic address it would deploy to. The endpoint is a thin
+  proxy — the contract owns the commitment derivation and the address computation.
+- Callers enumerating deployed sub-accounts take the leading `is_deployed` run (sub-accounts are
+  allocated consecutively from nonce 0); `identify(nonce)` requests the single-nonce range
+  `[nonce, nonce+1)`.
+- The scan span is capped: `end_nonce - start_nonce` must not exceed the anonymizer's
+  `MAX_SCAN_RANGE` (1024). The endpoint validates this and returns `400 INVALID_REQUEST` before
+  calling the contract (the anonymizer itself reverts with `RANGE_TOO_LARGE` above the cap).
+
+**Response:**
+
+```json
+{
+  "block_ref": "0x...",
+  "sub_accounts": [
+    { "nonce": 0, "address": "0x...", "is_deployed": true },
+    { "nonce": 1, "address": "0x...", "is_deployed": false }
+  ]
+}
+```
+
+**Error responses:**
+
+- `400 INVALID_REQUEST` — `end_nonce - start_nonce` exceeds `MAX_SCAN_RANGE` (1024).
+- `404 CONTRACT_NOT_FOUND` — the anonymizer is not deployed at the pinned block.
+- `409 BLOCK_REORGED` — `last_known_block` was reorged out.
+- `502 RPC_UNAVAILABLE` — the RPC `call` to the anonymizer failed.

--- a/crates/discovery-service/src/api/handlers.rs
+++ b/crates/discovery-service/src/api/handlers.rs
@@ -11,14 +11,15 @@ use discovery_core::events_backend::RawEventAccess;
 use discovery_core::io_budget::IoBudget;
 use discovery_core::storage_backend::StorageBackend;
 use starknet_core::types::{BlockId, Felt};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use discovery_core::privacy_pool::felt_hex;
 
 use crate::api::types::{
     error_codes, ApiErrorResponse, HealthResponse, HistoryRequest, HistoryResponse,
     IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest, OutgoingSyncResponse,
-    PreflightCheckRequest, PreflightCheckResponse, SyncRequestBase,
+    PreflightCheckRequest, PreflightCheckResponse, SubAccountEntry, SubAccountsRequest,
+    SubAccountsResponse, SyncRequestBase,
 };
 use crate::api::validators::{
     validate_block_ref, validate_cursor, validate_history_cursor, validate_recipients,
@@ -26,7 +27,9 @@ use crate::api::validators::{
 };
 use crate::api::AppState;
 use crate::chain_state::ChainState;
+use crate::rpc_backend::{ContractView, ContractViewError};
 use discovery_core::discovery::CursorLimits;
+use starknet_core::utils::get_selector_from_name;
 
 /// Handler for GET /health.
 pub async fn health_handler<B>(State(state): State<Arc<AppState<B>>>) -> impl IntoResponse
@@ -376,4 +379,189 @@ where
         transactions,
         cursor,
     })
+}
+
+/// Handler for POST /v1/sub_accounts.
+/// Maximum nonce span a single `get_sub_accounts` call may scan. Mirrors the anonymizer's on-chain
+/// `MAX_SCAN_RANGE` (packages/sub_account_anonymizer): the contract reverts above it, so the request
+/// is rejected here as a client error (`400`) rather than allowed to fail on-chain as a `502`.
+const MAX_SUB_ACCOUNT_SCAN_RANGE: u64 = 1024;
+
+pub async fn sub_accounts_handler<B>(
+    State(state): State<Arc<AppState<B>>>,
+    Json(request): Json<SubAccountsRequest>,
+) -> impl IntoResponse
+where
+    B: ContractView + ChainState + Clone + Send + Sync + 'static,
+{
+    match sub_accounts_impl(&state, request).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err((status, error)) => (status, Json(error)).into_response(),
+    }
+}
+
+async fn sub_accounts_impl<B>(
+    state: &AppState<B>,
+    request: SubAccountsRequest,
+) -> Result<SubAccountsResponse, (StatusCode, ApiErrorResponse)>
+where
+    B: ContractView + ChainState + Clone + Send + Sync + 'static,
+{
+    // Reject an over-large scan range as a client error before touching the chain. The anonymizer
+    // reverts above `MAX_SCAN_RANGE`; without this guard that revert surfaces as a misleading
+    // `502 RPC_UNAVAILABLE` (a `ContractViewError::Request`) rather than the `400` it is.
+    if request.end_nonce.saturating_sub(request.start_nonce) > MAX_SUB_ACCOUNT_SCAN_RANGE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            ApiErrorResponse::new(
+                error_codes::INVALID_REQUEST,
+                format!(
+                    "nonce range {}..{} exceeds MAX_SCAN_RANGE ({})",
+                    request.start_nonce, request.end_nonce, MAX_SUB_ACCOUNT_SCAN_RANGE
+                ),
+            ),
+        ));
+    }
+
+    let block_ref =
+        validate_block_ref(request.last_known_block, request.block_ref, &state.backend).await?;
+
+    debug!(
+        anonymizer = %format!("{:#x}", request.contract_address),
+        start_nonce = request.start_nonce,
+        end_nonce = request.end_nonce,
+        block = ?block_ref,
+        "sub_accounts request"
+    );
+
+    let resolved = state
+        .backend
+        .call_view(
+            request.contract_address,
+            selector("get_sub_accounts"),
+            vec![
+                request.partial_commitment,
+                Felt::from(request.start_nonce),
+                Felt::from(request.end_nonce),
+            ],
+            block_ref,
+        )
+        .await
+        .map_err(contract_view_error_to_response)?;
+    let sub_accounts = decode_sub_accounts(&resolved)?;
+
+    debug!(resolved = sub_accounts.len(), "sub_accounts response");
+
+    Ok(SubAccountsResponse {
+        block_ref,
+        sub_accounts,
+    })
+}
+
+/// Selector for a statically-known entrypoint name (the name is a compile-time invariant).
+fn selector(name: &str) -> Felt {
+    get_selector_from_name(name).expect("valid entrypoint name")
+}
+
+/// Decodes `get_sub_accounts`'s `Span<SubAccountInfo>` return, serialized as
+/// `[len, nonce_0, address_0, is_deployed_0, nonce_1, ...]` (3 felts per entry).
+fn decode_sub_accounts(
+    felts: &[Felt],
+) -> Result<Vec<SubAccountEntry>, (StatusCode, ApiErrorResponse)> {
+    let len = felt_to_u64(
+        *felts
+            .first()
+            .ok_or_else(|| internal_error("get_sub_accounts returned no length"))?,
+    ) as usize;
+    let mut sub_accounts = Vec::with_capacity(len.min(felts.len() / 3));
+    for index in 0..len {
+        let base = 1 + index * 3;
+        let entry = felts
+            .get(base..base + 3)
+            .ok_or_else(|| internal_error("get_sub_accounts result truncated"))?;
+        sub_accounts.push(SubAccountEntry {
+            nonce: felt_to_u64(entry[0]),
+            address: entry[1],
+            is_deployed: entry[2] != Felt::ZERO,
+        });
+    }
+    Ok(sub_accounts)
+}
+
+/// Reads the low 8 bytes of a felt as a `u64` (nonces and span lengths fit in `u64`).
+fn felt_to_u64(felt: Felt) -> u64 {
+    let bytes = felt.to_bytes_be();
+    u64::from_be_bytes(bytes[24..32].try_into().expect("8-byte slice"))
+}
+
+fn internal_error(message: &str) -> (StatusCode, ApiErrorResponse) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        ApiErrorResponse::new(error_codes::INTERNAL_ERROR, message),
+    )
+}
+
+fn contract_view_error_to_response(error: ContractViewError) -> (StatusCode, ApiErrorResponse) {
+    match error {
+        ContractViewError::ContractNotFound => (
+            StatusCode::NOT_FOUND,
+            ApiErrorResponse::new(error_codes::CONTRACT_NOT_FOUND, error.to_string()),
+        ),
+        ContractViewError::Request(_) => {
+            // Don't leak raw RPC/transport internals to the caller; log for observability instead.
+            warn!("get_sub_accounts RPC call failed: {}", error);
+            (
+                StatusCode::BAD_GATEWAY,
+                ApiErrorResponse::new(error_codes::RPC_UNAVAILABLE, "Upstream RPC is unavailable"),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode_sub_accounts, felt_to_u64};
+    use starknet_core::types::Felt;
+
+    #[test]
+    fn felt_to_u64_reads_low_bytes() {
+        assert_eq!(felt_to_u64(Felt::from(0u64)), 0);
+        assert_eq!(felt_to_u64(Felt::from(42u64)), 42);
+        assert_eq!(felt_to_u64(Felt::from(u64::MAX)), u64::MAX);
+    }
+
+    #[test]
+    fn decode_empty_span() {
+        let decoded = decode_sub_accounts(&[Felt::ZERO]).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn decode_span_of_entries() {
+        // Span<SubAccountInfo> serialized as [len, (nonce, address, is_deployed) * len].
+        let felts = [
+            Felt::from(2u64),
+            Felt::from(0u64),
+            Felt::from(0xaaau64),
+            Felt::ONE,
+            Felt::from(1u64),
+            Felt::from(0xbbbu64),
+            Felt::ZERO,
+        ];
+        let decoded = decode_sub_accounts(&felts).unwrap();
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].nonce, 0);
+        assert_eq!(decoded[0].address, Felt::from(0xaaau64));
+        assert!(decoded[0].is_deployed);
+        assert_eq!(decoded[1].nonce, 1);
+        assert_eq!(decoded[1].address, Felt::from(0xbbbu64));
+        assert!(!decoded[1].is_deployed);
+    }
+
+    #[test]
+    fn decode_truncated_span_errors() {
+        // len says 1 entry but the 3-felt tuple is missing.
+        let result = decode_sub_accounts(&[Felt::from(1u64)]);
+        assert!(result.is_err());
+    }
 }

--- a/crates/discovery-service/src/api/mod.rs
+++ b/crates/discovery-service/src/api/mod.rs
@@ -28,15 +28,17 @@ use crate::chain_state::ChainState;
 use crate::config::OhttpConfig;
 use crate::config::{ApiServerConfig, ValidationLimits};
 use crate::public_key_cache::PublicKeyCache;
+use crate::rpc_backend::ContractView;
 
 pub use handlers::{
     health_handler, history_handler, incoming_sync_handler, outgoing_sync_handler,
-    preflight_check_handler,
+    preflight_check_handler, sub_accounts_handler,
 };
 pub use types::{
     ApiErrorBody, ApiErrorResponse, HealthResponse, HistoryRequest, HistoryResponse,
     IncomingSyncRequest, IncomingSyncResponse, OutgoingSyncRequest, OutgoingSyncResponse,
-    PreflightCheckRequest, PreflightCheckResponse, SyncRequestBase,
+    PreflightCheckRequest, PreflightCheckResponse, SubAccountEntry, SubAccountsRequest,
+    SubAccountsResponse, SyncRequestBase,
 };
 
 /// API server for the discovery service.
@@ -69,7 +71,7 @@ pub struct AppState<B> {
 
 impl<B> ApiServer<B>
 where
-    B: StorageBackend + ChainState + Clone + Send + Sync + 'static,
+    B: StorageBackend + ChainState + ContractView + Clone + Send + Sync + 'static,
     B::Snapshot: RawEventAccess + Clone + Send + Sync + 'static,
 {
     /// Creates a new API server.
@@ -109,6 +111,7 @@ where
                 post(preflight_check_handler::<B>),
             )
             .route("/v1/history", post(history_handler::<B>))
+            .route("/v1/sub_accounts", post(sub_accounts_handler::<B>))
             .with_state(app_state);
 
         // Conditionally add OHTTP envelope encryption.

--- a/crates/discovery-service/src/api/types.rs
+++ b/crates/discovery-service/src/api/types.rs
@@ -357,6 +357,54 @@ pub struct HistoryResponse {
     pub cursor: HistoryCursor,
 }
 
+/// Request body for POST /v1/sub_accounts.
+///
+/// Proxies the sub-account anonymizer's `get_sub_accounts(partial_commitment, start_nonce,
+/// end_nonce)` view. `partial_commitment` is the caller-derived `hash(identity_key, dapp_name)`;
+/// it reveals neither the identity key nor the dapp, so no viewing key is sent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAccountsRequest {
+    /// The sub-account anonymizer contract address.
+    pub contract_address: Felt,
+    /// The user+dapp half of the commitment, `hash(identity_key, dapp_name)`.
+    pub partial_commitment: Felt,
+    /// First nonce to resolve (inclusive). Defaults to 0.
+    #[serde(default)]
+    pub start_nonce: u64,
+    /// Upper bound to resolve (exclusive).
+    pub end_nonce: u64,
+    /// Block hash for reorg detection; see [`SyncRequestBase::last_known_block`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_known_block: Option<Felt>,
+    /// Block identifier to pin reads to; see [`SyncRequestBase::block_ref`].
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "block_id_serde::option"
+    )]
+    pub block_ref: Option<BlockId>,
+}
+
+/// A resolved sub-account: its `nonce`, `address` (stored if deployed, else the deterministic
+/// deploy address), and whether it `is_deployed`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAccountEntry {
+    pub nonce: u64,
+    pub address: Felt,
+    pub is_deployed: bool,
+}
+
+/// Response body for POST /v1/sub_accounts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAccountsResponse {
+    /// Block identifier pinning the reads.
+    #[serde(with = "block_id_serde")]
+    pub block_ref: BlockId,
+    /// One entry per nonce in `[start_nonce, end_nonce)`, ascending. Callers enumerating deployed
+    /// sub-accounts take the leading `is_deployed` run.
+    pub sub_accounts: Vec<SubAccountEntry>,
+}
+
 /// Well-known error codes.
 pub mod error_codes {
     pub const INVALID_REQUEST: &str = "INVALID_REQUEST";

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -9,8 +9,8 @@ use discovery_core::storage_backend::{
 };
 use starknet_core::types::{
     requests::GetStorageAtRequest, AddressFilter, BlockId, BlockTag, EmittedEvent, EventFilter,
-    Felt, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey,
-    StorageResponseFlag, StorageResult,
+    Felt, FunctionCall, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError,
+    StorageKey, StorageResponseFlag, StorageResult,
 };
 use starknet_providers::{
     jsonrpc::{HttpTransport, JsonRpcClient},
@@ -89,6 +89,61 @@ impl RpcBackend {
                 event_page_size: config.event_page_size,
             }),
         })
+    }
+}
+
+/// Errors from a read-only contract view call.
+#[derive(Debug, Error)]
+pub enum ContractViewError {
+    /// The called contract is not deployed at the pinned block.
+    #[error("contract not found")]
+    ContractNotFound,
+    /// The RPC `call` request failed.
+    #[error("RPC request failed: {0}")]
+    Request(String),
+}
+
+/// Reads a contract's view entrypoints. Kept separate from [`StorageBackend`] (which reads storage
+/// slots) so the sub-account endpoints can call the anonymizer's views without a storage snapshot.
+#[async_trait]
+pub trait ContractView: Send + Sync {
+    /// Calls the read-only `selector` entrypoint on `contract_address` at `block_id`, returning the
+    /// raw felt result.
+    async fn call_view(
+        &self,
+        contract_address: Felt,
+        selector: Felt,
+        calldata: Vec<Felt>,
+        block_id: BlockId,
+    ) -> Result<Vec<Felt>, ContractViewError>;
+}
+
+#[async_trait]
+impl ContractView for RpcBackend {
+    async fn call_view(
+        &self,
+        contract_address: Felt,
+        selector: Felt,
+        calldata: Vec<Felt>,
+        block_id: BlockId,
+    ) -> Result<Vec<Felt>, ContractViewError> {
+        self.inner
+            .provider
+            .call(
+                FunctionCall {
+                    contract_address,
+                    entry_point_selector: selector,
+                    calldata,
+                },
+                block_id,
+            )
+            .await
+            .map_err(|e| match &e {
+                ProviderError::StarknetError(StarknetError::ContractNotFound) => {
+                    ContractViewError::ContractNotFound
+                }
+                _ => ContractViewError::Request(e.to_string()),
+            })
     }
 }
 


### PR DESCRIPTION
Adds a ContractView capability on RpcBackend (read-only contract call) and a
POST /v1/sub_accounts endpoint proxying the anonymizer's
get_sub_accounts(partial_commitment, start_nonce, end_nonce) view. The contract
resolves every nonce in range to { nonce, address, is_deployed } (stored address if
deployed, else the computed deploy address), so the backend is a pure decode/proxy
and no viewing key is sent. Spec 6.9 documents the endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/885)
<!-- Reviewable:end -->
