### PR TITLE
feat(client): PrivacyWallet seam (collapse the wallet-type zoo)

### DIFF
--- a/client/src/calls.ts
+++ b/client/src/calls.ts
@@ -1,0 +1,29 @@
+import type { Call, STRK20_CALLDATA_ITEM } from "starknet";
+
+/**
+ * A Starknet call in strk20 (snake_case) wire form — the shape shared by the wallet-api call
+ * (`STRK20_CALL_AND_PROOF["call"]`) and the local `Strk20Call` shim. `calldata` may be omitted.
+ */
+export interface Strk20WireCall {
+  contract_address: string;
+  entry_point: string;
+  calldata?: STRK20_CALLDATA_ITEM[];
+}
+
+/** Map a starknet.js {@link Call} to the strk20 (snake_case) wire shape (`calldata` always present). */
+export function toStrk20Call(call: Call): Required<Strk20WireCall> {
+  return {
+    contract_address: String(call.contractAddress),
+    entry_point: call.entrypoint,
+    calldata: (call.calldata ?? []) as STRK20_CALLDATA_ITEM[],
+  };
+}
+
+/** Map a strk20 (snake_case) call back to a starknet.js {@link Call}. */
+export function toStarknetCall(call: Strk20WireCall): Call {
+  return {
+    contractAddress: call.contract_address,
+    entrypoint: call.entry_point,
+    calldata: call.calldata,
+  };
+}

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,0 +1,18 @@
+import type { PrivacyClient, PrivacyClientConfig } from "./interfaces.js";
+
+/**
+ * The dapp client. Holds the config (wallet + read context: provider + sub-account anonymizer); the
+ * operation builder and `addresses()` are added upstack and read through them and
+ * `wallet.partialCommitment(dappName)`.
+ */
+class PrivacyClientImpl implements PrivacyClient {
+  constructor(private readonly config: PrivacyClientConfig) {}
+}
+
+/**
+ * Creates a dapp client for Starknet privacy from a {@link PrivacyWallet} the dapp constructs — a
+ * get-starknet v6 wallet directly, or (upstack) an `SdkWallet` over a signer.
+ */
+export function createPrivacyClient(config: PrivacyClientConfig): PrivacyClient {
+  return new PrivacyClientImpl(config);
+}

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,5 +1,12 @@
 // @starkware-libs/starknet-privacy-client — dapp client for Starknet privacy.
 //
 // Resolves sub-accounts, bridges Starknet/EVM wallet signing, and builds privacy operations
