### PR TITLE
fix(discovery): restore cursor after boundary finding

### DIFF
--- a/crates/discovery-core/src/discovery/last_note_index.rs
+++ b/crates/discovery-core/src/discovery/last_note_index.rs
@@ -95,6 +95,7 @@ pub async fn find_last_note_index<S: IViews>(
     .await?;
     budget.reclaim((max_bisect_steps - bisect_step_count) * COST_NOTE_PROBING);
     cursor.total_n_notes = Some(boundary + 1);
+    cursor.last_note_index = Some(boundary);
     Ok((cache, false))
 }
 
@@ -566,5 +567,37 @@ mod tests {
             remaining_after_first,
             "no budget consumed"
         );
+    }
+
+    /// Regression: cursor.last_note_index must be set after boundary finding.
+    #[tokio::test]
+    async fn test_find_last_note_index_sets_cursor_last_note_index() {
+        let fixture = load_devnet_fixture();
+        let backend = MockBackend::new(fixture.slots);
+
+        let channel_key = get_channel_key(
+            &backend,
+            fixture.constants.alice_address,
+            &fixture.constants.alice_viewing_key,
+        )
+        .await
+        .expect("Alice should have at least one channel");
+
+        let token = get_subchannel_token(&backend, &channel_key)
+            .await
+            .expect("should have a subchannel");
+
+        let mut cursor = SubchannelCursor::default();
+        let budget = IoBudget::new(500);
+
+        let (cache, has_more) =
+            find_last_note_index(&backend, &channel_key, token, &mut cursor, 30, &budget)
+                .await
+                .unwrap();
+
+        assert!(!has_more);
+        assert!(!cache.is_empty());
+        let boundary = *cache.keys().max().expect("cache non-empty");
+        assert_eq!(cursor.last_note_index, Some(boundary));
     }
 }


### PR DESCRIPTION
## Summary
Set `cursor.last_note_index = Some(boundary)` after bisection completes in `find_last_note_index()`, so that the next `discover_notes_paginated()` call resumes linear scan from the correct position instead of re-scanning already-filtered notes from the beginning.

## Root cause
`find_last_note_index()` persisted `total_n_notes` via bisection but omitted the corresponding `last_note_index` assignment. On the next `discover_notes_paginated()` call, `cursor.start_index()` returned 0, causing already-filtered notes to be re-scanned — wasting IO budget and leaking access patterns via repeated RPC calls to the same note indices.

## Solution
Add `cursor.last_note_index = Some(boundary)` after bisection completes. On the next call, `start_index() = boundary + 1`, resuming linear scan at the correct position without re-probing already-filtered notes.

## Validation
- Added regression test `test_find_last_note_index_sets_cursor_last_note_index`.
- 156 tests pass, 7/7 runs stable.
- No changes to Cairo contracts or SDK.

## Scope
- Changes limited to `crates/discovery-core/src/discovery/last_note_index.rs`.
- No changes to Cairo contracts, SDK, or discovery service API.

## References
- Issue: (none referenced)
- Upstream file(s): `crates/discovery-core/src/discovery/last_note_index.rs`
- Related PR(s): #899, #902, #903

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/901)
<!-- Reviewable:end -->
