### PR TITLE
feat(client): automatic deposit (regular paymaster) flow in SdkWallet

### DIFF
--- a/client/src/sdk-wallet.ts
+++ b/client/src/sdk-wallet.ts
@@ -1,19 +1,23 @@
-import type { Call, STRK20_CALL_AND_PROOF, STRK20_PROOF } from "starknet";
+import { cairo, num } from "starknet";
+import type { Call, SignerInterface, STRK20_CALL_AND_PROOF, STRK20_PROOF } from "starknet";
 import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
 import { toStarknetCall } from "./calls.js";
-import { toPaymasterCall } from "./paymaster.js";
-import type { Paymaster } from "./paymaster.js";
+import { normalizeSignature, toPaymasterCall } from "./paymaster.js";
+import type { Paymaster, PaymasterCall, PaymasterExecute } from "./paymaster.js";
 import type { PrivacyWallet, Strk20Action, Strk20Prover } from "./interfaces.js";
 
 /**
  * Dependencies for an {@link SdkWallet}: the {@link Strk20Prover} that proves actions (and owns the
- * viewing key), the {@link Paymaster} that sponsors + broadcasts the fee, and the privacy pool
- * address the paymaster applies actions against.
+ * viewing key), the {@link Paymaster} that sponsors + broadcasts the fee, the privacy pool address
+ * the paymaster applies actions against, and the user's `signer` + `userAddress` used to authorize
+ * the public `approve` a deposit needs (the "regular" paymaster flow).
  */
 export interface SdkWalletConfig {
   prover: Strk20Prover;
   paymaster: Paymaster;
   poolContractAddress: StarknetAddress;
+  signer: SignerInterface;
+  userAddress: StarknetAddress;
 }
 
 /**
@@ -21,15 +25,15 @@ export interface SdkWalletConfig {
  * legacy-SN, via a CallSet signer inside the prover). It proves through the injected prover and
  * broadcasts through the paymaster so the user never needs to hold the fee token.
  *
- * `strk20InvokeTransaction` runs the private (`apply_action`) flow: quote the fee, fold it in as a
- * `withdraw` so it is covered by the proof, prove, then hand the proven call to the paymaster. This
- * covers submissions that spend the user's existing notes (withdraw / transfer / invoke).
+ * `strk20InvokeTransaction` quotes the fee, folds it in as a `withdraw` so the proof covers it,
+ * proves, then hands the proven call to the paymaster. It picks the flow from the actions: with no
+ * deposit it is the private `apply_action`; with a deposit it is the "regular" `invoke_and_apply_action`,
+ * because a deposit needs an ERC-20 `approve` that must run as the user (the token owner) — under
+ * `apply_action` the executing account is the paymaster, not the user, so the approve rides in the
+ * paymaster's user-signed invoke instead.
  *
- * A deposit additionally needs an ERC-20 `approve`, which must run as the user (the token owner) —
- * but under `apply_action` the executing account is the paymaster, not the user, so the `approve`
- * cannot ride along here. That case is the "regular" flow (`invoke_and_apply_action`, which carries a
- * user-signed `approve` invoke) and is not implemented yet, so `executeWithProof` and
- * `estimateInvokeFee` — the client's surrounding-calls / fee-estimate paths — reject for now.
+ * `executeWithProof` / `estimateInvokeFee` — the client's pre-proved surrounding-calls / fee-estimate
+ * paths — are not used on this path and reject.
  */
 export class SdkWallet implements PrivacyWallet {
   constructor(private readonly config: SdkWalletConfig) {}
@@ -43,11 +47,29 @@ export class SdkWallet implements PrivacyWallet {
   }
 
   async strk20InvokeTransaction(actions: Strk20Action[]): Promise<{ transaction_hash: string }> {
-    const { prover, paymaster, poolContractAddress } = this.config;
+    const { prover, paymaster, poolContractAddress, signer, userAddress } = this.config;
     const poolAddress = String(poolContractAddress);
-    // Quote the fee, fold it in as a withdraw so the proof covers it, prove, then let the paymaster
-    // broadcast. Fee mode is the paymaster's own config; here we only add the quoted withdrawal.
-    const { feeAction } = await paymaster.buildTransaction({ kind: "applyAction", poolAddress });
+
+    // A deposit needs a user-signed `approve`, so switch to the regular (invoke_and_apply_action)
+    // flow; otherwise the private apply_action flow suffices.
+    const approveCalls = actions
+      .filter((action) => action.type === "deposit")
+      .map((deposit) => approveCall(poolAddress, deposit.token, deposit.amount));
+    const build = approveCalls.length
+      ? ({
+          kind: "invokeAndApplyAction",
+          poolAddress,
+          userAddress: String(userAddress),
+          calls: approveCalls,
+        } as const)
+      : ({ kind: "applyAction", poolAddress } as const);
+
+    // Quote the fee. TODO: once AVNU exposes it, run a simulate pass to get an exact quote instead
+    // of this up-front estimate.
+    const { feeAction, typedData } = await paymaster.buildTransaction(build);
+    // The fee is always paid as a `withdraw` of the fee token to the paymaster — never an in-pool
+    // `transfer`, even in the invoke_and_apply_action case — because pool fees are settled by
+    // withdrawing out of the pool. Folding it into the proven action set makes the proof cover it.
     const feeWithdraw: Strk20Action = {
       type: "withdraw",
       token: feeAction.token,
@@ -55,20 +77,33 @@ export class SdkWallet implements PrivacyWallet {
       recipient: feeAction.recipient,
     };
     const { call, proof } = await prover.prove([...actions, feeWithdraw]);
-    const { transactionHash } = await paymaster.executeTransaction({
-      kind: "applyAction",
+    const base = {
       applyActionsCall: toPaymasterCall(toStarknetCall(call)),
       proof: proof.data,
       proofFacts: proof.proof_facts,
-    });
+    };
+
+    // A deposit rides the invoke_and_apply_action flow — the user signs the paymaster's outside
+    // execution (the approve) via signMessage; everything else is a plain apply_action.
+    const execute: PaymasterExecute =
+      approveCalls.length && typedData
+        ? {
+            kind: "invokeAndApplyAction",
+            ...base,
+            userAddress: String(userAddress),
+            typedData,
+            signature: normalizeSignature(await signer.signMessage(typedData, String(userAddress))),
+          }
+        : { kind: "applyAction", ...base };
+    const { transactionHash } = await paymaster.executeTransaction(execute);
     return { transaction_hash: transactionHash };
   }
 
   executeWithProof(_calls: Call[], _proof?: STRK20_PROOF): Promise<{ transaction_hash: string }> {
     return Promise.reject(
       new Error(
-        "SdkWallet: submitting with surrounding calls (the regular deposit/approve flow) is not yet " +
-          "implemented; use strk20InvokeTransaction for private submissions"
+        "SdkWallet: submitting a pre-proved call with surrounding calls is not supported; deposits " +
+          "are handled automatically by strk20InvokeTransaction"
       )
     );
   }
@@ -78,4 +113,15 @@ export class SdkWallet implements PrivacyWallet {
       new Error("SdkWallet: fee estimation via the paymaster is not yet implemented")
     );
   }
+}
+
+/** The `approve(pool, amount)` a deposit needs, in the paymaster wire shape. */
+function approveCall(poolAddress: string, token: string, amount: string): PaymasterCall {
+  const value = cairo.uint256(num.toBigInt(amount));
+  const call: Call = {
+    contractAddress: token,
+    entrypoint: "approve",
+    calldata: [poolAddress, num.toHex(value.low), num.toHex(value.high)],
+  };
+  return toPaymasterCall(call);
 }

