### PR TITLE
fix(sdk): sub-account invoke encodes OpenNote.collect_policy

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -12,12 +12,23 @@
   a short string. Requires the new `subAccountAnonymizerAddress` field on the `createPrivateTransfers`
   config; calling `subaccounts(...)` without it throws. `identify()` and `deployed()` on the builder
   are declared but not yet implemented.
+- Sub-accounts: `invoke(nonce, { calls, collectPolicy })` now takes an optional `collectPolicy`
+  applied to every open note the invoke settles — `{ type: "all" }`, `{ type: "diff" }`, or
+  `{ type: "exact"; amount }` (the `exact` variant requires an `amount`); defaults to
+  `{ type: "all" }`. Exported the `CollectPolicy` type.
 - `@starkware-libs/starknet-privacy-sdk/signers` subpath export: `Snip12CallSetSigner`
   and `Eip712CallSetSigner` (starknet.js `SignerInterface` implementations for authorizing
   privacy-pool invocations with legacy SN wallets and `Eth712Account` / EVM wallets), plus the
   `computeCallSetHash` / `computeCallSet712Hash` golden-vector oracles. Both signers accept an
   optional `additionalData` bound into the signed `CallSet` message (empty by default, matching
   the pool). SDK core stays signer-agnostic.
+
+### Fixed
+
+- Sub-accounts: `invoke` now encodes the anonymizer `OpenNote.collect_policy` field. It was omitted
+  before — which only compiled because the committed `SubAccountAnonymizerABI` was stale (missing
+  `collect_policy`), and would have produced calldata the anonymizer rejects. The ABI is regenerated
+  to include `collect_policy`.
 
 ## 0.14.3-RC.3
 

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -520,6 +520,14 @@ export interface PrivateTransfersInterface {
 export type SubAccount = { nonce: number; address: StarknetAddressBigint };
 
 /**
+ * How much of the sub-account's balance a settled open note collects, per the anonymizer's
+ * `CollectPolicy`: `all` — the sub-account's entire token balance; `diff` — only the balance gained
+ * during this interaction; `exact` — the given amount. A single policy applies to every open note
+ * settled by a {@link SubAccountsBuilder.invoke}.
+ */
+export type CollectPolicy = { type: "all" } | { type: "diff" } | { type: "exact"; amount: Amount };
+
+/**
  * Sub-account operations for one user + dapp, driven through the sub-account anonymizer contract.
  * Each `nonce` maps to a distinct, deterministic sub-account address.
  */
@@ -542,11 +550,15 @@ export interface SubAccountsBuilder {
 
   /**
    * Queue a `computeAndInvoke` against the sub-account for `nonce`: run `calls` through it and
-   * settle the proceeds into the open notes created in the same transaction. Returns the builder so
-   * the caller can add the open-note creation (e.g. `.with(token).transfer({ recipient, amount: Open })`)
-   * and `.execute()`.
+   * settle the proceeds into the open notes created in the same transaction. `collectPolicy` (one
+   * policy for all of the transaction's open notes; default `{ type: "all" }`) selects how much of
+   * the sub-account's balance each note collects. Returns the builder so the caller can add the
+   * open-note creation (e.g. `.with(token).transfer({ recipient, amount: Open })`) and `.execute()`.
    */
-  invoke(nonce: BigNumberish, options: { calls: Call[] }): PrivateTransfersBuilder;
+  invoke(
+    nonce: BigNumberish,
+    options: { calls: Call[]; collectPolicy?: CollectPolicy }
+  ): PrivateTransfersBuilder;
 }
 
 // ============ Builder Types ============

--- a/sdk/src/internal/anonymizer-abi.ts
+++ b/sdk/src/internal/anonymizer-abi.ts
@@ -40,6 +40,24 @@ export const SubAccountAnonymizerABI = [
     ],
   },
   {
+    type: "enum",
+    name: "sub_account_anonymizer::sub_account_anonymizer::CollectPolicy",
+    variants: [
+      {
+        name: "All",
+        type: "()",
+      },
+      {
+        name: "Diff",
+        type: "()",
+      },
+      {
+        name: "Exact",
+        type: "core::integer::u128",
+      },
+    ],
+  },
+  {
     type: "struct",
     name: "sub_account_anonymizer::sub_account_anonymizer::OpenNote",
     members: [
@@ -50,6 +68,10 @@ export const SubAccountAnonymizerABI = [
       {
         name: "token",
         type: "core::starknet::contract_address::ContractAddress",
+      },
+      {
+        name: "collect_policy",
+        type: "sub_account_anonymizer::sub_account_anonymizer::CollectPolicy",
       },
     ],
   },
@@ -205,6 +227,22 @@ export const SubAccountAnonymizerABI = [
         outputs: [
           {
             type: "core::array::Span::<sub_account_anonymizer::sub_account_anonymizer::SubAccountInfo>",
+          },
+        ],
+        state_mutability: "view",
+      },
+      {
+        type: "function",
+        name: "get_sub_account",
+        inputs: [
+          {
+            name: "identity_commitment",
+            type: "core::felt252",
+          },
+        ],
+        outputs: [
+          {
+            type: "core::starknet::contract_address::ContractAddress",
           },
         ],
         state_mutability: "view",
@@ -761,6 +799,23 @@ export const SubAccountAnonymizerABI = [
   },
   {
     type: "event",
+    name: "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed",
+    kind: "struct",
+    members: [
+      {
+        name: "identity_commitment",
+        type: "core::felt252",
+        kind: "key",
+      },
+      {
+        name: "sub_account",
+        type: "core::starknet::contract_address::ContractAddress",
+        kind: "key",
+      },
+    ],
+  },
+  {
+    type: "event",
     name: "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::Event",
     kind: "enum",
     variants: [
@@ -783,6 +838,11 @@ export const SubAccountAnonymizerABI = [
         name: "SRC5Event",
         type: "openzeppelin_introspection::src5::SRC5Component::Event",
         kind: "flat",
+      },
+      {
+        name: "SubAccountDeployed",
+        type: "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer::SubAccountDeployed",
+        kind: "nested",
       },
     ],
   },

--- a/sdk/src/internal/sub-accounts.ts
+++ b/sdk/src/internal/sub-accounts.ts
@@ -1,5 +1,6 @@
-import { BigNumberish, Call, CallData, hash, shortString } from "starknet";
+import { BigNumberish, Call, CairoCustomEnum, CallData, hash, shortString } from "starknet";
 import type {
+  CollectPolicy,
   ComputeAndInvokeDetails,
   InvokeCalldataBuilderArgs,
   PrivateTransfersBuilder,
@@ -35,7 +36,10 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
     this.subAccountAnonymizerAddress = toBigInt(params.subAccountAnonymizerAddress);
   }
 
-  invoke(nonce: BigNumberish, options: { calls: Call[] }): PrivateTransfersBuilder {
+  invoke(
+    nonce: BigNumberish,
+    options: { calls: Call[]; collectPolicy?: CollectPolicy }
+  ): PrivateTransfersBuilder {
     const { dappName, subAccountAnonymizerAddress } = this;
     const nonceFelt = toBigInt(nonce);
     // The anonymizer's `privacy_invoke_with_computation` takes Cairo `Call`s (to/selector/calldata).
@@ -44,12 +48,15 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
       selector: hash.getSelectorFromName(call.entrypoint),
       calldata: CallData.compile(call.calldata ?? []),
     }));
+    // One CollectPolicy applies to every open note settled by this invoke (default: collect all).
+    const collectPolicy = toCollectPolicyEnum(options.collectPolicy ?? { type: "all" });
 
     return this.params.builder.computeAndInvoke(
       (args: InvokeCalldataBuilderArgs): ComputeAndInvokeDetails => {
         const openNotes = args.openNotes.map((note) => ({
           note_id: note.noteId,
           token: note.token,
+          collect_policy: collectPolicy,
         }));
         // Compile (calls, open_notes) via the ABI and drop the leading identity_commitment felt,
         // which the pool prepends from the privacy_compute result.
@@ -79,4 +86,13 @@ export class SubAccountsBuilderImpl implements SubAccountsBuilder {
   async commitment(nonce: BigNumberish): Promise<bigint> {
     return poseidonHash(await this.partialCommitment(), toBigInt(nonce));
   }
+}
+
+/** Map a {@link CollectPolicy} to the anonymizer's `CollectPolicy` Cairo enum for calldata. */
+function toCollectPolicyEnum(policy: CollectPolicy): CairoCustomEnum {
+  return new CairoCustomEnum({
+    All: policy.type === "all" ? {} : undefined,
+    Diff: policy.type === "diff" ? {} : undefined,
+    Exact: policy.type === "exact" ? policy.amount : undefined,
+  });
 }

--- a/sdk/tests/internal/sub-accounts.test.ts
+++ b/sdk/tests/internal/sub-accounts.test.ts
@@ -12,7 +12,7 @@ import { compute_identity_key } from "../../src/utils/hashes.js";
 import { hash as poseidonHash } from "../../src/utils/crypto.js";
 import { SubAccountAnonymizerABI } from "../../src/internal/anonymizer-abi.js";
 import { toBigInt } from "../../src/utils/index.js";
-import { StarknetAddress } from "../../src/interfaces.js";
+import { Open, StarknetAddress, type CollectPolicy } from "../../src/interfaces.js";
 
 const COMPUTED_MARKER = 0xc0ffeen;
 const ANONYMIZER = "0xab0a";
@@ -78,6 +78,61 @@ describe("SubAccountsBuilder.invoke", () => {
       .slice(1)
       .map(toBigInt);
     expect(anonymizer.invokeCalls).toEqual([[COMPUTED_MARKER, ...expectedInvokeData]]);
+  });
+
+  it("encodes each settled open note's collect_policy (all / diff / exact), defaulting to all", async () => {
+    const dappName = "DAPP";
+    const calls = [{ contractAddress: "0xda99", entrypoint: "pay_out", calldata: [0x1234n, 0n] }];
+    const EXACT_AMOUNT = 0x9999n;
+    const options = {
+      autoRegister: true,
+      autoDiscover: { channels: "refresh" as const, notes: "refresh" as const },
+      autoSetup: true,
+    };
+
+    // Fresh net per run: the single settled open note lands at the same index (so the same note_id)
+    // every time, leaving `collect_policy` as the only thing that varies between runs.
+    async function invokeWithOpenNote(collectPolicy?: CollectPolicy): Promise<bigint[]> {
+      const mocknet = new Mocknet({ poolAddress: 0x1n });
+      const env = mocknet.initialize();
+      const anonymizer = new MockComputeContract(ANONYMIZER);
+      mocknet.contracts.register(anonymizer);
+      const transfers = mocknet.createPrivateTransfers(env.alice.address, env.alice.privateKey, {
+        subAccountAnonymizerAddress: ANONYMIZER,
+      });
+      const token = toBigInt(env.ace);
+
+      mocknet.executeOutside(await transfers.build(options).register().execute());
+      mocknet.executeOutside(
+        await transfers
+          .build(options)
+          .with(token)
+          .transfer({ recipient: env.alice.address, amount: Open })
+          .done()
+          .subaccounts(dappName)
+          .invoke(1n, { calls, collectPolicy })
+          .execute()
+      );
+      const invoke = anonymizer.invokeCalls[0];
+      if (!invoke) throw new Error("expected one invoke call");
+      return invoke;
+    }
+
+    const all = await invokeWithOpenNote({ type: "all" });
+    const diff = await invokeWithOpenNote({ type: "diff" });
+    const exact = await invokeWithOpenNote({ type: "exact", amount: EXACT_AMOUNT });
+    const byDefault = await invokeWithOpenNote();
+
+    // Each policy encodes differently on the (identically-derived) open note.
+    expect(all).not.toEqual(diff);
+    expect(all).not.toEqual(exact);
+    expect(diff).not.toEqual(exact);
+    // Only the `exact` variant carries its amount into the calldata.
+    expect(exact).toContain(EXACT_AMOUNT);
+    expect(all).not.toContain(EXACT_AMOUNT);
+    expect(diff).not.toContain(EXACT_AMOUNT);
+    // Omitting collectPolicy is equivalent to `{ type: "all" }`.
+    expect(byDefault).toEqual(all);
   });
 
   it("encodes a felt dapp name equivalently to its short-string form", async () => {


### PR DESCRIPTION
Core's build().subaccounts(dappName).invoke omitted the anonymizer OpenNote's collect_policy field
when compiling privacy_invoke_with_computation calldata — it only compiled because the committed
SubAccountAnonymizerABI was stale (missing collect_policy), and would have produced calldata the
anonymizer rejects. invoke now takes an optional collectPolicy ({ type: 'all'|'diff'|'exact' },
default all) applied to every open note, encoded as the Cairo CollectPolicy enum. Regenerated the
ABI to include collect_policy. Exports the CollectPolicy type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/908)
<!-- Reviewable:end -->
