### PR TITLE
feat(client): SdkWallet — PrivacyWallet over prover + paymaster

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -3,6 +3,8 @@
 // Resolves sub-accounts, bridges Starknet/EVM wallet signing, and builds privacy operations
 // over @starkware-libs/starknet-privacy-sdk. More of the public API is added in later changesets.
 export { createPrivacyClient } from "./client.js";
+export { SdkWallet } from "./sdk-wallet.js";
+export type { SdkWalletConfig } from "./sdk-wallet.js";
 export { CorePrivateTransfersProver } from "./strk20-prover.js";
 export type { CorePrivateTransfersProverConfig } from "./strk20-prover.js";
 export { deriveViewingKey, passphraseViewingKeyProvider } from "./viewing-key.js";

--- a/client/src/sdk-wallet.ts
+++ b/client/src/sdk-wallet.ts
@@ -1,0 +1,81 @@
+import type { Call, STRK20_CALL_AND_PROOF, STRK20_PROOF } from "starknet";
+import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
+import { toStarknetCall } from "./calls.js";
+import { toPaymasterCall } from "./paymaster.js";
+import type { Paymaster } from "./paymaster.js";
+import type { PrivacyWallet, Strk20Action, Strk20Prover } from "./interfaces.js";
+
+/**
+ * Dependencies for an {@link SdkWallet}: the {@link Strk20Prover} that proves actions (and owns the
+ * viewing key), the {@link Paymaster} that sponsors + broadcasts the fee, and the privacy pool
+ * address the paymaster applies actions against.
+ */
+export interface SdkWalletConfig {
+  prover: Strk20Prover;
+  paymaster: Paymaster;
+  poolContractAddress: StarknetAddress;
+}
+
+/**
+ * The non-native {@link PrivacyWallet} for wallets that are not get-starknet v6 strk20 wallets (EVM /
+ * legacy-SN, via a CallSet signer inside the prover). It proves through the injected prover and
+ * broadcasts through the paymaster so the user never needs to hold the fee token.
+ *
+ * `strk20InvokeTransaction` runs the private (`apply_action`) flow: quote the fee, fold it in as a
+ * `withdraw` so it is covered by the proof, prove, then hand the proven call to the paymaster. This
+ * covers submissions that spend the user's existing notes (withdraw / transfer / invoke).
+ *
+ * A deposit additionally needs an ERC-20 `approve`, which must run as the user (the token owner) —
+ * but under `apply_action` the executing account is the paymaster, not the user, so the `approve`
+ * cannot ride along here. That case is the "regular" flow (`invoke_and_apply_action`, which carries a
+ * user-signed `approve` invoke) and is not implemented yet, so `executeWithProof` and
+ * `estimateInvokeFee` — the client's surrounding-calls / fee-estimate paths — reject for now.
+ */
+export class SdkWallet implements PrivacyWallet {
+  constructor(private readonly config: SdkWalletConfig) {}
+
+  partialCommitment(dappName: string): Promise<bigint> {
+    return this.config.prover.partialCommitment(dappName);
+  }
+
+  strk20PrepareInvoke(actions: Strk20Action[], simulate?: boolean): Promise<STRK20_CALL_AND_PROOF> {
+    return this.config.prover.prove(actions, simulate);
+  }
+
+  async strk20InvokeTransaction(actions: Strk20Action[]): Promise<{ transaction_hash: string }> {
+    const { prover, paymaster, poolContractAddress } = this.config;
+    const poolAddress = String(poolContractAddress);
+    // Quote the fee, fold it in as a withdraw so the proof covers it, prove, then let the paymaster
+    // broadcast. Fee mode is the paymaster's own config; here we only add the quoted withdrawal.
+    const { feeAction } = await paymaster.buildTransaction({ kind: "applyAction", poolAddress });
+    const feeWithdraw: Strk20Action = {
+      type: "withdraw",
+      token: feeAction.token,
+      amount: feeAction.amount,
+      recipient: feeAction.recipient,
+    };
+    const { call, proof } = await prover.prove([...actions, feeWithdraw]);
+    const { transactionHash } = await paymaster.executeTransaction({
+      kind: "applyAction",
+      applyActionsCall: toPaymasterCall(toStarknetCall(call)),
+      proof: proof.data,
+      proofFacts: proof.proof_facts,
+    });
+    return { transaction_hash: transactionHash };
+  }
+
+  executeWithProof(_calls: Call[], _proof?: STRK20_PROOF): Promise<{ transaction_hash: string }> {
+    return Promise.reject(
+      new Error(
+        "SdkWallet: submitting with surrounding calls (the regular deposit/approve flow) is not yet " +
+          "implemented; use strk20InvokeTransaction for private submissions"
+      )
+    );
+  }
+
+  estimateInvokeFee(): Promise<never> {
+    return Promise.reject(
+      new Error("SdkWallet: fee estimation via the paymaster is not yet implemented")
+    );
+  }
+}

