### PR TITLE
feat(sdk): subaccounts(dappName).identify + discovery getSubAccounts

### DIFF
--- a/e2e/tests/devnet/sub-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/sub-account-compute-invoke.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
-import { Open } from "@starkware-libs/starknet-privacy-sdk";
-import { CallData, cairo, hash, shortString } from "starknet";
+import {
+  Devnet,
+  ScreeningCallMockProofProvider,
+  IndexerDiscoveryProvider,
+} from "@starkware-libs/starknet-privacy-sdk/testing";
+import {
+  Open,
+  createPrivateTransfers,
+} from "@starkware-libs/starknet-privacy-sdk";
+import { CallData, cairo, constants, hash, num, shortString } from "starknet";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
 import { deployTestTokens, type TokenAddresses } from "../../src/vesu-setup.js";
 import {
@@ -50,7 +57,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
       return BigInt(result[0]) + (BigInt(result[1]) << 128n);
     };
 
-    // Fund the dapp so its `pay_out` can transfer the payout to the sub-account.
+    // Fund the dapp so its `transfer_to_caller` can pay out to the sub-account.
     const mintTx = await de.admin.execute({
       contractAddress: tokens.usdToken,
       entrypoint: "mint",
@@ -62,7 +69,9 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
     // the derived identity key. The commitment it returns selects the per-commitment sub-account.
     const dappName = BigInt(shortString.encodeShortString("DAPP"));
     const seqNonce = 0n;
-    const payOutSelector = BigInt(hash.getSelectorFromName("pay_out"));
+    const transferToCallerSelector = BigInt(
+      hash.getSelectorFromName("transfer_to_caller"),
+    );
     const usdToken = BigInt(tokens.usdToken);
 
     const poolBalanceBefore = await balanceOf(de.privacy.address);
@@ -90,7 +99,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
             [
               {
                 to: subAccount.mockDapp,
-                selector: payOutSelector,
+                selector: transferToCallerSelector,
                 calldata: CallData.compile([
                   usdToken,
                   cairo.uint256(payoutAmount),
@@ -122,5 +131,40 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
     expect(poolBalanceAfter - poolBalanceBefore).toBe(payoutAmount);
     expect(await balanceOf(subAccount.mockDapp)).toBe(0n);
     expect(await balanceOf(subAccount.anonymizer)).toBe(0n);
+
+    // `identify` resolves the same sub-account the compute-and-invoke just deployed: the SDK
+    // derives partial_commitment = hash(compute_identity_key(user, vk, anonymizer), dappName)
+    // off-chain and the anonymizer view resolves it. A config-bearing transfers instance is
+    // needed because the harness alice has no anonymizer address configured.
+    const aliceWithSubaccounts = createPrivateTransfers({
+      account: de.alice,
+      viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
+      provingProvider: new ScreeningCallMockProofProvider(
+        de.provider,
+        constants.StarknetChainId.SN_SEPOLIA,
+      ),
+      discoveryProvider: new IndexerDiscoveryProvider(
+        env.indexer.apiUrl,
+        de.privacy.address,
+      ),
+      poolContractAddress: de.privacy.address,
+      poolMode: "screening",
+      subAccountAnonymizerAddress: subAccount.anonymizer,
+    });
+
+    // Nonce 0 was consumed (and thus deployed) above; nonce 1 was never used.
+    const subs = await aliceWithSubaccounts
+      .subaccounts(dappName)
+      .identify(0, 2);
+    expect(subs.map((s) => [s.nonce, s.isDeployed])).toEqual([
+      [0, true],
+      [1, false],
+    ]);
+
+    // The resolved deployed address is a real contract on-chain.
+    const classHash = await de.provider.getClassHashAt(
+      num.toHex(subs[0].address),
+    );
+    expect(BigInt(classHash)).not.toBe(0n);
   });
 });

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,8 +9,23 @@
   and `invokeAdditionalData` compiled from the dapp `calls` via the generated anonymizer ABI — and returns the
   builder so the caller can add the open-note creation and `.execute()`. `dappName` accepts a felt or
   a short string. Requires the new `subAccountAnonymizerAddress` field on the `createPrivateTransfers`
-  config; calling `subaccounts(...)` without it throws. `identify()` and `deployed()` on the builder
-  are declared but not yet implemented.
+  config; calling `subaccounts(...)` without it throws.
+- Sub-accounts: `SubAccountsBuilder.identify(startNonce, endNonce = startNonce + 1)` resolves the
+  sub-accounts for a nonce range, returning `SubAccount[]` (`{ nonce, address, isDeployed }`) — a
+  passthrough of the anonymizer's `get_sub_accounts` view (single lookup = `identify(n)`; enumerate
+  deployed = `identify(0, max)` then take the leading `isDeployed` run). The SDK derives
+  `partial_commitment = hash(compute_identity_key(user, viewingKey, anonymizer), dappName)` off-chain
+  (no viewing key on the wire) and resolves it through the discovery provider's new `getSubAccounts`:
+  `IndexerDiscoveryProvider` posts to `/v1/sub_accounts`; `ContractDiscoveryProvider` delegates to a
+  `getSubAccounts` resolver supplied in `DiscoveryOptions` (throwing when absent). Replaces the
+  previously stubbed `identify()`/`deployed()`.
+
+### Breaking
+
+- `DiscoveryProviderInterface` now requires a `getSubAccounts(address, viewingKey, params)` method
+  (params typed by the new exported `GetSubAccountsParams`: `{ anonymizerAddress, partialCommitment,
+  startNonce, endNonce, blockIdentifier? }`). Custom implementations must add it. The `SubAccount`
+  type gained an `isDeployed: boolean` field.
 
 ## 0.14.3-RC.2
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -525,8 +525,28 @@ export interface PrivateTransfersInterface {
   subaccounts(dappName: string | BigNumberish): SubAccountsBuilder;
 }
 
-/** A sub-account: its `nonce` for the dapp and the deployed `address`. */
-export type SubAccount = { nonce: number; address: StarknetAddressBigint };
+/**
+ * A resolved sub-account for one nonce: its deterministic `address` (the stored address if
+ * `isDeployed`, otherwise the address it would deploy to) and whether it is already deployed.
+ */
+export type SubAccount = {
+  nonce: number;
+  address: StarknetAddressBigint;
+  isDeployed: boolean;
+};
+
+/**
+ * Parameters for resolving sub-accounts through a sub-account anonymizer. `partialCommitment =
+ * hash(identity_key, dappName)` is derived off-chain by the caller; the anonymizer resolves the
+ * nonces in `[startNonce, endNonce)` against it.
+ */
+export type GetSubAccountsParams = {
+  anonymizerAddress: StarknetAddressBigint;
+  partialCommitment: bigint;
+  startNonce: number;
+  endNonce: number;
+  blockIdentifier?: BlockIdentifier;
+};
 
 /**
  * Sub-account operations for one user + dapp, driven through the sub-account anonymizer contract.
@@ -534,16 +554,13 @@ export type SubAccount = { nonce: number; address: StarknetAddressBigint };
  */
 export interface SubAccountsBuilder {
   /**
-   * The deterministic sub-account address for `nonce` (deployed or not). Resolved through the
-   * anonymizer's on-chain views; see the discovery provider.
+   * Resolve the sub-accounts for nonces `[startNonce, endNonce)` (default `endNonce =
+   * startNonce + 1`, i.e. the single nonce). Each entry carries its deterministic `address` and
+   * whether it `isDeployed`, resolved through the anonymizer's `get_sub_accounts` view (see the
+   * discovery provider). Sub-accounts are allocated consecutively from nonce 0, so a caller
+   * enumerating the deployed ones takes the leading `isDeployed` run of `identify(0, max)`.
    */
-  identify(nonce: BigNumberish): Promise<StarknetAddressBigint>;
-
-  /**
-   * The sub-accounts already deployed for this dapp, scanning consecutive nonces from `startNonce`
-   * (default 0) and stopping at the first undeployed one or `maxNonce`.
-   */
-  deployed(opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]>;
+  identify(startNonce: number, endNonce?: number): Promise<SubAccount[]>;
 
   /**
    * Queue a `computeAndInvoke` against the sub-account for `nonce`: run `calls` through it and
@@ -797,6 +814,21 @@ export interface DiscoveryProviderInterface {
     recipient: StarknetAddressBigint,
     token: StarknetAddressBigint
   ): Promise<SetupRequirement>;
+
+  /**
+   * Resolve the sub-accounts for nonces `[startNonce, endNonce)` through a sub-account anonymizer.
+   *
+   * A thin proxy over the anonymizer's `get_sub_accounts` view: the contract owns the commitment
+   * derivation and address computation. `partialCommitment = hash(identity_key, dappName)` is
+   * derived off-chain by the caller and reveals neither the identity key nor the dapp, so no
+   * viewing key travels on the wire — `address`/`viewingKey` are accepted only for symmetry with
+   * the other discover methods and are unused by the proxy.
+   */
+  getSubAccounts(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    params: GetSubAccountsParams
+  ): Promise<{ subAccounts: SubAccount[] }>;
 }
 
 type BlobT = string | Uint8Array;

--- a/sdk/src/internal/abstract-discovery.ts
+++ b/sdk/src/internal/abstract-discovery.ts
@@ -2,8 +2,10 @@ import type { BlockIdentifier } from "starknet";
 import type {
   Channel,
   DiscoveryProviderInterface,
+  GetSubAccountsParams,
   Note,
   StarknetAddressBigint,
+  SubAccount,
   ViewingKey,
 } from "../interfaces.js";
 import { SetupRequirement } from "../interfaces.js";
@@ -33,6 +35,12 @@ export abstract class AbstractDiscoveryProvider implements DiscoveryProviderInte
     recipients: RecipientsFilter,
     params?: { cursor?: ChannelCursor; blockIdentifier?: BlockIdentifier }
   ): Promise<{ timestamp: BlockIdentifier; channels?: AddressMap<Channel>; total?: number }>;
