### PR TITLE
feat(sub-account-anonymizer): until_undeployed flag on get_sub_accounts

### DIFF
--- a/packages/privacy/src/tests/test_e2e.cairo
+++ b/packages/privacy/src/tests/test_e2e.cairo
@@ -1990,7 +1990,7 @@ fn test_e2e_sub_account_anonymizer_compute_invoke() {
     let anonymizer_disp = ISubAccountAnonymizerDispatcher { contract_address: anonymizer };
     let identity_key = user.compute_identity_key(contract_address: anonymizer);
     let sub_account_info = *anonymizer_disp
-        .get_sub_accounts(partial_commitment(:identity_key, :dapp_name), 0, 1)[0];
+        .get_sub_accounts(partial_commitment(:identity_key, :dapp_name), 0, 1, false)[0];
     assert!(sub_account_info.is_deployed);
     assert_eq!(token.balance_of(address: sub_account_info.address), 0);
 }

--- a/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/sub_account_anonymizer.cairo
@@ -141,17 +141,24 @@ pub trait ISubAccountAnonymizer<T> {
     /// the commitment, `hash(identity_key, dapp_name)`.
     /// - `start_nonce` (`u64`) - the first nonce to resolve (inclusive).
     /// - `end_nonce` (`u64`) - the upper bound (exclusive).
+    /// - `until_undeployed` (`bool`) - When true, resolution stops at the first undeployed nonce;
+    /// that nonce is not returned, so the result is the contiguous deployed prefix of the range.
+    /// When false, every nonce in the range is returned regardless of deployment.
     ///
     /// #### Returns
     /// - ([`Span<SubAccountInfo>`](SubAccountInfo)) - one entry per nonce in `[start_nonce,
-    /// end_nonce)`.
+    /// end_nonce)`, or the deployed prefix of that range when `until_undeployed` is true.
     ///
     /// #### Reverts
     /// - [`INVALID_RANGE`](errors::INVALID_RANGE): Thrown if `end_nonce < start_nonce`.
     /// - [`RANGE_TOO_LARGE`](errors::RANGE_TOO_LARGE): Thrown if `end_nonce - start_nonce` exceeds
     ///   [`MAX_SCAN_RANGE`](MAX_SCAN_RANGE).
     fn get_sub_accounts(
-        self: @T, partial_commitment: PartialCommitment, start_nonce: u64, end_nonce: u64,
+        self: @T,
+        partial_commitment: PartialCommitment,
+        start_nonce: u64,
+        end_nonce: u64,
+        until_undeployed: bool,
     ) -> Span<SubAccountInfo>;
 
     /// Returns the deployed sub-account address bound to `identity_commitment`.
@@ -318,6 +325,7 @@ pub mod SubAccountAnonymizer {
             partial_commitment: PartialCommitment,
             start_nonce: u64,
             end_nonce: u64,
+            until_undeployed: bool,
         ) -> Span<SubAccountInfo> {
             assert(end_nonce >= start_nonce, errors::INVALID_RANGE);
             assert(
@@ -330,6 +338,9 @@ pub mod SubAccountAnonymizer {
                 let commitment = commitment_from_partial(partial_commitment, nonce.into());
                 let stored = self.get_sub_account(commitment);
                 let is_deployed = stored.is_non_zero();
+                if until_undeployed && !is_deployed {
+                    break;
+                }
                 // Undeployed sub-accounts resolve to the address the deploy syscall would derive.
                 let address = if is_deployed {
                     stored

--- a/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
+++ b/packages/sub_account_anonymizer/src/tests/test_sub_account_anonymizer.cairo
@@ -29,7 +29,7 @@ const NOTE_ID: felt252 = 'NOTE_ID';
 /// Resolves the `('USER', 'DAPP', nonce)` sub-account via the range view.
 fn sub_account_info(anonymizer: ContractAddress, nonce: u64) -> SubAccountInfo {
     let infos = anonymizer_disp(anonymizer)
-        .get_sub_accounts(partial_commitment('USER', 'DAPP'), nonce, nonce + 1);
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), nonce, nonce + 1, false);
     *infos[0]
 }
 
@@ -620,7 +620,7 @@ fn test_get_sub_accounts_resolves_deployed_and_undeployed() {
     deploy_nonce(components, 1);
 
     // Nonce 2 is undeployed; the view resolves every nonce in range with an is_deployed flag.
-    let infos = anonymizer.get_sub_accounts(partial, 0, 3);
+    let infos = anonymizer.get_sub_accounts(partial, 0, 3, false);
     assert_eq!(infos.len(), 3);
     assert_eq!((*infos[0]).nonce, 0);
     assert!((*infos[0]).is_deployed);
@@ -633,15 +633,41 @@ fn test_get_sub_accounts_resolves_deployed_and_undeployed() {
 }
 
 #[test]
+fn test_get_sub_accounts_until_undeployed_returns_deployed_prefix() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let partial = partial_commitment('USER', 'DAPP');
+    deploy_nonce(components, 0);
+    deploy_nonce(components, 1);
+
+    // Nonce 2 is the first gap, so until_undeployed returns nonces 0 and 1 and stops there.
+    let infos = anonymizer.get_sub_accounts(partial, 0, 5, true);
+    assert_eq!(infos.len(), 2);
+    assert_eq!((*infos[0]).nonce, 0);
+    assert_eq!((*infos[1]).nonce, 1);
+}
+
+#[test]
+fn test_get_sub_accounts_until_undeployed_on_leading_gap_is_empty() {
+    let components = deploy_components();
+    let anonymizer = anonymizer_disp(components.anonymizer);
+    let partial = partial_commitment('USER', 'DAPP');
+
+    // The range's first nonce is undeployed, so the deployed prefix is empty.
+    let infos = anonymizer.get_sub_accounts(partial, 0, 5, true);
+    assert_eq!(infos.len(), 0);
+}
+
+#[test]
 fn test_get_sub_accounts_computed_address_matches_deploy() {
     let components = deploy_components();
     let anonymizer = anonymizer_disp(components.anonymizer);
     let partial = partial_commitment('USER', 'DAPP');
 
-    let before = *anonymizer.get_sub_accounts(partial, 0, 1)[0];
+    let before = *anonymizer.get_sub_accounts(partial, 0, 1, false)[0];
     assert!(!before.is_deployed);
     deploy_nonce(components, 0);
-    let after = *anonymizer.get_sub_accounts(partial, 0, 1)[0];
+    let after = *anonymizer.get_sub_accounts(partial, 0, 1, false)[0];
     assert!(after.is_deployed);
     // The address computed before deployment matches the actual on-chain deploy address.
     assert_eq!(before.address, after.address);
@@ -651,10 +677,11 @@ fn test_get_sub_accounts_computed_address_matches_deploy() {
 fn test_get_sub_accounts_scopes_by_dapp_and_nonce() {
     let components = deploy_components();
     let anonymizer = anonymizer_disp(components.anonymizer);
-    let dapp = anonymizer.get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, 2);
+    let dapp = anonymizer.get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, 2, false);
     let nonce0 = *dapp[0];
     let nonce1 = *dapp[1];
-    let other_dapp = *anonymizer.get_sub_accounts(partial_commitment('USER', 'OTHER'), 0, 1)[0];
+    let other_dapp = *anonymizer
+        .get_sub_accounts(partial_commitment('USER', 'OTHER'), 0, 1, false)[0];
     assert!(nonce0.address != nonce1.address);
     assert!(nonce0.address != other_dapp.address);
 }
@@ -668,7 +695,7 @@ fn test_get_sub_accounts_from_start_nonce() {
     deploy_nonce(components, 1);
 
     // Scanning from nonce 1 skips nonce 0; entries carry their own nonce.
-    let infos = anonymizer.get_sub_accounts(partial, 1, 3);
+    let infos = anonymizer.get_sub_accounts(partial, 1, 3, false);
     assert_eq!(infos.len(), 2);
     assert_eq!((*infos[0]).nonce, 1);
     assert!((*infos[0]).is_deployed);
@@ -680,7 +707,7 @@ fn test_get_sub_accounts_from_start_nonce() {
 fn test_get_sub_accounts_empty_range() {
     let components = deploy_components();
     let infos = anonymizer_disp(components.anonymizer)
-        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 5);
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 5, false);
     assert_eq!(infos.len(), 0);
 }
 
@@ -689,7 +716,7 @@ fn test_get_sub_accounts_empty_range() {
 fn test_get_sub_accounts_range_too_large_reverts() {
     let components = deploy_components();
     anonymizer_disp(components.anonymizer)
-        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, MAX_SCAN_RANGE + 1);
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 0, MAX_SCAN_RANGE + 1, false);
 }
 
 #[test]
@@ -697,5 +724,5 @@ fn test_get_sub_accounts_range_too_large_reverts() {
 fn test_get_sub_accounts_inverted_range_reverts() {
     let components = deploy_components();
     anonymizer_disp(components.anonymizer)
-        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 3);
+        .get_sub_accounts(partial_commitment('USER', 'DAPP'), 5, 3, false);
 }

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 - Exported `SubAccountAnonymizerABI` from the package entry point, so downstream packages can
   read the anonymizer (e.g. its `get_sub_accounts` view) against a single generated ABI source.
+  `get_sub_accounts` takes a trailing `until_undeployed: bool`: when true the view stops at the
+  first undeployed nonce and returns only the contiguous deployed prefix, when false it resolves
+  every nonce in the range.
 - Sub-accounts: `transfers.build().subaccounts(dappName)` returns a `SubAccountsBuilder` (hung off the
   builder so a sub-account `invoke` shares the builder's `ExecuteOptions`/context). `invoke(nonce, { calls })`
   queues a `ComputeAndInvoke` against the sub-account anonymizer — `computeAdditionalData = [dappName, nonce]`

--- a/sdk/src/internal/anonymizer-abi.ts
+++ b/sdk/src/internal/anonymizer-abi.ts
@@ -223,6 +223,10 @@ export const SubAccountAnonymizerABI = [
             name: "end_nonce",
             type: "core::integer::u64",
           },
+          {
+            name: "until_undeployed",
+            type: "core::bool",
+          },
         ],
         outputs: [
           {


### PR DESCRIPTION
Add a trailing `until_undeployed: bool` to the anonymizer's `get_sub_accounts` view. When true, the
view stops at the first undeployed nonce and returns only the contiguous deployed prefix; when
false it resolves every nonce in [start, end) (unchanged). This lets the client resolve a user's
deployed sub-accounts in one view call instead of scanning window-by-window client-side.

Regenerating SubAccountAnonymizerABI also picks up the OpenNote.collect_policy field, from which
the committed ABI had drifted (never regenerated after CollectPolicy landed in Cairo).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/921)
<!-- Reviewable:end -->
