### PR TITLE
refactor(sdk): move subaccounts() to PrivateTransfersBuilder

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Sub-accounts: `transfers.subaccounts(dappName)` returns a `SubAccountsBuilder`. `invoke(nonce, { calls })`
+- Sub-accounts: `transfers.build().subaccounts(dappName)` returns a `SubAccountsBuilder` (hung off the
+  builder so a sub-account `invoke` shares the builder's `ExecuteOptions`/context). `invoke(nonce, { calls })`
   queues a `ComputeAndInvoke` against the sub-account anonymizer — `computeAdditionalData = [dappName, nonce]`
   and `invokeAdditionalData` compiled from the dapp `calls` via the generated anonymizer ABI — and returns the
   builder so the caller can add the open-note creation and `.execute()`. `dappName` accepts a felt or

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -514,15 +514,6 @@ export interface PrivateTransfersInterface {
 
   /** Create a builder for batching multiple operations */
   build(options?: ExecuteOptions): PrivateTransfersBuilder;
-
-  /**
-   * Sub-account operations scoped to a single dapp.
-   *
-   * `dappName` scopes the derived sub-accounts to one dapp (a felt; a plain string is encoded as a
-   * Cairo short string). Requires `subAccountAnonymizerAddress` in the factory config; throws
-   * otherwise.
-   */
-  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder;
 }
 
 /** A sub-account: its `nonce` for the dapp and the deployed `address`. */
@@ -713,6 +704,15 @@ export interface PrivateTransfersBuilder {
    * Mutually exclusive with `invoke` — at most one invoke-phase action per transaction.
    */
   computeAndInvoke(callBuilder: (args: InvokeCalldataBuilderArgs) => ComputeAndInvokeDetails): this;
+
+  /**
+   * Sub-account operations scoped to a single dapp.
+   *
+   * `dappName` scopes the derived sub-accounts to one dapp (a felt; a plain string is encoded as a
+   * Cairo short string). Requires `subAccountAnonymizerAddress` in the factory config; throws
+   * otherwise.
+   */
+  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder;
 
   /**
    * Set the default recipient for any surplus across all tokens.

--- a/sdk/src/internal/abstract-private-transfers.ts
+++ b/sdk/src/internal/abstract-private-transfers.ts
@@ -20,16 +20,13 @@ import type {
   SimulateOptions,
   StarknetAddress,
   StarknetAddressBigint,
-  SubAccountsBuilder,
   ViewingKey,
   ViewingKeyProvider,
 } from "../interfaces.js";
-import type { BigNumberish } from "starknet";
 import { SetupRequirement } from "../interfaces.js";
 import { AddressMap } from "../utils/maps.js";
 import { toBigInt } from "../utils/crypto.js";
 import { PrivateTransfersBuilderImpl } from "./builders.js";
-import { SubAccountsBuilderImpl } from "./sub-accounts.js";
 import type { ChannelCursor, NotesCursor, RecipientsFilter } from "./channel.js";
 
 /**
@@ -103,20 +100,8 @@ export abstract class AbstractPrivateTransfers implements PrivateTransfersInterf
    * Create a builder for batching multiple operations
    */
   build(options?: ExecuteOptions): PrivateTransfersBuilder {
-    return new PrivateTransfersBuilderImpl(this, this.user, options);
-  }
-
-  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder {
-    if (this.subAccountAnonymizerAddress === undefined) {
-      throw new Error(
-        "subaccounts(...) requires `subAccountAnonymizerAddress` in the createPrivateTransfers config."
-      );
-    }
-    return new SubAccountsBuilderImpl({
-      transfers: this,
-      dappName,
-      subAccountAnonymizerAddress: this.subAccountAnonymizerAddress,
-      user: this.user,
+    return new PrivateTransfersBuilderImpl(this, this.user, options, {
+      anonymizerAddress: this.subAccountAnonymizerAddress,
       getViewingKey: () => this.getViewingKey(),
     });
   }

--- a/sdk/src/internal/builders.ts
+++ b/sdk/src/internal/builders.ts
@@ -29,13 +29,16 @@ import {
   type Amount,
   type InvokeCalldataBuilderArgs,
   type SimulateOptions,
+  type SubAccountsBuilder,
+  type ViewingKey,
   Open,
   PrivateTransfersInterface,
 } from "../interfaces.js";
 import { AddressMap, toBigInt } from "../utils/index.js";
 import { debugLog } from "../utils/logging.js";
 import { isOpenNote } from "../utils/validation.js";
-import type { CallDetails } from "starknet";
+import { SubAccountsBuilderImpl } from "./sub-accounts.js";
+import type { BigNumberish, CallDetails } from "starknet";
 
 // ============ Token Operations Builder ============
 
@@ -173,7 +176,11 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
   constructor(
     private transfers: PrivateTransfersInterface,
     public readonly userAddress: StarknetAddress,
-    options?: ExecuteOptions
+    options?: ExecuteOptions,
+    private subAccountDeps?: {
+      anonymizerAddress?: StarknetAddress;
+      getViewingKey: () => Promise<ViewingKey>;
+    }
   ) {
     this.buildOptions = options;
   }
@@ -214,6 +221,22 @@ export class PrivateTransfersBuilderImpl implements PrivateTransfersBuilder {
         "At most one invoke-phase action (.invoke() / .computeAndInvoke()) per transaction; already set."
       );
     }
+  }
+
+  subaccounts(dappName: string | BigNumberish): SubAccountsBuilder {
+    const deps = this.subAccountDeps;
+    if (deps?.anonymizerAddress === undefined) {
+      throw new Error(
+        "subaccounts(...) requires `subAccountAnonymizerAddress` in the createPrivateTransfers config."
+      );
+    }
+    return new SubAccountsBuilderImpl({
+      builder: this,
+      dappName,
+      subAccountAnonymizerAddress: deps.anonymizerAddress,
+      user: toBigInt(this.userAddress),
+      getViewingKey: deps.getViewingKey,
+    });
   }
 
   surplusTo(recipient: StarknetAddress, withdraw?: boolean): this {

--- a/sdk/src/internal/sub-accounts.ts
+++ b/sdk/src/internal/sub-accounts.ts
@@ -3,7 +3,6 @@ import type {
   ComputeAndInvokeDetails,
   InvokeCalldataBuilderArgs,
   PrivateTransfersBuilder,
-  PrivateTransfersInterface,
   StarknetAddress,
   SubAccountsBuilder,
   ViewingKey,
@@ -25,7 +24,7 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
 
   constructor(
     private readonly params: {
-      transfers: PrivateTransfersInterface;
+      builder: PrivateTransfersBuilder;
       dappName: string | BigNumberish;
       subAccountAnonymizerAddress: StarknetAddress;
       user: bigint;
@@ -46,9 +45,8 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       calldata: CallData.compile(call.calldata ?? []),
     }));
 
-    return this.params.transfers
-      .build()
-      .computeAndInvoke((args: InvokeCalldataBuilderArgs): ComputeAndInvokeDetails => {
+    return this.params.builder.computeAndInvoke(
+      (args: InvokeCalldataBuilderArgs): ComputeAndInvokeDetails => {
         const openNotes = args.openNotes.map((note) => ({
           note_id: note.noteId,
           token: note.token,
@@ -64,7 +62,8 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
           computeAdditionalData: [dappName, nonceFelt],
           invokeAdditionalData,
         };
-      });
+      }
+    );
   }
 
   async partialCommitment(): Promise<bigint> {

--- a/sdk/tests/internal/sub-accounts.test.ts
+++ b/sdk/tests/internal/sub-accounts.test.ts
@@ -51,7 +51,7 @@ describe("SubAccountsBuilder.invoke", () => {
     const nonce = 3n;
     const calls = [{ contractAddress: "0xda99", entrypoint: "pay_out", calldata: [0x1234n, 0n] }];
     mocknet.executeOutside(
-      await transfers.subaccounts(dappName).invoke(nonce, { calls }).execute()
+      await transfers.build().subaccounts(dappName).invoke(nonce, { calls }).execute()
     );
 
     const identityKey = compute_identity_key(
@@ -92,7 +92,7 @@ describe("SubAccountsBuilder.invoke", () => {
 
     const dappFelt = toBigInt(shortString.encodeShortString("DAPP"));
     mocknet.executeOutside(
-      await transfers.subaccounts(dappFelt).invoke(0n, { calls: [] }).execute()
+      await transfers.build().subaccounts(dappFelt).invoke(0n, { calls: [] }).execute()
     );
 
     expect(anonymizer.computeCalls[0]?.slice(1)).toEqual([dappFelt, 0n]);
@@ -102,7 +102,7 @@ describe("SubAccountsBuilder.invoke", () => {
     const mocknet = new Mocknet({ poolAddress: 0x1n });
     const env = mocknet.initialize();
     const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey);
-    expect(() => transfers.subaccounts("DAPP")).toThrow(/subAccountAnonymizerAddress/);
+    expect(() => transfers.build().subaccounts("DAPP")).toThrow(/subAccountAnonymizerAddress/);
   });
 });
 
@@ -124,7 +124,7 @@ describe("SubAccountsBuilder commitments", () => {
       toBigInt(shortString.encodeShortString("DAPP"))
     );
 
-    await expect(transfers.subaccounts("DAPP").partialCommitment()).resolves.toBe(
+    await expect(transfers.build().subaccounts("DAPP").partialCommitment()).resolves.toBe(
       partialCommitment
     );
   });
@@ -146,7 +146,7 @@ describe("SubAccountsBuilder commitments", () => {
       toBigInt(shortString.encodeShortString("DAPP"))
     );
 
-    await expect(transfers.subaccounts("DAPP").commitment(7n)).resolves.toBe(
+    await expect(transfers.build().subaccounts("DAPP").commitment(7n)).resolves.toBe(
       poseidonHash(partialCommitment, 7n)
     );
   });
@@ -159,8 +159,8 @@ describe("SubAccountsBuilder commitments", () => {
     });
 
     const dappFelt = toBigInt(shortString.encodeShortString("DAPP"));
-    await expect(transfers.subaccounts(dappFelt).partialCommitment()).resolves.toBe(
-      await transfers.subaccounts("DAPP").partialCommitment()
+    await expect(transfers.build().subaccounts(dappFelt).partialCommitment()).resolves.toBe(
+      await transfers.build().subaccounts("DAPP").partialCommitment()
     );
   });
 });


### PR DESCRIPTION
`subaccounts(dappName)` hung on `PrivateTransfersInterface`, but a sub-account
`invoke(nonce, {calls})` produces builder operations — so it belongs in the
builder namespace. Moving it there also fixes a latent bug: the old
`SubAccountsBuilderImpl.invoke` spun up its own `transfers.build()` internally,
discarding any `ExecuteOptions` the caller passed. Now `subaccounts` is reached
via `transfers.build(options).subaccounts(dappName)` and its `invoke` chains onto
that same builder, so options/context flow through.

`build()` threads the sub-account deps (anonymizer address + viewing-key getter)
into the builder; the anonymizer-address requirement now throws from
`builder.subaccounts(...)`. Reads (`partialCommitment`/`commitment`) are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/905)
<!-- Reviewable:end -->
