### PR TITLE
feat(client): injectable Paymaster port + AvnuPaymaster adapter

### DIFF
--- a/client/docs/avnu-paymaster-local-devnet.md
+++ b/client/docs/avnu-paymaster-local-devnet.md
@@ -1,0 +1,84 @@
+# Testing `AvnuPaymaster` against a real (self-hosted) AVNU paymaster
+
+`AvnuPaymaster` (`client/src/paymaster.ts`) speaks the SNIP-29 paymaster JSON-RPC to AVNU. Our
+devnet e2e tests **mock** the paymaster (inject a fake `Paymaster` that broadcasts the proven
+`apply_actions` with an ordinary account), so they never exercise the real AVNU **wire format** — the
+part where bugs like decimal-vs-hex felts live. This note records how the wire format *can* be
+validated against AVNU's own software, for whoever picks up a live-paymaster e2e later. (No such test
+exists yet — this is parked reference, not a plan of record.)
+
+## Key finding: our request is native to AVNU's open-source paymaster
+
+AVNU's paymaster is open-source and self-hostable: <https://github.com/avnu-labs/paymaster>
+(docs: <https://docs.out-of-gas.xyz>). It **natively** supports the privacy-pool flow we use — the
+README lists *"Privacy pool integration with sponsored, gasless, and sponsored-private fee modes."*
+Confirmed from the source (`crates/paymaster-rpc`):
+
+- **Methods:** `paymaster_buildTransaction`, `paymaster_executeTransaction` (+ `paymaster_health`,
+  `paymaster_isAvailable`, `paymaster_getSupportedTokens`).
+- **Fee mode wire shape** (`#[serde(tag = "mode", rename_all = "snake_case")]`):
+  `{ "mode": "sponsored_private", "pool_fee_token": "0x…", "tip": "normal" }` — matches our
+  `PaymasterFeeMode`.
+- **Transaction types:** `apply_action` / `invoke_and_apply_action` are real wire names, e.g.
+  `{ "type": "apply_action", "apply_action": { "pool_address": "0x…" } }` — matches our `PaymasterBuild`.
+
+So a locally-run AVNU paymaster is an authoritative oracle for the exact request `AvnuPaymaster` sends.
+
+## Running it against a local devnet
+
+AVNU's own integration tests do exactly this (a devnet container + `ChainID::Sepolia`), so the pattern
+is proven upstream.
+
+1. **Deploy** (writes the profile; signs one multicall with a prefunded master account):
+   ```
+   paymaster-cli quick-setup --chain-id=sepolia --rpc-url=<devnet-rpc> \
+     --master-address=<funded devnet acct> --master-pk=<pk> --force --profile=paymaster.json
+   ```
+   This deploys a forwarder, gas tank, estimate account, and 2 relayers on devnet.
+2. **Run** the service on port **12777** (default):
+   ```
+   docker run --rm -d -p 12777:12777 -e PAYMASTER_PROFILE=/p.json -v $PWD/paymaster.json:/p.json avnulabs/paymaster:latest
+   # or: cargo run --release --bin paymaster-service --profile=paymaster.json
+   ```
+3. **Deploy the privacy pool yourself** (quick-setup does NOT), then merge a `privacy` block into the
+   profile with its address, and restart.
+4. Point the client at it: `new AvnuPaymaster({ url: "http://localhost:12777", apiKey, feeMode: { mode: "sponsored_private", poolFeeToken } })`.
+
+### Minimal profile shape (assembled from the Rust `Configuration` structs — no combined example ships)
+
+```json
+{
+  "rpc": { "port": 12777 },
+  "starknet": { "chain_id": "sepolia", "endpoint": "http://127.0.0.1:5050/rpc/v0_9" },
+  "privacy": { "pool": "0x<POOL>", "pool_fee_amount": "1000000000000000", "gas_overhead": 80000000 },
+  "relayers": { "private_key": "0x…", "addresses": ["0x…", "0x…"], "lock": { "mode": "seggregated" } },
+  "sponsoring": { "mode": "self", "api_key": "paymaster_<KEY>" }
+  /* + forwarder / gas_tank / estimate_account / price — all populated by quick-setup */
+}
+```
+
+## Gotchas (why this must be an opt-in / non-hermetic test)
+
+- **chain-id is a closed enum** (`sepolia`/`mainnet` only). Devnet's default chain-id (`TESTNET`)
+  resolves to the same `SN_SEPOLIA` felt, so use `chain_id: "sepolia"` and **don't** override devnet's
+  chain-id. There is no live cross-check, so a mismatch silently yields invalid signatures.
+- **API key required** for `sponsored_private` — self-sponsor keys must start with `paymaster_`. Set
+  `AvnuPaymaster.apiKey` accordingly.
+- **Price oracle needs network egress** (Coingecko / AVNU). There is no offline price provider
+  selectable via config, and `sponsored_private` converts the STRK pool fee into `pool_fee_token` at
+  build time — so this **cannot run in a hermetic/offline CI**. (Possibly avoidable by setting
+  `poolFeeToken = STRK` to skip the conversion — unverified.)
+- **Relayers start at 0 STRK**; a rebalancing pass funds them from the gas tank. `buildTransaction`
+  returns `ServiceNotAvailable` until a relayer clears `min_relayer_balance` — poll `paymaster_isAvailable`
+  (not `/health`, which only means the HTTP server is up) before firing test traffic.
+- **Privacy pool is out-of-band:** quick-setup deploys relayer infra but never a pool.
+- AVNU's own devnet-backed CI for this flow is currently **skipped upstream** — treat a live-paymaster
+  e2e as first-of-its-kind.
+
+## Sources
+
+- <https://github.com/avnu-labs/paymaster> (crates: `paymaster-rpc`, `paymaster-starknet`,
+  `paymaster-cli`; `docs/private-transactions.md`)
+- <https://docs.out-of-gas.xyz>
+- SNIP-29: <https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-29.md>
+- starknet-devnet: <https://github.com/0xSpaceShard/starknet-devnet>

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -3,6 +3,17 @@
 // Resolves sub-accounts, bridges Starknet/EVM wallet signing, and builds privacy operations
 // over @starkware-libs/starknet-privacy-sdk. More of the public API is added in later changesets.
 export { createPrivacyClient } from "./client.js";
