### PR TITLE
test(e2e): import + deploy StarknetEth712Account, verify case-I EVM signature

### DIFF
--- a/.github/workflows/e2e-devnet.yaml
+++ b/.github/workflows/e2e-devnet.yaml
@@ -71,6 +71,9 @@ jobs:
           # SubAccount + MockDapp come from the test build (sierra only); the e2e setup
           # compiles casm with universal-sierra-compiler (set up above) at declare time.
           scarb build -t -p sub_account_anonymizer
+          # StarknetEth712Account (the EVM account the signing e2e deploys) is a
+          # build-external-contract of the privacy test target; same sierra-only + USC-at-declare flow.
+          scarb build -t -p privacy
       - name: Build ekubo contracts
         run: cd e2e/contracts/ekubo && scarb build
       - name: Build test token

--- a/e2e/src/eth712-account-setup.ts
+++ b/e2e/src/eth712-account-setup.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { keccak_256 } from "@noble/hashes/sha3";
+import { Account, CallData, RpcProvider, num, type Abi } from "starknet";
+import { declareClass, deployContract, repoRoot } from "./utils.js";
+
+/**
+ * Deploys a `StarknetEth712Account` (from `starkware_accounts`, emitted by the privacy test build) on
+ * devnet: a Starknet account that validates EVM/secp256k1 EIP-712 signatures. The account has no
+ * constructor — deploy it via the UDC, then `initialize(eth_address, ownership_signature)` proves
+ * EVM-key ownership and registers its SRC5 interfaces (incl. custom-signature-validation).
+ */
+
+const TEST_BUILD_DIR = join(repoRoot(), "target/dev");
+const ACCOUNT_CONTRACT =
+  "privacy_unittest_StarknetEth712Account.test.contract_class.json";
+
+// keccak256("\x19Ethereum Signed Message:\n41Sign to verify that you own this account.")
+// (starkware_accounts::eth_712_utils::OWNERSHIP_TRANSFER_MSG_HASH) — signing it with the EVM key
+// proves account ownership at initialize().
+const OWNERSHIP_TRANSFER_MSG_HASH =
+  0x3ce976d55131cd0bdd49f20afbded052d8e907dc6034d95cdf117a8fd7752e3cn;
+
+function to32(value: bigint): Uint8Array {
+  const out = new Uint8Array(32);
+  let rest = value;
+  for (let index = 31; index >= 0; index--) {
+    out[index] = Number(rest & 0xffn);
+    rest >>= 8n;
+  }
+  return out;
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+}
+
+/** The EVM address (low 160 bits of keccak(uncompressed pubkey)) for a secp256k1 private key. */
+export function evmAddress(evmPrivateKey: bigint): bigint {
+  const publicKey = secp256k1.getPublicKey(to32(evmPrivateKey), false).slice(1); // drop 0x04 prefix
+  return bytesToBigInt(keccak_256(publicKey).slice(12));
+}
+
+/**
+ * The EVM ownership signature over the fixed `OWNERSHIP_TRANSFER_MSG_HASH`, as the account's
+ * `Signature { r, s, y_parity }`. `y_parity` matches the 6-felt convention the account uses
+ * elsewhere (`v = 27 + recovery`, `y_parity = v % 2 == 0`), i.e. an odd recovery id.
+ */
+function ownershipSignature(evmPrivateKey: bigint): {
+  r: bigint;
+  s: bigint;
+  y_parity: boolean;
+} {
+  const signature = secp256k1.sign(
+    to32(OWNERSHIP_TRANSFER_MSG_HASH),
+    to32(evmPrivateKey),
+  );
+  return {
+    r: signature.r,
+    s: signature.s,
+    y_parity: signature.recovery % 2 === 1,
+  };
+}
+
+async function declareEth712Account(
+  admin: Account,
+  node: RpcProvider,
+): Promise<string> {
+  const sierraPath = join(TEST_BUILD_DIR, ACCOUNT_CONTRACT);
+  const casmPath = join(
+    mkdtempSync(join(tmpdir(), "eth712-casm-")),
+    "account.casm.json",
+  );
+  execFileSync("universal-sierra-compiler", [
+    "compile-contract",
+    "--sierra-path",
+    sierraPath,
+    "--output-path",
+    casmPath,
+  ]);
+  return declareClass(admin, node, sierraPath, casmPath);
+}
+
+export interface Eth712Account {
+  /** The deployed Starknet account address. */
+  address: string;
+  /** The EVM address the account validates signatures against. */
+  ethAddress: bigint;
+  /** The account ABI, for compiling `is_custom_signature_valid` / `execute_from_outside_v2` calls. */
+  abi: Abi;
+}
+
+/** Declare, UDC-deploy, and initialize a `StarknetEth712Account` owned by `evmPrivateKey`. */
+export async function deployEth712Account(
+  admin: Account,
+  node: RpcProvider,
+  evmPrivateKey: bigint,
+): Promise<Eth712Account> {
+  const classHash = await declareEth712Account(admin, node);
+  const abi: Abi = JSON.parse(
+    readFileSync(join(TEST_BUILD_DIR, ACCOUNT_CONTRACT), "utf8"),
+  ).abi;
+  const address = await deployContract(admin, node, classHash, [], "0xe712");
+
+  const ethAddress = evmAddress(evmPrivateKey);
+  const initialize = await admin.execute({
+    contractAddress: address,
+    entrypoint: "initialize",
+    calldata: new CallData(abi).compile("initialize", {
+      eth_address: num.toHex(ethAddress),
+      signature: ownershipSignature(evmPrivateKey),
+    }),
+  });
+  await node.waitForTransaction(initialize.transaction_hash);
+
+  return { address, ethAddress, abi };
+}

