### PR TITLE
fix(e2e): encode OpenNote.collect_policy in sub-account devnet test

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -161,6 +161,10 @@ Apply these guidelines when writing or reviewing code in this codebase.
 - Broken imports or syntax errors can mask that tests were never working
 - *Example:* `git stash && cargo build` to check if the original code even compiles before investigating test logic
 
+### A test suite's CI path filter must cover every layer the suite exercises
+- Filtering a CI job to the test directory alone lets changes to the code under test land without ever running the suite; include every layer it builds or links against (contracts, SDK, service crates)
+- *Example:* an e2e job filtered to `e2e/**` never ran when a Cairo struct gained a required field, so the test's hand-built calldata broke silently and only failed weeks later on a workflow-only PR
+
 ---
 
 ## Module Organization

--- a/.github/workflows/e2e-devnet.yaml
+++ b/.github/workflows/e2e-devnet.yaml
@@ -5,11 +5,15 @@ on:
   pull_request:
     paths:
       - 'e2e/**'
+      - 'sdk/**'
+      - 'packages/**'
       - '.github/workflows/e2e-devnet.yaml'
   push:
     branches: [main]
     paths:
       - 'e2e/**'
+      - 'sdk/**'
+      - 'packages/**'
       - '.github/workflows/e2e-devnet.yaml'
 
 env:

--- a/e2e/tests/devnet/sub-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/sub-account-compute-invoke.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
 import { Open } from "@starkware-libs/starknet-privacy-sdk";
-import { CallData, cairo, hash, shortString } from "starknet";
+import { CairoCustomEnum, CallData, cairo, hash, shortString } from "starknet";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
 import { deployTestTokens, type TokenAddresses } from "../../src/vesu-setup.js";
 import {
@@ -95,7 +95,14 @@ describe("SubAccount anonymizer compute-and-invoke on devnet", () => {
                 ]),
               },
             ],
-            [{ note_id: openNote.noteId, token: usdToken }],
+            [
+              {
+                note_id: openNote.noteId,
+                token: usdToken,
+                // Collect the sub-account's entire token balance into the open note.
+                collect_policy: new CairoCustomEnum({ All: {} }),
+              },
+            ],
           ])
           .slice(1)
           .map((felt) => BigInt(felt));


### PR DESCRIPTION
## What

- `e2e/tests/devnet/sub-account-compute-invoke.test.ts`: encode the required `collect_policy` member (`CollectPolicy::All`) in the hand-compiled `OpenNote` calldata.
- `.github/workflows/e2e-devnet.yaml`: add `packages/**` and `sdk/**` to the trigger path filters.
- `.claude/rules/code-style.md`: record the generalized lesson (CI path filters must cover every layer the suite exercises).

## Why

#882 added a required `collect_policy: CollectPolicy` field to the Cairo `OpenNote` struct. This test compiles `privacy_invoke_with_computation` calldata by hand against the freshly built anonymizer ABI, so it broke with `Missing parameter for type sub_account_anonymizer::sub_account_anonymizer::CollectPolicy` — but the e2e-devnet job only triggered on `e2e/**`, so the break stayed invisible until #930 touched the workflow file and the job finally ran. (#908 fixed the SDK's own encoding path; this test bypasses the SDK deliberately.)

`CollectPolicy::All` matches the SDK default and the test's assertions: the sub-account starts with zero balance, so collecting everything settles exactly the dapp payout into the open note.

The suite builds the contracts from `packages/**` and links the SDK from `sdk/` via a `file:` dependency, so changes to either can break it — the widened filter makes CI run the suite when they change.

## Verification

- Repro proven both ways: compile throws without `collect_policy`, succeeds with it.
- Fixed test passes end-to-end on local devnet (`starknet-devnet 0.8.0-rc.3`, same as CI): 1 passed, ~8s.
- prettier + eslint clean on the test file; workflow YAML parses with the intended path lists.
- This PR touches `e2e/**` and the workflow, so the full devnet suite runs on it in CI.

Unblocks the red `E2E Devnet` check on #930 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/932)
<!-- Reviewable:end -->
