### PR TITLE
feat(client): client.submit over the PrivacyWallet seam

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,12 +1,48 @@
-import type { PrivacyClient, PrivacyClientConfig } from "./interfaces.js";
+import type { Call, EstimateFeeResponseOverhead } from "starknet";
+import { toStarknetCall } from "./calls.js";
+import type {
+  PrivacyClient,
+  PrivacyClientConfig,
+  Strk20Action,
+  SubmitOptions,
+  SubmitResult,
+} from "./interfaces.js";
 
 /**
- * The dapp client. Holds the config (wallet + read context: provider + sub-account anonymizer); the
- * operation builder and `addresses()` are added upstack and read through them and
- * `wallet.partialCommitment(dappName)`.
+ * The dapp client. Holds the injected wallet + read context (provider + sub-account anonymizer) and
+ * drives the wallet seam. A native get-starknet v6 wallet satisfies {@link PrivacyWallet} directly,
+ * so `submit` passes straight through to its strk20 methods; an `SdkWallet` (upstack) makes the same
+ * seam calls but proves + submits through the core SDK + paymaster. The operation builder is added
+ * upstack over this low-level entry point.
  */
 class PrivacyClientImpl implements PrivacyClient {
   constructor(private readonly config: PrivacyClientConfig) {}
+
+  submit(
+    actions: Strk20Action[],
+    options?: SubmitOptions & { simulate?: false }
+  ): Promise<SubmitResult>;
+  submit(
+    actions: Strk20Action[],
+    options: SubmitOptions & { simulate: true }
+  ): Promise<EstimateFeeResponseOverhead>;
+  async submit(
+    actions: Strk20Action[],
+    options: SubmitOptions & { simulate?: boolean } = {}
+  ): Promise<SubmitResult | EstimateFeeResponseOverhead> {
+    const { wallet } = this.config;
+    const { preCalls = [], postCalls = [], simulate = false } = options;
+
+    // Fast path: nothing wraps the invoke and we are broadcasting → the combined prepare+submit.
+    if (preCalls.length === 0 && postCalls.length === 0 && !simulate) {
+      return wallet.strk20InvokeTransaction(actions);
+    }
+
+    const { call, proof } = await wallet.strk20PrepareInvoke(actions, simulate);
+    const calls: Call[] = [...preCalls, toStarknetCall(call), ...postCalls];
+    // simulate: estimate the assembled invoke on the node (empty proof) for a fee quote/preview.
+    return simulate ? wallet.estimateInvokeFee(calls) : wallet.executeWithProof(calls, proof);
+  }
 }
 
 /**

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -9,4 +9,6 @@ export type {
   PrivacyWallet,
   STRK20_COMPUTE_AND_INVOKE_ACTION,
   Strk20Action,
+  SubmitOptions,
+  SubmitResult,
 } from "./interfaces.js";

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -1,8 +1,12 @@
 import type {
+  Call,
+  EstimateFeeResponseOverhead,
   ProviderInterface,
   STRK20_ACTION,
   STRK20_CALL_AND_PROOF,
   STRK20_CALLDATA_ITEM,
+  STRK20_PROOF,
+  UniversalDetails,
 } from "starknet";
 import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
 
@@ -42,6 +46,13 @@ export interface PrivacyWallet {
   strk20PrepareInvoke(actions: Strk20Action[], simulate?: boolean): Promise<STRK20_CALL_AND_PROOF>;
   /** Prove + broadcast the actions in one step, returning the tx hash. */
   strk20InvokeTransaction(actions: Strk20Action[]): Promise<{ transaction_hash: string }>;
