### PR TITLE
fix(e2e): call transfer_to_caller instead of renamed pay_out in sub-account test

### DIFF
--- a/.github/workflows/e2e-devnet.yaml
+++ b/.github/workflows/e2e-devnet.yaml
@@ -58,6 +58,10 @@ jobs:
       # All workspace packages + ekubo-contracts + test-token use Scarb 2.17.0
       - name: Build contracts
         run: |
+          # Remove Scarb's dev build dir so we don't load stale incremental cache
+          # (rust-cache restores target/ which can contain Scarb's target/dev/ from a
+          # previous run; a dangling fingerprint there panics scarb — see rust-ci.yaml).
+          rm -rf target/dev
           scarb --profile release build -p privacy
           scarb build -p privacy -p vesu_lending_anonymizer -p ekubo_swap_anonymizer -p sub_account_anonymizer
           # SubAccount + MockDapp come from the test build (sierra only); the e2e setup

--- a/e2e/tests/devnet/sub-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/sub-account-compute-invoke.test.ts
@@ -50,7 +50,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
       return BigInt(result[0]) + (BigInt(result[1]) << 128n);
     };
 
-    // Fund the dapp so its `pay_out` can transfer the payout to the sub-account.
+    // Fund the dapp so its `transfer_to_caller` can transfer the payout to the sub-account.
     const mintTx = await de.admin.execute({
       contractAddress: tokens.usdToken,
       entrypoint: "mint",
@@ -62,7 +62,9 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
     // the derived identity key. The commitment it returns selects the per-commitment sub-account.
     const dappName = BigInt(shortString.encodeShortString("DAPP"));
     const seqNonce = 0n;
-    const payOutSelector = BigInt(hash.getSelectorFromName("pay_out"));
+    const transferToCallerSelector = BigInt(
+      hash.getSelectorFromName("transfer_to_caller"),
+    );
     const usdToken = BigInt(tokens.usdToken);
 
     const poolBalanceBefore = await balanceOf(de.privacy.address);
@@ -90,7 +92,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
             [
               {
                 to: subAccount.mockDapp,
-                selector: payOutSelector,
+                selector: transferToCallerSelector,
                 calldata: CallData.compile([
                   usdToken,
                   cairo.uint256(payoutAmount),


### PR DESCRIPTION
## Root cause of the E2E Devnet CI failure

Every **E2E Devnet** run on every branch (including `main`) has failed since July 5 with:

```
FAIL tests/devnet/sub-account-compute-invoke.test.ts
Error: executeOutside reverted: ... 0x454e545259504f494e545f4e4f545f464f554e44 ('ENTRYPOINT_NOT_FOUND')
```

**Cause:** a cross-PR race between #852 and #854:
- #852 renamed the mock dapp entrypoint `pay_out` → `transfer_to_caller` and updated all Cairo callers — but the TypeScript e2e test was still in flight on #854's branch, so it couldn't be updated.
- #854 added `sub-account-compute-invoke.test.ts`, which builds a call with `getSelectorFromName("pay_out")`. The branch was green on June 25 (pre-rename), went red once it included the rename from main, and was merged with the red check — breaking the workflow for all branches (e.g. #893, whose failure is unrelated to its content).

The rename changed only the entrypoint name (same `(token: ContractAddress, amount: u256)` signature), so the fix is to use the new selector.

## Verification

Ran locally against starknet-devnet v0.8.0-rc.3 (same as CI):
- unmodified `main` reproduces the exact CI failure (`ENTRYPOINT_NOT_FOUND`)
- with this fix: `Tests 1 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/894)
<!-- Reviewable:end -->
