### PR TITLE
fix(sdk): keep partial-withdrawal change with the sender

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- `SimplePrivateTransfers.withdraw(token, recipient, amount)` keeps the change with the sender.
+  Withdrawing a fixed amount selects every note the sender holds for that token, and the surplus is
+  now created as a private note owned by the sender instead of the withdrawal recipient — the
+  recipient receives only the requested amount, publicly. `withdraw(token, recipient, All)` is
+  unchanged, and still moves nothing — it requests the surplus without an action to select notes
+  for the token, so no notes are selected and no withdrawal is emitted. See the `TODO` on that
+  branch in `src/simple-private-transfers.ts`.
+
 ### Breaking
 
 - Node-provider fields are named `node`, not `provider`: `SimulateOptions.provider` →

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -37,11 +37,15 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     amount: Amount | All
   ): Promise<ExecuteResult> {
     const builder = this.build(token);
-    const surplustWithdraw = isAll(amount) ? true : false;
-    if (!isAll(amount)) {
-      builder.withdraw({ recipient, amount });
+    if (isAll(amount)) {
+      // Withdraw all: send everything as surplus to recipient's public balance
+      // TODO(Avi): no-op today — resolveNotes only enters a token into `balances` via
+      // deposits/useNotes/withdraws/createNotes, so a bare surplusTo with no other action
+      // on the token never selects notes or emits a withdraw. Needs a fix in internal/compiler.ts.
+      return builder.surplusTo(recipient, true).execute();
     }
-    return builder.surplusTo(recipient, surplustWithdraw).execute();
+    // Withdraw specific amount: pay recipient publicly, keep surplus as a private note
+    return builder.withdraw({ recipient, amount }).surplusTo(this.inner.user, false).execute();
   }
 
   transfer(

--- a/sdk/tests/simple-private-transfers.test.ts
+++ b/sdk/tests/simple-private-transfers.test.ts
@@ -1,8 +1,35 @@
-import { describe, expect, it, beforeEach, afterAll } from "vitest";
+import { describe, expect, it, beforeEach, afterAll, vi } from "vitest";
 import { createTestEnv, MockTestEnv, POOL_ADDRESS } from "./helpers/test-fixtures.js";
 import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
 import { debugHint, isDebugEnabled, toBigInt, toHex } from "../src/utils/index.js";
 import { MockSwapAnonymizer } from "../src/testing/contracts.js";
+import { All, PrivateTransfersInterface } from "../src/interfaces.js";
+
+interface SurplusCall {
+  recipient: bigint;
+  withdraw?: boolean;
+}
+
+// Spies on surplusTo to record each call's arguments while still invoking the real implementation.
+function spyOnSurplusTo(transfers: PrivateTransfersInterface): SurplusCall[] {
+  const surplusCalls: SurplusCall[] = [];
+  const build = transfers.build.bind(transfers);
+  vi.spyOn(transfers, "build").mockImplementation((options) => {
+    const builder = build(options);
+    const withToken = builder.with.bind(builder);
+    vi.spyOn(builder, "with").mockImplementation((token) => {
+      const tokenBuilder = withToken(token);
+      const surplusTo = tokenBuilder.surplusTo.bind(tokenBuilder);
+      vi.spyOn(tokenBuilder, "surplusTo").mockImplementation((recipient, withdraw) => {
+        surplusCalls.push({ recipient: toBigInt(recipient), withdraw });
+        return surplusTo(recipient, withdraw);
+      });
+      return tokenBuilder;
+    });
+    return builder;
+  });
+  return surplusCalls;
+}
 
 describe("SimplePrivateTransfers", () => {
   let testEnv: MockTestEnv;
@@ -56,6 +83,63 @@ describe("SimplePrivateTransfers", () => {
 
     // Verify: public balance reflects withdraw
     expect(env.contracts.get(ace).balanceOf(env.alice.address)).toBe(940n); // 1000 - 100 + 40
+  });
+
+  it("withdraw keeps surplus with the sender when paying a third party", async () => {
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+
+    // Both registered, so a private note to Bob would be constructible
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(await transfers.bob.build().register().execute());
+
+    const alice = new SimplePrivateTransfersImpl(transfers.alice);
+
+    // Two notes: note selection sweeps both, so the change is 160n
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+    mocknet.executeOutside(await alice.withdraw(env.ace, env.bob.address, 40n));
+
+    expect(env.contracts.get(ace).balanceOf(env.bob.address)).toBe(1040n); // 1000 + 40
+
+    const bobNotes = (await transfers.bob.discoverNotes()).notes.get(ace) ?? [];
+    expect(bobNotes).toEqual([]);
+
+    const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
+    expect(aliceNotes.length).toBe(1);
+    expect(aliceNotes[0].amount).toBe(160n);
+
+    expect(env.contracts.get(ace).balanceOf(env.alice.address)).toBe(800n); // 1000 - 200
+  });
+
+  it("withdraw routes surplus to the sender for an amount and to the recipient for All", async () => {
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(await transfers.bob.build().register().execute());
+
+    const alice = new SimplePrivateTransfersImpl(transfers.alice);
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+
+    const surplusCalls = spyOnSurplusTo(transfers.alice);
+
+    // An amount is paid out as a withdraw output, so the surplus is the sender's own change note
+    mocknet.executeOutside(await alice.withdraw(env.ace, env.bob.address, 40n));
+    expect(surplusCalls).toEqual([{ recipient: toBigInt(env.alice.address), withdraw: false }]);
+
+    // All has no separate output: the whole balance is the surplus, withdrawn to the recipient
+    surplusCalls.length = 0;
+    mocknet.executeOutside(await alice.withdraw(env.ace, env.bob.address, All));
+    expect(surplusCalls).toEqual([{ recipient: toBigInt(env.bob.address), withdraw: true }]);
+
+    // Nothing moved: with no action of its own to seed a balance for the token, the All call above
+    // selects no notes. These assertions must flip once the TODO on withdraw's isAll branch is fixed.
+    expect(env.contracts.get(ace).balanceOf(env.bob.address)).toBe(1040n); // unchanged since the 40n withdraw
+    const bobNotes = (await transfers.bob.discoverNotes()).notes.get(ace) ?? [];
+    expect(bobNotes).toEqual([]);
+    const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
+    expect(aliceNotes.map((note) => note.amount)).toEqual([60n]); // untouched change note from the first withdraw
   });
 
   it("transfer sends funds to recipient", async () => {


### PR DESCRIPTION
## What

`SimplePrivateTransfers.withdraw(token, recipient, amount)` sent the sender's private change to the **withdrawal recipient**. Fixed-amount withdrawals now keep the change with the sender.

## Why this matters

`withdraw` called `surplusTo(recipient, false)` on the fixed-amount path. `withdraw: false` makes the compiler emit the leftover balance as a `createNotes` action whose recipient is the surplus recipient — i.e. an encrypted private note owned by the party being paid.

Two things make this worse than "the surplus leaks":

1. **The amount is the sender's entire balance in that token, not a remainder.** `build()` sets `autoSelectNotes: "all"`, and the compiler's selection loop only breaks early when `autoSelectNotes !== "all"`. So every note the sender holds for the token is swept regardless of how little the withdrawal needs.
2. **Custody genuinely transfers.** The change note is built as `CreateEncNote` with `recipient_public_key: channel.publicKey`, and the note's channel key is a Diffie-Hellman shared secret. Only the recipient can rederive it and spend the note; the sender's registry does not even track it.

Reproduced against the mock pool: Alice deposits 3x100, calls `withdraw(ace, bob.address, 1n)` — Alice's notes become `[]`, Bob receives a **299** private note plus the 1 unit publicly.

No attacker is required. `withdraw` is a public, documented method whose purpose is paying an arbitrary third party (`swap()` uses it to pay an executor). Any ordinary partial withdrawal to someone other than the sender loses the sender's whole token balance.

## The fix

```ts
if (isAll(amount)) {
  return builder.surplusTo(recipient, true).execute();
}
builder.withdraw({ recipient, amount });
return builder.surplusTo(this.inner.user, false).execute();
```

This is the pattern `transfer()` ten lines below and `swap()` already use — `withdraw` was the outlier. The `All` path keeps `withdraw: true`, which routes the whole private balance to the recipient's public balance by design and is unchanged. The typo'd dead local `surplustWithdraw` goes away.

## Why existing tests missed it

`tests/simple-private-transfers.test.ts`'s "withdraw returns funds to public balance" passes `env.alice.address` as **both** sender and recipient, so `recipient === this.inner.user` and the misrouting is invisible. It still passes with the bug present.

## Tests

- `withdraw keeps surplus with the sender when paying a third party` — two deposits so selection sweeps both, then a partial withdrawal to Bob. Asserts Bob receives exactly the requested amount publicly, Bob gets **no** private note, and Alice holds the 160n change.
- `withdraw routes surplus to the sender for an amount and to the recipient for All` — records the actual `surplusTo` calls, pinning both branches so a future refactor cannot silently swap them.

Verified the tests have teeth — with the fix reverted:

```
× withdraw keeps surplus with the sender when paying a third party
  AssertionError: expected [ { ...(6) } ] to deeply equal []      // Bob held a 160n note
× withdraw routes surplus to the sender for an amount and to the recipient for All
  AssertionError: expected [ { recipient: 2827n, ... } ] to deeply equal [ { recipient: 659918n, ... } ]
Tests  2 failed | 4 passed (6)
```

## Verification

```
npm run lint    exit 0 (prettier + eslint + tsc)
npm test        28/28 files, 262/262 tests
```

## Not included

`withdraw(token, recipient, All)` is currently a **no-op** — a pre-existing, separate bug. The compiler seeds its balances map only from deposits/useNotes/withdraws/createNotes, so a bare `surplusTo(...)` never introduces the token key and the surplus loop never visits it. `transfer(..., All)` has the same shape. Fixing it needs `internal/compiler.ts` and is out of scope here; this is why the `All` assertion above checks the routing requested on the builder rather than a downstream balance, which would have enshrined the no-op as expected behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/936)
<!-- Reviewable:end -->