-// over @starkware-libs/starknet-privacy-sdk. The public API is added in subsequent changesets.
-export {};
+// over @starkware-libs/starknet-privacy-sdk. More of the public API is added in later changesets.
+export { createPrivacyClient } from "./client.js";
+export type {
+  PrivacyClient,
+  PrivacyClientConfig,
+  PrivacyWallet,
+  STRK20_COMPUTE_AND_INVOKE_ACTION,
+  Strk20Action,
+} from "./interfaces.js";

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -1,0 +1,68 @@
+import type {
+  ProviderInterface,
+  STRK20_ACTION,
+  STRK20_CALL_AND_PROOF,
+  STRK20_CALLDATA_ITEM,
+} from "starknet";
+import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
+
+/**
+ * LOCAL SHIM — remove when `@starknet-io/starknet-types` ships it. The compute-and-invoke sibling of
+ * `STRK20_INVOKE_ACTION`: two placeholder-capable calldata arrays that the SDK adapter maps to core's
+ * `ComputeAndInvokeDetails.computeAdditionalData` / `invokeAdditionalData`. Modeled here so
+ * `Strk20Action` can express core's `computeAndInvoke` uniformly; a real strk20 wallet gains it upstream.
+ */
+export interface STRK20_COMPUTE_AND_INVOKE_ACTION {
+  type: "compute_and_invoke";
+  contract: string;
+  compute_calldata: STRK20_CALLDATA_ITEM[];
+  invoke_calldata: STRK20_CALLDATA_ITEM[];
+}
+
+/**
+ * The privacy-action currency at the wallet seam: the starknet.js wallet-api `STRK20_ACTION` union
+ * widened with the {@link STRK20_COMPUTE_AND_INVOKE_ACTION} shim. Both invoke variants carry
+ * placeholder-capable calldata (`STRK20_CALLDATA_ITEM = FELT | placeholder string`), so the builder
+ * emits `${openNoteIds[N]}` / `${poolAddress}` placeholders for every wallet, and whoever proves +
+ * submits substitutes them (the native wallet at assembly; the SDK adapter before proving).
+ */
+export type Strk20Action = STRK20_ACTION | STRK20_COMPUTE_AND_INVOKE_ACTION;
+
+/**
+ * The wallet seam — the privacy subset of starknet.js `WalletAccountV6`. A get-starknet v6 wallet
+ * satisfies it natively (passed to {@link createPrivacyClient} directly); a legacy-SN / EVM wallet is
+ * an `SdkWallet` (added upstack) that wraps an injected CallSet `SignerInterface` and proves + submits
+ * via the core SDK. The client programs only against this — there is no wallet `kind`, and the dapp
+ * constructs the implementation it wants.
+ */
+export interface PrivacyWallet {
+  /** The nonce-independent commitment `hash(identity_key, dappName)`, for sub-account resolution. */
+  partialCommitment(dappName: string): Promise<bigint>;
+  /** Prove actions into a submittable `{ call, proof }` (`simulate` ⇒ empty proof); does not broadcast. */
+  strk20PrepareInvoke(actions: Strk20Action[], simulate?: boolean): Promise<STRK20_CALL_AND_PROOF>;
+  /** Prove + broadcast the actions in one step, returning the tx hash. */
+  strk20InvokeTransaction(actions: Strk20Action[]): Promise<{ transaction_hash: string }>;
+}
+
+/**
+ * Dependencies for {@link createPrivacyClient}. The dapp constructs the {@link PrivacyWallet} it wants
+ * (a get-starknet v6 wallet directly, or — upstack — an `SdkWallet` over a signer). `provider` +
+ * `subAccountAnonymizerAddress` are the client's read context: it queries the anonymizer view (through
+ * the provider) with `wallet.partialCommitment(dappName)` to resolve sub-account addresses.
+ */
+export interface PrivacyClientConfig {
+  /** The wallet — signs, proves, and submits privacy operations. */
+  wallet: PrivacyWallet;
+  /** Provider for the sub-account anonymizer view call. */
+  provider: ProviderInterface;
+  /** The sub-account anonymizer contract the client queries for sub-account addresses. */
+  subAccountAnonymizerAddress: StarknetAddress;
+}
+
+/**
+ * A dapp client for Starknet privacy — an opaque handle for now. The operation builder (`build()`)
+ * and sub-account address resolution (`addresses()`) are added in later changesets; `partialCommitment`
+ * is not public (the client calls `wallet.partialCommitment` internally when resolving addresses).
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface PrivacyClient {}

--- a/client/tests/client.test.ts
+++ b/client/tests/client.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import type { ProviderInterface } from "starknet";
+import { createPrivacyClient } from "../src/index.js";
+import type { PrivacyWallet } from "../src/index.js";
+
+const provider = { tag: "provider" } as unknown as ProviderInterface;
+
+/** A minimal {@link PrivacyWallet} double. */
+function fakeWallet(): PrivacyWallet {
+  return {
+    partialCommitment: async () => 0n,
+    strk20PrepareInvoke: async () => {
+      throw new Error("unused");
+    },
+    strk20InvokeTransaction: async () => {
+      throw new Error("unused");
+    },
+  };
+}
+
+describe("createPrivacyClient", () => {
+  it("builds a client from a wallet + read context", () => {
+    const client = createPrivacyClient({
+      wallet: fakeWallet(),
+      provider,
+      subAccountAnonymizerAddress: 0x2n,
+    });
+    expect(client).toBeDefined();
+  });
+});


### PR DESCRIPTION
One polymorphic seam, no `kind`:
  PrivacyWallet { partialCommitment; strk20PrepareInvoke; strk20InvokeTransaction }

- A get-starknet v6 wallet satisfies it directly — no wrapper, no separate
  `Strk20Wallet` type. `address` is off the seam (self-defaulting is per-impl).
- The EVM/legacy-SN path becomes one upstack `SdkWallet` over an injected CallSet
  `SignerInterface`; the old `EvmAccount` / `EvmBrowserWallet` / `EvmServerWallet` /
  `Eip1193Provider` types (mere signer-construction args) are deleted.
- No wallet detection in the library: `detectStarknetWalletKind` + `StarknetWalletApi`
  removed (vestigial from the `kind` design — the dapp constructs the wallet it wants;
  v6-vs-legacy detection is a get-starknet concern).
- Client holds { wallet, provider, subAccountAnonymizerAddress } — the read context for
  sub-account resolution; pool address lives in the SdkWallet's PrivateTransfers.
  `PrivacyClient` is an opaque handle (build()/addresses() upstack); `partialCommitment`
  is not public — the client uses it internally when resolving addresses.
- Kept: Strk20Action (+ STRK20_COMPUTE_AND_INVOKE_ACTION shim).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/913)
<!-- Reviewable:end -->
