### PR TITLE
feat(sdk): expose subaccount commitments

### DIFF
--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -534,16 +534,20 @@ export type SubAccount = { nonce: number; address: StarknetAddressBigint };
  */
 export interface SubAccountsBuilder {
   /**
-   * The deterministic sub-account address for `nonce` (deployed or not). Resolved through the
-   * anonymizer's on-chain views; see the discovery provider.
+   * Return the nonce-independent commitment for this user + dapp:
+   * `hash(identity_key, dappName)`.
+   *
+   * Computed locally in TypeScript; does not call the anonymizer contract.
    */
-  identify(nonce: BigNumberish): Promise<StarknetAddressBigint>;
+  partialCommitment(): Promise<bigint>;
 
   /**
-   * The sub-accounts already deployed for this dapp, scanning consecutive nonces from `startNonce`
-   * (default 0) and stopping at the first undeployed one or `maxNonce`.
+   * Return the full sub-account commitment for `nonce`:
+   * `hash(partialCommitment(), nonce)`.
+   *
+   * Computed locally in TypeScript; does not call the anonymizer contract.
    */
-  deployed(opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]>;
+  commitment(nonce: BigNumberish): Promise<bigint>;
 
   /**
    * Queue a `computeAndInvoke` against the sub-account for `nonce`: run `calls` through it and

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -116,6 +116,8 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
       transfers: this,
       dappName,
       subAccountAnonymizerAddress: this.subAccountAnonymizerAddress,
+      user: this.user,
+      getViewingKey: () => this.getViewingKey(),
     });
   }
 

--- a/sdk/src/internal/sub-accounts.ts
+++ b/sdk/src/internal/sub-accounts.ts
@@ -5,12 +5,12 @@ import type {
   PrivateTransfersBuilder,
   PrivateTransfersInterface,
   StarknetAddress,
-  StarknetAddressBigint,
-  SubAccount,
   SubAccountsBuilder,
+  ViewingKey,
 } from "../interfaces.js";
 import { SubAccountAnonymizerABI } from "./anonymizer-abi.js";
-import { toBigInt, toHex } from "../utils/index.js";
+import { hash as poseidonHash, toBigInt, toHex } from "../utils/index.js";
+import { compute_identity_key } from "../utils/hashes.js";
 
 /** Encodes a dapp name to a felt: a string is a Cairo short string, a felt passes through. */
 function encodeDappName(dappName: string | BigNumberish): bigint {
@@ -28,6 +28,8 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       transfers: PrivateTransfersInterface;
       dappName: string | BigNumberish;
       subAccountAnonymizerAddress: StarknetAddress;
+      user: bigint;
+      getViewingKey: () => Promise<ViewingKey>;
     }
   ) {
     this.dappName = encodeDappName(params.dappName);
@@ -65,11 +67,17 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       });
   }
 
-  async identify(_nonce: BigNumberish): Promise<StarknetAddressBigint> {
-    throw new Error("SubAccountsBuilder.identify() is not implemented yet.");
+  async partialCommitment(): Promise<bigint> {
+    const viewingKey = await this.params.getViewingKey();
+    const identityKey = compute_identity_key(
+      this.params.user,
+      toBigInt(viewingKey),
+      this.subAccountAnonymizerAddress
+    );
+    return poseidonHash(identityKey, this.dappName);
   }
 
-  async deployed(_opts?: { startNonce?: number; maxNonce?: number }): Promise<SubAccount[]> {
-    throw new Error("SubAccountsBuilder.deployed() is not implemented yet.");
+  async commitment(nonce: BigNumberish): Promise<bigint> {
+    return poseidonHash(await this.partialCommitment(), toBigInt(nonce));
   }
 }

--- a/sdk/tests/internal/sub-accounts.test.ts
+++ b/sdk/tests/internal/sub-accounts.test.ts
@@ -9,6 +9,7 @@ import { CallData, hash, shortString } from "starknet";
 import { Mocknet } from "../../src/testing/mocknet.js";
 import { MockContract } from "../../src/testing/contracts.js";
 import { compute_identity_key } from "../../src/utils/hashes.js";
+import { hash as poseidonHash } from "../../src/utils/crypto.js";
 import { SubAccountAnonymizerABI } from "../../src/internal/anonymizer-abi.js";
 import { toBigInt } from "../../src/utils/index.js";
 import { StarknetAddress } from "../../src/interfaces.js";
@@ -102,5 +103,64 @@ describe("SubAccountsBuilder.invoke", () => {
     const env = mocknet.initialize();
     const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey);
     expect(() => transfers.subaccounts("DAPP")).toThrow(/subAccountAnonymizerAddress/);
+  });
+});
+
+describe("SubAccountsBuilder commitments", () => {
+  it("derives partialCommitment = hash(identity_key, dappName) locally", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+
+    const identityKey = compute_identity_key(
+      toBigInt(env.alice.address),
+      toBigInt(env.alice.privateKey),
+      toBigInt(ANONYMIZER)
+    );
+    const partialCommitment = poseidonHash(
+      identityKey,
+      toBigInt(shortString.encodeShortString("DAPP"))
+    );
+
+    await expect(transfers.subaccounts("DAPP").partialCommitment()).resolves.toBe(
+      partialCommitment
+    );
+  });
+
+  it("derives commitment = hash(partialCommitment, nonce) locally", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+
+    const identityKey = compute_identity_key(
+      toBigInt(env.alice.address),
+      toBigInt(env.alice.privateKey),
+      toBigInt(ANONYMIZER)
+    );
+    const partialCommitment = poseidonHash(
+      identityKey,
+      toBigInt(shortString.encodeShortString("DAPP"))
+    );
+
+    await expect(transfers.subaccounts("DAPP").commitment(7n)).resolves.toBe(
+      poseidonHash(partialCommitment, 7n)
+    );
+  });
+
+  it("uses felt dapp names for local commitment derivation", async () => {
+    const mocknet = new Mocknet({ poolAddress: 0x1n });
+    const env = mocknet.initialize();
+    const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+      subAccountAnonymizerAddress: ANONYMIZER,
+    });
+
+    const dappFelt = toBigInt(shortString.encodeShortString("DAPP"));
+    await expect(transfers.subaccounts(dappFelt).partialCommitment()).resolves.toBe(
+      await transfers.subaccounts("DAPP").partialCommitment()
+    );
   });
 });


### PR DESCRIPTION
Adds local SDK helpers on subaccounts(dappName): partialCommitment() for hash(identity_key, dappName), and commitment(nonce) for hash(partialCommitment, nonce). These are computed entirely in TypeScript and do not call the anonymizer contract or discovery service.

Validation:
- npx vitest run --coverage.enabled=false tests/internal/sub-accounts.test.ts
- npm run build
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/892)
<!-- Reviewable:end -->
