### PR TITLE
ci(typescript): gate SDK Devnet Test on sdk/contract changes

### DIFF
--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -83,33 +83,58 @@ jobs:
         working-directory: sdk
 
     steps:
+      # fetch-depth: 2 so paths-filter can diff against the parent commit on push events (on
+      # pull_request it uses the GitHub API and needs no history).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      # The devnet suite exercises the SDK against the Cairo contracts, so run it only when the SDK, the
+      # contracts, or this workflow itself change (the last so a change to the job below is exercised by
+      # its own PR). Client-only PRs skip it (the steps no-op and the job still reports green, keeping a
+      # required check satisfied) rather than being gated on the unrelated Cairo/devnet build.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            devnet:
+              - 'sdk/**'
+              - 'packages/**'
+              - 'Scarb.toml'
+              - 'Scarb.lock'
+              - '.github/workflows/typescript-ci.yml'
 
       - uses: actions/setup-node@v4
+        if: steps.filter.outputs.devnet == 'true'
         with:
           node-version: '24'
           cache: 'npm'
           cache-dependency-path: sdk/package-lock.json
 
       - name: Install Scarb
+        if: steps.filter.outputs.devnet == 'true'
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: "2.17.0"
 
       - uses: software-mansion/setup-universal-sierra-compiler@v1
+        if: steps.filter.outputs.devnet == 'true'
         with:
           universal-sierra-compiler-version: "v2.8.0"
 
       - name: Install starknet-devnet
+        if: steps.filter.outputs.devnet == 'true'
         run: |
           curl -L https://github.com/0xSpaceShard/starknet-devnet/releases/download/v0.8.0-rc.3/starknet-devnet-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/local/bin
           chmod +x /usr/local/bin/starknet-devnet
 
       - name: Install npm dependencies
+        if: steps.filter.outputs.devnet == 'true'
         run: npm ci
 
       - name: Build Cairo contracts
+        if: steps.filter.outputs.devnet == 'true'
         run: npm run scarb:build
 
       - name: Run devnet tests
+        if: steps.filter.outputs.devnet == 'true'
         run: npm run test:devnet


### PR DESCRIPTION
Skip the Cairo build + devnet e2e on PRs that touch neither the SDK nor the
contracts (e.g. client-only PRs), mirroring the existing paths-filter on the
lint job. The steps no-op and the job still reports success, so a required
check stays satisfied without gating client PRs on the unrelated devnet build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/929)
<!-- Reviewable:end -->
