### PR TITLE
fix: declare Apache-2.0 license in sdk and client package metadata

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "typescript"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@noble/curves": "^1.7.0",
     "@noble/hashes": "^1.6.0",

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- `license` in `package.json` now reads `Apache-2.0`, matching the repository's `LICENSE`. It
+  previously declared `ISC` (an `npm init` default), so the registry metadata contradicted the
+  license the package actually ships under.
+
 ## 0.14.3-RC.4
 
 ### Added

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -69,7 +69,7 @@
     "typescript"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@~0.10.2",
     "ohttp-ts": "^0.3.0",


### PR DESCRIPTION
## What

`sdk/package.json` and `client/package.json` both declared **`"license": "ISC"`** — the `npm init` default — while this repository ships under **Apache-2.0** (`LICENSE`, and `license-file = "LICENSE"` in `Scarb.toml`).

Neither package is `private`, so the wrong license was going out in the published registry metadata. Anyone running a license audit on `@starkware-libs/starknet-privacy-sdk` would see `ISC` contradict the `LICENSE` file in this repo.

## Changes

- `sdk/package.json` — `ISC` → `Apache-2.0`
- `client/package.json` — `ISC` → `Apache-2.0`
- `sdk/CHANGELOG.md` — entry under `## Unreleased` → `### Fixed`

Only the two publishable packages are touched. `demo/`, `e2e/`, `elliptic-proxy/`, `proof-interceptor/` and `scripts/address_validation_signer/ts/` are all `private: true` and declare no license, which is correct for packages that never publish.

## Verification

- `cd sdk && npm run lint` → **exit 0** (prettier + eslint + `tsc --noEmit`)
- Both `package.json` files parse as valid JSON
- `prettier --check` on my `CHANGELOG.md` lines is clean. The file as a whole fails prettier at `HEAD` too (exit 1 before and after) — the sole disagreement is an indentation artifact at **line 153**, in an entry predating this PR. `npm run lint` only globs `src/` and `tests/`, so it isn't gated either way. Left alone rather than folded into a license PR.

## Context

Found while auditing [`starkware-libs/privacy-bridge`](https://github.com/starkware-libs/privacy-bridge) for open-source readiness — it depends on `@starkware-libs/starknet-privacy-sdk`, so it inherits this metadata. Companion PR adding Apache-2.0 there: starkware-libs/privacy-bridge#42.

Not addressed here: the Rust crates (`crates/discovery-core`, `crates/discovery-service`) declare no `license` field in their `Cargo.toml`. They aren't published to crates.io, so it's cosmetic — happy to add it if you want the metadata complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/933)
<!-- Reviewable:end -->
