### PR TITLE
feat(client): subaccounts(dappName).addresses via get_sub_accounts view

### DIFF
--- a/client/src/builder.ts
+++ b/client/src/builder.ts
@@ -2,6 +2,7 @@ import { num } from "starknet";
 import type { BigNumberish, EstimateFeeResponseOverhead, STRK20_CALLDATA_ITEM } from "starknet";
 import type { StarknetAddress } from "@starkware-libs/starknet-privacy-sdk";
 import type {
+  AddressRange,
   PrivacyBuilder,
   PrivacyClient,
   PrivacyComputeInvokeCallBuilder,
@@ -9,8 +10,16 @@ import type {
   PrivacyInvokeCallBuilder,
   PrivacyTokenBuilder,
   Strk20Action,
+  SubAccountInfo,
+  SubAccountsBuilder,
   SubmitResult,
 } from "./interfaces.js";
+
+/** Resolves a dapp's sub-account addresses — supplied by the client (anonymizer view + partial commitment). */
+export type ResolveAddresses = (
+  dappName: string,
+  range?: AddressRange
+) => Promise<SubAccountInfo[]>;
 
 const toFelt = (value: BigNumberish): string => num.toHex(num.toBigInt(value));
 
@@ -30,11 +39,16 @@ class PrivacyBuilderImpl implements PrivacyBuilder {
 
   constructor(
     private readonly userAddress: StarknetAddress,
-    private readonly submitActions: PrivacyClient["submit"]
+    private readonly submitActions: PrivacyClient["submit"],
+    private readonly resolveAddresses: ResolveAddresses
   ) {}
 
   with(token: StarknetAddress): PrivacyTokenBuilder {
     return new PrivacyTokenBuilderImpl(this, toFelt(token));
+  }
+
+  subaccounts(dappName: string): SubAccountsBuilder {
+    return new SubAccountsBuilderImpl(dappName, this.resolveAddresses);
   }
 
   invoke(callBuilder: PrivacyInvokeCallBuilder): PrivacyBuilder {
@@ -136,10 +150,23 @@ class PrivacyTokenBuilderImpl implements PrivacyTokenBuilder {
   }
 }
 
+/** The sub-account namespace for one dapp, opened by {@link PrivacyBuilderImpl.subaccounts}. */
+class SubAccountsBuilderImpl implements SubAccountsBuilder {
+  constructor(
+    private readonly dappName: string,
+    private readonly resolveAddresses: ResolveAddresses
+  ) {}
+
+  addresses(range?: AddressRange): Promise<SubAccountInfo[]> {
+    return this.resolveAddresses(this.dappName, range);
+  }
+}
+
 /** Create the fluent operation builder for {@link PrivacyClient.build}. */
 export function createPrivacyBuilder(
   userAddress: StarknetAddress,
-  submit: PrivacyClient["submit"]
+  submit: PrivacyClient["submit"],
+  resolveAddresses: ResolveAddresses
 ): PrivacyBuilder {
-  return new PrivacyBuilderImpl(userAddress, submit);
+  return new PrivacyBuilderImpl(userAddress, submit, resolveAddresses);
 }

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1,6 +1,10 @@
+import { Contract, num } from "starknet";
 import type { Call, EstimateFeeResponseOverhead } from "starknet";
+import { SubAccountAnonymizerABI } from "@starkware-libs/starknet-privacy-sdk";
 import { createPrivacyBuilder } from "./builder.js";
 import { toStarknetCall } from "./calls.js";
+import { resolveSubAccounts } from "./sub-accounts.js";
+import type { SubAccountAnonymizerContract } from "./sub-accounts.js";
 import type {
   PrivacyBuilder,
   PrivacyClient,
@@ -18,7 +22,15 @@ import type {
  * upstack over this low-level entry point.
  */
 class PrivacyClientImpl implements PrivacyClient {
-  constructor(private readonly config: PrivacyClientConfig) {}
+  private readonly anonymizer: SubAccountAnonymizerContract;
+
+  constructor(private readonly config: PrivacyClientConfig) {
+    this.anonymizer = new Contract({
+      abi: SubAccountAnonymizerABI,
+      address: num.toHex(config.subAccountAnonymizerAddress),
+      providerOrAccount: config.node,
+    }).typedv2(SubAccountAnonymizerABI);
+  }
 
   submit(
     actions: Strk20Action[],
@@ -47,7 +59,19 @@ class PrivacyClientImpl implements PrivacyClient {
   }
 
   build(): PrivacyBuilder {
-    return createPrivacyBuilder(this.config.userAddress, this.submit.bind(this));
+    return createPrivacyBuilder(
+      this.config.userAddress,
+      this.submit.bind(this),
+      (dappName, range) => this.resolveSubAccounts(dappName, range)
+    );
+  }
+
+  private async resolveSubAccounts(dappName: string, range = {}) {
+    return resolveSubAccounts({
+      anonymizer: this.anonymizer,
+      partialCommitment: await this.config.wallet.partialCommitment(dappName),
+      range,
+    });
   }
 }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -3,6 +3,8 @@
 // Resolves sub-accounts, bridges Starknet/EVM wallet signing, and builds privacy operations
 // over @starkware-libs/starknet-privacy-sdk. More of the public API is added in later changesets.
 export { createPrivacyClient } from "./client.js";
+export { resolveSubAccounts, DEFAULT_ADDRESS_RANGE_END } from "./sub-accounts.js";
+export type { ResolveSubAccountsParams, SubAccountAnonymizerContract } from "./sub-accounts.js";
 export { SdkWallet } from "./sdk-wallet.js";
 export type { SdkWalletConfig } from "./sdk-wallet.js";
 export { CorePrivateTransfersProver } from "./strk20-prover.js";
@@ -20,6 +22,7 @@ export type {
   PaymasterQuote,
 } from "./paymaster.js";
 export type {
+  AddressRange,
   PrivacyBuilder,
   PrivacyClient,
   PrivacyClientConfig,
@@ -33,6 +36,8 @@ export type {
   STRK20_COMPUTE_AND_INVOKE_ACTION,
   Strk20Action,
   Strk20Prover,
+  SubAccountInfo,
+  SubAccountsBuilder,
   SubmitOptions,
   SubmitResult,
 } from "./interfaces.js";

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -163,6 +163,39 @@ export type PrivacyComputeInvokeCallBuilder = (
   args: PrivacyInvokeArgs
 ) => PrivacyComputeInvokeDetails;
 
+/**
+ * A sub-account as resolved by the anonymizer's `get_sub_accounts` view — the decoded Cairo struct in
+ * the contract's field names (no camelCase copy). `is_deployed` is false when the account is not yet
+ * deployed, in which case `address` is the deterministic address it would deploy to.
+ */
+export interface SubAccountInfo {
+  nonce: bigint;
+  address: bigint;
+  is_deployed: boolean;
+}
+
+/**
+ * The nonce window for {@link SubAccountsBuilder.addresses}, resolved as `[start, end)`. `start`
+ * defaults to 0 and `end` to `start + DEFAULT_ADDRESS_RANGE_END`. `untilUndeployed` (default false)
+ * returns every nonce in the window; `untilUndeployed: true` stops at the first undeployed nonce and
+ * returns only the contiguous deployed prefix (the view's `until_undeployed` flag).
+ */
+export interface AddressRange {
+  start?: number;
+  end?: number;
+  untilUndeployed?: boolean;
+}
+
+/**
+ * The sub-account namespace for one user + dapp, opened by {@link PrivacyBuilder.subaccounts}.
+ * `addresses` is a read (resolved immediately via the anonymizer view). The `invoke` that operates a
+ * sub-account — delegating to the builder's bare `invoke` with the anonymizer parameters — is added
+ * with the roundtrip work.
+ */
+export interface SubAccountsBuilder {
+  addresses(range?: AddressRange): Promise<SubAccountInfo[]>;
+}
+
 /** Token-scoped operations, opened by {@link PrivacyBuilder.with}. Each queues an action + chains. */
 export interface PrivacyTokenBuilder {
   /** Deposit `amount` of the token from the user's public balance into the pool (always to self). */
@@ -184,6 +217,8 @@ export interface PrivacyTokenBuilder {
 export interface PrivacyBuilder {
   /** Open token-scoped operations for `token`. */
   with(token: StarknetAddress): PrivacyTokenBuilder;
+  /** Open the sub-account namespace for `dappName` (currently `addresses`, a read). */
+  subaccounts(dappName: string): SubAccountsBuilder;
   /** Queue a contract invocation that runs after the private operations. */
   invoke(callBuilder: PrivacyInvokeCallBuilder): PrivacyBuilder;
   /** Queue a two-stage compute-and-invoke that runs after the private operations. */

--- a/client/src/sub-accounts.ts
+++ b/client/src/sub-accounts.ts
@@ -1,0 +1,59 @@
+import type { TypedContractV2 } from "starknet";
+import { SubAccountAnonymizerABI } from "@starkware-libs/starknet-privacy-sdk";
+import type { AddressRange, SubAccountInfo } from "./interfaces.js";
+
+/** The anonymizer contract typed against its generated ABI, as the client caches it. */
+export type SubAccountAnonymizerContract = TypedContractV2<typeof SubAccountAnonymizerABI>;
+
+/**
+ * Upper bound (mirrors the Cairo `MAX_SCAN_RANGE`) on the nonce span a single `get_sub_accounts`
+ * view call may resolve; larger ranges are paginated across successive calls.
+ */
+const MAX_SCAN_RANGE = 1024;
+
+/** Default upper bound (exclusive) for {@link AddressRange.end} when the caller gives none. */
+export const DEFAULT_ADDRESS_RANGE_END = 100;
+
+export interface ResolveSubAccountsParams {
+  /** The anonymizer contract (typed, created once by the client). */
+  anonymizer: SubAccountAnonymizerContract;
+  /** `hash(identity_key, dapp_name)`, from the identity source. */
+  partialCommitment: bigint;
+  range: AddressRange;
+}
+
+/**
+ * Resolves the sub-accounts under `partialCommitment` via the anonymizer's `get_sub_accounts` view
+ * for `[start, end)`, paginated across `MAX_SCAN_RANGE` windows.
+ *
+ * The address is deliberately not recomputed client-side: it depends on the sub-account class hash,
+ * so a client-side derivation would stop matching accounts already deployed under a prior hash. The
+ * view returns the address stored on chain, which is authoritative across a class-hash change.
+ *
+ * With `untilUndeployed: true` the view stops at the first undeployed nonce and returns the
+ * contiguous deployed prefix; a short window is the signal it stopped, so pagination ends there.
+ */
+export async function resolveSubAccounts(
+  params: ResolveSubAccountsParams
+): Promise<SubAccountInfo[]> {
+  const { anonymizer, partialCommitment, range } = params;
+  const start = range.start ?? 0;
+  const end = range.end ?? start + DEFAULT_ADDRESS_RANGE_END;
+  const untilUndeployed = range.untilUndeployed ?? false;
+
+  const infos: SubAccountInfo[] = [];
+  for (let from = start; from < end; from += MAX_SCAN_RANGE) {
+    const to = Math.min(from + MAX_SCAN_RANGE, end);
+    // abi-wan statically types the ContractAddress field as `string`, but the runtime decoder returns
+    // a bigint (pinned by the client integration test), which is the {@link SubAccountInfo} shape.
+    const window = (await anonymizer.get_sub_accounts(
+      partialCommitment,
+      from,
+      to,
+      untilUndeployed
+    )) as unknown as SubAccountInfo[];
+    infos.push(...window);
+    if (untilUndeployed && window.length < to - from) break;
+  }
+  return infos;
+}

--- a/client/tests/integration.test.ts
+++ b/client/tests/integration.test.ts
@@ -68,7 +68,7 @@ function harness() {
     wallet,
     userAddress: USER,
     node,
-    subAccountAnonymizerAddress: "0xanon",
+    subAccountAnonymizerAddress: "0xa11",
   });
   return { client, prover, paymaster, signed };
 }
@@ -157,5 +157,44 @@ describe("integration: build → submit", () => {
     await expect(
       client.build().with(TOKEN).withdraw({ amount: 5n, recipient: "0x9" }).simulate()
     ).rejects.toThrow(/not yet implemented/);
+  });
+
+  it("subaccounts(dappName).addresses resolves via the anonymizer keyed by the wallet's partial commitment", async () => {
+    const seenDapp: string[] = [];
+    const viewCalldata: string[][] = [];
+    // the node answers the anonymizer get_sub_accounts view: [len, (nonce, address, is_deployed)…]
+    const anonymizerNode = {
+      callContract: async (call: { calldata: string[] }) => {
+        viewCalldata.push(call.calldata);
+        return ["0x1", "0x0", num.toHex(0x1000n), "0x1"];
+      },
+    } as unknown as ProviderInterface;
+    const wallet = new SdkWallet({
+      prover: {
+        partialCommitment: async (dappName) => {
+          seenDapp.push(dappName);
+          return 0x7n;
+        },
+        prove: async () => PROVEN,
+      },
+      paymaster: fakePaymaster({}),
+      poolContractAddress: POOL,
+      userAddress: USER,
+      signer: {} as never,
+    });
+    const client = createPrivacyClient({
+      wallet,
+      userAddress: USER,
+      node: anonymizerNode,
+      subAccountAnonymizerAddress: "0xa11",
+    });
+
+    const infos = await client.build().subaccounts("my-dapp").addresses({ end: 1 });
+
+    expect(seenDapp).toEqual(["my-dapp"]);
+    expect(infos).toEqual([{ nonce: 0n, address: 0x1000n, is_deployed: true }]);
+    // partial commitment (0x7) is the view's first arg; until_undeployed defaults to false
+    expect(num.toBigInt(viewCalldata[0][0])).toBe(0x7n);
+    expect(num.toBigInt(viewCalldata[0][3])).toBe(0n);
   });
 });

--- a/client/tests/strk20-prover.test.ts
+++ b/client/tests/strk20-prover.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Capture the operations the prover replays onto the core builder by faking createPrivateTransfers.
 const h = vi.hoisted(() => {
   const coreCallAndProof = {
-    call: { contractAddress: "0xpool", entrypoint: "apply", calldata: ["0x1"] },
+    call: { contractAddress: "0xf001", entrypoint: "apply", calldata: ["0x1"] },
     proof: { data: "0xdata", output: ["0x2"], proofFacts: ["0x3"] },
   };
   const state: {
@@ -77,8 +77,8 @@ function makeProver() {
     node: {} as never,
     discovery: {} as never,
     prover: {} as never,
-    poolContractAddress: "0xpool",
-    subAccountAnonymizerAddress: "0xanon",
+    poolContractAddress: "0xf001",
+    subAccountAnonymizerAddress: "0xa11",
     storage: {
       loadRegistry: async () => loadedRegistry as never,
       saveRegistry: async (registry) => {
@@ -116,7 +116,7 @@ describe("CorePrivateTransfersProver", () => {
     ]);
     // core CallAndProof (camelCase) → strk20 RPC shape (snake_case, proof_facts).
     expect(result).toEqual({
-      call: { contract_address: "0xpool", entry_point: "apply", calldata: ["0x1"] },
+      call: { contract_address: "0xf001", entry_point: "apply", calldata: ["0x1"] },
       proof: { data: "0xdata", output: ["0x2"], proof_facts: ["0x3"] },
     });
   });
@@ -139,7 +139,7 @@ describe("CorePrivateTransfersProver", () => {
     );
     expect(h.state.simulateArg).toBeDefined();
     expect(saved).toBeUndefined();
-    expect(estimate.call.contract_address).toBe("0xpool");
+    expect(estimate.call.contract_address).toBe("0xf001");
   });
 
   it("resolves invoke placeholders against the compiled transaction's open notes and pool", async () => {

--- a/client/tests/sub-accounts.test.ts
+++ b/client/tests/sub-accounts.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { resolveSubAccounts } from "../src/index.js";
+import type { SubAccountAnonymizerContract, SubAccountInfo } from "../src/index.js";
+
+const PARTIAL = 0x7n;
+
+/**
+ * Fake anonymizer contract standing in for the typed `get_sub_accounts` view. For `[from, to)` it
+ * yields one `SubAccountInfo` per nonce (a distinct address, `is_deployed` per `deployed(nonce)`),
+ * replicating the Cairo `until_undeployed` behavior: when set, it stops at the first undeployed nonce and
+ * returns the deployed prefix. Optionally records each call's `[from, to, untilUndeployed]`.
+ */
+function mockAnonymizer(
+  deployed: (nonce: number) => boolean,
+  calls?: Array<[number, number, boolean]>
+): SubAccountAnonymizerContract {
+  return {
+    get_sub_accounts: async (
+      _partial: bigint,
+      from: number,
+      to: number,
+      untilUndeployed: boolean
+    ): Promise<SubAccountInfo[]> => {
+      calls?.push([from, to, untilUndeployed]);
+      const infos: SubAccountInfo[] = [];
+      for (let nonce = from; nonce < to; nonce++) {
+        if (untilUndeployed && !deployed(nonce)) break;
+        // The typedv2 decoder yields bigint for the Cairo u64 nonce and ContractAddress address.
+        infos.push({
+          nonce: BigInt(nonce),
+          address: 0x1000n + BigInt(nonce),
+          is_deployed: deployed(nonce),
+        });
+      }
+      return infos;
+    },
+  } as unknown as SubAccountAnonymizerContract;
+}
+
+describe("resolveSubAccounts", () => {
+  it("returns every nonce in [start, end) with its stored address (untilUndeployed default)", async () => {
+    const infos = await resolveSubAccounts({
+      anonymizer: mockAnonymizer(() => true),
+      partialCommitment: PARTIAL,
+      range: { end: 3 },
+    });
+    expect(infos.map((info) => info.nonce)).toEqual([0n, 1n, 2n]);
+    expect(infos.every((info) => info.is_deployed)).toBe(true);
+    expect(new Set(infos.map((info) => info.address)).size).toBe(3);
+  });
+
+  it("honors start and marks undeployed nonces", async () => {
+    const infos = await resolveSubAccounts({
+      anonymizer: mockAnonymizer(() => false),
+      partialCommitment: PARTIAL,
+      range: { start: 5, end: 7 },
+    });
+    expect(infos.map((info) => info.nonce)).toEqual([5n, 6n]);
+    expect(infos.every((info) => !info.is_deployed)).toBe(true);
+  });
+
+  it("defaults end to start + DEFAULT_ADDRESS_RANGE_END", async () => {
+    const fromZero = await resolveSubAccounts({
+      anonymizer: mockAnonymizer(() => false),
+      partialCommitment: PARTIAL,
+      range: {},
+    });
+    expect(fromZero.map((info) => info.nonce)).toEqual([...Array(100).keys()].map(BigInt));
+
+    // A non-zero start shifts the whole window instead of shrinking it: [10, 110).
+    const fromTen = await resolveSubAccounts({
+      anonymizer: mockAnonymizer(() => false),
+      partialCommitment: PARTIAL,
+      range: { start: 10 },
+    });
+    expect(fromTen).toHaveLength(100);
+    expect(fromTen[0].nonce).toBe(10n);
+    expect(fromTen[99].nonce).toBe(109n);
+  });
+
+  it("paginates across MAX_SCAN_RANGE windows", async () => {
+    const calls: Array<[number, number, boolean]> = [];
+    const infos = await resolveSubAccounts({
+      anonymizer: mockAnonymizer(() => true, calls),
+      partialCommitment: PARTIAL,
+      range: { end: 1025 },
+    });
+    expect(infos).toHaveLength(1025);
+    expect(infos[1024].nonce).toBe(1024n);
+    expect(calls).toEqual([
+      [0, 1024, false],
+      [1024, 1025, false],
+    ]);
+  });
+
+  it("untilUndeployed:true returns the deployed prefix and stops at the first gap", async () => {
+    const infos = await resolveSubAccounts({
+      anonymizer: mockAnonymizer((nonce) => nonce < 3), // nonces 0,1,2 deployed
+      partialCommitment: PARTIAL,
+      range: { end: 50, untilUndeployed: true },
+    });
+    expect(infos.map((info) => info.nonce)).toEqual([0n, 1n, 2n]);
+    expect(infos.every((info) => info.is_deployed)).toBe(true);
+  });
+
+  it("untilUndeployed:true stops paginating once a window comes back short", async () => {
+    const calls: Array<[number, number, boolean]> = [];
+    const infos = await resolveSubAccounts({
+      anonymizer: mockAnonymizer((nonce) => nonce < 1030, calls),
+      partialCommitment: PARTIAL,
+      range: { end: 4096, untilUndeployed: true },
+    });
+    // First window [0,1024) is full, so it continues; [1024,2048) stops at nonce 1030.
+    expect(infos).toHaveLength(1030);
+    expect(infos[1029].nonce).toBe(1029n);
+    expect(calls).toEqual([
+      [0, 1024, true],
+      [1024, 2048, true],
+    ]);
+  });
+});


### PR DESCRIPTION
client.build().subaccounts(dappName).addresses(range) resolves a dapp's sub-account addresses through
the anonymizer's get_sub_accounts view over a typed Contract cached on the client, keyed by
wallet.partialCommitment(dappName). AddressRange { start?=0, end?=start+DEFAULT_ADDRESS_RANGE_END,
untilUndeployed?=false }: untilUndeployed=true passes the view's until_undeployed flag to return the
contiguous deployed prefix. SubAccountInfo is the decoded struct (nonce, address, is_deployed) — both
felts are bigint (the abi-wan static type says string for the address, but the runtime decoder returns
bigint, pinned by the integration test). The subaccounts(dappName) namespace will grow invoke with the
roundtrip work. resolveSubAccounts / SubAccountInfo / AddressRange exported. 6 unit + 1 integration test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/922)
<!-- Reviewable:end -->
