### PR TITLE
fix(demo): read nonce and estimate fees at pre-confirmed block

### DIFF
--- a/demo/src/starknet.ts
+++ b/demo/src/starknet.ts
@@ -1,5 +1,6 @@
 import {
   Account,
+  BlockTag,
   RpcProvider,
   TransactionFinalityStatus,
   type waitForTransactionOptions,
@@ -51,7 +52,10 @@ export function createDiscoveryProvider(
 }
 
 export function createProvider(rpcUrl: string): RpcProvider {
-  return new RpcProvider({ nodeUrl: rpcUrl, batch: 50 });
+  // Nonce reads and fee estimates must use the block tag the flow waits for
+  // (WAIT_OPTIONS → PRE_CONFIRMED); the default `latest` omits pre-confirmed
+  // txs, so a dependent follow-up tx would build on a stale nonce.
+  return new RpcProvider({ nodeUrl: rpcUrl, batch: 50, blockIdentifier: BlockTag.PRE_CONFIRMED });
 }
 
 export function createAccount(provider: RpcProvider, address: string, privateKey: string): Account {


### PR DESCRIPTION
## Problem

The deposit flow submits dependent account transactions (approve, then the proof invocation) and only waits for `PRE_CONFIRMED` between them, but the RPC provider used the default `latest` block tag for nonce reads and fee estimation. A pre-confirmed transaction is not yet in `latest`, so the follow-up transaction was built with a stale nonce and sporadically failed `estimateFee`:

```
Invalid transaction nonce of contract at address 0x…
Account nonce: 0x40; got: 0x3f
```

`Account.getNonce()` and fee estimation both fall back to the provider's default block tag (`BlockTag.LATEST` in starknet.js v10), which lags a merely pre-confirmed tx — so the next tx reads a nonce that becomes stale the instant the earlier tx is accepted. Intermittent because it depends on when the approve crosses pre-confirmed→accepted relative to the deposit's nonce fetch and estimate.

## Fix

Pin the provider's default block tag to `PRE_CONFIRMED` in `createProvider` (`demo/src/starknet.ts`) so nonce reads and fee estimates use the same state the flow already waits for (`WAIT_OPTIONS` → `PRE_CONFIRMED`).

## Verification

- `tsc --noEmit`, eslint, and prettier clean on the changed file.
- Demo redeployed from this branch: loads and connects (Discovery / RPC / Proving healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/907)
<!-- Reviewable:end -->
