### PR TITLE
feat(client): fluent PrivacyBuilder over the wallet seam

### DIFF
--- a/client/src/builder.ts
+++ b/client/src/builder.ts
@@ -1,0 +1,145 @@
+import { num } from "starknet";
+import type { BigNumberish, EstimateFeeResponseOverhead, STRK20_CALLDATA_ITEM } from "starknet";
+import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
+import type {
+  PrivacyBuilder,
+  PrivacyClient,
+  PrivacyComputeInvokeCallBuilder,
+  PrivacyInvokeArgs,
+  PrivacyInvokeCallBuilder,
+  PrivacyTokenBuilder,
+  Strk20Action,
+  SubmitResult,
+} from "./interfaces.js";
+
+const toFelt = (value: BigNumberish): string => num.toHex(num.toBigInt(value));
+
+/**
+ * The fluent operation builder behind {@link PrivacyClient.build}. Each method appends a
+ * {@link Strk20Action}; `submit`/`simulate` hand the accumulated actions to `client.submit`.
+ *
+ * Invoke call builders receive `${openNoteIds[N]}` / `${poolAddress}` placeholders the wallet
+ * substitutes at proving time. `openNoteIds` is sized to the open notes created *so far*, so open
+ * notes must be created before the `invoke` / `invokeWithComputation` that references them —
+ * `createOpenNote` after an invoke throws.
+ */
+class PrivacyBuilderImpl implements PrivacyBuilder {
+  private readonly actions: Strk20Action[] = [];
+  private openNoteCount = 0;
+  private invoked = false;
+
+  constructor(
+    private readonly userAddress: StarknetAddress,
+    private readonly submitActions: PrivacyClient["submit"]
+  ) {}
+
+  with(token: StarknetAddress): PrivacyTokenBuilder {
+    return new PrivacyTokenBuilderImpl(this, toFelt(token));
+  }
+
+  invoke(callBuilder: PrivacyInvokeCallBuilder): PrivacyBuilder {
+    this.invoked = true;
+    const details = callBuilder(this.invokeArgs());
+    return this.append({
+      type: "invoke",
+      contract: String(details.contractAddress),
+      calldata: (details.calldata ?? []) as STRK20_CALLDATA_ITEM[],
+    });
+  }
+
+  invokeWithComputation(callBuilder: PrivacyComputeInvokeCallBuilder): PrivacyBuilder {
+    this.invoked = true;
+    const details = callBuilder(this.invokeArgs());
+    return this.append({
+      type: "compute_and_invoke",
+      contract: details.contractAddress,
+      compute_calldata: details.computeCalldata,
+      invoke_calldata: details.invokeCalldata,
+    });
+  }
+
+  submit(): Promise<SubmitResult> {
+    return this.submitActions(this.actions);
+  }
+
+  simulate(): Promise<EstimateFeeResponseOverhead> {
+    return this.submitActions(this.actions, { simulate: true });
+  }
+
+  /** Append an action and return the builder for chaining. Used by the sub-builders. */
+  append(action: Strk20Action): PrivacyBuilder {
+    this.actions.push(action);
+    return this;
+  }
+
+  /** Append an open note (a transfer of `"OPEN"` to the user), enforcing open-notes-before-invoke. */
+  appendOpenNote(token: string): PrivacyBuilder {
+    if (this.invoked) {
+      throw new Error(
+        "PrivacyBuilder: create open notes before invoke/invokeWithComputation (an invoke's " +
+          "calldata references the open notes by index)"
+      );
+    }
+    this.openNoteCount += 1;
+    return this.append({
+      type: "transfer",
+      token,
+      amount: "OPEN",
+      recipient: toFelt(this.userAddress),
+    });
+  }
+
+  private invokeArgs(): PrivacyInvokeArgs {
+    return {
+      openNoteIds: Array.from(
+        { length: this.openNoteCount },
+        (_, index) => `\${openNoteIds[${index}]}`
+      ),
+      poolAddress: "${poolAddress}",
+    };
+  }
+}
+
+/** Token-scoped operations for one token, opened by {@link PrivacyBuilderImpl.with}. */
+class PrivacyTokenBuilderImpl implements PrivacyTokenBuilder {
+  constructor(
+    private readonly builder: PrivacyBuilderImpl,
+    private readonly token: string
+  ) {}
+
+  deposit({ amount }: { amount: BigNumberish }): PrivacyBuilder {
+    return this.builder.append({ type: "deposit", token: this.token, amount: toFelt(amount) });
+  }
+
+  withdraw(args: { amount: BigNumberish; recipient: StarknetAddress }): PrivacyBuilder {
+    return this.recipientAction("withdraw", args);
+  }
+
+  transfer(args: { amount: BigNumberish; recipient: StarknetAddress }): PrivacyBuilder {
+    return this.recipientAction("transfer", args);
+  }
+
+  private recipientAction(
+    type: "withdraw" | "transfer",
+    { amount, recipient }: { amount: BigNumberish; recipient: StarknetAddress }
+  ): PrivacyBuilder {
+    return this.builder.append({
+      type,
+      token: this.token,
+      amount: toFelt(amount),
+      recipient: toFelt(recipient),
+    } as Strk20Action);
+  }
+
+  createOpenNote(): PrivacyBuilder {
+    return this.builder.appendOpenNote(this.token);
+  }
+}
+
+/** Create the fluent operation builder for {@link PrivacyClient.build}. */
+export function createPrivacyBuilder(
+  userAddress: StarknetAddress,
+  submit: PrivacyClient["submit"]
+): PrivacyBuilder {
+  return new PrivacyBuilderImpl(userAddress, submit);
+}

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,6 +1,8 @@
 import type { Call, EstimateFeeResponseOverhead } from "starknet";