+export { AvnuPaymaster, toPaymasterCall, normalizeSignature } from "./paymaster.js";
+export type {
+  AvnuPaymasterOptions,
+  Paymaster,
+  PaymasterBuild,
+  PaymasterCall,
+  PaymasterExecute,
+  PaymasterFeeAction,
+  PaymasterFeeMode,
+  PaymasterQuote,
+} from "./paymaster.js";
 export type {
   PrivacyClient,
   PrivacyClientConfig,

--- a/client/src/paymaster.ts
+++ b/client/src/paymaster.ts
@@ -1,0 +1,199 @@
+/**
+ * Paymaster port for privacy submissions, plus the default AVNU adapter.
+ *
+ * A submission through a paymaster is a two-call flow (SNIP-29-style JSON-RPC, mirrored from the
+ * reference in `demo/src/paymaster.ts`):
+ *   1. {@link Paymaster.buildTransaction} quotes the fee as a {@link PaymasterFeeAction} — a `withdraw`
+ *      (to the paymaster, for the fee token/amount) the caller adds to the action chain before proving.
+ *      For an `invokeAndApplyAction` (deposits needing `approve`) it also returns `typedData` to sign.
+ *   2. {@link Paymaster.executeTransaction} takes the proven `apply_actions` call + proof (+ the signed
+ *      invoke for the `invokeAndApplyAction` case) and broadcasts it, returning the tx hash.
+ *
+ * `Paymaster` is injected into `SdkWallet` (via its constructor config), so a dapp can swap providers
+ * or a fake in tests; {@link AvnuPaymaster} is the shipped default.
+ */
+
+import { hash, num, stark } from "starknet";
+import type { BigNumberish, Call, Signature, TypedData } from "starknet";
+
+/** Fee-payment mode. `sponsored_private` funds the fee from the pool via a fee-token withdrawal. */
+export type PaymasterFeeMode = {
+  mode: "sponsored_private";
+  poolFeeToken: string;
+  tip?: "low" | "normal" | "high";
+};
+
+/** The fee quote: a `withdraw` of `amount` `token` to the paymaster `recipient`, added to the chain. */
+export type PaymasterFeeAction = {
+  type: "withdraw";
+  recipient: string;
+  token: string;
+  amount: string;
+};
+
+/** A Starknet call in the paymaster's wire shape (selector + raw calldata). */
+export type PaymasterCall = {
+  to: string;
+  selector: string;
+  calldata: string[];
+};
+
+/** `buildTransaction` request: apply actions on the pool, optionally with an invoke that needs approvals. */
+export type PaymasterBuild =
+  | { kind: "applyAction"; poolAddress: string }
+  | {
+      kind: "invokeAndApplyAction";
+      poolAddress: string;
+      userAddress: string;
+      calls: PaymasterCall[];
+    };
+
+/** `buildTransaction` result: the fee quote, plus (invoke case) the typed data the user must sign. */
+export type PaymasterQuote = {
+  feeAction: PaymasterFeeAction;
+  typedData?: TypedData;
+};
+
+/** `executeTransaction` request: the proven apply-actions call + proof, plus the signed invoke if any. */
+export type PaymasterExecute =
+  | { kind: "applyAction"; applyActionsCall: PaymasterCall; proof: string; proofFacts: string[] }
+  | {
+      kind: "invokeAndApplyAction";
+      applyActionsCall: PaymasterCall;
+      proof: string;
+      proofFacts: string[];
+      userAddress: string;
+      typedData: TypedData;
+      signature: string[];
+    };
+
+/** The paymaster the client drives for non-strk20 submissions. */
+export interface Paymaster {
+  /** Quote the fee (and, for the invoke case, the typed data to sign) for the given transaction. */
+  buildTransaction(build: PaymasterBuild): Promise<PaymasterQuote>;
+  /** Broadcast the proven transaction through the paymaster; resolves to the tx hash. */
+  executeTransaction(execute: PaymasterExecute): Promise<{ transactionHash: string }>;
+}
+
+/** Convert a starknet.js {@link Call} into the paymaster wire shape. */
+export function toPaymasterCall(call: Call): PaymasterCall {
+  return {
+    to: call.contractAddress,
+    selector: hash.getSelectorFromName(call.entrypoint),
+    // Calldata may arrive as numbers/bigints; the wire needs 0x-hex FELTs (num.toHex, not String,
+    // which would emit decimal — the same class of bug as the signature felts).
+    calldata: ((call.calldata ?? []) as BigNumberish[]).map((item) => num.toHex(item)),
+  };
+}
+
+/**
+ * Normalize a starknet.js {@link Signature} to the 0x-hex `FELT[]` the SNIP-29/AVNU paymaster expects.
+ * `stark.signatureToHexArray` yields hex for both array and Weierstrass inputs; stringifying an array
+ * directly would emit decimal felts, which AVNU rejects.
+ */
+export function normalizeSignature(signature: Signature): string[] {
+  return stark.signatureToHexArray(signature);
+}
+
+export interface AvnuPaymasterOptions {
+  /** Paymaster JSON-RPC endpoint. */
+  url: string;
+  /** Fee mode (mode + pool fee token + tip) applied to every request. */
+  feeMode: PaymasterFeeMode;
+  /** Optional AVNU API key, sent as the `x-paymaster-api-key` header. */
+  apiKey?: string;
+  /** Injectable fetch (defaults to the global). */
+  fetch?: typeof fetch;
+}
+
+/** Wire representation of {@link PaymasterFeeMode} (snake_case, per the RPC). */
+type WireFeeMode = { mode: string; pool_fee_token: string; tip?: string };
+
+/** The default {@link Paymaster}: a thin JSON-RPC client for the AVNU privacy paymaster. */
+export class AvnuPaymaster implements Paymaster {
+  private readonly parameters: { version: "0x1"; fee_mode: WireFeeMode };
+  private readonly fetchFn: typeof fetch;
+
+  constructor(private readonly options: AvnuPaymasterOptions) {
+    this.parameters = {
+      version: "0x1",
+      fee_mode: {
+        mode: options.feeMode.mode,
+        pool_fee_token: options.feeMode.poolFeeToken,
+        ...(options.feeMode.tip !== undefined ? { tip: options.feeMode.tip } : {}),
+      },
+    };
+    this.fetchFn = options.fetch ?? fetch;
+  }
+
+  async buildTransaction(build: PaymasterBuild): Promise<PaymasterQuote> {
+    const transaction =
+      build.kind === "applyAction"
+        ? { type: "apply_action", apply_action: { pool_address: build.poolAddress } }
+        : {
+            type: "invoke_and_apply_action",
+            apply_action: { pool_address: build.poolAddress },
+            invoke: { user_address: build.userAddress, calls: build.calls },
+          };
+    const result = await this.rpc<{ fee_action: PaymasterFeeAction; typed_data?: TypedData }>(
+      "paymaster_buildTransaction",
+      { transaction, parameters: this.parameters }
+    );
+    return { feeAction: result.fee_action, typedData: result.typed_data };
+  }
+
+  async executeTransaction(execute: PaymasterExecute): Promise<{ transactionHash: string }> {
+    const applyAction = {
+      apply_actions_call: execute.applyActionsCall,
+      proof: execute.proof,
+      proof_facts: execute.proofFacts,
+    };
+    const transaction =
+      execute.kind === "applyAction"
+        ? { type: "apply_action", apply_action: applyAction }
+        : {
+            type: "invoke_and_apply_action",
+            apply_action: applyAction,
+            invoke: {
+              user_address: execute.userAddress,
+              typed_data: execute.typedData,
+              signature: execute.signature,
+            },
+          };
+    const result = await this.rpc<{ transaction_hash: string }>("paymaster_executeTransaction", {
+      transaction,
+      parameters: this.parameters,
+    });
+    return { transactionHash: result.transaction_hash };
+  }
+
+  private async rpc<T>(method: string, params: unknown): Promise<T> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.options.apiKey) headers["x-paymaster-api-key"] = this.options.apiKey;
+    const response = await this.fetchFn(this.options.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const json = (await response.json()) as {
+      result?: T;
+      error?: { message: string; code: number; data?: unknown };
+    };
+    if (json.error) {
+      const { data } = json.error;
+      let detail = "";
+      if (typeof data === "string") detail = `: ${data}`;
+      else if (data && typeof data === "object") {
+        const execError = (data as { execution_error?: string }).execution_error;
+        detail = `: ${execError ?? JSON.stringify(data)}`;
+      }
+      throw new Error(
+        `Paymaster ${method}: ${json.error.message} (code: ${json.error.code})${detail}`
+      );
+    }
+    if (json.result === undefined) {
+      throw new Error(`Paymaster ${method}: malformed response (neither 'result' nor 'error')`);
+    }
+    return json.result;
+  }
+}

