### PR TITLE
fix(sub_account): remove SubAccountDeployed event to prevent identity linkage leak

### DIFF
--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -382,7 +382,9 @@ pub mod SubAccountAnonymizer {
             // Sanity check: deployed address cannot be zero.
             assert(sub_account.is_non_zero(), errors::ZERO_ADDRESS);
             self.sub_accounts.write(identity_commitment, sub_account);
-            self.emit(SubAccountDeployed { identity_commitment, sub_account });
+            // NOTE: SubAccountDeployed event intentionally omitted — emitting it
+            // exposes identity_commitment -> sub_account linkage on-chain, enabling
+            // off-chain enumeration attacks (BUG-06). Storage write preserved.
             ISubAccountDispatcher { contract_address: sub_account }
         }
 

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -12,7 +12,6 @@ use starkware_utils_testing::test_utils::{
     TokenHelperTrait, assert_expected_event_emitted, assert_panic_with_felt_error,
     cheat_caller_address_once,
 };
-use sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed;
 use sub_account_anonymizer::sub_account_anonymizer::{
     CollectPolicy, ISubAccountAnonymizerDispatcherTrait, ISubAccountAnonymizerSafeDispatcher,
     ISubAccountAnonymizerSafeDispatcherTrait, MAX_SCAN_RANGE, OpenNote, SubAccountInfo,
@@ -123,30 +122,19 @@ fn test_invoke_executes_and_collects_open_note() {
 }
 
 #[test]
-fn test_deploy_emits_sub_account_deployed_event() {
+fn test_deploy_no_sub_account_deployed_event() {
     let components = deploy_components();
     let anonymizer = anonymizer_disp(components.anonymizer);
     let identity_commitment = anonymizer.privacy_compute('USER', 'DAPP', 1);
 
-    // The first invoke deploys the sub-account and emits the event.
-    let mut spy = spy_events();
-    components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
-    let sub_account = anonymizer.get_sub_account(identity_commitment);
-    let expected_event = SubAccountDeployed { identity_commitment, sub_account };
-    let events = spy.get_events().emitted_by(contract_address: components.anonymizer).events;
-    assert_eq!(events.len(), 1);
-    assert_expected_event_emitted(
-        spied_event: events[0],
-        :expected_event,
-        expected_event_selector: @selector!("SubAccountDeployed"),
-        expected_event_name: "SubAccountDeployed",
-    );
-
-    // A second invoke reuses the sub-account, so no new deployment event is emitted.
+    // Deploying a sub-account should NOT emit SubAccountDeployed.
+    // This event was removed because it leaked identity_commitment → sub_account linkage
+    // to off-chain observers, enabling sub-account enumeration attacks.
     let mut spy = spy_events();
     components.invoke(:identity_commitment, calls: array![], open_notes: array![].span());
     let events = spy.get_events().emitted_by(contract_address: components.anonymizer).events;
-    assert_eq!(events.len(), 0);
+    // SubAccountDeployed is no longer emitted; sub-account is still deployed and tracked.
+    assert(events.len() == 0, 'expected no events');
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Remove the `SubAccountDeployed` event emission that publicly exposes the mapping between `identity_commitment` and `sub_account` addresses on-chain.

## Root cause
The `SubAccount::deploy` function emits a `SubAccountDeployed` event containing both the `sub_account` address and the `identity_commitment`. This allows any on-chain observer to link a user's identity to their deployed sub-account by parsing the event logs.

## Solution
Remove the `emit(SubAccountDeployed { ... })` call from `SubAccount::deploy`. Storage writes are preserved — only the public event emission is removed.

## Validation
- `scarb test -p sub_account_anonymizer` — 27/27 PASS
- Regression test `test_deploy_no_sub_account_deployed_event` verifies zero events emitted on deploy

## Scope
- `packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo` — event removal
- `packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo` — regression test

## References
- Related: nonce enumeration follow-up

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/904)
<!-- Reviewable:end -->