--- a/e2e/tests/devnet/eth712-account.test.ts
+++ b/e2e/tests/devnet/eth712-account.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { CallData, hash, num, shortString, type Call } from "starknet";
+import {
+  Devnet,
+  type DevnetEnvironment,
+} from "@starkware-libs/starknet-privacy-sdk/testing";
+import {
+  Eip712HashSigner,
+  secp256k1SignFn,
+} from "@starkware-libs/starknet-privacy-client/signers";
+import {
+  deployEth712Account,
+  type Eth712Account,
+} from "../../src/eth712-account-setup.js";
+import { E2E_TIMEOUTS } from "../../src/timeouts.js";
+
+/**
+ * Deploys a real `StarknetEth712Account` and checks that the client's `Eip712HashSigner` produces a
+ * `CallSet` signature the account accepts on-chain via `is_custom_signature_valid` (case I). This is
+ * the setup branch's own verification: the imported account + the client's EVM signer agree on the
+ * EIP-712 `CallSet` hash.
+ */
+describe("StarknetEth712Account custom-signature validation on devnet", () => {
+  let devnet: Devnet;
+  let env: DevnetEnvironment;
+  let account: Eth712Account;
+
+  // Same EVM key as starkware_accounts' test fixtures — its eth address is what the account is
+  // initialized with, so signatures with it validate.
+  const EVM_KEY =
+    0xa6d86467b6ec9e161649b27edfd8519e75a2e1cf5f4c309c628706e6999780e8n;
+  const VALIDATED = BigInt(shortString.encodeShortString("VALID"));
+
+  beforeAll(async () => {
+    devnet = new Devnet();
+    env = await devnet.initialize();
+    account = await deployEth712Account(env.admin, env.node, EVM_KEY);
+  }, E2E_TIMEOUTS.hook);
+
+  afterAll(async () => {
+    await devnet?.cleanup();
+  });
+
+  it(
+    "accepts a client Eip712 CallSet signature (case I)",
+    async () => {
+      const approveCalldata = ["0x1234", "0x1f4", "0x0"];
+      const signer = new Eip712HashSigner({
+        accountAddress: account.address,
+        snChainName: "SN_SEPOLIA", // devnet chain id — keccak'd into the EIP-712 domain name
+        evmChainId: 1n,
+        sign: secp256k1SignFn(EVM_KEY),
+      });
+
+      const signature = (await signer.signTransaction(
+        [
+          {
+            contractAddress: "0x111",
+            entrypoint: "approve",
+            calldata: approveCalldata,
+          },
+        ],
+        {} as never,
+      )) as string[];
+
+      // The on-chain Call uses the raw selector; it must be the same call the signer hashed.
+      const onChainCalls: Call[] = [
+        {
+          contractAddress: "0x111",
+          entrypoint: hash.getSelectorFromName("approve"),
+          calldata: approveCalldata,
+        },
+      ];
+      const result = await env.node.callContract({
+        contractAddress: account.address,
+        entrypoint: "is_custom_signature_valid",
+        calldata: new CallData(account.abi).compile(
+          "is_custom_signature_valid",
+          {
+            calls: onChainCalls.map((call) => ({
+              to: call.contractAddress,
+              selector: call.entrypoint,
+              calldata: call.calldata,
+            })),
+            additional_data: [],
+            signature,
+          },
+        ),
+      });
+
+      expect(num.toBigInt(result[0])).toBe(VALIDATED);
+    },
+    E2E_TIMEOUTS.test,
+  );
+});

--- a/packages/privacy/Scarb.toml
+++ b/packages/privacy/Scarb.toml
@@ -29,6 +29,7 @@ name = "privacy_unittest"
 build-external-contracts = [
     "starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock",
     "starkware_accounts::sub_account::SubAccount",
+    "starkware_accounts::eth_712_account::StarknetEth712Account",
     "ekubo_swap_anonymizer::ekubo_swap_anonymizer::EkuboSwapAnonymizer",
     "ekubo_swap_anonymizer::test_utils_contracts::mock_ekubo_amm::MockEkuboAMM",
     "sub_account_anonymizer::sub_account_anonymizer::SubAccountAnonymizer",


### PR DESCRIPTION
Add starkware_accounts::StarknetEth712Account to the privacy test build's build-external-contracts so
it is declarable on devnet. e2e/src/eth712-account-setup.ts deploys + initializes one (EVM key ->
address, ownership signature over the fixed hash, UDC deploy + initialize). The test confirms the
client's Eip712HashSigner produces a CallSet signature the deployed account accepts on-chain via
is_custom_signature_valid (case I).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/927)
<!-- Reviewable:end -->
