### PR TITLE
feat(client): Strk20Prover seam + core prover + passphrase viewing key

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -9,7 +9,7 @@ import type {
 } from "./interfaces.js";
 
 /**
- * The dapp client. Holds the injected wallet + read context (provider + sub-account anonymizer) and
+ * The dapp client. Holds the injected wallet + read context (node + sub-account anonymizer) and
  * drives the wallet seam. A native get-starknet v6 wallet satisfies {@link PrivacyWallet} directly,
  * so `submit` passes straight through to its strk20 methods; an `SdkWallet` (upstack) makes the same
  * seam calls but proves + submits through the core SDK + paymaster. The operation builder is added

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -3,6 +3,9 @@
 // Resolves sub-accounts, bridges Starknet/EVM wallet signing, and builds privacy operations
 // over @starkware-libs/starknet-privacy-sdk. More of the public API is added in later changesets.
 export { createPrivacyClient } from "./client.js";
+export { CorePrivateTransfersProver } from "./strk20-prover.js";
+export type { CorePrivateTransfersProverConfig } from "./strk20-prover.js";
+export { deriveViewingKey, passphraseViewingKeyProvider } from "./viewing-key.js";
 export { AvnuPaymaster, toPaymasterCall, normalizeSignature } from "./paymaster.js";
 export type {
   AvnuPaymasterOptions,
@@ -17,9 +20,11 @@ export type {
 export type {
   PrivacyClient,
   PrivacyClientConfig,
+  PrivacyStorage,
   PrivacyWallet,
   STRK20_COMPUTE_AND_INVOKE_ACTION,
   Strk20Action,
+  Strk20Prover,
   SubmitOptions,
   SubmitResult,
 } from "./interfaces.js";

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -8,7 +8,7 @@ import type {
   STRK20_PROOF,
   UniversalDetails,
 } from "starknet";
-import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
+import type { PrivateRegistry, StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
 
 /**
  * LOCAL SHIM — remove when `@starknet-io/starknet-types` ships it. The compute-and-invoke sibling of
@@ -31,6 +31,30 @@ export interface STRK20_COMPUTE_AND_INVOKE_ACTION {
  * submits substitutes them (the native wallet at assembly; the SDK adapter before proving).
  */
 export type Strk20Action = STRK20_ACTION | STRK20_COMPUTE_AND_INVOKE_ACTION;
+
+/**
+ * Proves {@link Strk20Action}s into a submittable `{ call, proof }` and resolves the user's partial
+ * commitment. This is strk20-specific (not a general prover). Crucially, the viewing key needed to
+ * prove and to derive the partial commitment is the prover's own concern — it is retrieved inside the
+ * implementation, never passed in by the dapp. That keeps a future on-device prover free to fetch the
+ * key locally (more secure, and shareable across dapps).
+ */
+export interface Strk20Prover {
+  /** The nonce-independent commitment `hash(identity_key, dappName)` (derived from the viewing key). */
+  partialCommitment(dappName: string): Promise<bigint>;
+  /** Prove `actions` into `{ call, proof }`; `simulate` yields an empty proof. Does not broadcast. */
+  prove(actions: Strk20Action[], simulate?: boolean): Promise<STRK20_CALL_AND_PROOF>;
+}
+
+/**
+ * Persists the core note registry between transactions so proofs see previously-created notes. A
+ * fresh user with nothing stored returns an empty registry; the SDK path saves the updated registry
+ * after a proven (non-simulated) transaction.
+ */
+export interface PrivacyStorage {
+  loadRegistry(): Promise<PrivateRegistry>;
+  saveRegistry(registry: PrivateRegistry): Promise<void>;
+}
 
 /**
  * The wallet seam — the privacy subset of starknet.js `WalletAccountV6`. A get-starknet v6 wallet
@@ -57,15 +81,15 @@ export interface PrivacyWallet {
 
 /**
  * Dependencies for {@link createPrivacyClient}. The dapp constructs the {@link PrivacyWallet} it wants
- * (a get-starknet v6 wallet directly, or — upstack — an `SdkWallet` over a signer). `provider` +
+ * (a get-starknet v6 wallet directly, or — upstack — an `SdkWallet` over a signer). `node` +
  * `subAccountAnonymizerAddress` are the client's read context: it queries the anonymizer view (through
- * the provider) with `wallet.partialCommitment(dappName)` to resolve sub-account addresses.
+ * the node) with `wallet.partialCommitment(dappName)` to resolve sub-account addresses.
  */
 export interface PrivacyClientConfig {
   /** The wallet — signs, proves, and submits privacy operations. */
   wallet: PrivacyWallet;
-  /** Provider for the sub-account anonymizer view call. */
-  provider: ProviderInterface;
+  /** Node the sub-account anonymizer view call is read from. */
+  node: ProviderInterface;
   /** The sub-account anonymizer contract the client queries for sub-account addresses. */
   subAccountAnonymizerAddress: StarknetAddress;
 }

--- a/client/src/json.ts
+++ b/client/src/json.ts
@@ -1,0 +1,18 @@
+/**
+ * Stringify any value for a diagnostic message, without the serializer itself becoming the failure.
+ * `JSON.stringify` throws on a `bigint`, and values reaching an error path here come from dapp
+ * callers or an RPC peer — a strk20 action's `amount` is typed as a hex string but nothing stops a
+ * caller passing `5n` — so bigints are cast to their decimal form. Anything JSON still cannot
+ * represent (a cycle, a `toJSON` that throws) falls back to `String(value)`, so the caller's error
+ * survives instead of being replaced by a `TypeError`.
+ */
+export function safeStringify(value: unknown): string {
+  try {
+    return (
+      JSON.stringify(value, (_key, item) => (typeof item === "bigint" ? item.toString() : item)) ??
+      String(value)
+    );
+  } catch {
+    return String(value);
+  }
+}

--- a/client/src/paymaster.ts
+++ b/client/src/paymaster.ts
@@ -15,6 +15,7 @@
 
 import { hash, num, stark } from "starknet";
 import type { BigNumberish, Call, Signature, TypedData } from "starknet";