--- a/client/tests/sdk-wallet.test.ts
+++ b/client/tests/sdk-wallet.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { hash } from "starknet";
+import { cairo, hash, num } from "starknet";
+import type { TypedData } from "starknet";
 import { SdkWallet } from "../src/index.js";
-import type { Paymaster, Strk20Action } from "../src/index.js";
-import type { Strk20Prover } from "../src/index.js";
+import type { Paymaster, Strk20Action, Strk20Prover } from "../src/index.js";
 
 const PROVEN = {
-  call: { contract_address: "0xpool", entry_point: "apply_actions", calldata: ["0xc"] },
+  call: { contract_address: "0xf001", entry_point: "apply_actions", calldata: ["0xc"] },
   proof: { data: "0xproofdata", output: ["0xo"], proof_facts: ["0xf1", "0xf2"] },
 };
+const TYPED_DATA = { domain: {}, types: {}, primaryType: "X", message: {} } as unknown as TypedData;
 
 /** A prover double recording what it was asked to prove. */
 function fakeProver(seen: { proved?: Strk20Action[] } = {}): Strk20Prover {
@@ -20,12 +21,15 @@ function fakeProver(seen: { proved?: Strk20Action[] } = {}): Strk20Prover {
   };
 }
 
-/** A paymaster double quoting a fixed fee and recording the execute request. */
+/** A paymaster double quoting a fixed fee (and typed data for the invoke case). */
 function fakePaymaster(seen: { build?: unknown; execute?: unknown } = {}): Paymaster {
   return {
     buildTransaction: async (build) => {
       seen.build = build;
-      return { feeAction: { type: "withdraw", recipient: "0xpm", token: "0xfee", amount: "0x2a" } };
+      return {
+        feeAction: { type: "withdraw", recipient: "0xpm", token: "0xfee", amount: "0x2a" },
+        typedData: TYPED_DATA,
+      };
     },
     executeTransaction: async (execute) => {
       seen.execute = execute;
@@ -34,49 +38,56 @@ function fakePaymaster(seen: { build?: unknown; execute?: unknown } = {}): Payma
   };
 }
 
+function makeWallet(
+  proverSeen: { proved?: Strk20Action[] } = {},
+  paymasterSeen: { build?: unknown; execute?: unknown } = {},
+  signed: { typedData?: TypedData; account?: string } = {}
+) {
+  return new SdkWallet({
+    prover: fakeProver(proverSeen),
+    paymaster: fakePaymaster(paymasterSeen),
+    poolContractAddress: "0xf001",
+    userAddress: "0xuser",
+    signer: {
+      signMessage: async (typedData: TypedData, account: string) => {
+        signed.typedData = typedData;
+        signed.account = account;
+        return ["0x1", "0x2"];
+      },
+    } as never,
+  });
+}
+
+const withdrawActions = [
+  { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
+] as Strk20Action[];
+
 describe("SdkWallet", () => {
   it("partialCommitment and strk20PrepareInvoke delegate to the prover", async () => {
     const proverSeen: { proved?: Strk20Action[] } = {};
-    const wallet = new SdkWallet({
-      prover: fakeProver(proverSeen),
-      paymaster: fakePaymaster(),
-      poolContractAddress: "0xpool",
-    });
+    const wallet = makeWallet(proverSeen);
     expect(await wallet.partialCommitment("my-dapp")).toBe(0xc0ffeen);
-
-    const actions = [
-      { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
-    ] as Strk20Action[];
-    const prepared = await wallet.strk20PrepareInvoke(actions);
-    expect(proverSeen.proved).toBe(actions);
+    const prepared = await wallet.strk20PrepareInvoke(withdrawActions);
+    expect(proverSeen.proved).toBe(withdrawActions);
     expect(prepared).toBe(PROVEN);
   });
 
-  it("strk20InvokeTransaction folds the quoted fee into the proof and broadcasts via the paymaster", async () => {
+  it("private flow: no deposit → apply_action, fee folded into the proof, broadcast via paymaster", async () => {
     const proverSeen: { proved?: Strk20Action[] } = {};
     const paymasterSeen: { build?: unknown; execute?: unknown } = {};
-    const wallet = new SdkWallet({
-      prover: fakeProver(proverSeen),
-      paymaster: fakePaymaster(paymasterSeen),
-      poolContractAddress: "0xpool",
-    });
-    const actions = [
-      { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
-    ] as Strk20Action[];
+    const result = await makeWallet(proverSeen, paymasterSeen).strk20InvokeTransaction(
+      withdrawActions
+    );
 
-    const result = await wallet.strk20InvokeTransaction(actions);
-
-    expect(paymasterSeen.build).toEqual({ kind: "applyAction", poolAddress: "0xpool" });
-    // the fee withdraw is appended to the proven action set, so the proof covers it
+    expect(paymasterSeen.build).toEqual({ kind: "applyAction", poolAddress: "0xf001" });
     expect(proverSeen.proved).toEqual([
-      ...actions,
+      ...withdrawActions,
       { type: "withdraw", token: "0xfee", amount: "0x2a", recipient: "0xpm" },
     ]);
-    // the proven strk20 call is mapped to the paymaster wire shape (selector + calldata)
     expect(paymasterSeen.execute).toEqual({
       kind: "applyAction",
       applyActionsCall: {
-        to: "0xpool",
+        to: "0xf001",
         selector: hash.getSelectorFromName("apply_actions"),
         calldata: ["0xc"],
       },
@@ -86,13 +97,48 @@ describe("SdkWallet", () => {
     expect(result).toEqual({ transaction_hash: "0xsent" });
   });
 
-  it("rejects the not-yet-implemented regular flow (executeWithProof / estimateInvokeFee)", async () => {
-    const wallet = new SdkWallet({
-      prover: fakeProver(),
-      paymaster: fakePaymaster(),
-      poolContractAddress: "0xpool",
+  it("regular flow: a deposit → invoke_and_apply_action with a signed approve", async () => {
+    const paymasterSeen: { build?: unknown; execute?: unknown } = {};
+    const signed: { typedData?: TypedData; account?: string } = {};
+    const actions = [{ type: "deposit", token: "0xtok", amount: "0x64" }] as Strk20Action[];
+    const amount = cairo.uint256(0x64n);
+    const expectedApprove = {
+      to: "0xtok",
+      selector: hash.getSelectorFromName("approve"),
+      calldata: ["0xf001", num.toHex(amount.low), num.toHex(amount.high)],
+    };
+
+    const result = await makeWallet({}, paymasterSeen, signed).strk20InvokeTransaction(actions);
+
+    // build switches to the regular flow, carrying the user-signed approve
+    expect(paymasterSeen.build).toEqual({
+      kind: "invokeAndApplyAction",
+      poolAddress: "0xf001",
+      userAddress: "0xuser",
+      calls: [expectedApprove],
     });
-    await expect(wallet.executeWithProof([])).rejects.toThrow(/regular/);
+    // the user signs the paymaster's typed data for their own account
+    expect(signed.typedData).toBe(TYPED_DATA);
+    expect(signed.account).toBe("0xuser");
+    expect(paymasterSeen.execute).toEqual({
+      kind: "invokeAndApplyAction",
+      applyActionsCall: {
+        to: "0xf001",
+        selector: hash.getSelectorFromName("apply_actions"),
+        calldata: ["0xc"],
+      },
+      proof: "0xproofdata",
+      proofFacts: ["0xf1", "0xf2"],
+      userAddress: "0xuser",
+      typedData: TYPED_DATA,
+      signature: ["0x1", "0x2"],
+    });
+    expect(result).toEqual({ transaction_hash: "0xsent" });
+  });
+
+  it("rejects the unsupported pre-proved surrounding-calls / estimate paths", async () => {
+    const wallet = makeWallet();
+    await expect(wallet.executeWithProof([])).rejects.toThrow(/not supported/);
     await expect(wallet.estimateInvokeFee()).rejects.toThrow(/not yet implemented/);
   });
 });


### PR DESCRIPTION
strk20InvokeTransaction picks the paymaster flow from the actions: with a deposit it derives the
user-signed approve(pool, amount) and switches to invoke_and_apply_action (a deposit's approve must
run as the user, but apply_action executes as the paymaster); with no deposit it stays on the private
apply_action. The user signs the paymaster's typed data via the injected signer. The fee is always
folded in as a withdraw out of the pool so the proof covers it (a simulate-based exact quote is a
TODO pending AVNU support). SdkWalletConfig gains signer + userAddress. 7 tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/918)
<!-- Reviewable:end -->