+  /** Broadcast `calls` (the prepared strk20 call plus any surrounding calls) with `proof`. */
+  executeWithProof(calls: Call[], proof?: STRK20_PROOF): Promise<{ transaction_hash: string }>;
+  /** Estimate the fee for `calls` on the node — the wallet is the account, so no sender is passed. */
+  estimateInvokeFee(
+    calls: Call[],
+    details?: UniversalDetails
+  ): Promise<EstimateFeeResponseOverhead>;
 }
 
 /**
@@ -59,10 +70,42 @@ export interface PrivacyClientConfig {
   subAccountAnonymizerAddress: StarknetAddress;
 }
 
+/** The result of broadcasting a transaction: the Starknet transaction hash. */
+export interface SubmitResult {
+  transaction_hash: string;
+}
+
 /**
- * A dapp client for Starknet privacy — an opaque handle for now. The operation builder (`build()`)
- * and sub-account address resolution (`addresses()`) are added in later changesets; `partialCommitment`
- * is not public (the client calls `wallet.partialCommitment` internally when resolving addresses).
+ * Extra Starknet calls to run around the private invoke. `preCalls` run before it (e.g. a deposit's
+ * `approve`, which has no depositor privacy anyway); `postCalls` after. The builder supplies these.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface PrivacyClient {}
+export interface SubmitOptions {
+  preCalls?: Call[];
+  postCalls?: Call[];
+}
+
+/**
+ * A dapp client for Starknet privacy. It drives the injected {@link PrivacyWallet} — for a native
+ * get-starknet v6 wallet that is a direct pass-through; for an `SdkWallet` (upstack) it routes
+ * through the core SDK + paymaster. The ergonomic operation builder (`build()`) and sub-account
+ * reads (`addresses()`) are layered on top of this low-level entry point in later changesets.
+ */
+export interface PrivacyClient {
+  /**
+   * Prove and broadcast `actions` through the wallet, returning the transaction hash. With no
+   * surrounding calls this is the combined `strk20InvokeTransaction`; with `preCalls`/`postCalls`
+   * it prepares the proof and submits the assembled calls via `executeWithProof`.
+   */
+  submit(
+    actions: Strk20Action[],
+    options?: SubmitOptions & { simulate?: false }
+  ): Promise<SubmitResult>;
+  /**
+   * Prove `actions` in simulate mode (empty proof) and estimate the assembled invoke's fee on the
+   * node — no broadcast. Returns a standard Starknet fee estimate, for a quote or preview.
+   */
+  submit(
+    actions: Strk20Action[],
+    options: SubmitOptions & { simulate: true }
+  ): Promise<EstimateFeeResponseOverhead>;
+}

--- a/client/tests/client.test.ts
+++ b/client/tests/client.test.ts
@@ -1,30 +1,100 @@
 import { describe, it, expect } from "vitest";
-import type { ProviderInterface } from "starknet";
+import type {
+  Call,
+  EstimateFeeResponseOverhead,
+  ProviderInterface,
+  STRK20_CALL_AND_PROOF,
+  STRK20_PROOF,
+} from "starknet";
 import { createPrivacyClient } from "../src/index.js";
-import type { PrivacyWallet } from "../src/index.js";
+import type { PrivacyWallet, Strk20Action } from "../src/index.js";
 
 const provider = { tag: "provider" } as unknown as ProviderInterface;
 