--- a/client/tests/sdk-wallet.test.ts
+++ b/client/tests/sdk-wallet.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { hash } from "starknet";
+import { SdkWallet } from "../src/index.js";
+import type { Paymaster, Strk20Action } from "../src/index.js";
+import type { Strk20Prover } from "../src/index.js";
+
+const PROVEN = {
+  call: { contract_address: "0xpool", entry_point: "apply_actions", calldata: ["0xc"] },
+  proof: { data: "0xproofdata", output: ["0xo"], proof_facts: ["0xf1", "0xf2"] },
+};
+
+/** A prover double recording what it was asked to prove. */
+function fakeProver(seen: { proved?: Strk20Action[] } = {}): Strk20Prover {
+  return {
+    partialCommitment: async (dappName) => (dappName === "my-dapp" ? 0xc0ffeen : 0n),
+    prove: async (actions) => {
+      seen.proved = actions;
+      return PROVEN;
+    },
+  };
+}
+
+/** A paymaster double quoting a fixed fee and recording the execute request. */
+function fakePaymaster(seen: { build?: unknown; execute?: unknown } = {}): Paymaster {
+  return {
+    buildTransaction: async (build) => {
+      seen.build = build;
+      return { feeAction: { type: "withdraw", recipient: "0xpm", token: "0xfee", amount: "0x2a" } };
+    },
+    executeTransaction: async (execute) => {
+      seen.execute = execute;
+      return { transactionHash: "0xsent" };
+    },
+  };
+}
+
+describe("SdkWallet", () => {
+  it("partialCommitment and strk20PrepareInvoke delegate to the prover", async () => {
+    const proverSeen: { proved?: Strk20Action[] } = {};
+    const wallet = new SdkWallet({
+      prover: fakeProver(proverSeen),
+      paymaster: fakePaymaster(),
+      poolContractAddress: "0xpool",
+    });
+    expect(await wallet.partialCommitment("my-dapp")).toBe(0xc0ffeen);
+
+    const actions = [
+      { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
+    ] as Strk20Action[];
+    const prepared = await wallet.strk20PrepareInvoke(actions);
+    expect(proverSeen.proved).toBe(actions);
+    expect(prepared).toBe(PROVEN);
+  });
+
+  it("strk20InvokeTransaction folds the quoted fee into the proof and broadcasts via the paymaster", async () => {
+    const proverSeen: { proved?: Strk20Action[] } = {};
+    const paymasterSeen: { build?: unknown; execute?: unknown } = {};
+    const wallet = new SdkWallet({
+      prover: fakeProver(proverSeen),
+      paymaster: fakePaymaster(paymasterSeen),
+      poolContractAddress: "0xpool",
+    });
+    const actions = [
+      { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
+    ] as Strk20Action[];
+
+    const result = await wallet.strk20InvokeTransaction(actions);
+
+    expect(paymasterSeen.build).toEqual({ kind: "applyAction", poolAddress: "0xpool" });
+    // the fee withdraw is appended to the proven action set, so the proof covers it
+    expect(proverSeen.proved).toEqual([
+      ...actions,
+      { type: "withdraw", token: "0xfee", amount: "0x2a", recipient: "0xpm" },
+    ]);
+    // the proven strk20 call is mapped to the paymaster wire shape (selector + calldata)
+    expect(paymasterSeen.execute).toEqual({
+      kind: "applyAction",
+      applyActionsCall: {
+        to: "0xpool",
+        selector: hash.getSelectorFromName("apply_actions"),
+        calldata: ["0xc"],
+      },
+      proof: "0xproofdata",
+      proofFacts: ["0xf1", "0xf2"],
+    });
+    expect(result).toEqual({ transaction_hash: "0xsent" });
+  });
+
+  it("rejects the not-yet-implemented regular flow (executeWithProof / estimateInvokeFee)", async () => {
+    const wallet = new SdkWallet({
+      prover: fakeProver(),
+      paymaster: fakePaymaster(),
+      poolContractAddress: "0xpool",
+    });
+    await expect(wallet.executeWithProof([])).rejects.toThrow(/regular/);
+    await expect(wallet.estimateInvokeFee()).rejects.toThrow(/not yet implemented/);
+  });
+});


### PR DESCRIPTION
The non-native PrivacyWallet (EVM / legacy-SN via a CallSet signer inside the prover). It composes
the Strk20Prover (proves, owns the viewing key) and the Paymaster (sponsors + broadcasts the fee, so
the user needn't hold the fee token). partialCommitment/strk20PrepareInvoke delegate to the prover.
strk20InvokeTransaction runs the private apply_action flow: quote the fee, fold it in as a withdraw
so the proof covers it, prove, then paymaster broadcasts the proven call. The regular flow (a
deposit's approve, which must run as the user but can't under apply_action where the paymaster is the
executing account — needs invoke_and_apply_action) is deferred: executeWithProof/estimateInvokeFee
reject for now. 6 tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/917)
<!-- Reviewable:end -->