+import { createPrivacyBuilder } from "./builder.js";
 import { toStarknetCall } from "./calls.js";
 import type {
+  PrivacyBuilder,
   PrivacyClient,
   PrivacyClientConfig,
   Strk20Action,
@@ -42,6 +44,10 @@ class PrivacyClientImpl implements PrivacyClient {
     const calls: Call[] = [...preCalls, toStarknetCall(call), ...postCalls];
     // simulate: estimate the assembled invoke on the node (empty proof) for a fee quote/preview.
     return simulate ? wallet.estimateInvokeFee(calls) : wallet.executeWithProof(calls, proof);
+  }
+
+  build(): PrivacyBuilder {
+    return createPrivacyBuilder(this.config.userAddress, this.submit.bind(this));
   }
 }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -20,9 +20,15 @@ export type {
   PaymasterQuote,
 } from "./paymaster.js";
 export type {
+  PrivacyBuilder,
   PrivacyClient,
   PrivacyClientConfig,
+  PrivacyComputeInvokeCallBuilder,
+  PrivacyComputeInvokeDetails,
+  PrivacyInvokeArgs,
+  PrivacyInvokeCallBuilder,
   PrivacyStorage,
+  PrivacyTokenBuilder,
   PrivacyWallet,
   STRK20_COMPUTE_AND_INVOKE_ACTION,
   Strk20Action,

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -1,5 +1,7 @@
 import type {
+  BigNumberish,
   Call,
+  CallDetails,
   EstimateFeeResponseOverhead,
   ProviderInterface,
   STRK20_ACTION,
@@ -88,6 +90,8 @@ export interface PrivacyWallet {
 export interface PrivacyClientConfig {
   /** The wallet — signs, proves, and submits privacy operations. */
   wallet: PrivacyWallet;
+  /** The user's Starknet account address — the default recipient for self-directed ops (open notes). */
+  userAddress: StarknetAddress;
   /** Node the sub-account anonymizer view call is read from. */
   node: ProviderInterface;
   /** The sub-account anonymizer contract the client queries for sub-account addresses. */
@@ -132,4 +136,60 @@ export interface PrivacyClient {
     actions: Strk20Action[],
     options: SubmitOptions & { simulate: true }
   ): Promise<EstimateFeeResponseOverhead>;
+  /** Open a fluent operation builder that compiles into one privacy transaction. */
+  build(): PrivacyBuilder;
+}
+
+/** The transaction-time values an invoke call builder may reference, as wallet-resolved placeholders. */
+export interface PrivacyInvokeArgs {
+  /** Placeholder per open note created in this transaction: `openNoteIds[N]` is the Nth open note's id. */
+  openNoteIds: string[];
+  /** Placeholder for the privacy pool address. */
+  poolAddress: string;
+}
+
+/** Builds a plain invoke's target + calldata (which may embed {@link PrivacyInvokeArgs} placeholders). */
+export type PrivacyInvokeCallBuilder = (args: PrivacyInvokeArgs) => CallDetails;
+
+/** The target + compute/invoke calldata a compute-and-invoke produces, for the two-stage invocation. */
+export interface PrivacyComputeInvokeDetails {
+  contractAddress: string;
+  computeCalldata: STRK20_CALLDATA_ITEM[];
+  invokeCalldata: STRK20_CALLDATA_ITEM[];
+}
+
+/** Builds a compute-and-invoke's target + two calldata arrays (may embed placeholders). */
+export type PrivacyComputeInvokeCallBuilder = (
+  args: PrivacyInvokeArgs
+) => PrivacyComputeInvokeDetails;
+
+/** Token-scoped operations, opened by {@link PrivacyBuilder.with}. Each queues an action + chains. */
+export interface PrivacyTokenBuilder {
+  /** Deposit `amount` of the token from the user's public balance into the pool (always to self). */
+  deposit(output: { amount: BigNumberish }): PrivacyBuilder;
+  /** Withdraw `amount` of the token from the pool to `recipient`. */
+  withdraw(output: { amount: BigNumberish; recipient: StarknetAddress }): PrivacyBuilder;
+  /** Privately transfer `amount` of the token to `recipient` inside the pool. */
+  transfer(output: { amount: BigNumberish; recipient: StarknetAddress }): PrivacyBuilder;
+  /** Create an open note for the token owned by the user — its amount is settled later in the same tx. */
+  createOpenNote(): PrivacyBuilder;
+}
+
+/**
+ * A fluent builder for one privacy transaction. Token operations are opened with `with(token)`;
+ * `invoke` / `invokeWithComputation` run a contract after the private operations. Every method queues
+ * an action and returns the builder; `submit` proves + broadcasts the whole set, `simulate` returns a
+ * fee estimate without broadcasting.
+ */
+export interface PrivacyBuilder {
+  /** Open token-scoped operations for `token`. */
+  with(token: StarknetAddress): PrivacyTokenBuilder;
+  /** Queue a contract invocation that runs after the private operations. */
+  invoke(callBuilder: PrivacyInvokeCallBuilder): PrivacyBuilder;
+  /** Queue a two-stage compute-and-invoke that runs after the private operations. */
+  invokeWithComputation(callBuilder: PrivacyComputeInvokeCallBuilder): PrivacyBuilder;
+  /** Prove and broadcast the queued operations, returning the transaction hash. */
+  submit(): Promise<SubmitResult>;
+  /** Prove the queued operations in simulate mode and return the node fee estimate. */
+  simulate(): Promise<EstimateFeeResponseOverhead>;
 }

--- a/client/tests/client.test.ts
+++ b/client/tests/client.test.ts
@@ -51,6 +51,7 @@ function fakeWallet(seen: Seen = {}): PrivacyWallet {
 function client(seen: Seen = {}) {
   return createPrivacyClient({
     wallet: fakeWallet(seen),
+    userAddress: "0x5e1f",
     node,
     subAccountAnonymizerAddress: 0x2n,
   });
@@ -96,5 +97,61 @@ describe("submit", () => {
     expect(seen.estimate).toEqual([mappedCall]);
     expect(seen.invoke).toBeUndefined();
     expect(seen.execute).toBeUndefined();
+  });
+});
+
+describe("client.build()", () => {
+  it("compiles token ops into strk20 actions and submits them", async () => {
+    const seen: Seen = {};
+    await client(seen)
+      .build()
+      .with("0x7")
+      .deposit({ amount: 100n })
+      .with("0x7")
+      .withdraw({ amount: 5n, recipient: "0x9" })
+      .with("0x7")
+      .transfer({ amount: 3n, recipient: "0xb" })
+      .with("0x7")
+      .createOpenNote()
+      .submit();
+
+    expect(seen.invoke).toEqual([
+      { type: "deposit", token: "0x7", amount: "0x64" },
+      { type: "withdraw", token: "0x7", amount: "0x5", recipient: "0x9" },
+      { type: "transfer", token: "0x7", amount: "0x3", recipient: "0xb" },
+      // createOpenNote → transfer OPEN to the user (userAddress)
+      { type: "transfer", token: "0x7", amount: "OPEN", recipient: "0x5e1f" },
+    ]);
+  });
+
+  it("resolves invoke calldata with per-open-note placeholders at compile time", async () => {
+    const seen: Seen = {};
+    await client(seen)
+      .build()
+      .with("0x7")
+      .createOpenNote()
+      .invoke((args) => ({
+        contractAddress: "0xdapp",
+        calldata: [args.openNoteIds[0], args.poolAddress],
+      }))
+      .submit();
+
+    expect(seen.invoke).toEqual([
+      { type: "transfer", token: "0x7", amount: "OPEN", recipient: "0x5e1f" },
+      { type: "invoke", contract: "0xdapp", calldata: ["${openNoteIds[0]}", "${poolAddress}"] },
+    ]);
+  });
+
+  it("simulate compiles the same actions and routes through submit's simulate path", async () => {
+    const seen: Seen = {};
+    const estimate = await client(seen).build().with("0x7").deposit({ amount: 1n }).simulate();
+    expect(estimate).toBe(feeEstimate);
+    expect(seen.prepare?.[1]).toBe(true);
+  });
+
+  it("throws when an open note is created after an invoke", () => {
+    const builder = client().build();
+    builder.invoke(() => ({ contractAddress: "0xdapp", calldata: [] }));
+    expect(() => builder.with("0x7").createOpenNote()).toThrow(/before invoke/);
   });
 });


### PR DESCRIPTION
client.build() opens a fluent builder that appends Strk20Actions and hands them to client.submit.
Token ops live under .with(token): deposit / withdraw / transfer / createOpenNote (an open note is a
transfer of the OPEN sentinel to the user — recipient from the new config.userAddress, so
createOpenNote takes no args). Top level: invoke / invokeWithComputation (call builders resolved at
call time with ${openNoteIds[N]} / ${poolAddress} placeholders the wallet substitutes), submit
(proves + broadcasts) and simulate (fee estimate). Open notes must precede the invoke that references
them (createOpenNote after an invoke throws). PrivacyClientConfig gains userAddress. 7 tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/919)
<!-- Reviewable:end -->
