### PR TITLE
ci(workflows): scope secrets and fork-guard demo deploy

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: Build & Deploy
     runs-on: ubuntu-latest
 

--- a/.github/workflows/on-merge.yaml
+++ b/.github/workflows/on-merge.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
-    secrets: inherit
 
   notify-slack:
     needs: test
@@ -17,4 +16,5 @@ jobs:
     with:
       context_title: "main branch"
       failed_job_name: "test"
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
-    secrets: inherit
 
   check_formatting:
     uses: ./.github/workflows/check_formatting.yaml


### PR DESCRIPTION
## Summary

Two CI hardening changes ahead of open-sourcing, both narrowing what secrets a workflow can reach and what a reviewer must be able to see to catch a leak.

### 1. Drop `secrets: inherit` on the reusable-workflow calls
`secrets: inherit` hands the called workflow the **entire** repo secret pool (`VERCEL_TOKEN`, `SLACK_WEBHOOK_URL`, …). The grant lives at the call site but the *use* lives in the called workflow, so a future edit that starts reading a secret produces no call-site diff for a reviewer to catch.

- **`test.yaml` calls** (`on-merge.yaml`, `on-pull-request.yaml`): removed `inherit` entirely. `test.yaml` declares no `workflow_call` secrets and runs only `scarb test -w`, so it needed none.
- **`notify-slack.yaml` call** (`on-merge.yaml`): replaced `inherit` with an explicit pass of the single secret it declares:
  ```yaml
  secrets:
    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
  ```
  Now any new secret a called workflow consumes requires a matching call-site change that shows up in review.

### 2. Fork-guard the demo deploy job
`demo-deploy.yml` runs on `pull_request` and uses `VERCEL_TOKEN`. Fork PRs get no secrets, so the job fails on every external PR touching `demo/`. The tempting "fix" — switching to `pull_request_target` — would run untrusted PR code with secrets present, a direct `VERCEL_TOKEN` exfiltration path.

Added a job-level guard so external PRs skip the job cleanly:
```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```
Same-repo (internal branch) PRs still get preview deploys unchanged. The `pull_request` trigger is intentionally kept — **do not** switch to `pull_request_target`.

## Test plan
- YAML of all three files validated (`yaml.safe_load`).
- PR title conforms to `.github/scripts/pr_title_lint.py`.
- Behavior is verifiable post-merge: internal branch PRs still deploy; fork PRs show the deploy job as skipped, not failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/897)
<!-- Reviewable:end -->