+
+  abstract getSubAccounts(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    params: GetSubAccountsParams
+  ): Promise<{ subAccounts: SubAccount[] }>;
 
   // Default implementation provided by the abstract class
   async discoverRequirement(

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -116,6 +116,9 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
       transfers: this,
       dappName,
       subAccountAnonymizerAddress: this.subAccountAnonymizerAddress,
+      user: this.user,
+      getViewingKey: () => this.getViewingKey(),
+      discoveryProvider: this.discoveryProvider,
     });
   }
 

--- a/sdk/src/internal/contract-discovery.ts
+++ b/sdk/src/internal/contract-discovery.ts
@@ -1,5 +1,13 @@
 import { BlockIdentifier } from "starknet";
-import { ViewingKey, Note, Channel, StarknetAddressBigint } from "../interfaces.js";
+import {
+  ViewingKey,
+  Note,
+  Channel,
+  StarknetAddressBigint,
+  DiscoveryProviderInterface,
+  GetSubAccountsParams,
+  SubAccount,
+} from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { AbstractDiscoveryProvider } from "./abstract-discovery.js";
 import { debugLog } from "../utils/logging.js";
@@ -381,14 +389,36 @@ class ChannelsDiscovery {
 export type DiscoveryOptions = {
   /** Rate limiting for pool contract RPC calls */
   rateLimit?: RateLimitOptions;
+  /**
+   * Resolver for `getSubAccounts`. The pool interface this provider wraps has no view for the
+   * sub-account anonymizer, so sub-account resolution is delegated to a caller-supplied function
+   * (e.g. one that calls the anonymizer's `get_sub_accounts` over RPC). `getSubAccounts` throws
+   * when this is absent.
+   */
+  getSubAccounts?: DiscoveryProviderInterface["getSubAccounts"];
 };
 
 export class ContractDiscoveryProvider extends AbstractDiscoveryProvider {
   private readonly pool: PoolContractInterface;
+  private readonly subAccountsResolver?: DiscoveryProviderInterface["getSubAccounts"];
 
   constructor(pool: PoolContractInterface, options?: DiscoveryOptions) {
     super();
     this.pool = options?.rateLimit ? createRateLimitedObject(pool, options.rateLimit) : pool;
+    this.subAccountsResolver = options?.getSubAccounts;
+  }
+
+  async getSubAccounts(
+    address: StarknetAddressBigint,
+    viewingKey: ViewingKey,
+    params: GetSubAccountsParams
+  ): Promise<{ subAccounts: SubAccount[] }> {
+    if (!this.subAccountsResolver) {
+      throw new Error(
+        "ContractDiscoveryProvider cannot resolve sub-accounts: pass a `getSubAccounts` option, or use IndexerDiscoveryProvider."
+      );
+    }
+    return this.subAccountsResolver(address, viewingKey, params);
   }
 
   async discoverNotes(

--- a/sdk/src/internal/indexer-discovery.ts
+++ b/sdk/src/internal/indexer-discovery.ts
@@ -2,9 +2,11 @@ import type { BlockIdentifier } from "starknet";
 import {
   SetupRequirement,
   type Channel as ChannelInterface,
+  type GetSubAccountsParams,
   type Note,
   type StarknetAddress,
   type StarknetAddressBigint,
+  type SubAccount,
   type ViewingKey,
 } from "../interfaces.js";
 import { toBigInt } from "../utils/crypto.js";
@@ -94,6 +96,17 @@ type ApiOutgoingSyncResponse = {
   channels: ApiOutgoingChannel[];
   subchannels: ApiOutgoingSubchannelInfo[];
   cursor: ApiDiscoveryCursor;
+};
+
+type ApiSubAccountEntry = {
+  nonce: number;
+  address: string;
+  is_deployed: boolean;
+};
+
+type ApiSubAccountsResponse = {
+  block_ref: BlockIdentifier;
+  sub_accounts: ApiSubAccountEntry[];
 };
 
 export type DiscoveryHealthResponse = {
@@ -383,6 +396,30 @@ export class IndexerDiscoveryProvider extends AbstractDiscoveryProvider {
     if (!resp.channel_exists) return SetupRequirement.SetupChannel;
     if (!resp.subchannel_exists) return SetupRequirement.SetupToken;
     return SetupRequirement.Ready;
+  }
+
+  async getSubAccounts(
+    _address: StarknetAddressBigint,
+    _viewingKey: ViewingKey,
+    params: GetSubAccountsParams
+  ): Promise<{ subAccounts: SubAccount[] }> {
+    const body: Record<string, unknown> = {
+      contract_address: toHex(params.anonymizerAddress),
+      partial_commitment: toHex(params.partialCommitment),
+      start_nonce: params.startNonce,
+      end_nonce: params.endNonce,
+    };
+    if (params.blockIdentifier !== undefined) {
+      body.block_ref = params.blockIdentifier;
+    }
+    const resp = await this.post<ApiSubAccountsResponse>("/v1/sub_accounts", body);
+    return {
+      subAccounts: resp.sub_accounts.map((entry) => ({
+        nonce: entry.nonce,
+        address: toBigInt(entry.address),
+        isDeployed: entry.is_deployed,
+      })),
+    };
   }
 
   async fetchHistory(

--- a/sdk/src/internal/sub-accounts.ts
+++ b/sdk/src/internal/sub-accounts.ts
@@ -1,16 +1,18 @@
 import { BigNumberish, Call, CallData, hash, shortString } from "starknet";
 import type {
   ComputeAndInvokeDetails,
+  DiscoveryProviderInterface,
   InvokeCalldataBuilderArgs,
   PrivateTransfersBuilder,
   PrivateTransfersInterface,
   StarknetAddress,
-  StarknetAddressBigint,
   SubAccount,
   SubAccountsBuilder,
+  ViewingKey,
 } from "../interfaces.js";
 import { SubAccountAnonymizerABI } from "./anonymizer-abi.js";
-import { toBigInt, toHex } from "../utils/index.js";
+import { hash as poseidonHash, toBigInt, toHex } from "../utils/index.js";
+import { compute_identity_key } from "../utils/hashes.js";
 
 /** Encodes a dapp name to a felt: a string is a Cairo short string, a felt passes through. */
 function encodeDappName(dappName: string | BigNumberish): bigint {
@@ -28,6 +30,9 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       transfers: PrivateTransfersInterface;
       dappName: string | BigNumberish;
       subAccountAnonymizerAddress: StarknetAddress;
+      user: bigint;
+      getViewingKey: () => Promise<ViewingKey>;
+      discoveryProvider: DiscoveryProviderInterface;
     }
   ) {
     this.dappName = encodeDappName(params.dappName);
@@ -65,11 +70,24 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       });
   }
 
-  async identify(_nonce: BigNumberish): Promise<StarknetAddressBigint> {
-    throw new Error("SubAccountsBuilder.identify() is not implemented yet.");
-  }
-
-  async deployed(_opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]> {
-    throw new Error("SubAccountsBuilder.deployed() is not implemented yet.");
+  async identify(startNonce: number, endNonce: number = startNonce + 1): Promise<SubAccount[]> {
+    const { user, getViewingKey, discoveryProvider } = this.params;
+    const viewingKey = await getViewingKey();
+    // partial_commitment = hash(identity_key, dapp_name); it reveals neither the identity key nor
+    // the dapp, so the anonymizer's `get_sub_accounts` view can resolve addresses without a
+    // viewing key. Mirrors `partial_commitment` in the anonymizer Cairo.
+    const identityKey = compute_identity_key(
+      user,
+      toBigInt(viewingKey),
+      this.subAccountAnonymizerAddress
+    );
+    const partialCommitment = poseidonHash(identityKey, this.dappName);
+    const { subAccounts } = await discoveryProvider.getSubAccounts(user, viewingKey, {
+      anonymizerAddress: this.subAccountAnonymizerAddress,
+      partialCommitment,
+      startNonce,
+      endNonce,
+    });
+    return subAccounts;
   }
 }

--- a/sdk/src/testing/mocknet.ts
+++ b/sdk/src/testing/mocknet.ts
@@ -6,7 +6,13 @@
  */
 
 import type { SignerInterface } from "starknet";
-import type { ExecuteResult, PrivateRegistry, StarknetAddress, ViewingKey } from "../interfaces.js";
+import type {
+  DiscoveryProviderInterface,
+  ExecuteResult,
+  PrivateRegistry,
+  StarknetAddress,
+  ViewingKey,
+} from "../interfaces.js";
 import { PrivateTransfers } from "../internal/private-transfers.js";
 import { MockContracts } from "./contracts.js";
 import { MockPoolContract } from "./mock-pool-contract.js";
@@ -135,7 +141,11 @@ export class Mocknet {
   createPrivateTransfers(
     userAddress: bigint,
     viewingKey: ViewingKey,
-    options?: { subAccountAnonymizerAddress?: StarknetAddress }
+    options?: {
+      subAccountAnonymizerAddress?: StarknetAddress;
+      /** Resolver for `subaccounts(...).identify(...)`; the mock pool has no anonymizer view. */
+      getSubAccounts?: DiscoveryProviderInterface["getSubAccounts"];
+    }
   ): PrivateTransfers {
     const pool = this.pool;
 
@@ -147,7 +157,9 @@ export class Mocknet {
       },
       viewingKeyProvider: { getViewingKey: async () => viewingKey },
       provingProvider: new MockProofProvider(pool),
-      discoveryProvider: new ContractDiscoveryProvider(pool),
+      discoveryProvider: new ContractDiscoveryProvider(pool, {
+        getSubAccounts: options?.getSubAccounts,
+      }),
       proofInvocationFactory: new MockProofInvocationFactory(),
       poolContractAddress: `0x${this.poolAddress.toString(16)}`,
       subAccountAnonymizerAddress: options?.subAccountAnonymizerAddress,

--- a/sdk/tests/internal/compiler-reorg.test.ts
+++ b/sdk/tests/internal/compiler-reorg.test.ts
@@ -26,6 +26,7 @@ function createMockProvider(overrides: Partial<DiscoveryProviderInterface> = {})
       ]),
     }),
     discoverRequirement: vi.fn().mockResolvedValue(SetupRequirement.Ready),
