### PR TITLE
fix(discovery): set cursor.last_note_index after boundary finding

### DIFF
--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -95,6 +95,10 @@ pub async fn find_last_note_index<S: IViews>(
     .await?;
     budget.reclaim((max_bisect_steps - bisect_step_count) * COST_NOTE_PROBING);
     cursor.total_n_notes = Some(boundary + 1);
+    // Persist the boundary so the next sync resumes at boundary + 1.
+    // Otherwise the cursor loses the last-scanned position and rescans
+    // already-filtered notes from start_index = 0 on every subsequent call.
+    cursor.last_note_index = Some(boundary);
     Ok((cache, false))
 }
 
@@ -565,6 +569,49 @@ mod tests {
             budget.remaining(),
             remaining_after_first,
             "no budget consumed"
+        );
+    }
+
+    /// Regression test: after `find_last_note_index` completes, the cursor's
+    /// `last_note_index` must be set to the boundary so that the next
+    /// `discover_notes_paginated` call resumes at `boundary + 1` instead of
+    /// rescanning from 0.
+    #[tokio::test]
+    async fn test_find_last_note_index_sets_cursor_last_note_index() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, &channel_key)
+            .await
+            .expect("Alice's channel should have at least one subchannel");
+
+        let mut cursor = SubchannelCursor::default();
+        let budget = IoBudget::new(500);
+
+        let (cache, has_more) =
+            find_last_note_index(&backend, &channel_key, token, &mut cursor, 30, &budget)
+                .await
+                .unwrap();
+
+        // Boundary finding succeeded.
+        assert!(!has_more);
+        // Cache must contain the boundary hit.
+        assert!(!cache.is_empty());
+        let boundary = *cache.keys().max().expect("cache non-empty");
+
+        // THE FIX: cursor.last_note_index must be set to the boundary.
+        assert_eq!(
+            cursor.last_note_index,
+            Some(boundary),
+            "last_note_index must equal boundary after find_last_note_index"
         );
     }
 }


### PR DESCRIPTION
## Problem\n\nfind_last_note_index() left cursor.last_note_index as None after determining total_n_notes via bisection. On the next discover_notes_paginated() call, cursor.start_index() returned 0 and already-filtered notes were re-scanned from the beginning — wasting IO budget and leaking access patterns via repeated RPC calls to the same note indices.\n\n## Cause\n\nBoundary determination persisted total_n_notes but omitted the corresponding last_note_index assignment.\n\n## Fix\n\nSet cursor.last_note_index = Some(boundary) after bisection completes. On the next call, start_index() = boundary + 1, resuming linear scan at the correct position without re-probing already-filtered notes.\n\n## Testing\n\nNew regression test test_find_last_note_index_sets_cursor_last_note_index (156 tests pass, 7/7 runs stable).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/900)
<!-- Reviewable:end -->