--- a/client/tests/paymaster.test.ts
+++ b/client/tests/paymaster.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { hash } from "starknet";
+import type { Call, TypedData } from "starknet";
+import {
+  AvnuPaymaster,
+  toPaymasterCall,
+  normalizeSignature,
+  type PaymasterFeeMode,
+} from "../src/paymaster.js";
+
+const FEE_MODE: PaymasterFeeMode = {
+  mode: "sponsored_private",
+  poolFeeToken: "0xfee",
+  tip: "normal",
+};
+const POOL = "0xpool";
+
+/** Records each JSON-RPC request and replies with `result` (or an `error` when configured). */
+function mockFetch(
+  result: unknown,
+  opts?: { error?: { message: string; code: number; data?: unknown } }
+) {
+  const calls: Array<{ method: string; params: unknown; headers: Record<string, string> }> = [];
+  const fetchFn = (async (
+    _url: string,
+    init: { headers: Record<string, string>; body: string }
+  ) => {
+    const body = JSON.parse(init.body);
+    calls.push({ method: body.method, params: body.params, headers: init.headers });
+    return {
+      json: async () => (opts?.error ? { error: opts.error } : { result }),
+    };
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+describe("toPaymasterCall / normalizeSignature", () => {
+  it("maps a Call to selector + calldata wire shape", () => {
+    const call: Call = { contractAddress: "0x1", entrypoint: "approve", calldata: ["0x2", "0x3"] };
+    expect(toPaymasterCall(call)).toEqual({
+      to: "0x1",
+      selector: hash.getSelectorFromName("approve"),
+      calldata: ["0x2", "0x3"],
+    });
+  });
+
+  it("normalizes an array signature to hex felts matching the SNIP-29 FELT pattern", () => {
+    const felts = normalizeSignature([1n, 2n] as unknown as string[]);
+    expect(felts).toEqual(["0x1", "0x2"]);
+    // Conformance to the FELT pattern SNIP-29/AVNU enforces (from @starknet-io/starknet-types):
+    const SNIP29_FELT = /^0x(0|[a-fA-F1-9][a-fA-F0-9]{0,62})$/;
+    for (const felt of felts) expect(felt).toMatch(SNIP29_FELT);
+  });
+});
+
+describe("AvnuPaymaster", () => {
+  it("buildTransaction (applyAction) sends the pool + fee mode and returns the fee quote", async () => {
+    const feeAction = { type: "withdraw", recipient: "0xpm", token: "0xfee", amount: "0x2a" };
+    const { fetchFn, calls } = mockFetch({ fee_action: feeAction });
+    const pm = new AvnuPaymaster({
+      url: "http://pm",
+      feeMode: FEE_MODE,
+      apiKey: "k",
+      fetch: fetchFn,
+    });
+
+    const quote = await pm.buildTransaction({ kind: "applyAction", poolAddress: POOL });
+
+    expect(quote.feeAction).toEqual(feeAction);
+    expect(quote.typedData).toBeUndefined();
+    expect(calls[0].method).toBe("paymaster_buildTransaction");
+    expect(calls[0].headers["x-paymaster-api-key"]).toBe("k");
+    expect(calls[0].params).toEqual({
+      transaction: { type: "apply_action", apply_action: { pool_address: POOL } },
+      parameters: {
+        version: "0x1",
+        fee_mode: { mode: "sponsored_private", pool_fee_token: "0xfee", tip: "normal" },
+      },
+    });
+  });
+
+  it("buildTransaction (invokeAndApplyAction) forwards the invoke calls and returns typed data", async () => {
+    const feeAction = { type: "withdraw", recipient: "0xpm", token: "0xfee", amount: "0x1" };
+    const typed_data = { domain: {}, types: {}, primaryType: "X", message: {} };
+    const { fetchFn, calls } = mockFetch({ fee_action: feeAction, typed_data });
+    const pm = new AvnuPaymaster({ url: "http://pm", feeMode: FEE_MODE, fetch: fetchFn });
+    const approve = toPaymasterCall({
+      contractAddress: "0xtok",
+      entrypoint: "approve",
+      calldata: ["0x1"],
+    });
+
+    const quote = await pm.buildTransaction({
+      kind: "invokeAndApplyAction",
+      poolAddress: POOL,
+      userAddress: "0xuser",
+      calls: [approve],
+    });
+
+    expect(quote.typedData).toEqual(typed_data);
+    expect((calls[0].params as { transaction: { invoke: unknown } }).transaction.invoke).toEqual({
+      user_address: "0xuser",
+      calls: [approve],
+    });
+    expect(calls[0].headers["x-paymaster-api-key"]).toBeUndefined();
+  });
+
+  it("executeTransaction (applyAction) sends the proven call + proof and returns the tx hash", async () => {
+    const { fetchFn, calls } = mockFetch({ transaction_hash: "0xdead" });
+    const pm = new AvnuPaymaster({ url: "http://pm", feeMode: FEE_MODE, fetch: fetchFn });
+    const applyActionsCall = { to: "0xpool", selector: "0xsel", calldata: ["0x0"] };
+
+    const res = await pm.executeTransaction({
+      kind: "applyAction",
+      applyActionsCall,
+      proof: "cafe",
+      proofFacts: ["0x1", "0x2"],
+    });
+
+    expect(res.transactionHash).toBe("0xdead");
+    expect(calls[0].method).toBe("paymaster_executeTransaction");
+    expect(
+      (calls[0].params as { transaction: { apply_action: unknown } }).transaction.apply_action
+    ).toEqual({
+      apply_actions_call: applyActionsCall,
+      proof: "cafe",
+      proof_facts: ["0x1", "0x2"],
+    });
+  });
+
+  it("executeTransaction (invokeAndApplyAction) forwards the signed invoke as hex-felt signature", async () => {
+    const { fetchFn, calls } = mockFetch({ transaction_hash: "0xbeef" });
+    const pm = new AvnuPaymaster({ url: "http://pm", feeMode: FEE_MODE, fetch: fetchFn });
+    const applyActionsCall = { to: "0xpool", selector: "0xsel", calldata: ["0x0"] };
+    const typedData = {
+      primaryType: "T",
+      domain: {},
+      types: {},
+      message: {},
+    } as unknown as TypedData;
+    const signature = normalizeSignature([1n, 2n] as unknown as string[]);
+
+    const res = await pm.executeTransaction({
+      kind: "invokeAndApplyAction",
+      applyActionsCall,
+      proof: "cafe",
+      proofFacts: ["0x1"],
+      userAddress: "0xuser",
+      typedData,
+      signature,
+    });
+
+    expect(res.transactionHash).toBe("0xbeef");
+    const { transaction } = calls[0].params as {
+      transaction: {
+        type: string;
+        invoke: { user_address: string; typed_data: unknown; signature: string[] };
+      };
+    };
+    expect(transaction.type).toBe("invoke_and_apply_action");
+    expect(transaction.invoke.user_address).toBe("0xuser");
+    expect(transaction.invoke.typed_data).toEqual(typedData);
+    expect(transaction.invoke.signature).toEqual(["0x1", "0x2"]);
+    // The signature must reach the wire as SNIP-29 hex felts (from @starknet-io/starknet-types):
+    const SNIP29_FELT = /^0x(0|[a-fA-F1-9][a-fA-F0-9]{0,62})$/;
+    for (const felt of transaction.invoke.signature) expect(felt).toMatch(SNIP29_FELT);
+  });
+
+  it("surfaces a paymaster JSON-RPC error with its execution_error detail", async () => {
+    const { fetchFn } = mockFetch(null, {
+      error: { message: "bad", code: -32000, data: { execution_error: "reverted: no funds" } },
+    });
+    const pm = new AvnuPaymaster({ url: "http://pm", feeMode: FEE_MODE, fetch: fetchFn });
+
+    await expect(pm.buildTransaction({ kind: "applyAction", poolAddress: POOL })).rejects.toThrow(
+      /paymaster_buildTransaction: bad \(code: -32000\): reverted: no funds/
+    );
+  });
+});


### PR DESCRIPTION
The Paymaster port (buildTransaction quote -> executeTransaction) the SDK-backed submit path drives
for non-strk20 wallets, and the default AvnuPaymaster JSON-RPC adapter (apply_action /
invoke_and_apply_action; injectable fetch; typed errors) + toPaymasterCall/normalizeSignature. 6
unit tests over a mock fetch. Consumed by SdkWallet in the next branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/915)
<!-- Reviewable:end -->