+    getSubAccounts: vi.fn().mockResolvedValue({ subAccounts: [] }),
     ...overrides,
   } satisfies DiscoveryProviderInterface;
 }

--- a/sdk/tests/internal/indexer-discovery.test.ts
+++ b/sdk/tests/internal/indexer-discovery.test.ts
@@ -533,6 +533,64 @@ describe("IndexerDiscoveryProvider", () => {
     });
   });
 
+  describe("getSubAccounts", () => {
+    const ANONYMIZER = 0xab0an;
+    const PARTIAL = 0xdead_beefn;
+
+    it("posts the anonymizer address + partial_commitment + nonce range and maps the response", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({
+        body: {
+          block_ref: BLOCK_REF,
+          sub_accounts: [
+            { nonce: 0, address: "0x5a10", is_deployed: true },
+            { nonce: 1, address: "0x5a11", is_deployed: false },
+          ],
+        },
+      });
+
+      const { subAccounts } = await provider.getSubAccounts(USER_ADDRESS, VIEWING_KEY, {
+        anonymizerAddress: ANONYMIZER,
+        partialCommitment: PARTIAL,
+        startNonce: 0,
+        endNonce: 2,
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${API_URL}/v1/sub_accounts`);
+      const requestBody = JSON.parse(init.body);
+      expect(requestBody).toEqual({
+        contract_address: "0xab0a",
+        partial_commitment: "0xdeadbeef",
+        start_nonce: 0,
+        end_nonce: 2,
+      });
+      // Sub-account discovery reveals no viewing key; the partial commitment stands in for it.
+      expect(requestBody.viewing_key).toBeUndefined();
+
+      expect(subAccounts).toEqual([
+        { nonce: 0, address: 0x5a10n, isDeployed: true },
+        { nonce: 1, address: 0x5a11n, isDeployed: false },
+      ]);
+    });
+
+    it("pins reads with block_ref when a block identifier is given", async () => {
+      const provider = createProvider();
+      const fetchMock = mockFetchJson({ body: { block_ref: BLOCK_REF, sub_accounts: [] } });
+
+      await provider.getSubAccounts(USER_ADDRESS, VIEWING_KEY, {
+        anonymizerAddress: ANONYMIZER,
+        partialCommitment: PARTIAL,
+        startNonce: 0,
+        endNonce: 1,
+        blockIdentifier: BLOCK_REF,
+      });
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.block_ref).toBe(BLOCK_REF);
+    });
+  });
+
   describe("request body validation", () => {
     it("includes contract_address and viewing_key in discoverNotes requests", async () => {
       const provider = createProvider();

--- a/sdk/tests/internal/sub-accounts.test.ts
+++ b/sdk/tests/internal/sub-accounts.test.ts
@@ -4,14 +4,15 @@
  * ABI. The MockPoolContract simulate flow forwards these to the target's `privacy_compute` /
  * `privacy_invoke_with_computation`, mirroring Cairo.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CallData, hash, shortString } from "starknet";
 import { Mocknet } from "../../src/testing/mocknet.js";
 import { MockContract } from "../../src/testing/contracts.js";
 import { compute_identity_key } from "../../src/utils/hashes.js";
+import { hash as poseidonHash } from "../../src/utils/crypto.js";
 import { SubAccountAnonymizerABI } from "../../src/internal/anonymizer-abi.js";
 import { toBigInt } from "../../src/utils/index.js";
-import { StarknetAddress } from "../../src/interfaces.js";
+import { StarknetAddress, SubAccount } from "../../src/interfaces.js";
 
 const COMPUTED_MARKER = 0xc0ffeen;
 const ANONYMIZER = "0xab0a";
@@ -102,5 +103,70 @@ describe("SubAccountsBuilder.invoke", () => {
     const env = mocknet.initialize();
     const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey);
     expect(() => transfers.subaccounts("DAPP")).toThrow(/subAccountAnonymizerAddress/);
+  });
+});
+
+describe("SubAccountsBuilder.identify", () => {
+  const RESOLVED_SUB_ACCOUNTS: SubAccount[] = [
+    { nonce: 0, address: 0x5a10n, isDeployed: true },
+    { nonce: 1, address: 0x5a11n, isDeployed: false },
+  ];
+
+  it("derives partial_commitment = hash(identity_key, dappName) and passes the nonce range", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const getSubAccounts = vi.fn().mockResolvedValue({ subAccounts: RESOLVED_SUB_ACCOUNTS });
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+      getSubAccounts,
+    });
+
+    const result = await transfers.subaccounts("DAPP").identify(0, 8);
+
+    expect(result).toEqual(RESOLVED_SUB_ACCOUNTS);
+    const identityKey = compute_identity_key(
+      toBigInt(env.alice.address),
+      toBigInt(env.alice.privateKey),
+      toBigInt(ANONYMIZER)
+    );
+    const partialCommitment = poseidonHash(
+      identityKey,
+      toBigInt(shortString.encodeShortString("DAPP"))
+    );
+    expect(getSubAccounts).toHaveBeenCalledWith(toBigInt(env.alice.address), env.alice.privateKey, {
+      anonymizerAddress: toBigInt(ANONYMIZER),
+      partialCommitment,
+      startNonce: 0,
+      endNonce: 8,
+    });
+  });
+
+  it("defaults endNonce to startNonce + 1 (single-nonce lookup)", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const getSubAccounts = vi.fn().mockResolvedValue({ subAccounts: RESOLVED_SUB_ACCOUNTS });
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+      getSubAccounts,
+    });
+
+    await transfers.subaccounts("DAPP").identify(3);
+
+    expect(getSubAccounts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ startNonce: 3, endNonce: 4 })
+    );
+  });
+
+  it("throws when the discovery provider cannot resolve sub-accounts", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    // No getSubAccounts resolver: the mock pool's ContractDiscoveryProvider has no anonymizer view.
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+
+    await expect(transfers.subaccounts("DAPP").identify(0)).rejects.toThrow(/sub-accounts/);
   });
 });


### PR DESCRIPTION
Implement SubAccountsBuilder.identify(startNonce, endNonce = startNonce + 1),
a passthrough of the anonymizer's get_sub_accounts view returning
SubAccount[] ({ nonce, address, isDeployed }). Single lookup = identify(n);
enumerate deployed = identify(0, max) then take the leading isDeployed run.

The SDK derives partial_commitment = hash(compute_identity_key(user,
viewingKey, anonymizer), dappName) off-chain (no viewing key on the wire) and
resolves it via the discovery provider's new getSubAccounts method:
- IndexerDiscoveryProvider posts to /v1/sub_accounts.
- ContractDiscoveryProvider delegates to a getSubAccounts resolver supplied in
  DiscoveryOptions (throws when absent), since the pool interface it wraps has
  no anonymizer view.

DiscoveryProviderInterface gains getSubAccounts; SubAccount gains isDeployed.
Adds unit tests for the wire request/response mapping and the builder's
commitment derivation, and an e2e assertion that identify(0) resolves the
sub-account the compute-and-invoke just deployed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/887)
<!-- Reviewable:end -->