-/** A minimal {@link PrivacyWallet} double. */
-function fakeWallet(): PrivacyWallet {
+/** Records every seam call so tests can assert which wallet path a submit took. */
+interface Seen {
+  invoke?: Strk20Action[];
+  prepare?: [Strk20Action[], boolean | undefined];
+  execute?: [Call[], STRK20_PROOF | undefined];
+  estimate?: Call[];
+}
+
+const preparedProof = { data: "0xproof", output: [], proof_facts: [] } as STRK20_PROOF;
+const feeEstimate = { overall_fee: 42n } as unknown as EstimateFeeResponseOverhead;
+
+/** A {@link PrivacyWallet} double whose prepared call is a fixed snake_case strk20 call. */
+function fakeWallet(seen: Seen = {}): PrivacyWallet {
   return {
     partialCommitment: async () => 0n,
-    strk20PrepareInvoke: async () => {
-      throw new Error("unused");
+    strk20PrepareInvoke: async (actions, simulate) => {
+      seen.prepare = [actions, simulate];
+      return {
+        call: { contract_address: "0xpool", entry_point: "apply", calldata: ["0x1"] },
+        proof: preparedProof,
+      } as STRK20_CALL_AND_PROOF;
     },
-    strk20InvokeTransaction: async () => {
-      throw new Error("unused");
+    strk20InvokeTransaction: async (actions) => {
+      seen.invoke = actions;
+      return { transaction_hash: "0xfast" };
+    },
+    executeWithProof: async (calls, proof) => {
+      seen.execute = [calls, proof];
+      return { transaction_hash: "0xwrapped" };
+    },
+    estimateInvokeFee: async (calls) => {
+      seen.estimate = calls;
+      return feeEstimate;
     },
   };
 }
 
+function client(seen: Seen = {}) {
+  return createPrivacyClient({
+    wallet: fakeWallet(seen),
+    provider,
+    subAccountAnonymizerAddress: 0x2n,
+  });
+}
+
+const actions = [{ type: "withdraw" }] as unknown as Strk20Action[];
+const mappedCall = { contractAddress: "0xpool", entrypoint: "apply", calldata: ["0x1"] };
+
 describe("createPrivacyClient", () => {
   it("builds a client from a wallet + read context", () => {
-    const client = createPrivacyClient({
-      wallet: fakeWallet(),
-      provider,
-      subAccountAnonymizerAddress: 0x2n,
-    });
-    expect(client).toBeDefined();
+    expect(client()).toBeDefined();
+  });
+});
+
+describe("submit", () => {
+  it("with no surrounding calls uses the combined strk20InvokeTransaction", async () => {
+    const seen: Seen = {};
+    const result = await client(seen).submit(actions);
+    expect(result).toEqual({ transaction_hash: "0xfast" });
+    expect(seen.invoke).toBe(actions);
+    expect(seen.prepare).toBeUndefined();
+    expect(seen.execute).toBeUndefined();
+  });
+
+  it("with preCalls/postCalls prepares then executeWithProof over the assembled, mapped calls", async () => {
+    const seen: Seen = {};
+    const pre = { contractAddress: "0xtoken", entrypoint: "approve", calldata: ["0x9"] };
+    const post = { contractAddress: "0xother", entrypoint: "ping" };
+    const result = await client(seen).submit(actions, { preCalls: [pre], postCalls: [post] });
+    expect(result).toEqual({ transaction_hash: "0xwrapped" });
+    expect(seen.prepare).toEqual([actions, false]);
+    const [calls, proof] = seen.execute!;
+    // pre, the mapped strk20 call (snake→camel), then post.
+    expect(calls).toEqual([pre, mappedCall, post]);
+    expect(proof).toBe(preparedProof);
+  });
+
+  it("with simulate:true prepares in simulate mode and estimates the assembled invoke's fee", async () => {
+    const seen: Seen = {};
+    const estimate = await client(seen).submit(actions, { simulate: true });
+    expect(estimate).toBe(feeEstimate);
+    expect(seen.prepare).toEqual([actions, true]);
+    expect(seen.estimate).toEqual([mappedCall]);
+    expect(seen.invoke).toBeUndefined();
+    expect(seen.execute).toBeUndefined();
   });
 });


### PR DESCRIPTION
The dapp client drives the injected PrivacyWallet. submit(actions, { preCalls?, postCalls?,
simulate? }): with no surrounding calls and not simulating it is the combined
strk20InvokeTransaction (fast path); otherwise strk20PrepareInvoke(actions, simulate) then — on
simulate, estimateInvokeFee over the assembled calls returning a Starknet fee estimate; else
executeWithProof(assembled calls, proof). A native get-starknet v6 wallet satisfies the seam
directly (pass-through); the ergonomic build() wraps this upstack. The seam gains executeWithProof +
estimateInvokeFee; exports SubmitResult + SubmitOptions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/914)
<!-- Reviewable:end -->