+import { safeStringify } from "./json.js";
 
 /** Fee-payment mode. `sponsored_private` funds the fee from the pool via a fee-token withdrawal. */
 export type PaymasterFeeMode = {
@@ -185,7 +186,7 @@ export class AvnuPaymaster implements Paymaster {
       if (typeof data === "string") detail = `: ${data}`;
       else if (data && typeof data === "object") {
         const execError = (data as { execution_error?: string }).execution_error;
-        detail = `: ${execError ?? JSON.stringify(data)}`;
+        detail = `: ${execError ?? safeStringify(data)}`;
       }
       throw new Error(
         `Paymaster ${method}: ${json.error.message} (code: ${json.error.code})${detail}`

--- a/client/src/strk20-prover.ts
+++ b/client/src/strk20-prover.ts
@@ -1,0 +1,165 @@
+import { num } from "starknet";
+import type { SignerInterface, STRK20_CALL_AND_PROOF, STRK20_CALLDATA_ITEM } from "starknet";
+import { createPrivateTransfers, Open } from "@starkware-libs/starknet-privacy-sdk";
+import type {
+  CallAndProof,
+  DiscoveryProviderInterface,
+  InvokeCalldataBuilderArgs,
+  PrivateTransfersBuilder,
+  PrivateTransfersInterface,
+  ProofProviderInterface,
+  StarknetAddress,
+} from "@starkware-libs/starknet-privacy-sdk";
+import { toStrk20Call } from "./calls.js";
+import { safeStringify } from "./json.js";
+import { passphraseViewingKeyProvider } from "./viewing-key.js";
+import type { PrivacyStorage, Strk20Action, Strk20Prover } from "./interfaces.js";
+
+/**
+ * The node `simulate` needs, taken from the builder's own signature so it matches the core SDK's
+ * `starknet` version (which can differ from the client's, making a bare `ProviderInterface` import
+ * incompatible).
+ */
+type NodeProvider = Parameters<PrivateTransfersBuilder["simulate"]>[0]["node"];
+
+/**
+ * Dependencies for a {@link CorePrivateTransfersProver}. The `passphrase` is the viewing-key source
+ * the prover owns — it is derived (salted + iterated) into the viewing key internally, never surfaced
+ * to the caller. The rest is what the core `PrivateTransfers` needs; `node` is what simulate reads
+ * through for fee estimation, and `storage` persists the note registry across transactions.
+ */
+export interface CorePrivateTransfersProverConfig {
+  signer: SignerInterface;
+  address: StarknetAddress;
+  passphrase: string;
+  node: NodeProvider;
+  discovery: DiscoveryProviderInterface;
+  prover: ProofProviderInterface;
+  poolContractAddress: StarknetAddress;
+  subAccountAnonymizerAddress: StarknetAddress;
+  storage: PrivacyStorage;
+}
+
+/**
+ * The default {@link Strk20Prover}: it proves through a core `PrivateTransfers`, translating each
+ * {@link Strk20Action} into the core builder's operations. The viewing key is derived from the
+ * passphrase inside this class, so no caller ever handles it. Before proving, the stored note
+ * registry is loaded (so spends see prior notes); after a real (non-simulate) proof it is saved back.
+ */
+export class CorePrivateTransfersProver implements Strk20Prover {
+  private readonly transfers: PrivateTransfersInterface;
+  private readonly node: NodeProvider;
+  private readonly storage: PrivacyStorage;
+
+  constructor(config: CorePrivateTransfersProverConfig) {
+    this.node = config.node;
+    this.storage = config.storage;
+    this.transfers = createPrivateTransfers({
+      account: { address: config.address, signer: config.signer },
+      viewingKeyProvider: passphraseViewingKeyProvider(config.passphrase, config.address),
+      provingProvider: config.prover,
+      discoveryProvider: config.discovery,
+      poolContractAddress: config.poolContractAddress,
+      subAccountAnonymizerAddress: config.subAccountAnonymizerAddress,
+    });
+  }
+
+  partialCommitment(dappName: string): Promise<bigint> {
+    return this.transfers.build().subaccounts(dappName).partialCommitment();
+  }
+
+  async prove(actions: Strk20Action[], simulate = false): Promise<STRK20_CALL_AND_PROOF> {
+    const registry = await this.storage.loadRegistry();
+    // register / channel setup / note selection are automatic for the SDK path; explicit builder
+    // operations could be added later for finer information-hiding (e.g. which notes are spent).
+    const builder = this.transfers.build({
+      autoRegister: true,
+      autoSetup: true,
+      autoSelectNotes: "naive",
+      autoDiscover: { channels: "refresh", notes: "refresh" },
+      registry,
+    });
+    translate(builder, actions);
+    if (simulate) {
+      const simulated = await builder.simulate({ node: this.node });
+      return toStrk20CallAndProof(simulated.callAndProof);
+    }
+    const result = await builder.execute();
+    await this.storage.saveRegistry(result.registry);
+    return toStrk20CallAndProof(result.callAndProof);
+  }
+}
+
+/** Replay the strk20 actions onto a core builder as its native operations. */
+function translate(builder: PrivateTransfersBuilder, actions: Strk20Action[]): void {
+  for (const action of actions) {
+    switch (action.type) {
+      case "deposit":
+        // strk20 deposit is always to self, so no recipient.
+        builder.with(action.token).deposit({ amount: num.toBigInt(action.amount) });
+        break;
+      case "withdraw":
+        builder
+          .with(action.token)
+          .withdraw({ recipient: action.recipient, amount: num.toBigInt(action.amount) });
+        break;
+      case "transfer":
+        builder.with(action.token).transfer({
+          recipient: action.recipient,
+          amount: action.amount === "OPEN" ? Open : num.toBigInt(action.amount),
+        });
+        break;
+      case "invoke":
+        builder.invoke((args) => ({
+          contractAddress: action.contract,
+          calldata: action.calldata.map((item) => substitute(item, args)),
+        }));
+        break;
+      case "compute_and_invoke":
+        builder.computeAndInvoke((args) => ({
+          contractAddress: action.contract,
+          computeAdditionalData: action.compute_calldata.map((item) => substitute(item, args)),
+          invokeAdditionalData: action.invoke_calldata.map((item) => substitute(item, args)),
+        }));
+        break;
+      default:
+        throw new Error(`unsupported strk20 action: ${safeStringify(action satisfies never)}`);
+    }
+  }
+}
+
+const OPEN_NOTE_PLACEHOLDER = /^\$\{openNoteIds\[(\d+)\]\}$/;
+
+/**
+ * Resolve a strk20 calldata item to a concrete felt. Placeholders reference values only known once
+ * the transaction is compiled: `${openNoteIds[N]}` is the id of the Nth open note created in this
+ * transaction, `${poolAddress}` is the privacy pool address. Any other item is a literal felt.
+ */
+function substitute(item: STRK20_CALLDATA_ITEM, args: InvokeCalldataBuilderArgs): string {
+  const openNote = OPEN_NOTE_PLACEHOLDER.exec(item);
+  if (openNote) {
+    // The index comes from dapp calldata, so it can point past the notes this transaction creates.
+    const index = Number(openNote[1]);
+    const note = args.openNotes[index];
+    if (!note) {
+      throw new Error(
+        `${item} is out of range: this transaction creates ${args.openNotes.length} open note(s)`
+      );
+    }
+    return num.toHex(note.noteId);
+  }
+  if (item === "${poolAddress}") return num.toHex(args.poolAddress);
+  return num.toHex(num.toBigInt(item));
+}
+
+/** Map a core `CallAndProof` to the strk20 RPC shape (snake_case call fields, `proof_facts`). */
+function toStrk20CallAndProof(result: CallAndProof): STRK20_CALL_AND_PROOF {
+  return {
+    call: toStrk20Call(result.call),
+    proof: {
+      data: result.proof.data,
+      output: result.proof.output,
+      proof_facts: result.proof.proofFacts,
+    },
+  };
+}

--- a/client/src/viewing-key.ts
+++ b/client/src/viewing-key.ts
@@ -1,0 +1,84 @@
+import { ec, num } from "starknet";
+import type { BigNumberish } from "starknet";
+import type { ViewingKey, ViewingKeyProvider } from "@starkware-libs/starknet-privacy-sdk";
+
+const poseidonHashMany = ec.starkCurve.poseidonHashMany;
+
+/**
+ * Stark curve order and its half. A canonical viewing key is a non-zero scalar below the half-order
+ * (`privacy::utils::is_canonical_key`) — the only form the privacy pool accepts as a user key.
+ */
+const CURVE_ORDER = ec.starkCurve.CURVE.n;
+const HALF_ORDER = CURVE_ORDER >> 1n;
+
+/**
+ * Poseidon rounds folded into the derivation. The per-account salt (below) is what defeats shared
+ * rainbow tables; the rounds add a linear brute-force cost on top. Poseidon in JS is ~100× slower
+ * per op than SHA-256, so this modest count is wall-clock-comparable to a large SHA-256 KDF (~300ms
+ * one-time) without making key derivation painful.
+ */
+const KDF_ROUNDS = 1000;
+
+/** Bytes packed per felt: a felt holds 251 bits, so 31 bytes (248 bits) always fits. */
+const BYTES_PER_FELT = 31;
+
+/**
+ * Pack a UTF-8 passphrase into big-endian felt limbs, prefixed by its byte length. The length is what
+ * makes the encoding injective: big-endian packing drops leading zero bytes within a limb, so without
+ * it `"\0a"` and `"a"` would pack to the same limb and derive the same key. The prefix also means an
+ * empty passphrase still hashes something.
+ */
+function passphraseToFelts(passphrase: string): bigint[] {
+  const bytes = new TextEncoder().encode(passphrase);
+  const felts: bigint[] = [BigInt(bytes.length)];
+  for (let offset = 0; offset < bytes.length; offset += BYTES_PER_FELT) {
+    let limb = 0n;
+    for (const byte of bytes.subarray(offset, offset + BYTES_PER_FELT)) {
+      limb = (limb << 8n) | BigInt(byte);
+    }
+    felts.push(limb);
+  }
+  return felts;
+}
+
+/**
+ * Derives a viewing key from a user passphrase. The passphrase is salted with the account `address`
+ * — so the same passphrase yields a different key per account, defeating shared rainbow tables — and
+ * folded through {@link KDF_ROUNDS} Poseidon rounds (each re-mixing the salt) to make brute-forcing
+ * costly. The result is a canonical viewing key (a non-zero scalar below the Stark curve half-order),
+ * which the privacy pool accepts directly.
+ */
+export function deriveViewingKey(passphrase: string, address: BigNumberish): bigint {
+  const salt = num.toBigInt(address);
+  let key = poseidonHashMany([...passphraseToFelts(passphrase), salt]);
+  for (let round = 1; round < KDF_ROUNDS; round++) {
+    key = poseidonHashMany([key, salt]);
+  }
+  return canonicalViewingKey(key);
+}
+
+/**
+ * Folds a KDF output into a canonical viewing key. The pool rejects a non-canonical user key
+ * (`privacy::utils::is_canonical_key`: `key < HALF_ORDER`), so reduce into the scalar field and
+ * mirror the upper half below the half-order. Zero and the ~2^-250 fixed points fall back to 1, so
+ * every passphrase yields a usable, non-zero key.
+ */
+function canonicalViewingKey(key: bigint): bigint {
+  let scalar = key % CURVE_ORDER;
+  if (scalar >= HALF_ORDER) scalar = CURVE_ORDER - scalar;
+  return scalar === 0n || scalar >= HALF_ORDER ? 1n : scalar;
+}
+
+/**
+ * A {@link ViewingKeyProvider} backed by {@link deriveViewingKey}. Derivation is lazy and memoized —
+ * the (relatively costly) KDF runs on first use, not at construction, and the result is cached in
+ * memory. This is the default viewing-key source for the SDK-backed prover: recoverable from the
+ * passphrase, never written to disposable storage.
+ */
+export function passphraseViewingKeyProvider(
+  passphrase: string,
+  address: BigNumberish
+): ViewingKeyProvider {
+  let cached: ViewingKey | undefined;
+  return { getViewingKey: async () => (cached ??= deriveViewingKey(passphrase, address)) };
+}

--- a/client/tests/client.test.ts
+++ b/client/tests/client.test.ts
@@ -9,7 +9,7 @@ import type {
 import { createPrivacyClient } from "../src/index.js";
 import type { PrivacyWallet, Strk20Action } from "../src/index.js";
 
-const provider = { tag: "provider" } as unknown as ProviderInterface;
+const node = { tag: "node" } as unknown as ProviderInterface;
 
 /** Records every seam call so tests can assert which wallet path a submit took. */
 interface Seen {
@@ -51,7 +51,7 @@ function fakeWallet(seen: Seen = {}): PrivacyWallet {
 function client(seen: Seen = {}) {
   return createPrivacyClient({
     wallet: fakeWallet(seen),
-    provider,
+    node,
     subAccountAnonymizerAddress: 0x2n,
   });
 }

--- a/client/tests/strk20-prover.test.ts
+++ b/client/tests/strk20-prover.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture the operations the prover replays onto the core builder by faking createPrivateTransfers.
+const h = vi.hoisted(() => {
+  const coreCallAndProof = {
+    call: { contractAddress: "0xpool", entrypoint: "apply", calldata: ["0x1"] },
+    proof: { data: "0xdata", output: ["0x2"], proofFacts: ["0x3"] },
+  };
+  const state: {
+    ops: Array<Record<string, unknown>>;
+    buildOptions?: Record<string, unknown>;
+    saved?: unknown;
+    simulateArg?: unknown;
+  } = { ops: [] };
+
+  const tokenOps = (token: unknown) => ({
+    deposit(input: unknown) {
+      state.ops.push({ op: "deposit", token, input });
+      return this;
+    },
+    withdraw(output: unknown) {
+      state.ops.push({ op: "withdraw", token, output });
+      return this;
+    },
+    transfer(output: unknown) {
+      state.ops.push({ op: "transfer", token, output });
+      return this;
+    },
+  });
+  const builder = {
+    with: (token: unknown) => tokenOps(token),
+    invoke(callBuilder: unknown) {
+      state.ops.push({ op: "invoke", callBuilder });
+      return builder;
+    },
+    computeAndInvoke(callBuilder: unknown) {
+      state.ops.push({ op: "computeAndInvoke", callBuilder });
+      return builder;
+    },
+    execute: async () => ({ callAndProof: coreCallAndProof, registry: { tag: "saved-registry" } }),
+    simulate: async (arg: unknown) => {
+      state.simulateArg = arg;
+      return { callAndProof: coreCallAndProof, registry: {} };
+    },
+    // subaccounts now hangs off the builder (core #905: transfers.build().subaccounts(...)).
+    subaccounts: (dappName: string) => ({
+      partialCommitment: async () => (dappName === "my-dapp" ? 0xc0ffeen : 0n),
+    }),
+  };
+  const transfers = {
+    build(options: Record<string, unknown>) {
+      state.buildOptions = options;
+      return builder;
+    },
+  };
+  return { state, coreCallAndProof, createPrivateTransfers: () => transfers };
+});
+
+vi.mock("@starkware-libs/starknet-privacy-sdk", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@starkware-libs/starknet-privacy-sdk")>()),
+  createPrivateTransfers: h.createPrivateTransfers,
+}));
+
+const { Open } = await import("@starkware-libs/starknet-privacy-sdk");
+const { CorePrivateTransfersProver } = await import("../src/index.js");
+import type { Strk20Action } from "../src/index.js";
+
+const loadedRegistry = { tag: "loaded-registry" };
+let saved: unknown;
+
+function makeProver() {
+  saved = undefined;
+  return new CorePrivateTransfersProver({
+    signer: {} as never,
+    address: "0xacc",
+    passphrase: "correct horse",
+    node: {} as never,
+    discovery: {} as never,
+    prover: {} as never,
+    poolContractAddress: "0xpool",
+    subAccountAnonymizerAddress: "0xanon",
+    storage: {
+      loadRegistry: async () => loadedRegistry as never,
+      saveRegistry: async (registry) => {
+        saved = registry;
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  h.state.ops = [];
+  h.state.buildOptions = undefined;
+  h.state.simulateArg = undefined;
+});
+
+describe("CorePrivateTransfersProver", () => {
+  it("partialCommitment delegates to the core subaccounts builder for the dapp", async () => {
+    expect(await makeProver().partialCommitment("my-dapp")).toBe(0xc0ffeen);
+  });
+
+  it("translates each strk20 action onto the core builder and maps the proof to strk20 shape", async () => {
+    const actions: Strk20Action[] = [
+      { type: "deposit", token: "0xt", amount: "0x64" },
+      { type: "withdraw", token: "0xt", amount: "0xa", recipient: "0xr" },
+      { type: "transfer", token: "0xt", amount: "OPEN", recipient: "0xr" },
+      { type: "transfer", token: "0xt", amount: "0x5", recipient: "0xr2" },
+    ];
+    const result = await makeProver().prove(actions);
+
+    expect(h.state.ops).toEqual([
+      { op: "deposit", token: "0xt", input: { amount: 100n } },
+      { op: "withdraw", token: "0xt", output: { recipient: "0xr", amount: 10n } },
+      { op: "transfer", token: "0xt", output: { recipient: "0xr", amount: Open } },
+      { op: "transfer", token: "0xt", output: { recipient: "0xr2", amount: 5n } },
+    ]);
+    // core CallAndProof (camelCase) → strk20 RPC shape (snake_case, proof_facts).
+    expect(result).toEqual({
+      call: { contract_address: "0xpool", entry_point: "apply", calldata: ["0x1"] },
+      proof: { data: "0xdata", output: ["0x2"], proof_facts: ["0x3"] },
+    });
+  });
+
+  it("loads the registry into build and saves the updated one after a real proof", async () => {
+    await makeProver().prove([{ type: "deposit", token: "0xt", amount: "0x1" }]);
+    expect(h.state.buildOptions).toMatchObject({
+      autoRegister: true,
+      autoSetup: true,
+      autoSelectNotes: "naive",
+      registry: loadedRegistry,
+    });
+    expect(saved).toEqual({ tag: "saved-registry" });
+  });
+
+  it("simulate estimates through the node provider and does not save the registry", async () => {
+    const estimate = await makeProver().prove(
+      [{ type: "deposit", token: "0xt", amount: "0x1" }],
+      true
+    );
+    expect(h.state.simulateArg).toBeDefined();
+    expect(saved).toBeUndefined();
+    expect(estimate.call.contract_address).toBe("0xpool");
+  });
+
+  it("resolves invoke placeholders against the compiled transaction's open notes and pool", async () => {
+    await makeProver().prove([
+      { type: "transfer", token: "0xt", amount: "OPEN", recipient: "0xr" },
+      {
+        type: "invoke",
+        contract: "0xdapp",
+        calldata: ["0x5", "${openNoteIds[0]}", "${poolAddress}"],
+      },
+    ]);
+    const invoke = h.state.ops.find((op) => op.op === "invoke")!;
+    const callBuilder = invoke.callBuilder as (args: unknown) => {
+      contractAddress: string;
+      calldata: string[];
+    };
+    const built = callBuilder({
+      openNotes: [{ noteId: 0xaan, token: 0xabcn }],
+      withdrawals: [],
+      poolAddress: 0xdeadn,
+    });
+    expect(built.contractAddress).toBe("0xdapp");
+    expect(built.calldata).toEqual(["0x5", "0xaa", "0xdead"]);
+  });
+
+  it("maps compute_and_invoke to the core compute/invoke additional data with substitution", async () => {
+    await makeProver().prove([
+      {
+        type: "compute_and_invoke",
+        contract: "0xdapp",
+        compute_calldata: ["${poolAddress}"],
+        invoke_calldata: ["0x7"],
+      },
+    ]);
+    const op = h.state.ops.find((entry) => entry.op === "computeAndInvoke")!;
+    const callBuilder = op.callBuilder as (args: unknown) => {
+      contractAddress: string;
+      computeAdditionalData: string[];
+      invokeAdditionalData: string[];
+    };
+    const built = callBuilder({ openNotes: [], withdrawals: [], poolAddress: 0xdeadn });
+    expect(built).toEqual({
+      contractAddress: "0xdapp",
+      computeAdditionalData: ["0xdead"],
+      invokeAdditionalData: ["0x7"],
+    });
+  });
+});

--- a/client/tests/viewing-key.test.ts
+++ b/client/tests/viewing-key.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { ec } from "starknet";
+import { deriveViewingKey, passphraseViewingKeyProvider } from "../src/index.js";
+
+const ADDRESS = 0x123n;
+const OTHER_ADDRESS = 0x456n;
+const STARK_PRIME = 2n ** 251n + 17n * 2n ** 192n + 1n;
+// The privacy pool accepts a user key only when it is below the Stark curve half-order
+// (privacy::utils::is_canonical_key); the KDF must canonicalize into this range.
+const HALF_ORDER = ec.starkCurve.CURVE.n >> 1n;
+
+// Each derivation runs KDF_ROUNDS (1000) Poseidon rounds by design, and some cases derive several
+// keys, so these tests need more than the 5s suite default when the machine is busy.
+describe("deriveViewingKey", { timeout: 60_000 }, () => {
+  it("is deterministic for the same passphrase + address", () => {
+    expect(deriveViewingKey("correct horse", ADDRESS)).toBe(
+      deriveViewingKey("correct horse", ADDRESS)
+    );
+  });
+
+  it("is salted by the address — same passphrase, different account, different key", () => {
+    expect(deriveViewingKey("correct horse", ADDRESS)).not.toBe(
+      deriveViewingKey("correct horse", OTHER_ADDRESS)
+    );
+  });
+
+  it("depends on the passphrase", () => {
+    expect(deriveViewingKey("correct horse", ADDRESS)).not.toBe(
+      deriveViewingKey("battery staple", ADDRESS)
+    );
+  });
+
+  it("produces a Stark-field element", () => {
+    const key = deriveViewingKey("correct horse", ADDRESS);
+    expect(key).toBeGreaterThan(0n);
+    expect(key).toBeLessThan(STARK_PRIME);
+  });
+
+  it("produces a canonical key (non-zero, below the half-order) for any passphrase", () => {
+    // "e2e-signing-passphrase" derived a non-canonical key before canonicalization was added.
+    for (const passphrase of [
+      "e2e-signing-passphrase",
+      "correct horse",
+      "",
+      "x".repeat(40),
+      "another passphrase entirely",
+    ]) {
+      const key = deriveViewingKey(passphrase, ADDRESS);
+      expect(key).toBeGreaterThan(0n);
+      expect(key).toBeLessThan(HALF_ORDER);
+    }
+  });
+
+  it("handles an empty passphrase without throwing", () => {
+    expect(deriveViewingKey("", ADDRESS)).toBeGreaterThan(0n);
+  });
+
+  it("distinguishes passphrases longer than one felt limb (>31 bytes)", () => {
+    const long = "x".repeat(40);
+    expect(deriveViewingKey(long, ADDRESS)).not.toBe(deriveViewingKey(`${long}y`, ADDRESS));
+  });
+});
+
+describe("passphraseViewingKeyProvider", () => {
+  it("getViewingKey resolves to deriveViewingKey and is stable across calls", async () => {
+    const viewingKeyProvider = passphraseViewingKeyProvider("correct horse", ADDRESS);
+    const first = await viewingKeyProvider.getViewingKey();
+    expect(first).toBe(deriveViewingKey("correct horse", ADDRESS));
+    expect(await viewingKeyProvider.getViewingKey()).toBe(first);
+  });
+});

--- a/e2e/scripts/generate-dump.ts
+++ b/e2e/scripts/generate-dump.ts
@@ -48,14 +48,14 @@ const transfers = {
   alice: createPrivateTransfers({
     account: env.alice,
     viewingKeyProvider: { getViewingKey: async () => ALICE_VIEWING_KEY },
-    provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
+    provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
   }),
   bob: createPrivateTransfers({
     account: env.bob,
     viewingKeyProvider: { getViewingKey: async () => BOB_VIEWING_KEY },
-    provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
+    provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
   }),
@@ -149,11 +149,11 @@ async function dumpContractState(
   env: DevnetEnvironment,
   outputPath: string,
 ): Promise<void> {
-  const latestBlock = await env.provider.getBlockNumber();
+  const latestBlock = await env.node.getBlockNumber();
   const storageState: Record<string, string> = {};
 
   for (let blockNum = 0; blockNum <= latestBlock; blockNum++) {
-    const stateUpdate = await env.provider.getStateUpdate(blockNum);
+    const stateUpdate = await env.node.getStateUpdate(blockNum);
     for (const diff of stateUpdate.state_diff.storage_diffs) {
       if (diff.address.toLowerCase() === env.privacy.address.toLowerCase()) {
         for (const entry of diff.storage_entries) {

--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -131,10 +131,7 @@ export async function createE2eTestEnv(
     alice: createPrivateTransfers({
       account: env.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new ScreeningCallMockProofProvider(
-        env.provider,
-        chainId,
-      ),
+      provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
       discoveryProvider: new IndexerDiscoveryProvider(
         indexer.apiUrl,
         env.privacy.address,
@@ -144,10 +141,7 @@ export async function createE2eTestEnv(
     bob: createPrivateTransfers({
       account: env.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
-      provingProvider: new ScreeningCallMockProofProvider(
-        env.provider,
-        chainId,
-      ),
+      provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
       discoveryProvider: new IndexerDiscoveryProvider(
         indexer.apiUrl,
         env.privacy.address,

--- a/e2e/tests/devnet/ohttp-relay.test.ts
+++ b/e2e/tests/devnet/ohttp-relay.test.ts
@@ -84,7 +84,7 @@ describe("E2E OHTTP via relay", () => {
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
@@ -121,7 +121,7 @@ describe("E2E OHTTP via relay", () => {
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -80,7 +80,7 @@ describe("E2E OHTTP", () => {
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,
@@ -114,7 +114,7 @@ describe("E2E OHTTP", () => {
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: ohttpDiscovery,

--- a/e2e/tests/devnet/pagination-discovery.test.ts
+++ b/e2e/tests/devnet/pagination-discovery.test.ts
@@ -71,7 +71,7 @@ describe("Discovery pagination with small budget", () => {
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,
@@ -105,7 +105,7 @@ describe("Discovery pagination with small budget", () => {
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,
@@ -122,7 +122,7 @@ describe("Discovery pagination with small budget", () => {
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: discovery,

--- a/e2e/tests/devnet/payment-service-discovery.test.ts
+++ b/e2e/tests/devnet/payment-service-discovery.test.ts
@@ -55,10 +55,7 @@ describe("Payment Service Discovery", () => {
       createPrivateTransfers({
         account,
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new ScreeningCallMockProofProvider(
-          de.provider,
-          chainId,
-        ),
+        provingProvider: new ScreeningCallMockProofProvider(de.node, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
       }),
@@ -230,7 +227,7 @@ describe("Payment Service Discovery", () => {
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => ALICE_KEY },
-      provingProvider: new ScreeningCallMockProofProvider(de.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(de.node, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
     });
@@ -259,7 +256,7 @@ describe("Payment Service Discovery", () => {
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => ALICE_KEY },
-      provingProvider: new ScreeningCallMockProofProvider(de.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(de.node, chainId),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
     });
@@ -287,10 +284,7 @@ describe("Payment Service Discovery", () => {
       const userDiscover = createPrivateTransfers({
         account: users[i],
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new ScreeningCallMockProofProvider(
-          de.provider,
-          chainId,
-        ),
+        provingProvider: new ScreeningCallMockProofProvider(de.node, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
       });
@@ -317,10 +311,7 @@ describe("Payment Service Discovery", () => {
       const userDiscover = createPrivateTransfers({
         account: users[i],
         viewingKeyProvider: { getViewingKey: async () => userKey(i) },
-        provingProvider: new ScreeningCallMockProofProvider(
-          de.provider,
-          chainId,
-        ),
+        provingProvider: new ScreeningCallMockProofProvider(de.node, chainId),
         discoveryProvider: indexerDiscovery,
         poolContractAddress: de.privacy.address,
       });

--- a/e2e/tests/devnet/proving-block-id.test.ts
+++ b/e2e/tests/devnet/proving-block-id.test.ts
@@ -41,7 +41,7 @@ describe("E2E provingBlockId", () => {
     await env.indexer.waitForBlock(devnet.url);
 
     // 2. Record current block number (after first deposit is confirmed)
-    const oldBlock = await de.provider.getBlockNumber();
+    const oldBlock = await de.node.getBlockNumber();
 
     // 3. Mine 10 empty blocks to advance the chain
     for (let blockIndex = 0; blockIndex < 10; blockIndex++) {

--- a/e2e/tests/devnet/smoke.test.ts
+++ b/e2e/tests/devnet/smoke.test.ts
@@ -69,7 +69,7 @@ describe("E2E Smoke", () => {
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: indexerDiscovery,
@@ -100,7 +100,7 @@ describe("E2E Smoke", () => {
       account: de.bob,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
-        de.provider,
+        de.node,
         constants.StarknetChainId.SN_SEPOLIA,
       ),
       discoveryProvider: indexerDiscovery,

--- a/e2e/tests/devnet/sub-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/sub-account-compute-invoke.test.ts
@@ -22,13 +22,9 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
       indexer: { logFile: "sub-account-compute-invoke-indexer.log" },
     });
 
-    const { admin, provider, privacy } = env.env;
-    tokens = await deployTestTokens(admin, provider);
-    subAccount = await deploySubAccountAnonymizer(
-      admin,
-      provider,
-      privacy.address,
-    );
+    const { admin, node, privacy } = env.env;
+    tokens = await deployTestTokens(admin, node);
+    subAccount = await deploySubAccountAnonymizer(admin, node, privacy.address);
   });
 
   afterAll(async () => {
@@ -42,7 +38,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
     const payoutAmount = 100n * ONE_TOKEN;
 
     const balanceOf = async (owner: string): Promise<bigint> => {
-      const result = await de.provider.callContract({
+      const result = await de.node.callContract({
         contractAddress: tokens.usdToken,
         entrypoint: "balance_of",
         calldata: [owner],
@@ -56,7 +52,7 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
       entrypoint: "mint",
       calldata: [subAccount.mockDapp, ...u256Calldata(payoutAmount)],
     });
-    await de.provider.waitForTransaction(mintTx.transaction_hash);
+    await de.node.waitForTransaction(mintTx.transaction_hash);
 
     // `compute_data` feeds privacy_compute(identity_key, dapp_name, nonce); the pool prepends
     // the derived identity key. The commitment it returns selects the per-commitment sub-account.

--- a/e2e/tests/devnet/swap-ekubo.test.ts
+++ b/e2e/tests/devnet/swap-ekubo.test.ts
@@ -24,10 +24,10 @@ describe("Ekubo swap on devnet", () => {
       indexer: { logFile: "swap-ekubo-indexer.log" },
     });
 
-    const { admin, provider } = env.env;
-    tokens = await deployTestTokens(admin, provider);
-    ekubo = await deployEkuboInfra(admin, provider, tokens);
-    executorAddress = await deployEkuboExecutor(admin, provider);
+    const { admin, node } = env.env;
+    tokens = await deployTestTokens(admin, node);
+    ekubo = await deployEkuboInfra(admin, node, tokens);
+    executorAddress = await deployEkuboExecutor(admin, node);
   });
 
   afterAll(async () => {

--- a/e2e/tests/devnet/vesu-lending.test.ts
+++ b/e2e/tests/devnet/vesu-lending.test.ts
@@ -24,10 +24,10 @@ describe("Vesu lending on devnet", () => {
       indexer: { logFile: "vesu-lending-indexer.log" },
     });
 
-    const { admin, provider } = env.env;
-    tokens = await deployTestTokens(admin, provider);
-    vesu = await deployVesuInfra(admin, provider, tokens);
-    anonymizerAddress = await deployVesuAnonymizer(admin, provider);
+    const { admin, node } = env.env;
+    tokens = await deployTestTokens(admin, node);
+    vesu = await deployVesuInfra(admin, node, tokens);
+    anonymizerAddress = await deployVesuAnonymizer(admin, node);
   });
 
   afterAll(async () => {
@@ -47,14 +47,14 @@ describe("Vesu lending on devnet", () => {
       entrypoint: "mint",
       calldata: [de.alice.address, ...u256Calldata(depositAmount)],
     });
-    await de.provider.waitForTransaction(mintTx.transaction_hash);
+    await de.node.waitForTransaction(mintTx.transaction_hash);
 
     const approveTx = await de.alice.execute({
       contractAddress: tokens.usdToken,
       entrypoint: "approve",
       calldata: [de.privacy.address, depositAmount, 0n],
     });
-    await de.provider.waitForTransaction(approveTx.transaction_hash);
+    await de.node.waitForTransaction(approveTx.transaction_hash);
 
     // Phase 1: Deposit USD into privacy pool
     const { callAndProof: depositCall } = await transfers.alice

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking
+
+- Node-provider fields are named `node`, not `provider`: `SimulateOptions.provider` →
+  `SimulateOptions.node` (`builder.simulate({ node })`) and `DevnetEnvironment.provider` →
+  `DevnetEnvironment.node` (`env.node`) on the `/testing` surface. `provider` is reserved for the
+  proving / discovery / viewing-key providers, so a bare `provider` no longer means the node.
+
 ## 0.14.3-RC.4
 
 ### Added

--- a/sdk/src/interfaces.ts
+++ b/sdk/src/interfaces.ts
@@ -340,11 +340,10 @@ export type ExecuteOptions = {
 
 export type SimulateOptions = {
   /**
-   * Node provider used to call the pool's view function for fee estimation.
-   * Required because the minimal `PrivateTransfersUser` ({ address, signer })
-   * carries no provider of its own.
+   * Node used to call the pool's view function for fee estimation. Required because the minimal
+   * `PrivateTransfersUser` ({ address, signer }) carries no node of its own.
    */
-  provider: ProviderInterface;
+  node: ProviderInterface;
   /** When true, validate the user's signature during simulation. Default: false. */
   validateSignature?: boolean;
 };

--- a/sdk/src/internal/mock-proving.ts
+++ b/sdk/src/internal/mock-proving.ts
@@ -23,7 +23,7 @@ const VALIDATED = encode.utf8ToBigInt("VALID");
  */
 export class CallMockProofProvider implements ProofProviderInterface {
   constructor(
-    protected readonly provider: ProviderInterface,
+    protected readonly node: ProviderInterface,
     protected readonly chainId: constants.StarknetChainId,
     private readonly options?: { validateSignature?: boolean }
   ) {}
@@ -43,7 +43,7 @@ export class CallMockProofProvider implements ProofProviderInterface {
     // Layout: [1, to, selector, inner_len, ...inner_calldata]
     const executeViewCalldata = extractExecuteViewCalldata(invocation.calldata as string[]);
 
-    const result = await this.provider.callContract(
+    const result = await this.node.callContract(
       {
         contractAddress: invocation.sender_address,
         entrypoint: "compile_actions",
@@ -52,7 +52,7 @@ export class CallMockProofProvider implements ProofProviderInterface {
       blockIdentifier
     );
 
-    const poolClassHash = await this.provider.getClassHashAt(
+    const poolClassHash = await this.node.getClassHashAt(
       invocation.sender_address,
       blockIdentifier
     );
@@ -64,15 +64,15 @@ export class CallMockProofProvider implements ProofProviderInterface {
     // can verify the block hash from state.
     let baseBlockNumber: bigint;
     if (blockIdentifier != null) {
-      const block = await this.provider.getBlock(blockIdentifier);
+      const block = await this.node.getBlock(blockIdentifier);
       baseBlockNumber = BigInt(block.block_number);
     } else {
-      const latestBlock = await this.provider.getBlock("latest");
+      const latestBlock = await this.node.getBlock("latest");
       const currentBlockNumber = BigInt(latestBlock.block_number);
       const blocksBack = 10n;
       baseBlockNumber = currentBlockNumber > blocksBack ? currentBlockNumber - blocksBack : 1n;
     }
-    const baseBlock = await this.provider.getBlock(Number(baseBlockNumber));
+    const baseBlock = await this.node.getBlock(Number(baseBlockNumber));
     const proofFacts = buildProofFacts(
       invocation.sender_address,
       poolClassHash,
@@ -127,7 +127,7 @@ export class CallMockProofProvider implements ProofProviderInterface {
     // Calldata format: [hash, signature_length, ...signature_elements]
     const isValidCalldata = [txHash, num.toHex(signatureArray.length), ...signatureArray];
 
-    const result = await this.provider.callContract({
+    const result = await this.node.callContract({
       contractAddress: userAddress,
       entrypoint: "is_valid_signature",
       calldata: isValidCalldata,

--- a/sdk/src/internal/private-transfers.ts
+++ b/sdk/src/internal/private-transfers.ts
@@ -145,9 +145,9 @@ export class PrivateTransfers extends AbstractPrivateTransfers {
     // Source chainId from the same provider the mock prover calls, so proof
     // facts and signature validation are computed for the chain that actually
     // executes the view call.
-    const chainId = await options.provider.getChainId();
+    const chainId = await options.node.getChainId();
 
-    const mockProvider = new CallMockProofProvider(options.provider, chainId, {
+    const mockProvider = new CallMockProofProvider(options.node, chainId, {
       validateSignature: options.validateSignature ?? false,
     });
 

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -85,12 +85,12 @@ export interface DevnetEnvironment {
   strk: string;
   eth: string;
   privacy: PrivacyPoolContract;
-  provider: RpcProvider;
+  node: RpcProvider;
 }
 
 export class Devnet {
   private devnet?: StarknetDevnet;
-  private provider?: RpcProvider;
+  private node?: RpcProvider;
   public setup?: DevnetEnvironment;
   private accountNonces = new AddressMap<number>(() => 0);
   private config: Required<DevnetConfig>;
@@ -163,7 +163,7 @@ export class Devnet {
     console.log(`Devnet running at: ${this.devnet.provider.url}`);
 
     // Create a TracingRpcProvider for enhanced error debugging
-    this.provider = new TracingRpcProvider({
+    this.node = new TracingRpcProvider({
       nodeUrl: this.devnet.provider.url,
       transactionRetryIntervalFallback: 50,
       batch: 0,
@@ -198,7 +198,7 @@ export class Devnet {
           .map((byte) => parseInt(byte, 16))
       );
       userAccounts.push(
-        new Account({ provider: this.provider, address: raw.address, signer: keyBytes })
+        new Account({ provider: this.node, address: raw.address, signer: keyBytes })
       );
     }
     const [alice, bob] = userAccounts;
@@ -213,7 +213,7 @@ export class Devnet {
     );
     const admin = this.wrapAccount(
       new Account({
-        provider: this.provider,
+        provider: this.node,
         address: adminRaw.address,
         signer: adminKeyBytes,
         cairoVersion: "1",
@@ -249,7 +249,7 @@ export class Devnet {
       strk,
       eth,
       privacy,
-      provider: this.provider,
+      node: this.node,
     };
 
     debugLog("devnet", "initialize", () =>
@@ -405,7 +405,7 @@ export class Devnet {
       proofFacts: callAndProof.proof.proofFacts,
       proof: callAndProof.proof.data,
     });
-    const receipt = await this.provider!.waitForTransaction(response.transaction_hash);
+    const receipt = await this.node!.waitForTransaction(response.transaction_hash);
     if (!receipt.isSuccess()) {
       const reason = (receipt as { revert_reason?: string }).revert_reason ?? "unknown";
       throw new Error(`executeOutside reverted: ${reason}`);
@@ -496,14 +496,14 @@ export async function createDevnetTestEnv(
     alice: createPrivateTransfers({
       account: env.alice,
       viewingKeyProvider: { getViewingKey: async () => toBigInt("0xA11CE") },
-      provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
     }),
     bob: createPrivateTransfers({
       account: env.bob,
       viewingKeyProvider: { getViewingKey: async () => toBigInt("0xB0B") },
-      provingProvider: new ScreeningCallMockProofProvider(env.provider, chainId),
+      provingProvider: new ScreeningCallMockProofProvider(env.node, chainId),
       discoveryProvider: new ContractDiscoveryProvider(env.privacy, config?.discoveryOptions),
       poolContractAddress: env.privacy.address,
     }),
@@ -523,7 +523,7 @@ export function createUnattestedAliceTransfers(env: DevnetEnvironment): PrivateT
   return createPrivateTransfers({
     account: env.alice,
     viewingKeyProvider: { getViewingKey: async () => toBigInt("0xA11CE") },
-    provingProvider: new CallMockProofProvider(env.provider, constants.StarknetChainId.SN_SEPOLIA),
+    provingProvider: new CallMockProofProvider(env.node, constants.StarknetChainId.SN_SEPOLIA),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
   });

--- a/sdk/src/testing/screening-mock-proving.ts
+++ b/sdk/src/testing/screening-mock-proving.ts
@@ -34,8 +34,8 @@ export class ScreeningCallMockProofProvider extends CallMockProofProvider {
     // (get_tx_info().chain_id), queried from the chain rather than assumed, and
     // an issued_at <= the block timestamp the contract reads (else
     // SCREENING_FUTURE_DATED) — use the chain's own clock, not the host's.
-    const chainId = await this.provider.getChainId();
-    const block = await this.provider.getBlock(blockIdentifier ?? "latest");
+    const chainId = await this.node.getChainId();
+    const block = await this.node.getBlock(blockIdentifier ?? "latest");
     const signature = signScreeningAttestation(
       SCREENING_SIGNER_PRIVATE_KEY,
       BigInt(chainId),

--- a/sdk/tests/devnet.test.ts
+++ b/sdk/tests/devnet.test.ts
@@ -286,7 +286,7 @@ describe("Devnet Integration", () => {
         body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "devnet_createBlock" }),
       });
     }
-    const latestBlock = await env.provider.getBlockNumber();
+    const latestBlock = await env.node.getBlockNumber();
     const olderBlock = latestBlock - 10;
 
     const buildOptions = {
@@ -301,7 +301,7 @@ describe("Devnet Integration", () => {
       .with(env.strk)
       .withdraw({ amount: 50n, recipient: env.alice.address })
       .surplusTo(env.alice.address)
-      .simulate({ provider: env.provider });
+      .simulate({ node: env.node });
 
     // Structure checks
     expect(simResult.callAndProof.call.entrypoint).toBe("apply_actions");


### PR DESCRIPTION
Strk20Prover (strk20-specific): partialCommitment(dappName) + prove(actions, simulate?). It owns
viewing-key retrieval — never dapp-passed — so a future on-device prover can fetch the key locally.
CorePrivateTransfersProver is the default: derives the viewing key from a passphrase (salted with
the account address, iterated), wraps core PrivateTransfers, and translates Strk20Action[] via its
builder (deposit/withdraw/transfer/OPEN-note/invoke/computeAndInvoke), substituting the
${openNoteIds[N]}/${poolAddress} placeholders against the compiled tx, then maps core CallAndProof
to the strk20 shape. Loads the note registry before proving, saves it after a real proof; simulate
estimates via the node provider. deriveViewingKey + passphraseViewingKeyProvider (lazy, memoized).
PrivacyStorage added to the seam. 20 tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/916)
<!-- Reviewable:end -->
