### PR TITLE
feat(client): EVM CallSet signers — Eip712 Hash/TypedData split, additional_data, signMessage

### DIFF
--- a/client/src/signers/eip712-call-set-signer.ts
+++ b/client/src/signers/eip712-call-set-signer.ts
@@ -1,18 +1,20 @@
 /**
- * EIP-712 `CallSet` signer (Browser EVM wallets, or an EVM server key, for an
- * `Eth712Account`).
+ * EIP-712 `CallSet` signers (EVM wallets, for an `Eth712Account`).
  *
- * A `SignerInterface` whose `signTransaction` authorizes the account's invocation (any operation —
- * deposit / transfer / withdraw / setup …) by signing the EIP-712 `CallSet` message the Eth712Account
- * verifies in `is_custom_signature_valid` (earn-contracts eth_712_utils.cairo `get_call_set_hash`) —
- * which the privacy pool calls for a capable account. See the README "Account signers
- * (native-wallet support)" section. Returns the account's 6-felt signature
- * `[r_high, r_low, s_high, s_low, v, evm_chain_id]`.
+ * Two `SignerInterface` implementations, one per signature source, selected explicitly (by the factory
+ * or the dapp) rather than by a runtime `sign` / `signTypedData` toggle:
+ *   - {@link Eip712TypedDataSigner} — a browser wallet (MetaMask …) via `eth_signTypedData_v4`; the
+ *     wallet is handed the EIP-712 typed data and returns a 65-byte `(r‖s‖v)` signature.
+ *   - {@link Eip712HashSigner} — a raw secp256k1 key (server-side / tests) signing the message hash.
  *
- * Keccak-based (so it is byte-compatible with the keccak Cairo verifier and with browser wallets'
- * `eth_signTypedData_v4`), via `@noble/hashes`. The type hashes + domain layout below mirror L1
- * exactly; the cross-layer golden vector is reproduced by `scripts/eip712.py::call_set_msg_hash`
- * (earn-contracts) and pinned in the test.
+ * Both authorize the account's invocation (any operation — deposit / transfer / withdraw / setup …) by
+ * signing the EIP-712 `CallSet` message the Eth712Account verifies in `is_custom_signature_valid`
+ * (earn-contracts eth_712_utils.cairo `get_call_set_hash`) — which the privacy pool calls for a capable
+ * account. Both return the account's 6-felt signature `[r_high, r_low, s_high, s_low, v, evm_chain_id]`.
+ *
+ * Keccak-based and byte-compatible with browser wallets' `eth_signTypedData_v4`. The hashing and typed
+ * data live in shared free functions ({@link computeCallSet712Hash}, {@link callSetTypedData}); the type
+ * hashes + domain layout mirror earn-contracts exactly.
  *
  *   msg = keccak256( 0x19 0x01 || domainSeparator || hashStruct(CallSet) )
  *   domainSeparator = keccak256(EIP712_DOMAIN_TYPE_HASH, keccak256(snChainName), keccak256("2"),
@@ -23,7 +25,7 @@
 
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { keccak_256 } from "@noble/hashes/sha3";
-import { concatBytes } from "@noble/hashes/utils";
+import { concatBytes, hexToBytes } from "@noble/hashes/utils";
 import { hash, num } from "starknet";
 import type {
   BigNumberish,
@@ -39,12 +41,31 @@ import type {
 const MASK_128 = (1n << 128n) - 1n;
 const toFelt = (v: BigNumberish): bigint => num.toBigInt(v);
 
-// EIP-712 type hashes (keccak of the encodeType strings) — identical to earn-contracts
-// eth_712_utils.cairo.
-const EIP712_DOMAIN_TYPE_HASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400fn;
-const CALL_TYPE_HASH = 0x7793b9bed3b87c6119fe923f0da4e85e1f97a03272a446514622ee7bd62ad25fn;
-const CALL_SET_TYPE_HASH = 0xa6b8079d8aedb3bfd5ee9effaf1c1d19c1514c55ed0dc439faf8aabe5460582fn;
-const VERSION_HASH = 0xad7c5bef027816a800da1736444fb58a807ef4c9603b7848673f7e3a68eb14a5n; // keccak("2")
+// The EIP-712 domain version is the constant "2"; `eip712DomainSeparator` keccaks it.
+const DOMAIN_VERSION = "2";
+
+/**
+ * EIP-712 type definitions for `eth_signTypedData_v4`. A wallet derives the type hashes from these
+ * the same way, so `keccak(encodeType)` of each equals the pinned constants above — meaning the
+ * wallet's v4 digest equals {@link computeCallSet712Hash}.
+ */
+export const CALL_SET_EIP712_TYPES = {
+  EIP712Domain: [
+    { name: "name", type: "string" },
+    { name: "version", type: "string" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ],
+  CallSet: [
+    { name: "calls", type: "Call[]" },
+    { name: "additional_data", type: "uint256[]" },
+  ],
+  Call: [
+    { name: "address", type: "uint256" },
+    { name: "selector", type: "uint256" },
+    { name: "data", type: "uint256[]" },
+  ],
+} as const;
 
 function bytesToBigInt(b: Uint8Array): bigint {
   let x = 0n;
@@ -66,41 +87,74 @@ function to32(v: bigint): Uint8Array {
 const keccak = (b: Uint8Array): bigint => bytesToBigInt(keccak_256(b));
 const keccakFelts = (...vals: bigint[]): bigint => keccak(concatBytes(...vals.map(to32)));
 
-function hashCall(call: Call): bigint {
-  const calldata = ((call.calldata ?? []) as BigNumberish[]).map(toFelt);
-  return keccakFelts(
-    CALL_TYPE_HASH,
+// EIP-712 type hashes = keccak of the encodeType string (computed once at load, not hand-pinned). These
+// mirror the same-named constants in starkware_accounts::eth_712_utils; the type-hash test pins each
+// against the on-chain golden value.
+const keccakType = (encodeType: string): bigint => keccak(new TextEncoder().encode(encodeType));
+const EIP712_DOMAIN_TYPE_HASH = keccakType(
+  "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+);
+const CALL_TYPE_HASH = keccakType("Call(uint256 address,uint256 selector,uint256[] data)");
+const CALL_SET_TYPE_HASH = keccakType(
+  "CallSet(Call[] calls,uint256[] additional_data)Call(uint256 address,uint256 selector,uint256[] data)"
+);
+const OUTSIDE_EXECUTION_TYPE_HASH = keccakType(
+  "OutsideExecution(Call[] calls,uint256 caller,uint256 nonce,uint256 execute_after,uint256 execute_before)Call(uint256 address,uint256 selector,uint256[] data)"
+);
+
+// EIP-712 message hash: keccak256(0x19 0x01 || domainSeparator || structHash).
+const wrapEip712 = (domainSep: bigint, structHash: bigint): bigint =>
+  keccak(concatBytes(Uint8Array.from([0x19, 0x01]), to32(domainSep), to32(structHash)));
+
+// keccak of the per-item struct hashes concatenated (empty → keccak("")), matching Cairo push_*_array.
+const hashArray = <T>(items: T[], hashItem: (item: T) => bigint): bigint =>
+  keccak(concatBytes(...items.map((item) => to32(hashItem(item)))));
+
+// The EIP-712 `Call` struct hash: keccak256(CALL_TYPE_HASH, address, selector, keccak256(data felts)).
+const hashCallStruct = (address: bigint, selector: bigint, data: bigint[]): bigint =>
+  keccakFelts(CALL_TYPE_HASH, address, selector, keccak(concatBytes(...data.map(to32))));
+
+const hashCall = (call: Call): bigint =>
+  hashCallStruct(
     toFelt(call.contractAddress),
     toFelt(hash.getSelectorFromName(call.entrypoint)),
-    keccak(concatBytes(...calldata.map(to32)))
+    ((call.calldata ?? []) as BigNumberish[]).map(toFelt)
   );
-}
 
-const hashCallArray = (calls: Call[]): bigint =>
-  keccak(concatBytes(...calls.map((c) => to32(hashCall(c)))));
+const hashCallArray = (calls: Call[]): bigint => hashArray(calls, hashCall);
 
-/** EIP-712 `uint256[]` array hash (matches Cairo `push_felt_array` / py `hash_felt_array`). */
+// keccak of the concatenated u256-encoded felts (empty → keccak("")), matching Cairo push_felt_array.
 const hashFeltArray = (felts: bigint[]): bigint => keccak(concatBytes(...felts.map(to32)));
 
 const hashCallSet = (calls: Call[], additionalData: bigint[]): bigint =>
   keccakFelts(CALL_SET_TYPE_HASH, hashCallArray(calls), hashFeltArray(additionalData));
 
-function domainSeparator(snChainName: string, account: bigint, evmChainId: bigint): bigint {
-  const nameHash = keccak(new TextEncoder().encode(snChainName));
+/**
+ * EIP-712 domain separator: `keccak(EIP712_DOMAIN_TYPE_HASH, keccak(name), keccak(version), chainId,
+ * verifyingContract)`. `verifyingContract` is used as given (the account's low 128 bits) so the digest
+ * matches what a wallet computes from the same domain object.
+ */
+function eip712DomainSeparator(
+  name: string,
+  version: string,
+  chainId: bigint,
+  verifyingContract: bigint
+): bigint {
   return keccakFelts(
     EIP712_DOMAIN_TYPE_HASH,
-    nameHash,
-    VERSION_HASH,
-    evmChainId,
-    account & MASK_128
+    keccak(new TextEncoder().encode(name)),
+    keccak(new TextEncoder().encode(version)),
+    chainId,
+    verifyingContract
   );
 }
 
 /**
  * Recompute the EIP-712 `CallSet` message hash the Eth712Account verifies, for `calls` authorized by
  * `accountAddress` on `snChainName` (the Starknet chain name, e.g. "SN_SEPOLIA") with EIP-712 domain
- * `chainId = evmChainId`. The off-chain golden oracle — must equal
- * earn-contracts `get_call_set_hash` / `scripts/eip712.py::call_set_msg_hash`.
+ * `chainId = evmChainId`. `additionalData` is opaque extra data bound into the message (the privacy
+ * pool passes it empty). The off-chain oracle — must equal
+ * `starkware_accounts::eth_712_utils::get_call_set_hash`.
  */
 export function computeCallSet712Hash(
   accountAddress: BigNumberish,
@@ -109,9 +163,170 @@ export function computeCallSet712Hash(
   evmChainId: BigNumberish,
   additionalData: BigNumberish[] = []
 ): bigint {
-  const ds = domainSeparator(snChainName, toFelt(accountAddress), toFelt(evmChainId));
+  const ds = eip712DomainSeparator(
+    snChainName,
+    DOMAIN_VERSION,
+    toFelt(evmChainId),
+    toFelt(accountAddress) & MASK_128
+  );
   const sh = hashCallSet(calls, additionalData.map(toFelt));
-  return keccak(concatBytes(Uint8Array.from([0x19, 0x01]), to32(ds), to32(sh)));
+  return wrapEip712(ds, sh);
+}
+
+/** A SNIP-9 call as it appears in an OutsideExecution message: the selector is already hashed. */
+export interface OutsideExecutionCall {
+  address: BigNumberish;
+  selector: BigNumberish;
+  data: BigNumberish[];
+}
+
+const hashOutsideCall = (call: OutsideExecutionCall): bigint =>
+  hashCallStruct(toFelt(call.address), toFelt(call.selector), call.data.map(toFelt));
+
+/** The EIP-712 domain of an `OutsideExecution`, as carried in the typed data (fields used as given). */
+export interface OutsideExecution712Domain {
+  name: string;
+  version: string;
+  chainId: BigNumberish;
+  verifyingContract: BigNumberish;
+}
+
+/**
+ * Inputs to {@link computeOutsideExecution712Hash}. A struct rather than positional args because most
+ * fields are same-typed felts, so an ordering mistake would silently produce a valid-but-wrong hash.
+ */
+export interface OutsideExecution712Input {
+  domain: OutsideExecution712Domain;
+  calls: OutsideExecutionCall[];
+  caller: BigNumberish;
+  nonce: BigNumberish;
+  executeAfter: BigNumberish;
+  executeBefore: BigNumberish;
+}
+
+/**
+ * Recompute the EIP-712 `OutsideExecution` message hash the Eth712Account verifies in
+ * `execute_from_outside_v2` — `starkware_accounts::eth_712_utils::get_outside_execution_hash`. The
+ * domain is taken from the supplied `domain` (the caller/paymaster's typed data), not re-derived here:
+ * the account re-derives and verifies it on-chain, so a wrong domain only yields a rejected signature.
+ * `calls` carry raw (already-hashed) selectors, matching the SNIP-9 OutsideExecution the paymaster relays.
+ */
+export function computeOutsideExecution712Hash(input: OutsideExecution712Input): bigint {
+  const { domain, calls, caller, nonce, executeAfter, executeBefore } = input;
+  const callArray = hashArray(calls, hashOutsideCall);
+  const structHash = keccakFelts(
+    OUTSIDE_EXECUTION_TYPE_HASH,
+    callArray,
+    toFelt(caller),
+    toFelt(nonce),
+    toFelt(executeAfter),
+    toFelt(executeBefore)
+  );
+  const ds = eip712DomainSeparator(
+    domain.name,
+    domain.version,
+    toFelt(domain.chainId),
+    toFelt(domain.verifyingContract)
+  );
+  return wrapEip712(ds, structHash);
+}
+
+/** The EIP-712 typed data of a `CallSet`; its `eth_signTypedData_v4` digest equals {@link computeCallSet712Hash}. */
+export type CallSetTypedData = ReturnType<typeof callSetTypedData>;
+
+/**
+ * Builds the EIP-712 typed-data object for `eth_signTypedData_v4`. `verifyingContract` is the
+ * account's low 128 bits (per earn-contracts); `chainId` is the source EVM chain id.
+ */
+export function callSetTypedData(
+  accountAddress: BigNumberish,
+  calls: Call[],
+  snChainName: string,
+  evmChainId: BigNumberish,
+  additionalData: BigNumberish[] = []
+) {
+  return {
+    types: CALL_SET_EIP712_TYPES,
+    primaryType: "CallSet" as const,
+    domain: {
+      name: snChainName,
+      version: "2",
+      chainId: num.toHex(toFelt(evmChainId)),
+      verifyingContract: num.toHex(toFelt(accountAddress) & MASK_128),
+    },
+    message: {
+      calls: calls.map((call) => ({
+        address: num.toHex(toFelt(call.contractAddress)),
+        selector: num.toHex(toFelt(hash.getSelectorFromName(call.entrypoint))),
+        data: ((call.calldata ?? []) as BigNumberish[]).map((felt) => num.toHex(toFelt(felt))),
+      })),
+      additional_data: additionalData.map((felt) => num.toHex(toFelt(felt))),
+    },
+  };
+}
+
+/**
+ * EIP-712 type definitions for an `OutsideExecution` typed data (`eth_signTypedData_v4`). The paymaster
+ * builds this so both the wallet and {@link computeOutsideExecution712Hash} hash the same OutsideExecution.
+ */
+export const OUTSIDE_EXECUTION_EIP712_TYPES = {
+  EIP712Domain: [
+    { name: "name", type: "string" },
+    { name: "version", type: "string" },
+    { name: "chainId", type: "uint256" },
+    { name: "verifyingContract", type: "address" },
+  ],
+  OutsideExecution: [
+    { name: "calls", type: "Call[]" },
+    { name: "caller", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "execute_after", type: "uint256" },
+    { name: "execute_before", type: "uint256" },
+  ],
+  Call: [
+    { name: "address", type: "uint256" },
+    { name: "selector", type: "uint256" },
+    { name: "data", type: "uint256[]" },
+  ],
+} as const;
+
+/**
+ * Builds the EIP-712 `OutsideExecution` typed data the paymaster hands the signer. The domain mirrors
+ * the account's on-chain domain (name = Starknet chain, version "2", `verifyingContract` = account low
+ * 128 bits, `chainId` = source EVM chain); the account re-derives and verifies it on-chain, so a wrong
+ * domain only yields a rejected signature. `calls` carry raw (already-hashed) selectors.
+ */
+export function outsideExecutionTypedData(input: {
+  accountAddress: BigNumberish;
+  snChainName: string;
+  evmChainId: BigNumberish;
+  calls: OutsideExecutionCall[];
+  caller: BigNumberish;
+  nonce: BigNumberish;
+  executeAfter: BigNumberish;
+  executeBefore: BigNumberish;
+}) {
+  return {
+    types: OUTSIDE_EXECUTION_EIP712_TYPES,
+    primaryType: "OutsideExecution" as const,
+    domain: {
+      name: input.snChainName,
+      version: DOMAIN_VERSION,
+      chainId: num.toHex(toFelt(input.evmChainId)),
+      verifyingContract: num.toHex(toFelt(input.accountAddress) & MASK_128),
+    },
+    message: {
+      calls: input.calls.map((call) => ({
+        address: num.toHex(toFelt(call.address)),
+        selector: num.toHex(toFelt(call.selector)),
+        data: call.data.map((felt) => num.toHex(toFelt(felt))),
+      })),
+      caller: num.toHex(toFelt(input.caller)),
+      nonce: num.toHex(toFelt(input.nonce)),
+      execute_after: num.toHex(toFelt(input.executeAfter)),
+      execute_before: num.toHex(toFelt(input.executeBefore)),
+    },
+  };
 }
 
 /** secp256k1 signature components of the EIP-712 message hash. `v` is 27/28 (yParity + 27). */
@@ -133,7 +348,7 @@ function toSixFelt(sig: EthSignatureParts, evmChainId: bigint): string[] {
   ].map(num.toHex);
 }
 
-/** Signs the EIP-712 message hash and yields its secp256k1 components. */
+/** Signs the EIP-712 message hash and yields its secp256k1 components (e.g. a raw server key). */
 export type Eip712SignFn = (messageHash: bigint) => EthSignatureParts | Promise<EthSignatureParts>;
 
 /** Convenience transport for a raw EVM private key (server-side / tests). */
@@ -145,54 +360,172 @@ export function secp256k1SignFn(privateKey: BigNumberish): Eip712SignFn {
   };
 }
 
-export interface Eip712CallSetSignerOptions {
+/**
+ * Signs the EIP-712 typed data via a browser wallet's `eth_signTypedData_v4`, returning the
+ * 0x-prefixed 65-byte `(r ‖ s ‖ v)` hex signature. E.g. with ethers:
+ * `(td) => signer.signTypedData(td.domain, { CallSet: td.types.CallSet, Call: td.types.Call }, td.message)`.
+ */
+export type Eip712SignTypedDataFn = (typedData: CallSetTypedData) => string | Promise<string>;
+
+/**
+ * Splits a 0x-prefixed 65-byte `(r ‖ s ‖ v)` signature into its components, normalizing the yParity
+ * `v` (0/1) to the legacy 27/28 the account expects. Assumes `eth_signTypedData_v4` semantics: rejects
+ * any other `v` (e.g. an EIP-155 chain-encoded `v = 2*chainId + 35/36`) rather than mis-normalizing it.
+ */
+function parseEthSignature(hexSignature: string): EthSignatureParts {
+  const bytes = hexToBytes(hexSignature.startsWith("0x") ? hexSignature.slice(2) : hexSignature);
+  const v = bytes[64];
+  if (v !== 0 && v !== 1 && v !== 27 && v !== 28) {
+    throw new Error(`unexpected signature recovery byte v=${v}; expected 0/1 or 27/28`);
+  }
+  return {
+    r: bytesToBigInt(bytes.slice(0, 32)),
+    s: bytesToBigInt(bytes.slice(32, 64)),
+    v: v < 27 ? v + 27 : v,
+  };
+}
+
+/** Common configuration shared by both EIP-712 `CallSet` signers. */
+export interface Eip712SignerOptions {
   /** The Eth712Account address — its low 128 bits are the EIP-712 `verifyingContract`. */
   accountAddress: BigNumberish;
   /** Starknet chain name string, e.g. "SN_SEPOLIA" — keccak'd into the EIP-712 domain `name`. */
   snChainName: string;
   /** EIP-712 domain `chainId` (the source EVM chain id); also rides as felt[5] of the signature. */
   evmChainId: BigNumberish;
-  /** Produces the secp256k1 signature over the EIP-712 message hash (wallet or `secp256k1SignFn`). */
-  sign: Eip712SignFn;
-  /**
-   * Opaque extra data bound into the signed `CallSet` message (e.g. a nonce). Defaults to empty,
-   * matching the privacy pool, which passes no `additional_data`.
-   */
+  /** Opaque extra data bound into the signed `CallSet` message. Defaults to empty, matching the pool. */
   additionalData?: BigNumberish[];
 }
 
 /**
- * Plugs into `createPrivateTransfers({ account: { address, signer } })` for an Eth712Account
- * depositor. Only `signTransaction` is exercised; the other `SignerInterface` methods are unsupported.
+ * Shared base for the EIP-712 `CallSet` signers. Plugs into
+ * `createPrivateTransfers({ account: { address, signer } })` for an Eth712Account depositor: only
+ * `signTransaction` is exercised (it derives the 6-felt account signature from the subclass's
+ * secp256k1 components); the other `SignerInterface` methods are unsupported.
  */
-export class Eip712CallSetSigner implements SignerInterface {
-  constructor(private readonly options: Eip712CallSetSignerOptions) {}
+abstract class Eip712CallSetSignerBase<
+  TOptions extends Eip712SignerOptions,
+> implements SignerInterface {
+  protected constructor(protected readonly options: TOptions) {}
+
+  /** Produce the secp256k1 components over this `CallSet` — the signature-source-specific step. */
+  protected abstract signParts(calls: Call[]): Promise<EthSignatureParts>;
 
   async signTransaction(calls: Call[], _details: InvocationsSignerDetails): Promise<Signature> {
-    const messageHash = computeCallSet712Hash(
-      this.options.accountAddress,
-      calls,
-      this.options.snChainName,
-      this.options.evmChainId,
-      this.options.additionalData ?? []
-    );
-    const sig = await this.options.sign(messageHash);
-    return toSixFelt(sig, toFelt(this.options.evmChainId));
+    const parts = await this.signParts(calls);
+    return toSixFelt(parts, toFelt(this.options.evmChainId));
   }
 
   async getPubKey(): Promise<string> {
-    throw new Error("Eip712CallSetSigner: getPubKey is not supported");
+    throw new Error(`${this.constructor.name}: getPubKey is not supported`);
   }
 
-  async signMessage(_typedData: TypedData, _accountAddress: string): Promise<Signature> {
-    throw new Error("Eip712CallSetSigner: signMessage is not supported");
+  /** Produce the secp256k1 components over an `OutsideExecution` message — source-specific. */
+  protected abstract signOutsideExecution(typedData: TypedData): Promise<EthSignatureParts>;
+
+  /**
+   * Signs the SNIP-9 `OutsideExecution` EIP-712 message the Eth712Account verifies in
+   * `execute_from_outside_v2` — the envelope the privacy paymaster relays for a deposit's `approve`.
+   * Returns the account's 6-felt signature.
+   */
+  async signMessage(typedData: TypedData, _accountAddress: string): Promise<Signature> {
+    // This path only signs OutsideExecution — `outsideExecutionHash` reads OutsideExecution message
+    // fields, so reject anything else instead of hashing over misread/missing fields.
+    if (typedData.primaryType !== "OutsideExecution") {
+      throw new Error(
+        `${this.constructor.name}: signMessage only signs OutsideExecution typed data, ` +
+          `got primaryType "${typedData.primaryType}"`
+      );
+    }
+    const parts = await this.signOutsideExecution(typedData);
+    // felt[5] is the EVM chain id the account reads back from the signature and folds into the domain,
+    // so it must be the chain id in the signed domain — taken from the typed data, not the signer config.
+    const domain = typedData.domain as unknown as OutsideExecution712Domain;
+    return toSixFelt(parts, toFelt(domain.chainId));
+  }
+
+  /** The EIP-712 `OutsideExecution` message hash from the typed data's domain + message fields. */
+  protected outsideExecutionHash(typedData: TypedData): bigint {
+    const domain = typedData.domain as unknown as OutsideExecution712Domain;
+    const message = typedData.message as {
+      calls: OutsideExecutionCall[];
+      caller: BigNumberish;
+      nonce: BigNumberish;
+      execute_after: BigNumberish;
+      execute_before: BigNumberish;
+    };
+    return computeOutsideExecution712Hash({
+      domain,
+      calls: message.calls,
+      caller: message.caller,
+      nonce: message.nonce,
+      executeAfter: message.execute_after,
+      executeBefore: message.execute_before,
+    });
   }
 
   async signDeclareTransaction(_details: DeclareSignerDetails): Promise<Signature> {
-    throw new Error("Eip712CallSetSigner: signDeclareTransaction is not supported");
+    throw new Error(`${this.constructor.name}: signDeclareTransaction is not supported`);
   }
 
   async signDeployAccountTransaction(_details: DeployAccountSignerDetails): Promise<Signature> {
-    throw new Error("Eip712CallSetSigner: signDeployAccountTransaction is not supported");
+    throw new Error(`${this.constructor.name}: signDeployAccountTransaction is not supported`);
+  }
+}
+
+export interface Eip712HashSignerOptions extends Eip712SignerOptions {
+  /** Raw signer over the EIP-712 message hash (e.g. `secp256k1SignFn` for a server key). */
+  sign: Eip712SignFn;
+}
+
+/**
+ * Signs the EIP-712 `CallSet` message hash with a raw secp256k1 key (server-side / tests). Computes the
+ * digest itself and calls {@link Eip712HashSignerOptions.sign} — unsuitable for browser wallets, which
+ * will not sign an arbitrary 32-byte hash (use {@link Eip712TypedDataSigner} there).
+ */
+export class Eip712HashSigner extends Eip712CallSetSignerBase<Eip712HashSignerOptions> {
+  constructor(options: Eip712HashSignerOptions) {
+    super(options);
+  }
+
+  protected async signParts(calls: Call[]): Promise<EthSignatureParts> {
+    const { accountAddress, snChainName, evmChainId, additionalData } = this.options;
+    return this.options.sign(
+      computeCallSet712Hash(accountAddress, calls, snChainName, evmChainId, additionalData ?? [])
+    );
+  }
+
+  protected async signOutsideExecution(typedData: TypedData): Promise<EthSignatureParts> {
+    return this.options.sign(this.outsideExecutionHash(typedData));
+  }
+}
+
+export interface Eip712TypedDataSignerOptions extends Eip712SignerOptions {
+  /** Browser-wallet signer via `eth_signTypedData_v4` (receives the typed data, returns 65-byte hex). */
+  signTypedData: Eip712SignTypedDataFn;
+}
+
+/**
+ * Signs the EIP-712 `CallSet` via a browser wallet's `eth_signTypedData_v4`: hands the wallet the typed
+ * data (so it derives and displays the digest itself) and parses the returned 65-byte `(r‖s‖v)`
+ * signature. The wallet's v4 digest equals {@link computeCallSet712Hash} for these types.
+ */
+export class Eip712TypedDataSigner extends Eip712CallSetSignerBase<Eip712TypedDataSignerOptions> {
+  constructor(options: Eip712TypedDataSignerOptions) {
+    super(options);
+  }
+
+  protected async signParts(calls: Call[]): Promise<EthSignatureParts> {
+    const { accountAddress, snChainName, evmChainId, additionalData } = this.options;
+    const signature = await this.options.signTypedData(
+      callSetTypedData(accountAddress, calls, snChainName, evmChainId, additionalData ?? [])
+    );
+    return parseEthSignature(signature);
+  }
+
+  protected async signOutsideExecution(typedData: TypedData): Promise<EthSignatureParts> {
+    return parseEthSignature(
+      await this.options.signTypedData(typedData as unknown as CallSetTypedData)
+    );
   }
 }

--- a/client/src/signers/index.ts
+++ b/client/src/signers/index.ts
@@ -1,11 +1,18 @@
 export {
-  Eip712CallSetSigner,
+  Eip712HashSigner,
+  Eip712TypedDataSigner,
+  callSetTypedData,
   computeCallSet712Hash,
+  outsideExecutionTypedData,
   secp256k1SignFn,
 } from "./eip712-call-set-signer.js";
 export type {
-  Eip712CallSetSignerOptions,
+  Eip712SignerOptions,
+  Eip712HashSignerOptions,
+  Eip712TypedDataSignerOptions,
   Eip712SignFn,
+  Eip712SignTypedDataFn,
+  CallSetTypedData,
   EthSignatureParts,
 } from "./eip712-call-set-signer.js";
 

--- a/client/tests/signers/eip712-call-set-signer.test.ts
+++ b/client/tests/signers/eip712-call-set-signer.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { keccak_256 } from "@noble/hashes/sha3";
-import { num } from "starknet";
-import type { Call, InvocationsSignerDetails } from "starknet";
+import { num, shortString } from "starknet";
+import type { Call, InvocationsSignerDetails, TypedData } from "starknet";
 import {
-  Eip712CallSetSigner,
+  callSetTypedData,
   computeCallSet712Hash,
+  computeOutsideExecution712Hash,
+  Eip712HashSigner,
+  Eip712TypedDataSigner,
+  outsideExecutionTypedData,
   secp256k1SignFn,
 } from "../../src/signers/eip712-call-set-signer.js";
 
@@ -16,10 +20,6 @@ const SAMPLE_CALLS: Call[] = [
   { contractAddress: "0x111", entrypoint: "approve", calldata: ["0x1", "0x2"] },
 ];
 
-// Equal to `get_call_set_hash` / scripts/eip712.py::call_set_msg_hash for the same vector
-// (account=0x1234, [approve(0x111,[1,2])], SN_SEPOLIA, evm chain 1, empty additional_data).
-const GOLDEN = "0x33eb87d7a470834c89fe6aec8b899a706fe26c5af2fe82c2c89df613b418a650";
-
 function to32(v: bigint): Uint8Array {
   const o = new Uint8Array(32);
   let x = v;
@@ -29,21 +29,105 @@ function to32(v: bigint): Uint8Array {
   }
   return o;
 }
+const keccakStr = (s: string): bigint =>
+  num.toBigInt("0x" + Buffer.from(keccak_256(new TextEncoder().encode(s))).toString("hex"));
 const ethAddrFromPub = (pub64: Uint8Array): bigint =>
   num.toBigInt("0x" + Buffer.from(keccak_256(pub64).slice(12)).toString("hex"));
 const ethAddressOfKey = (pk: bigint): bigint =>
   ethAddrFromPub(secp256k1.getPublicKey(to32(pk), false).slice(1));
 
-describe("Eip712CallSetSigner", () => {
-  it("computeCallSet712Hash matches the L1 golden vector", () => {
-    expect(num.toHex(computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN))).toBe(
-      GOLDEN
+describe("EIP-712 CallSet signers", () => {
+  it("pins the starkware_accounts EIP-712 type hashes (keccak of encodeType)", () => {
+    // Proves the wallet (which derives type hashes from the `types` object the same way) computes
+    // the same type hashes as the on-chain Eth712Account.
+    expect(keccakStr("Call(uint256 address,uint256 selector,uint256[] data)")).toBe(
+      0x7793b9bed3b87c6119fe923f0da4e85e1f97a03272a446514622ee7bd62ad25fn
     );
+    expect(
+      keccakStr(
+        "CallSet(Call[] calls,uint256[] additional_data)Call(uint256 address,uint256 selector,uint256[] data)"
+      )
+    ).toBe(0xa6b8079d8aedb3bfd5ee9effaf1c1d19c1514c55ed0dc439faf8aabe5460582fn);
+    expect(
+      keccakStr(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+      )
+    ).toBe(0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400fn);
+    expect(
+      keccakStr(
+        "OutsideExecution(Call[] calls,uint256 caller,uint256 nonce,uint256 execute_after,uint256 execute_before)Call(uint256 address,uint256 selector,uint256[] data)"
+      )
+    ).toBe(0x57fbef2abe14202f3651b3935a8feddd357b8f83a862e046239d196ec76f281en);
+  });
+
+  it("reproduces the starkware_accounts on-chain-validated CallSet signature (approve fixture)", async () => {
+    // Golden vector from starkware_accounts eth_712_utils test_utils.cairo
+    // `get_call_set_with_approve_signature()` — an approve(0x1234, 500) CallSet on SN_MAIN / evm chain 1.
+    const account = 0x07120acc07120acc07120acc07120accn;
+    const privateKey = 0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n;
+    const approveCall: Call = {
+      contractAddress: "0x0e2c200e2c200e2c200e2c200e2c2000",
+      entrypoint: "approve",
+      calldata: ["0x1234", "0x1f4", "0x0"], // spender, amount.low (500), amount.high
+    };
+    const signer = new Eip712HashSigner({
+      accountAddress: account,
+      snChainName: "SN_MAIN",
+      evmChainId: 1n,
+      sign: secp256k1SignFn(privateKey),
+    });
+
+    const felts = (await signer.signTransaction(
+      [approveCall],
+      {} as InvocationsSignerDetails
+    )) as string[];
+
+    expect(felts.map((f) => num.toBigInt(f))).toEqual([
+      0x278778484aaed07e7aedfde9d083a8efn,
+      0x887154c31481c204416d3d323bcb108cn,
+      0x25eed52af478ac87dcf1dd528475af22n,
+      0xfd39cb55c54d25904c96ff0d079b89b6n,
+      28n,
+      1n,
+    ]);
+  });
+
+  it("reproduces the starkware_accounts golden with non-empty additional_data", async () => {
+    // starkware_accounts `get_call_set_with_additional_data_signature()`: same approve CallSet, but
+    // additional_data = [10, 11] bound into the message.
+    const account = 0x07120acc07120acc07120acc07120accn;
+    const privateKey = 0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n;
+    const approveCall: Call = {
+      contractAddress: "0x0e2c200e2c200e2c200e2c200e2c2000",
+      entrypoint: "approve",
+      calldata: ["0x1234", "0x1f4", "0x0"],
+    };
+    const signer = new Eip712HashSigner({
+      accountAddress: account,
+      snChainName: "SN_MAIN",
+      evmChainId: 1n,
+      additionalData: [10n, 11n],
+      sign: secp256k1SignFn(privateKey),
+    });
+
+    const felts = (await signer.signTransaction(
+      [approveCall],
+      {} as InvocationsSignerDetails
+    )) as string[];
+
+    expect(felts.map((f) => num.toBigInt(f))).toEqual([
+      0xcefcd06a012378cceb1bfa5b2831ef0dn,
+      0xa5424ce854f5a39bf61df96013f21f94n,
+      0x390242713792f83e134ccabc69a153can,
+      0x8916d2267a20441a5a60b0b565735d03n,
+      27n,
+      1n,
+    ]);
   });
 
   it("signTransaction returns a 6-felt signature that recovers to the signer's eth address", async () => {
     const pk = 0xdeadbeefn;
-    const signer = new Eip712CallSetSigner({
+    const signer = new Eip712HashSigner({
       accountAddress: ACCOUNT,
       snChainName: SN_CHAIN,
       evmChainId: EVM_CHAIN,
@@ -56,11 +140,10 @@ describe("Eip712CallSetSigner", () => {
     )) as string[];
 
     expect(felts).toHaveLength(6);
-    expect(num.toBigInt(felts[5])).toBe(EVM_CHAIN); // evm_chain_id slot
+    expect(num.toBigInt(felts[5])).toBe(EVM_CHAIN);
     const v = Number(num.toBigInt(felts[4]));
     expect([27, 28]).toContain(v);
 
-    // Reconstruct (r, s) from the felt halves and recover — mirrors the account's is_valid_eth_signature.
     const r = (num.toBigInt(felts[0]) << 128n) | num.toBigInt(felts[1]);
     const s = (num.toBigInt(felts[2]) << 128n) | num.toBigInt(felts[3]);
     const msgHash = computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN);
@@ -80,17 +163,136 @@ describe("Eip712CallSetSigner", () => {
     expect(computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, 2n)).not.toBe(base);
   });
 
-  it("binds additional_data (empty vs non-empty, and differing values -> different hash)", () => {
-    const empty = computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN);
-    const withData = computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN, [
-      0xan,
-      0xbn,
+  it("callSetTypedData maps domain + calls into the EIP-712 message", () => {
+    const td = callSetTypedData(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN);
+    expect(td.primaryType).toBe("CallSet");
+    expect(td.domain.name).toBe(SN_CHAIN);
+    expect(td.domain.version).toBe("2");
+    expect(num.toBigInt(td.domain.verifyingContract)).toBe(ACCOUNT & ((1n << 128n) - 1n));
+    expect(num.toBigInt(td.message.calls[0].address)).toBe(0x111n);
+    expect(td.message.calls[0].data.map((d) => num.toBigInt(d))).toEqual([0x1n, 0x2n]);
+  });
+
+  it("signTypedData path yields the same 6-felt signature as the raw-hash path", async () => {
+    const pk = 0xdeadbeefn;
+    const rawSigner = new Eip712HashSigner({
+      accountAddress: ACCOUNT,
+      snChainName: SN_CHAIN,
+      evmChainId: EVM_CHAIN,
+      sign: secp256k1SignFn(pk),
+    });
+    // A wallet signing the v4 digest of the typed data (equal to computeCallSet712Hash for these
+    // types — see the type-hash test), returned as a 0x-prefixed 65-byte (r‖s‖v) signature.
+    const walletSigner = new Eip712TypedDataSigner({
+      accountAddress: ACCOUNT,
+      snChainName: SN_CHAIN,
+      evmChainId: EVM_CHAIN,
+      signTypedData: (td) => {
+        expect(td.primaryType).toBe("CallSet");
+        const digest = computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN);
+        const sig = secp256k1.sign(to32(digest), to32(pk));
+        const raw = new Uint8Array([...to32(sig.r), ...to32(sig.s), 27 + sig.recovery]);
+        return "0x" + Buffer.from(raw).toString("hex");
+      },
+    });
+
+    const fromRaw = await rawSigner.signTransaction(SAMPLE_CALLS, {} as InvocationsSignerDetails);
+    const fromWallet = await walletSigner.signTransaction(
+      SAMPLE_CALLS,
+      {} as InvocationsSignerDetails
+    );
+    expect(fromWallet).toEqual(fromRaw);
+  });
+
+  it("reproduces the starkware_accounts OutsideExecution golden signature", async () => {
+    // starkware_accounts `get_outside_execution_signature()` for `get_test_outside_execution()`:
+    // empty calls, caller=ANY_CALLER, nonce=1, execute_after=1000, execute_before=3000, SN_MAIN, evm 1.
+    const MASK_128 = (1n << 128n) - 1n;
+    const privateKey = 0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n;
+    const hash = computeOutsideExecution712Hash({
+      domain: {
+        name: "SN_MAIN",
+        version: "2",
+        chainId: 1n,
+        verifyingContract: 0x07120acc07120acc07120acc07120accn,
+      },
+      calls: [],
+      caller: BigInt(shortString.encodeShortString("ANY_CALLER")),
+      nonce: 1n,
+      executeAfter: 1000n,
+      executeBefore: 3000n,
+    });
+    const { r, s, v } = await secp256k1SignFn(privateKey)(hash);
+
+    expect([r >> 128n, r & MASK_128, s >> 128n, s & MASK_128, BigInt(v), 1n]).toEqual([
+      0x7ffb66a7163f54ab83a435079d74198dn,
+      0x5ceb653460c57bda62685e60d4b67dc9n,
+      0x7c07a7689645c4ec1775cd794e6a6bdcn,
+      0xfaecbd63a4629b6e3d43e88568000326n,
+      27n,
+      1n,
     ]);
-    const otherData = computeCallSet712Hash(ACCOUNT, SAMPLE_CALLS, SN_CHAIN, EVM_CHAIN, [
-      0xan,
-      0xcn,
+  });
+
+  it("signMessage authorizes an OutsideExecution and reproduces the golden signature", async () => {
+    // signMessage reads the domain + message off the supplied typed data (built here the way a paymaster
+    // would), so the digest and felt[5] come from that typed data, not the signer's config.
+    const signer = new Eip712HashSigner({
+      accountAddress: 0x07120acc07120acc07120acc07120accn,
+      snChainName: "SN_MAIN",
+      evmChainId: 1n,
+      sign: secp256k1SignFn(0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n),
+    });
+    const outsideExecution = outsideExecutionTypedData({
+      accountAddress: 0x07120acc07120acc07120acc07120accn,
+      snChainName: "SN_MAIN",
+      evmChainId: 1n,
+      calls: [],
+      caller: shortString.encodeShortString("ANY_CALLER"),
+      nonce: 1n,
+      executeAfter: 1000n,
+      executeBefore: 3000n,
+    }) as unknown as TypedData;
+
+    const felts = (await signer.signMessage(outsideExecution, "0x07120acc")) as string[];
+
+    expect(felts.map((f) => num.toBigInt(f))).toEqual([
+      0x7ffb66a7163f54ab83a435079d74198dn,
+      0x5ceb653460c57bda62685e60d4b67dc9n,
+      0x7c07a7689645c4ec1775cd794e6a6bdcn,
+      0xfaecbd63a4629b6e3d43e88568000326n,
+      27n,
+      1n,
     ]);
-    expect(withData).not.toBe(empty);
-    expect(withData).not.toBe(otherData);
+  });
+
+  it("signMessage rejects typed data that is not an OutsideExecution", async () => {
+    const signer = new Eip712HashSigner({
+      accountAddress: ACCOUNT,
+      snChainName: SN_CHAIN,
+      evmChainId: EVM_CHAIN,
+      sign: secp256k1SignFn(0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n),
+    });
+    const callSet = {
+      primaryType: "CallSet",
+      domain: {},
+      types: {},
+      message: { calls: [], additional_data: [] },
+    } as unknown as TypedData;
+    await expect(signer.signMessage(callSet, "0x1")).rejects.toThrow(/OutsideExecution/);
+  });
+
+  it("rejects a wallet signature with an unexpected recovery byte (not 0/1/27/28)", async () => {
+    // v = 0x25 (37) — e.g. an EIP-155 chain-encoded v, which eth_signTypedData_v4 never returns.
+    const badSignature = "0x" + "11".repeat(32) + "22".repeat(32) + "25";
+    const signer = new Eip712TypedDataSigner({
+      accountAddress: ACCOUNT,
+      snChainName: SN_CHAIN,
+      evmChainId: EVM_CHAIN,
+      signTypedData: () => badSignature,
+    });
+    await expect(
+      signer.signTransaction(SAMPLE_CALLS, {} as InvocationsSignerDetails)
+    ).rejects.toThrow(/v=37/);
   });
 });

--- a/client/tests/signers/eip712-call-set-signer.wiring.test.ts
+++ b/client/tests/signers/eip712-call-set-signer.wiring.test.ts
@@ -5,14 +5,14 @@ import { createPrivateTransfers } from "@starkware-libs/starknet-privacy-sdk";
 import { MockProofProvider } from "@starkware-libs/starknet-privacy-sdk/testing";
 import { ContractDiscoveryProvider } from "@starkware-libs/starknet-privacy-sdk/testing";
 import {
-  Eip712CallSetSigner,
+  Eip712HashSigner,
   computeCallSet712Hash,
   secp256k1SignFn,
 } from "../../src/signers/eip712-call-set-signer.js";
 
 const POOL_ADDRESS = 0x1n;
 
-describe("Eip712CallSetSigner wiring", () => {
+describe("Eip712HashSigner wiring", () => {
   it("flows through createPrivateTransfers and emits the 6-felt CallSet signature", async () => {
     const mocknet = new Mocknet({ poolAddress: POOL_ADDRESS });
     const env = mocknet.initialize();
@@ -22,7 +22,7 @@ describe("Eip712CallSetSigner wiring", () => {
     const evmChainId = 1n;
     const evmPrivateKey = 0xc0ffeen;
 
-    const signer = new Eip712CallSetSigner({
+    const signer = new Eip712HashSigner({
       accountAddress,
       snChainName,
       evmChainId,


### PR DESCRIPTION
Split the EVM CallSet signer into Eip712HashSigner (raw key) + Eip712TypedDataSigner (browser
eth_signTypedData_v4). Align the CallSet EIP-712 type to starkware_accounts (add additional_data,
type hash 0xa6b8...). Add computeOutsideExecution712Hash + signMessage over a SNIP-9 OutsideExecution.
Verified against starkware_accounts' golden vectors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/912)
<!-- Reviewable:end -->
