### PR TITLE
test(e2e): dapp client sub-account invoke + shared signing-client helpers

### DIFF
--- a/.github/workflows/e2e-devnet.yaml
+++ b/.github/workflows/e2e-devnet.yaml
@@ -92,6 +92,10 @@ jobs:
       - name: Build SDK
         run: cd sdk && npm ci && npm run build
 
+      # Build client (e2e depends on it via file: link; it resolves the built dist/, not source)
+      - name: Build client
+        run: cd client && npm ci && npm run build
+
       # Install e2e deps + run devnet tests
       - name: Install e2e dependencies
         run: cd e2e && npm ci

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,8 +8,9 @@
       "name": "starknet-privacy-e2e",
       "version": "0.1.0",
       "dependencies": {
+        "@starkware-libs/starknet-privacy-client": "file:../client",
         "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
-        "starknet": "10.0.0-beta.6"
+        "starknet": "10.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -22,14 +23,34 @@
         "vitest": "^4.0.15"
       }
     },
+    "../client": {
+      "name": "@starkware-libs/starknet-privacy-client",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "^1.7.0",
+        "@noble/hashes": "^1.6.0",
+        "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+        "starknet": "^10.0.0-beta.6"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.2",
+        "@types/node": "^24.10.1",
+        "eslint": "^9.39.2",
+        "prettier": "^3.7.4",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.51.0",
+        "vitest": "^4.0.15"
+      }
+    },
     "../sdk": {
       "name": "@starkware-libs/starknet-privacy-sdk",
-      "version": "0.14.2",
+      "version": "0.14.3-rc.4",
       "license": "ISC",
       "dependencies": {
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
         "ohttp-ts": "^0.3.0",
-        "starknet": "^10.0.0-beta.6",
+        "starknet": "10.5.0",
         "starknet-devnet": "^0.7.2",
         "zod": "^3.24.0"
       },
@@ -1173,11 +1194,37 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
     "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
       "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {
@@ -1192,6 +1239,10 @@
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT"
+    },
+    "node_modules/@starkware-libs/starknet-privacy-client": {
+      "resolved": "../client",
+      "link": true
     },
     "node_modules/@starkware-libs/starknet-privacy-sdk": {
       "resolved": "../sdk",
@@ -1646,24 +1697,24 @@
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@wallet-standard/features": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.1.0"
+        "@wallet-standard/base": "^1.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/abi-wan-kanabi": {
@@ -3246,9 +3297,9 @@
       "license": "MIT"
     },
     "node_modules/starknet": {
-      "version": "10.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.0.0-beta.6.tgz",
-      "integrity": "sha512-Ta+dR9NqJr0zE+tu8Q1Z9/3W+bwIrNiqsbT//SlZCOXeHMteUyYYuxQIpqvWY4X9g58zQsWi2uta6mYw/59HoA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.7.0",
@@ -3256,7 +3307,9 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
         "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,8 +26,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "starknet": "10.0.0-beta.6",
-    "@starkware-libs/starknet-privacy-sdk": "file:../sdk"
+    "@starkware-libs/starknet-privacy-client": "file:../client",
+    "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+    "starknet": "10.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/e2e/scripts/batch-operations.ts
+++ b/e2e/scripts/batch-operations.ts
@@ -41,6 +41,7 @@ import {
   type CallAndProof,
   type TokenOperationsBuilder,
 } from "@starkware-libs/starknet-privacy-sdk";
+import { accountOn } from "../src/utils.js";
 interface AccountEntry {
   name: string;
   address: string;
@@ -136,22 +137,22 @@ const POOL_RESOURCE_BOUNDS = {
 const PROVING_BLOCK_OFFSET = 10;
 
 async function waitForProvingBlock(
-  provider: RpcProvider,
+  node: RpcProvider,
   minProvingBlock: number,
 ): Promise<number> {
-  let latestBlockNumber = await provider.getBlockNumber();
+  let latestBlockNumber = await node.getBlockNumber();
   while (latestBlockNumber - PROVING_BLOCK_OFFSET < minProvingBlock) {
     const blocksToWait =
       minProvingBlock - (latestBlockNumber - PROVING_BLOCK_OFFSET);
     process.stdout.write(`  waiting for ${blocksToWait} more blocks...\r`);
     await new Promise((resolve) => setTimeout(resolve, 10_000));
-    latestBlockNumber = await provider.getBlockNumber();
+    latestBlockNumber = await node.getBlockNumber();
   }
   return latestBlockNumber - PROVING_BLOCK_OFFSET;
 }
 
 async function submitOutsideExecution(
-  provider: RpcProvider,
+  node: RpcProvider,
   aliceAccount: Account,
   adminAccount: Account,
   callAndProof: CallAndProof,
@@ -173,7 +174,7 @@ async function submitOutsideExecution(
     proofFacts: callAndProof.proof.proofFacts,
     proof: callAndProof.proof.data,
   });
-  const receipt = await provider.waitForTransaction(executeTx.transaction_hash);
+  const receipt = await node.waitForTransaction(executeTx.transaction_hash);
   if (!receipt.isSuccess()) {
     console.error("  REVERTED:", JSON.stringify(receipt, null, 2));
     process.exit(1);
@@ -214,16 +215,14 @@ async function runDeposit() {
   console.log(`Pool: ${POOL_ADDRESS}`);
   console.log(`Token: ${TOKEN}`);
 
-  const provider = new RpcProvider({ nodeUrl: RPC });
-  const adminAccount = new Account({
-    provider,
-    address: admin.address,
+  const node = new RpcProvider({ nodeUrl: RPC });
+  const adminAccount = accountOn(node, {
+        address: admin.address,
     signer: admin.privateKey,
     cairoVersion: "1",
   });
-  const aliceAccount = new Account({
-    provider,
-    address: alice.address,
+  const aliceAccount = accountOn(node, {
+        address: alice.address,
     signer: alice.privateKey,
     cairoVersion: "1",
   });
@@ -239,7 +238,7 @@ async function runDeposit() {
     },
     { tip: 0n, resourceBounds: ERC20_RESOURCE_BOUNDS },
   );
-  const mintReceipt = await provider.waitForTransaction(
+  const mintReceipt = await node.waitForTransaction(
     mintTx.transaction_hash,
   );
   if (!mintReceipt.isSuccess()) {
@@ -257,7 +256,7 @@ async function runDeposit() {
     },
     { tip: 0n, resourceBounds: ERC20_RESOURCE_BOUNDS },
   );
-  const approveReceipt = await provider.waitForTransaction(
+  const approveReceipt = await node.waitForTransaction(
     approveTx.transaction_hash,
   );
   if (!approveReceipt.isSuccess()) {
@@ -295,7 +294,7 @@ async function runDeposit() {
     console.log(
       `\n[${iteration + 1}/${numIterations}] Depositing ${depositsThisChunk} notes...`,
     );
-    const provingBlockId = await waitForProvingBlock(provider, minProvingBlock);
+    const provingBlockId = await waitForProvingBlock(node, minProvingBlock);
 
     const { callAndProof } = await transfers
       .build({
@@ -309,7 +308,7 @@ async function runDeposit() {
       .execute({ provingBlockId });
 
     const result = await submitOutsideExecution(
-      provider,
+      node,
       aliceAccount,
       adminAccount,
       callAndProof,
@@ -342,16 +341,14 @@ async function runTransfer() {
   console.log(`Pool: ${POOL_ADDRESS}`);
   console.log(`Token: ${TOKEN}`);
 
-  const provider = new RpcProvider({ nodeUrl: RPC });
-  const adminAccount = new Account({
-    provider,
-    address: admin.address,
+  const node = new RpcProvider({ nodeUrl: RPC });
+  const adminAccount = accountOn(node, {
+        address: admin.address,
     signer: admin.privateKey,
     cairoVersion: "1",
   });
-  const aliceAccount = new Account({
-    provider,
-    address: alice.address,
+  const aliceAccount = accountOn(node, {
+        address: alice.address,
     signer: alice.privateKey,
     cairoVersion: "1",
   });
@@ -422,7 +419,7 @@ async function runTransfer() {
     console.log(
       `\n[${iteration + 1}/${numIterations}] Transferring ${transfersThisChunk} notes to ${recipient.name}...`,
     );
-    const provingBlockId = await waitForProvingBlock(provider, minProvingBlock);
+    const provingBlockId = await waitForProvingBlock(node, minProvingBlock);
 
     const { callAndProof } = await transfers
       .build({
@@ -438,7 +435,7 @@ async function runTransfer() {
       .execute({ provingBlockId });
 
     const result = await submitOutsideExecution(
-      provider,
+      node,
       aliceAccount,
       adminAccount,
       callAndProof,

--- a/e2e/scripts/declare-class.ts
+++ b/e2e/scripts/declare-class.ts
@@ -8,7 +8,8 @@
  * Usage: npm run declare-class   (from e2e/, with .env populated)
  */
 
-import { Account, RpcProvider } from "starknet";
+import { RpcProvider } from "starknet";
+import { accountOn } from "../src/utils.js";
 import { declarePoolClass } from "../src/harness.js";
 
 function requireEnv(name: string): string {
@@ -29,9 +30,8 @@ const allAccounts: AccountEntry[] = JSON.parse(requireEnv("ACCOUNTS"));
 const admin = allAccounts.find((a) => a.admin);
 if (!admin) throw new Error("No admin account (admin: true) found in ACCOUNTS");
 
-const provider = new RpcProvider({ nodeUrl: rpcUrl });
-const adminAccount = new Account({
-  provider,
+const node = new RpcProvider({ nodeUrl: rpcUrl });
+const adminAccount = accountOn(node, {
   address: admin.address,
   signer: admin.privateKey,
   cairoVersion: "1",

--- a/e2e/scripts/deploy-accounts.ts
+++ b/e2e/scripts/deploy-accounts.ts
@@ -18,7 +18,8 @@
  * Usage: npm run deploy-accounts   (from e2e/, with .env populated)
  */
 
-import { Account, RpcProvider, ec, hash } from "starknet";
+import { RpcProvider, ec, hash, type Account } from "starknet";
+import { accountOn } from "../src/utils.js";
 
 interface AccountEntry {
   name: string;
@@ -74,11 +75,11 @@ const userAccounts = allAccounts.filter((a) => !a.admin);
 const cliArgs = process.argv.slice(2);
 const fundAmount = BigInt(parseIntArg(cliArgs, "--fund", 1)) * 10n ** 18n;
 
-const provider = new RpcProvider({ nodeUrl: rpcUrl });
+const node = new RpcProvider({ nodeUrl: rpcUrl });
 
 async function isDeployed(address: string): Promise<boolean> {
   try {
-    const classHash = await provider.getClassHashAt(address);
+    const classHash = await node.getClassHashAt(address);
     console.log(`  Already deployed (class: ${classHash}) — skipping`);
     return true;
   } catch {
@@ -101,8 +102,7 @@ async function deployAccount(
   addressSalt: string,
   name: string,
 ): Promise<void> {
-  const account = new Account({
-    provider,
+  const account = accountOn(node, {
     address,
     signer: privateKey,
     cairoVersion: "1",
@@ -114,9 +114,7 @@ async function deployAccount(
     constructorCalldata: [publicKey],
     addressSalt,
   });
-  const receipt = await provider.waitForTransaction(
-    deployResult.transaction_hash,
-  );
+  const receipt = await node.waitForTransaction(deployResult.transaction_hash);
   if (!receipt.isSuccess()) {
     console.error(`  Deploy ${name} FAILED:`, JSON.stringify(receipt, null, 2));
     process.exit(1);
@@ -141,9 +139,7 @@ async function fundAccount(
   const transferTx = await adminAccount.execute(transferCall, {
     resourceBounds: fee.resourceBounds,
   });
-  const receipt = await provider.waitForTransaction(
-    transferTx.transaction_hash,
-  );
+  const receipt = await node.waitForTransaction(transferTx.transaction_hash);
   if (!receipt.isSuccess()) {
     console.error(`  Fund ${name} FAILED:`, JSON.stringify(receipt, null, 2));
     process.exit(1);
@@ -185,8 +181,7 @@ async function main(): Promise<void> {
     );
   }
 
-  const adminAccount = new Account({
-    provider,
+  const adminAccount = accountOn(node, {
     address: adminEntry.address,
     signer: adminEntry.privateKey,
     cairoVersion: "1",

--- a/e2e/scripts/deploy-ekubo.ts
+++ b/e2e/scripts/deploy-ekubo.ts
@@ -27,7 +27,7 @@ import { deployTestTokens } from "../src/vesu-setup.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { adminAccount, provider } = setupAdmin();
+const { adminAccount, node } = setupAdmin();
 
 // Reuse existing tokens if provided, otherwise deploy fresh ones
 const existingUsd = process.env.USD_TOKEN_ADDRESS;
@@ -45,7 +45,7 @@ if (hasExistingTokens) {
   console.log(`  BTC: ${btcToken}`);
 } else {
   console.log("\n=== Deploying test tokens ===");
-  ({ usdToken, btcToken } = await deployTestTokens(adminAccount, provider));
+  ({ usdToken, btcToken } = await deployTestTokens(adminAccount, node));
 }
 
 // Pool config: use env overrides where set, fall back to DEVNET_POOL_CONFIG
@@ -80,13 +80,13 @@ const poolConfig: EkuboPoolConfig = {
 console.log("\n=== Deploying Ekubo infrastructure ===");
 const ekubo = await deployEkuboInfra(
   adminAccount,
-  provider,
+  node,
   { usdToken, btcToken },
   poolConfig,
 );
 
 console.log("\n=== Deploying Ekubo executor ===");
-const executorAddress = await deployEkuboExecutor(adminAccount, provider);
+const executorAddress = await deployEkuboExecutor(adminAccount, node);
 
 const ekuboPool = {
   token0: ekubo.poolToken0,

--- a/e2e/scripts/deploy-vesu.ts
+++ b/e2e/scripts/deploy-vesu.ts
@@ -25,7 +25,7 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { adminAccount, provider } = setupAdmin();
+const { adminAccount, node } = setupAdmin();
 
 // Reuse existing tokens if provided, otherwise deploy fresh ones
 const existingUsd = process.env.USD_TOKEN_ADDRESS;
@@ -43,17 +43,17 @@ if (hasExistingTokens) {
   console.log(`  BTC: ${btcToken}`);
 } else {
   console.log("\n=== Deploying test tokens ===");
-  ({ usdToken, btcToken } = await deployTestTokens(adminAccount, provider));
+  ({ usdToken, btcToken } = await deployTestTokens(adminAccount, node));
 }
 
 console.log("\n=== Deploying Vesu infrastructure ===");
-const vesu = await deployVesuInfra(adminAccount, provider, {
+const vesu = await deployVesuInfra(adminAccount, node, {
   usdToken,
   btcToken,
 });
 
 console.log("\n=== Deploying Vesu lending anonymizer ===");
-const anonymizerAddress = await deployVesuAnonymizer(adminAccount, provider);
+const anonymizerAddress = await deployVesuAnonymizer(adminAccount, node);
 
 // Build output env vars
 const tokens = [

--- a/e2e/scripts/generate-dump.ts
+++ b/e2e/scripts/generate-dump.ts
@@ -42,7 +42,7 @@ const devnet = new Devnet();
 const env = await devnet.initialize();
 const chainId = constants.StarknetChainId.SN_SEPOLIA;
 
-// The pool screens deposits, so the proving provider signs each deposit's attestation with the
+// The pool screens deposits, so the proving node signs each deposit's attestation with the
 // screener key the pool was deployed with.
 const transfers = {
   alice: createPrivateTransfers({

--- a/e2e/scripts/test-lending.ts
+++ b/e2e/scripts/test-lending.ts
@@ -8,7 +8,7 @@
 
 import { setupAdmin, requireEnv, u256Calldata } from "../src/utils.js";
 
-const { adminAccount: account, provider } = setupAdmin();
+const { adminAccount: account, node } = setupAdmin();
 
 const USD_TOKEN = requireEnv("USD_TOKEN_ADDRESS");
 const USD_VTOKEN = requireEnv("USD_VTOKEN_ADDRESS");
@@ -18,7 +18,7 @@ const fmt = (raw: bigint) =>
   `${raw / ONE_TOKEN}.${(raw % ONE_TOKEN).toString().padStart(18, "0").slice(0, 4)}`;
 
 async function getBalance(token: string): Promise<bigint> {
-  const result = await provider.callContract({
+  const result = await node.callContract({
     contractAddress: token,
     entrypoint: "balance_of",
     calldata: [account.address],
@@ -34,7 +34,7 @@ const mintTx = await account.execute({
   entrypoint: "mint",
   calldata: [account.address, ...u256Calldata(mintAmount)],
 });
-await provider.waitForTransaction(mintTx.transaction_hash);
+await node.waitForTransaction(mintTx.transaction_hash);
 
 // Approve vToken contract (the ERC-4626 vault) to pull USD
 console.log("Approving vToken vault...");
@@ -43,7 +43,7 @@ const approveTx = await account.execute({
   entrypoint: "approve",
   calldata: [USD_VTOKEN, ...u256Calldata(mintAmount)],
 });
-await provider.waitForTransaction(approveTx.transaction_hash);
+await node.waitForTransaction(approveTx.transaction_hash);
 
 const balUsdBefore = await getBalance(USD_TOKEN);
 const balVTokenBefore = await getBalance(USD_VTOKEN);
@@ -57,7 +57,7 @@ const depositTx = await account.execute({
   entrypoint: "deposit",
   calldata: [...u256Calldata(depositAmount), account.address],
 });
-const depositReceipt = await provider.waitForTransaction(
+const depositReceipt = await node.waitForTransaction(
   depositTx.transaction_hash,
 );
 console.log(
@@ -81,9 +81,7 @@ const redeemTx = await account.execute({
   entrypoint: "redeem",
   calldata: [...u256Calldata(sharesToRedeem), account.address, account.address],
 });
-const redeemReceipt = await provider.waitForTransaction(
-  redeemTx.transaction_hash,
-);
+const redeemReceipt = await node.waitForTransaction(redeemTx.transaction_hash);
 console.log(
   `Redeem tx: ${redeemTx.transaction_hash}, success: ${redeemReceipt.isSuccess()}`,
 );

--- a/e2e/scripts/test-swap.ts
+++ b/e2e/scripts/test-swap.ts
@@ -7,7 +7,7 @@
 
 import { setupAdmin, requireEnv, u256Calldata } from "../src/utils.js";
 
-const { adminAccount: account, provider } = setupAdmin();
+const { adminAccount: account, node } = setupAdmin();
 
 const ROUTER = requireEnv("EKUBO_ROUTER_ADDRESS");
 const TOKEN0 = requireEnv("EKUBO_POOL_TOKEN0");
@@ -21,7 +21,7 @@ const fmt = (raw: bigint) =>
   `${raw / ONE_TOKEN}.${(raw % ONE_TOKEN).toString().padStart(18, "0").slice(0, 4)}`;
 
 async function getBalance(token: string): Promise<bigint> {
-  const result = await provider.callContract({
+  const result = await node.callContract({
     contractAddress: token,
     entrypoint: "balance_of",
     calldata: [account.address],
@@ -37,7 +37,7 @@ const mintTx = await account.execute({
   entrypoint: "mint",
   calldata: [account.address, ...u256Calldata(mintAmount)],
 });
-await provider.waitForTransaction(mintTx.transaction_hash);
+await node.waitForTransaction(mintTx.transaction_hash);
 
 const balBtcBefore = await getBalance(TOKEN0);
 const balUsdBefore = await getBalance(TOKEN1);
@@ -78,7 +78,7 @@ const swapTx = await account.execute([
     calldata: [TOKEN1], // clear USD to caller
   },
 ]);
-const receipt = await provider.waitForTransaction(swapTx.transaction_hash);
+const receipt = await node.waitForTransaction(swapTx.transaction_hash);
 console.log(
   `Swap tx: ${swapTx.transaction_hash}, success: ${receipt.isSuccess()}`,
 );

--- a/e2e/src/ekubo-setup.ts
+++ b/e2e/src/ekubo-setup.ts
@@ -52,7 +52,7 @@ function parseI129(value: bigint): { mag: bigint; sign: boolean } {
  */
 export async function deployEkuboInfra(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   tokens: TokenAddresses,
   poolConfig: EkuboPoolConfig = DEVNET_POOL_CONFIG,
 ): Promise<EkuboAddresses> {
@@ -65,7 +65,7 @@ export async function deployEkuboInfra(
 
   const declareEkubo = async (name: string) => {
     const { classPath, compiledPath } = ekuboArtifact(name);
-    return declareClass(admin, provider, classPath, compiledPath);
+    return declareClass(admin, node, classPath, compiledPath);
   };
 
   const coreClassHash = await declareEkubo("Core");
@@ -75,7 +75,7 @@ export async function deployEkuboInfra(
 
   const coreAddress = await deployContract(
     admin,
-    provider,
+    node,
     coreClassHash,
     [admin.address],
     "0x100",
@@ -83,7 +83,7 @@ export async function deployEkuboInfra(
 
   const routerAddress = await deployContract(
     admin,
-    provider,
+    node,
     routerClassHash,
     [coreAddress],
     "0x200",
@@ -91,7 +91,7 @@ export async function deployEkuboInfra(
 
   const positionsAddress = await deployContract(
     admin,
-    provider,
+    node,
     positionsClassHash,
     [admin.address, coreAddress, ownedNftClassHash, "0"],
     "0x300",
@@ -116,36 +116,36 @@ export async function deployEkuboInfra(
   ];
 
   // Initialize pool
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: coreAddress,
     entrypoint: "initialize_pool",
     calldata: [...poolKey, initialTick.mag, initialTick.sign],
   });
 
   // Mint seed tokens to admin and transfer to Positions contract
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolToken0,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(poolConfig.seedAmount0)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolToken1,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(poolConfig.seedAmount1)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolToken0,
     entrypoint: "transfer",
     calldata: [positionsAddress, poolConfig.seedAmount0, 0n],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolToken1,
     entrypoint: "transfer",
     calldata: [positionsAddress, poolConfig.seedAmount1, 0n],
   });
 
   // Mint position and deposit liquidity
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: positionsAddress,
     entrypoint: "mint_and_deposit_and_clear_both",
     calldata: [
@@ -173,7 +173,7 @@ export async function deployEkuboInfra(
  */
 export async function deployEkuboExecutor(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
 ): Promise<string> {
   const executorArtifact = artifactPair(
     join(repoRoot(), "target/dev"),
@@ -183,14 +183,14 @@ export async function deployEkuboExecutor(
 
   const executorClassHash = await declareClass(
     admin,
-    provider,
+    node,
     executorArtifact.classPath,
     executorArtifact.compiledPath,
   );
 
   return deployContract(
     admin,
-    provider,
+    node,
     executorClassHash,
     [], // stateless — no constructor args
     "0x100",

--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { join } from "path";
 import { constants, hash, type Account } from "starknet";
-import { repoRoot } from "./utils.js";
+import { nodeOf, repoRoot } from "./utils.js";
 import {
   Devnet,
   type DevnetEnvironment,
@@ -36,7 +36,7 @@ export async function declarePoolClass(adminAccount: Account): Promise<string> {
   const classHash = hash.computeContractClassHash(contractClass);
 
   try {
-    await adminAccount.provider.getClass(classHash);
+    await nodeOf(adminAccount).getClass(classHash);
     console.log("[declare] class already declared:", classHash);
     return classHash;
   } catch (error: unknown) {
@@ -87,7 +87,7 @@ export async function declarePoolClass(adminAccount: Account): Promise<string> {
     }
     throw error;
   }
-  const receipt = await adminAccount.provider.waitForTransaction(
+  const receipt = await nodeOf(adminAccount).waitForTransaction(
     response.transaction_hash,
   );
   if (!receipt.isSuccess()) {
@@ -125,7 +125,7 @@ export async function createE2eTestEnv(
   });
   await indexer.waitUntilReady(devnet.url);
 
-  // The pool screens deposits, so the proving provider signs each deposit's attestation with the
+  // The pool screens deposits, so the proving node signs each deposit's attestation with the
   // screener key the pool was deployed with.
   const transfers = {
     alice: createPrivateTransfers({

--- a/e2e/src/indexer-client.ts
+++ b/e2e/src/indexer-client.ts
@@ -138,7 +138,7 @@ export class IndexerClient {
    */
   async waitForBlock(
     rpcUrl: string,
-    timeoutMs = E2E_TIMEOUTS.indexerLog,
+    timeoutMs: number = E2E_TIMEOUTS.indexerLog,
   ): Promise<string> {
     const logPromise = this.waitForNewLog("New block #", timeoutMs);
     await fetch(rpcUrl, {

--- a/e2e/src/signing-client.ts
+++ b/e2e/src/signing-client.ts
@@ -1,0 +1,140 @@
+import {
+  constants,
+  type ProviderInterface,
+  type SignerInterface,
+} from "starknet";
+import {
+  Devnet,
+  ScreeningCallMockProofProvider,
+  IndexerDiscoveryProvider,
+} from "@starkware-libs/starknet-privacy-sdk/testing";
+import {
+  createEmptyRegistry,
+  type StarknetAddress,
+} from "@starkware-libs/starknet-privacy-sdk";
+import {
+  createPrivacyClient,
+  CorePrivateTransfersProver,
+  SdkWallet,
+} from "@starkware-libs/starknet-privacy-client";
+import type {
+  Paymaster,
+  PaymasterExecute,
+  PrivacyClient,
+} from "@starkware-libs/starknet-privacy-client";
+
+/**
+ * Shared devnet plumbing for the client-driven signing/sub-account tests: the identical
+ * `CorePrivateTransfersProver` construction, an `SdkWallet`-backed client, a token-balance read, and
+ * the `executeOutside` broadcast of a proven `apply_actions`. Only the signer and the paymaster/wallet
+ * seam differ between tests, so those stay in each test.
+ */
+
+const CHAIN_ID = constants.StarknetChainId.SN_SEPOLIA;
+
+export interface CoreProverParams {
+  signer: SignerInterface;
+  address: StarknetAddress;
+  passphrase: string;
+  node: ProviderInterface;
+  indexerApiUrl: string;
+  poolAddress: string;
+  /** Only needed when the flow calls `subaccounts(...)`; unused otherwise. */
+  subAccountAnonymizerAddress?: string;
+}
+
+/** The `CorePrivateTransfersProver` every client test builds (mock prover, indexer discovery). */
+export function makeCoreProver(
+  params: CoreProverParams,
+): CorePrivateTransfersProver {
+  return new CorePrivateTransfersProver({
+    signer: params.signer,
+    address: params.address,
+    passphrase: params.passphrase,
+    node: params.node,
+    discovery: new IndexerDiscoveryProvider(
+      params.indexerApiUrl,
+      params.poolAddress,
+    ),
+    prover: new ScreeningCallMockProofProvider(params.node, CHAIN_ID),
+    poolContractAddress: params.poolAddress,
+    subAccountAnonymizerAddress: params.subAccountAnonymizerAddress ?? "0x1",
+    storage: {
+      loadRegistry: async () => createEmptyRegistry(),
+      saveRegistry: async () => {},
+    },
+  });
+}
+
+/** A `PrivacyClient` over `SdkWallet` (prover + the given paymaster) — the shape both signing tests use. */
+export function makeSdkWalletClient(
+  params: CoreProverParams & { paymaster: Paymaster },
+): PrivacyClient {
+  const prover = makeCoreProver(params);
+  const wallet = new SdkWallet({
+    prover,
+    paymaster: params.paymaster,
+    poolContractAddress: params.poolAddress,
+    signer: params.signer,
+    userAddress: params.address,
+  });
+  return createPrivacyClient({
+    wallet,
+    userAddress: params.address,
+    node: params.node,
+    subAccountAnonymizerAddress: params.subAccountAnonymizerAddress ?? "0x1",
+  });
+}
+
+/** The token balance `holder` holds, as a bigint (u256 `balance_of`). */
+export async function tokenBalance(
+  node: ProviderInterface,
+  token: string,
+  holder: string,
+): Promise<bigint> {
+  const result = await node.callContract({
+    contractAddress: token,
+    entrypoint: "balance_of",
+    calldata: [holder],
+  });
+  return BigInt(result[0]) + (BigInt(result[1]) << 128n);
+}
+
+/** Broadcast a proven `apply_actions` call with an ordinary account, as a paymaster would. */
+export async function broadcastProvenCall(
+  devnet: Devnet,
+  call: { contractAddress: string; entrypoint: string; calldata: string[] },
+  proof: { data: string; output?: string[]; proofFacts: string[] },
+): Promise<{ transaction_hash: string }> {
+  const receipt = await devnet.executeOutside({
+    call,
+    proof: {
+      data: proof.data,
+      output: proof.output ?? [],
+      proofFacts: proof.proofFacts,
+    },
+  });
+  if (!receipt.isSuccess()) {
+    throw new Error("executeOutside did not produce a successful receipt");
+  }
+  return { transaction_hash: receipt.transaction_hash };
+}
+
+/**
+ * Broadcast the proven `apply_actions` from a paymaster `execute` request with an ordinary account —
+ * the public leg a real paymaster performs after relaying any user-signed invoke.
+ */
+export function broadcastAppliedActions(
+  devnet: Devnet,
+  execute: PaymasterExecute,
+): Promise<{ transaction_hash: string }> {
+  return broadcastProvenCall(
+    devnet,
+    {
+      contractAddress: execute.applyActionsCall.to,
+      entrypoint: "apply_actions",
+      calldata: execute.applyActionsCall.calldata,
+    },
+    { data: execute.proof, proofFacts: execute.proofFacts },
+  );
+}

--- a/e2e/src/sub-account-setup.ts
+++ b/e2e/src/sub-account-setup.ts
@@ -32,7 +32,7 @@ export interface SubAccountAddresses {
  */
 async function declareTestBuildContract(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   contractName: string,
 ): Promise<string> {
   const sierraPath = join(
@@ -50,7 +50,7 @@ async function declareTestBuildContract(
     "--output-path",
     casmPath,
   ]);
-  return declareClass(admin, provider, sierraPath, casmPath);
+  return declareClass(admin, node, sierraPath, casmPath);
 }
 
 /**
@@ -64,12 +64,12 @@ async function declareTestBuildContract(
  */
 export async function deploySubAccountAnonymizer(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   privacyAddress: string,
 ): Promise<SubAccountAddresses> {
   const subAccountClassHash = await declareTestBuildContract(
     admin,
-    provider,
+    node,
     "SubAccount",
   );
 
@@ -80,7 +80,7 @@ export async function deploySubAccountAnonymizer(
   );
   const anonymizerClassHash = await declareClass(
     admin,
-    provider,
+    node,
     anonymizerArtifact.classPath,
     anonymizerArtifact.compiledPath,
   );
@@ -90,7 +90,7 @@ export async function deploySubAccountAnonymizer(
   // constructor(privacy_contract, sub_account_class_hash, governance_admin)
   const anonymizer = await deployContract(
     admin,
-    provider,
+    node,
     anonymizerClassHash,
     [privacyAddress, subAccountClassHash, admin.address],
     "0x900",
@@ -98,12 +98,12 @@ export async function deploySubAccountAnonymizer(
 
   const mockDappClassHash = await declareTestBuildContract(
     admin,
-    provider,
+    node,
     "MockDapp",
   );
   const mockDapp = await deployContract(
     admin,
-    provider,
+    node,
     mockDappClassHash,
     [],
     "0x901",

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -7,8 +7,10 @@ import {
   byteArray,
   ec,
   hash,
+  type AccountOptions,
   type Call,
   type GetTransactionReceiptResponse,
+  type ProviderInterface,
 } from "starknet";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,11 +61,11 @@ export async function declareFromArtifacts(
  */
 export async function executeAndWait(
   account: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   calls: Call | Call[],
 ): Promise<GetTransactionReceiptResponse> {
   const tx = await account.execute(calls);
-  const receipt = await provider.waitForTransaction(tx.transaction_hash);
+  const receipt = await node.waitForTransaction(tx.transaction_hash);
   if (!receipt.isSuccess()) {
     throw new Error(`Transaction failed: ${tx.transaction_hash}`);
   }
@@ -101,8 +103,24 @@ export function requireEnv(name: string): string {
   return value;
 }
 
+/**
+ * starknet.js names the account's node `provider` (`AccountOptions.provider`, `Account.provider`).
+ * These two wrappers are the only place e2e spells it that way — everywhere else a node is `node`.
+ */
+export function accountOn(
+  node: ProviderInterface,
+  options: Omit<AccountOptions, "provider">,
+): Account {
+  return new Account({ provider: node, ...options });
+}
+
+/** The node an account talks to. */
+export function nodeOf(account: Account): ProviderInterface {
+  return account.provider;
+}
+
 export function setupAdmin(): {
-  provider: RpcProvider;
+  node: RpcProvider;
   adminAccount: Account;
   admin: AccountEntry;
 } {
@@ -111,14 +129,13 @@ export function setupAdmin(): {
   const admin = accounts.find((entry) => entry.name.toLowerCase() === "admin");
   if (!admin) throw new Error('No "admin" entry found in ACCOUNTS env var');
 
-  const provider = new RpcProvider({ nodeUrl: rpcUrl });
-  const adminAccount = new Account({
-    provider,
+  const node = new RpcProvider({ nodeUrl: rpcUrl });
+  const adminAccount = accountOn(node, {
     address: admin.address,
     signer: admin.privateKey,
     cairoVersion: "1",
   });
-  return { provider, adminAccount, admin };
+  return { node, adminAccount, admin };
 }
 
 /**
@@ -127,7 +144,7 @@ export function setupAdmin(): {
  */
 export async function declareClass(
   account: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   classPath: string,
   compiledPath: string,
 ): Promise<string> {
@@ -136,7 +153,7 @@ export async function declareClass(
 
   const classHash = hash.computeContractClassHash(contractClass);
   try {
-    await provider.getClass(classHash);
+    await node.getClass(classHash);
     console.log(`  Already declared: ${classHash}`);
     return classHash;
   } catch {
@@ -165,9 +182,7 @@ export async function declareClass(
       tip: 0n,
       resourceBounds: declareResourceBounds,
     });
-    const receipt = await provider.waitForTransaction(
-      declaration.transaction_hash,
-    );
+    const receipt = await node.waitForTransaction(declaration.transaction_hash);
     if (!receipt.isSuccess()) {
       throw new Error(`Declare failed: ${declaration.transaction_hash}`);
     }
@@ -211,7 +226,7 @@ export async function declareClass(
  */
 export async function deployContract(
   account: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   classHash: string,
   constructorCalldata: Array<string | bigint>,
   salt: string,
@@ -222,7 +237,7 @@ export async function deployContract(
     constructorCalldata,
     salt: ec.starkCurve.pedersen(seed, salt),
   });
-  const receipt = await provider.waitForTransaction(
+  const receipt = await node.waitForTransaction(
     deployResponse.transaction_hash,
   );
   if (!receipt.isSuccess()) {

--- a/e2e/src/vesu-setup.ts
+++ b/e2e/src/vesu-setup.ts
@@ -68,7 +68,7 @@ function filterEvents(
  */
 export async function deployTestTokens(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
 ): Promise<TokenAddresses> {
   const tokenArtifact = artifactPair(
     join(repoRoot(), "e2e/contracts/test-token/target/dev"),
@@ -78,7 +78,7 @@ export async function deployTestTokens(
 
   const tokenClassHash = await declareClass(
     admin,
-    provider,
+    node,
     tokenArtifact.classPath,
     tokenArtifact.compiledPath,
   );
@@ -86,7 +86,7 @@ export async function deployTestTokens(
   // TestToken constructor: (name: ByteArray, symbol: ByteArray)
   const usdToken = await deployContract(
     admin,
-    provider,
+    node,
     tokenClassHash,
     [...serializeByteArray("TestUSD"), ...serializeByteArray("USD")] as Array<
       string | bigint
@@ -96,7 +96,7 @@ export async function deployTestTokens(
 
   const btcToken = await deployContract(
     admin,
-    provider,
+    node,
     tokenClassHash,
     [...serializeByteArray("TestBTC"), ...serializeByteArray("BTC")] as Array<
       string | bigint
@@ -115,7 +115,7 @@ export async function deployTestTokens(
  */
 export async function deployVesuInfra(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
   tokens: TokenAddresses,
 ): Promise<VesuAddresses> {
   const { usdToken, btcToken } = tokens;
@@ -130,7 +130,7 @@ export async function deployVesuInfra(
   // Declare all Vesu classes
   const declareVesu = async (name: string) => {
     const { classPath, compiledPath } = vesuArtifact(name);
-    return declareClass(admin, provider, classPath, compiledPath);
+    return declareClass(admin, node, classPath, compiledPath);
   };
 
   const poolClassHash = await declareVesu("Pool");
@@ -143,7 +143,7 @@ export async function deployVesuInfra(
   // Deploy PoolFactory
   const factoryAddress = await deployContract(
     admin,
-    provider,
+    node,
     factoryClassHash,
     [admin.address, poolClassHash, vtokenClassHash, oracleClassHash],
     "0x600",
@@ -152,14 +152,14 @@ export async function deployVesuInfra(
   // Deploy mock oracle contracts
   const pragmaOracleAddress = await deployContract(
     admin,
-    provider,
+    node,
     mockPragmaClassHash,
     [],
     "0x601",
   );
   const pragmaSummaryAddress = await deployContract(
     admin,
-    provider,
+    node,
     mockSummaryClassHash,
     [],
     "0x602",
@@ -167,7 +167,7 @@ export async function deployVesuInfra(
 
   // Create Oracle via PoolFactory
   const createOracleSelector = hash.getSelectorFromName("CreateOracle");
-  const oracleReceipt = await executeAndWait(admin, provider, {
+  const oracleReceipt = await executeAndWait(admin, node, {
     contractAddress: factoryAddress,
     entrypoint: "create_oracle",
     calldata: [admin.address, pragmaOracleAddress, pragmaSummaryAddress],
@@ -175,12 +175,12 @@ export async function deployVesuInfra(
   const oracleAddress = findEventKey(oracleReceipt, createOracleSelector, 1);
 
   // Set mock prices (1:1 = 1e18)
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: pragmaOracleAddress,
     entrypoint: "set_price",
     calldata: [USD_PRAGMA_KEY, SCALE],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: pragmaOracleAddress,
     entrypoint: "set_price",
     calldata: [BTC_PRAGMA_KEY, SCALE],
@@ -188,12 +188,12 @@ export async function deployVesuInfra(
 
   // Register assets in Oracle
   // OracleConfig: pragma_key, timeout, number_of_sources, start_time_offset, time_window, aggregation_mode
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: oracleAddress,
     entrypoint: "add_asset",
     calldata: [usdToken, USD_PRAGMA_KEY, 0, 2, 0, 0, 0],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: oracleAddress,
     entrypoint: "add_asset",
     calldata: [btcToken, BTC_PRAGMA_KEY, 0, 2, 0, 0, 0],
@@ -201,22 +201,22 @@ export async function deployVesuInfra(
 
   // Mint inflation fee tokens and approve factory (required for pool creation)
   const inflationAmount = 4000n;
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: usdToken,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(inflationAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: btcToken,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(inflationAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: usdToken,
     entrypoint: "approve",
     calldata: [factoryAddress, ...u256Calldata(inflationAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: btcToken,
     entrypoint: "approve",
     calldata: [factoryAddress, ...u256Calldata(inflationAmount)],
@@ -278,7 +278,7 @@ export async function deployVesuInfra(
 
   const createPoolSelector = hash.getSelectorFromName("CreatePool");
   const createVTokenSelector = hash.getSelectorFromName("CreateVToken");
-  const poolReceipt = await executeAndWait(admin, provider, {
+  const poolReceipt = await executeAndWait(admin, node, {
     contractAddress: factoryAddress,
     entrypoint: "create_pool",
     calldata: createPoolCalldata.map(String),
@@ -303,22 +303,22 @@ export async function deployVesuInfra(
   // Supply initial liquidity (1000 tokens each side)
   const liquidityAmount = 1000n * 10n ** 18n;
 
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: usdToken,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(liquidityAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: btcToken,
     entrypoint: "mint",
     calldata: [admin.address, ...u256Calldata(liquidityAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: usdToken,
     entrypoint: "approve",
     calldata: [poolAddress, ...u256Calldata(liquidityAmount)],
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: btcToken,
     entrypoint: "approve",
     calldata: [poolAddress, ...u256Calldata(liquidityAmount)],
@@ -326,7 +326,7 @@ export async function deployVesuInfra(
 
   // modify_position: supply as collateral (no borrowing)
   // Amount: denomination (Assets=1), value (i257: abs_low, abs_high, is_negative)
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolAddress,
     entrypoint: "modify_position",
     calldata: [
@@ -341,7 +341,7 @@ export async function deployVesuInfra(
       0,
     ].map(String),
   });
-  await executeAndWait(admin, provider, {
+  await executeAndWait(admin, node, {
     contractAddress: poolAddress,
     entrypoint: "modify_position",
     calldata: [
@@ -366,7 +366,7 @@ export async function deployVesuInfra(
  */
 export async function deployVesuAnonymizer(
   admin: Account,
-  provider: RpcProvider,
+  node: RpcProvider,
 ): Promise<string> {
   const anonymizerArtifact = artifactPair(
     join(repoRoot(), "target/dev"),
@@ -376,10 +376,10 @@ export async function deployVesuAnonymizer(
 
   const anonymizerClassHash = await declareClass(
     admin,
-    provider,
+    node,
     anonymizerArtifact.classPath,
     anonymizerArtifact.compiledPath,
   );
 
-  return deployContract(admin, provider, anonymizerClassHash, [], "0x700");
+  return deployContract(admin, node, anonymizerClassHash, [], "0x700");
 }

--- a/e2e/tests/devnet/ohttp-relay.test.ts
+++ b/e2e/tests/devnet/ohttp-relay.test.ts
@@ -73,7 +73,7 @@ describe("E2E OHTTP via relay", () => {
     await devnet.executeOutside(callAndProof);
     await env.indexer.waitForBlock(devnet.url);
 
-    // Create OHTTP-enabled discovery provider routed through the relay
+    // Create OHTTP-enabled discovery node routed through the relay
     const ohttpDiscovery = new IndexerDiscoveryProvider(
       env.indexer.apiUrl,
       de.privacy.address,

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -69,7 +69,7 @@ describe("E2E OHTTP", () => {
     await devnet.executeOutside(callAndProof);
     await env.indexer.waitForBlock(devnet.url);
 
-    // Create OHTTP-enabled discovery provider
+    // Create OHTTP-enabled discovery node
     const ohttpDiscovery = new IndexerDiscoveryProvider(
       env.indexer.apiUrl,
       de.privacy.address,

--- a/e2e/tests/devnet/subaccount-invoke.test.ts
+++ b/e2e/tests/devnet/subaccount-invoke.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { CallData, cairo, num, shortString } from "starknet";
+import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
+import { createPrivacyClient } from "@starkware-libs/starknet-privacy-client";
+import type {
+  PrivacyClient,
+  PrivacyWallet,
+  Strk20Action,
+} from "@starkware-libs/starknet-privacy-client";
+import {
+  makeCoreProver,
+  broadcastProvenCall,
+} from "../../src/signing-client.js";
+import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
+import { deployTestTokens, type TokenAddresses } from "../../src/vesu-setup.js";
+import {
+  deploySubAccountAnonymizer,
+  type SubAccountAddresses,
+} from "../../src/sub-account-setup.js";
+import { u256Calldata } from "../../src/utils.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
+
+/**
+ * End-to-end sub-account invoke through the dapp client on devnet, plus address validation.
+ *
+ * `client.build().with(token).createOpenNote().subaccounts(dappName).invoke(nonce, { calls })` runs
+ * the dapp `calls` through the user's sub-account (deploying it) and settles the payout into the open
+ * note — the same roundtrip as the Cairo/core tests, but driven by the client. There is no paymaster:
+ * the injected wallet proves via the SDK prover and broadcasts the proven call with an ordinary
+ * account (`devnet.executeOutside`), which is all AVNU does in production. Afterwards
+ * `build().subaccounts(dappName).addresses()` must report the now-deployed sub-account at the address
+ * a `SubAccount` contract is actually deployed to.
+ */
+describe("dapp client: subaccounts(dappName).invoke + addresses on devnet", () => {
+  let devnet: Devnet;
+  let env: E2eTestEnv;
+  let tokens: TokenAddresses;
+  let subAccount: SubAccountAddresses;
+  let client: PrivacyClient;
+
+  const DAPP = "DAPP";
+  const ONE_TOKEN = 10n ** 18n;
+  const payoutAmount = 100n * ONE_TOKEN;
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await createE2eTestEnv(devnet, {
+      indexer: { logFile: "sub-account-invoke-client-indexer.log" },
+    });
+    const { admin, alice, node, privacy } = env.env;
+    tokens = await deployTestTokens(admin, node);
+    subAccount = await deploySubAccountAnonymizer(admin, node, privacy.address);
+
+    // Fund the dapp so its `transfer_to_caller` can pay the sub-account.
+    const mintTx = await admin.execute({
+      contractAddress: tokens.usdToken,
+      entrypoint: "mint",
+      calldata: [subAccount.mockDapp, ...u256Calldata(payoutAmount)],
+    });
+    await node.waitForTransaction(mintTx.transaction_hash);
+
+    // The SDK prover proves the client's actions; a devnet wallet broadcasts the proven call with an
+    // ordinary account instead of a paymaster (no fee — any account may execute the public part).
+    const prover = makeCoreProver({
+      signer: alice.signer,
+      address: alice.address,
+      passphrase: "e2e-passphrase",
+      node: node,
+      indexerApiUrl: env.indexer.apiUrl,
+      poolAddress: privacy.address,
+      subAccountAnonymizerAddress: subAccount.anonymizer,
+    });
+    const wallet = {
+      partialCommitment: (dappName: string) =>
+        prover.partialCommitment(dappName),
+      strk20PrepareInvoke: (actions: Strk20Action[], simulate?: boolean) =>
+        prover.prove(actions, simulate),
+      strk20InvokeTransaction: async (actions: Strk20Action[]) => {
+        const { call, proof } = await prover.prove(actions);
+        return broadcastProvenCall(
+          devnet,
+          {
+            contractAddress: call.contract_address,
+            entrypoint: call.entry_point,
+            calldata: call.calldata ?? [],
+          },
+          {
+            data: proof.data,
+            output: proof.output,
+            proofFacts: proof.proof_facts,
+          },
+        );
+      },
+      executeWithProof: async () => {
+        throw new Error("unused");
+      },
+      estimateInvokeFee: async () => {
+        throw new Error("unused");
+      },
+    } as unknown as PrivacyWallet;
+
+    client = createPrivacyClient({
+      wallet,
+      userAddress: alice.address,
+      node: node,
+      subAccountAnonymizerAddress: subAccount.anonymizer,
+    });
+  }, E2E_TIMEOUTS.hook);
+
+  afterAll(async () => {
+    await env?.indexer.shutdown();
+    await devnet?.cleanup();
+  });
+
+  it(
+    "runs a sub-account invoke (deploying the sub-account) and reports it via addresses()",
+    async () => {
+      // Roundtrip: create the open note the payout settles into, then run the dapp payout through
+      // the sub-account at nonce 0. Broadcasts (executeOutside) without reverting iff the invoke +
+      // settlement succeed on-chain.
+      await client
+        .build()
+        .with(tokens.usdToken)
+        .createOpenNote()
+        .subaccounts(DAPP)
+        .invoke(0, {
+          calls: [
+            {
+              contractAddress: subAccount.mockDapp,
+              entrypoint: "transfer_to_caller",
+              calldata: CallData.compile([
+                tokens.usdToken,
+                cairo.uint256(payoutAmount),
+              ]),
+            },
+          ],
+        })
+        .submit();
+      await env.indexer.waitForBlock(devnet.url);
+
+      // The invoke deployed nonce 0's sub-account; nonces 1 and 2 remain undeployed.
+      const infos = await client
+        .build()
+        .subaccounts(DAPP)
+        .addresses({ end: 3 });
+      expect(infos.map((info) => Number(info.nonce))).toEqual([0, 1, 2]);
+      expect(infos[0].is_deployed).toBe(true);
+      expect(infos[1].is_deployed).toBe(false);
+      expect(infos[2].is_deployed).toBe(false);
+
+      // The reported address is correct: a SubAccount contract of the anonymizer's class is actually
+      // deployed there.
+      const [expectedClassHash] = await env.env.node.callContract({
+        contractAddress: subAccount.anonymizer,
+        entrypoint: "get_sub_account_class_hash",
+        calldata: [],
+      });
+      const deployedClassHash = await env.env.node.getClassHashAt(
+        num.toHex(infos[0].address),
+      );
+      expect(num.toBigInt(deployedClassHash)).toBe(
+        num.toBigInt(expectedClassHash),
+      );
+    },
+    E2E_TIMEOUTS.test,
+  );
+
+  it(
+    "untilUndeployed:true returns the deployed prefix (just nonce 0)",
+    async () => {
+      const infos = await client
+        .build()
+        .subaccounts(DAPP)
+        .addresses({ end: 5, untilUndeployed: true });
+      expect(infos.map((info) => Number(info.nonce))).toEqual([0]);
+      expect(infos[0].is_deployed).toBe(true);
+    },
+    E2E_TIMEOUTS.test,
+  );
+
+  it(
+    "dappName scopes the sub-accounts — a different dapp has none deployed",
+    async () => {
+      const other = shortString.encodeShortString("OTHER");
+      const infos = await client
+        .build()
+        .subaccounts(other)
+        .addresses({ end: 3 });
+      expect(infos.every((info) => info.is_deployed === false)).toBe(true);
+    },
+    E2E_TIMEOUTS.test,
+  );
+});

--- a/e2e/tests/integration/privacy-starknet-integration.test.ts
+++ b/e2e/tests/integration/privacy-starknet-integration.test.ts
@@ -14,6 +14,7 @@ import {
   type HistoryTransaction,
 } from "@starkware-libs/starknet-privacy-sdk";
 import { declarePoolClass } from "../../src/harness.js";
+import { accountOn } from "../../src/utils.js";
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -55,21 +56,19 @@ const alice = findAccount("alice");
 
 describe("Privacy StarkNet integration", () => {
   let discovery: IndexerDiscoveryProvider;
-  let provider: RpcProvider;
+  let node: RpcProvider;
   let adminAccount: Account;
   let aliceAccount: Account;
   let poolAddress: string;
 
   beforeAll(async () => {
-    provider = new RpcProvider({ nodeUrl: RPC });
-    adminAccount = new Account({
-      provider,
+    node = new RpcProvider({ nodeUrl: RPC });
+    adminAccount = accountOn(node, {
       address: admin.address,
       signer: admin.privateKey,
       cairoVersion: "1",
     });
-    aliceAccount = new Account({
-      provider,
+    aliceAccount = accountOn(node, {
       address: alice.address,
       signer: alice.privateKey,
       cairoVersion: "1",
@@ -78,7 +77,7 @@ describe("Privacy StarkNet integration", () => {
     // Verify RPC connectivity before proceeding
     console.log("[debug] RPC endpoint:", RPC);
     try {
-      const chainId = await provider.getChainId();
+      const chainId = await node.getChainId();
       console.log("[debug] RPC connected, chain:", chainId);
     } catch (error) {
       console.error("[debug] RPC connectivity failed:", RPC, error);
@@ -115,7 +114,7 @@ describe("Privacy StarkNet integration", () => {
     );
     console.log("[debug] deploy tx submitted:", deployResult.transaction_hash);
     console.log("[debug] waiting for deploy receipt...");
-    const deployReceipt = await provider.waitForTransaction(
+    const deployReceipt = await node.waitForTransaction(
       deployResult.transaction_hash,
     );
     if (!deployReceipt.isSuccess()) {
@@ -181,9 +180,7 @@ describe("Privacy StarkNet integration", () => {
       resourceBounds: mintFee.resourceBounds,
     });
     log(`mint tx: ${mintTx.transaction_hash}, waiting...`);
-    const mintReceipt = await provider.waitForTransaction(
-      mintTx.transaction_hash,
-    );
+    const mintReceipt = await node.waitForTransaction(mintTx.transaction_hash);
     log(`mint ${mintReceipt.isSuccess() ? "OK" : "FAILED"}`);
 
     // Approve pool to spend Alice's tokens
@@ -200,13 +197,13 @@ describe("Privacy StarkNet integration", () => {
       resourceBounds: approveFee.resourceBounds,
     });
     log(`approve tx: ${approveTx.transaction_hash}, waiting...`);
-    const approveReceipt = await provider.waitForTransaction(
+    const approveReceipt = await node.waitForTransaction(
       approveTx.transaction_hash,
     );
     log(`approve ${approveReceipt.isSuccess() ? "OK" : "FAILED"}`);
 
     // Deposit 100 tokens — SDK checks state internally and registers if needed
-    const latestBlockNumber = await provider.getBlockNumber();
+    const latestBlockNumber = await node.getBlockNumber();
     const provingBlockId = latestBlockNumber - 10;
     log(
       `building deposit: block=${latestBlockNumber}, provingBlock=${provingBlockId}`,
@@ -266,9 +263,7 @@ describe("Privacy StarkNet integration", () => {
       },
     );
     log(`executeFromOutside tx: ${executeTx.transaction_hash}, waiting...`);
-    const receipt = await provider.waitForTransaction(
-      executeTx.transaction_hash,
-    );
+    const receipt = await node.waitForTransaction(executeTx.transaction_hash);
     log(`receipt: ${receipt.isSuccess() ? "SUCCESS" : "REVERTED"}`);
     if (!receipt.isSuccess()) {
       console.error("Transaction reverted:", JSON.stringify(receipt, null, 2));

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,6 +9,13 @@
   `DevnetEnvironment.node` (`env.node`) on the `/testing` surface. `provider` is reserved for the
   proving / discovery / viewing-key providers, so a bare `provider` no longer means the node.
 
+### Changed
+
+- `starknet` dependency pinned to 10.5.0 (was `^10.0.0-beta.6`), matching the version the client
+  package needs for its `STRK20_*` wallet-api types. With one version across sdk/client/e2e their
+  `ProviderInterface` declarations line up, so a node can be passed between the packages without a
+  cast.
+
 ## 0.14.3-RC.4
 
 ### Added
@@ -154,7 +161,7 @@
   original rather than mislabeling a transient fault as terminal.
 - Screening v2: `apply_actions` calldata carries the screening attestation as a
   trailing Serde-encoded `Option` — `[0x1]` when absent, `[0x0, issued_at,
-  sig_r, sig_s]` when the prove response carries a signature (Cairo's `Option`
+sig_r, sig_s]` when the prove response carries a signature (Cairo's `Option`
   Serde tags: `Some` = 0, `None` = 1). `Proof` gains an
   optional `additionalData` relaying the prove response's `additional_data`.
   Emitted **only against a screening-capable pool**, identified with zero RPC

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
         "ohttp-ts": "^0.3.0",
-        "starknet": "^10.0.0-beta.6",
+        "starknet": "10.5.0",
         "starknet-devnet": "^0.7.2",
         "zod": "^3.24.0"
       },
@@ -1277,11 +1277,37 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
+      "license": "MIT"
+    },
     "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
       "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {
@@ -1783,24 +1809,24 @@
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@wallet-standard/features": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.1.0"
+        "@wallet-standard/base": "^1.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/abi-wan-kanabi": {
@@ -4214,9 +4240,9 @@
       "license": "MIT"
     },
     "node_modules/starknet": {
-      "version": "10.0.0-beta.6",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.0.0-beta.6.tgz",
-      "integrity": "sha512-Ta+dR9NqJr0zE+tu8Q1Z9/3W+bwIrNiqsbT//SlZCOXeHMteUyYYuxQIpqvWY4X9g58zQsWi2uta6mYw/59HoA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.7.0",
@@ -4224,7 +4250,9 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
         "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
     "ohttp-ts": "^0.3.0",
-    "starknet": "^10.0.0-beta.6",
+    "starknet": "10.5.0",
     "starknet-devnet": "^0.7.2",
     "zod": "^3.24.0"
   },


### PR DESCRIPTION
Sub-account invoke + addresses roundtrip driven by the dapp client on devnet, plus e2e/src/signing-client.ts
(makeCoreProver, makeSdkWalletClient, tokenBalance, broadcastProvenCall) — the plumbing shared with the
snip12/EVM signing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/924)
<!-- Reviewable:end -->
