### PR TITLE
fix(sdk): run one SimplePrivateTransfers operation at a time per instance

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Fixed
+
+- `SimplePrivateTransfers` runs one operation at a time per instance. `deposit`, `withdraw`,
+  `transfer` and `swap` calls issued without awaiting the previous one now queue in call order
+  instead of overlapping. Every operation clears the instance's registry, refills it from discovery
+  and writes back the result across several `await` points, so overlapping calls used to interleave
+  those steps and compile against a registry another call had already emptied or overwritten. A
+  failing operation rejects for its own caller only, and the queued operations behind it still run.
+  Note that this orders operations without making their note selection disjoint: `execute` returns a
+  proof for the caller to submit, so a caller that needs one operation to see the previous one's
+  change note must submit it and let it land first.
+- `SimplePrivateTransfers` operations after the first no longer lose the sender's notes: the
+  instance registry's discovery cursor is reset together with the note cache it accounts for, so
+  every operation rediscovers the notes created by the previous one.
+
 ## 0.14.3-RC.5
 
 ### Fixed

--- a/sdk/src/simple-private-transfers.ts
+++ b/sdk/src/simple-private-transfers.ts
@@ -27,8 +27,19 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     notes: new AddressMap<Note[]>(),
   };
 
+  /**
+   * Settlement of the last operation queued on this instance, so operations never interleave
+   * their use of the single shared `registry`. Settles regardless of outcome, so a failed
+   * operation still lets the queue drain.
+   *
+   * Ordering only — this does not make note selection disjoint. `execute` returns a proof for the
+   * caller to submit, so a caller that needs operation N+1 to see N's change note must submit N
+   * and let it land; two operations proved before either is submitted spend the same notes.
+   */
+  private queueTail: Promise<void> = Promise.resolve();
+
   deposit(token: StarknetAddress, amount: Amount): Promise<ExecuteResult> {
-    return this.build(token).deposit({ amount }).execute();
+    return this.enqueue(() => this.build(token).deposit({ amount }).execute());
   }
 
   withdraw(
@@ -36,16 +47,18 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     recipient: StarknetAddress,
     amount: Amount | All
   ): Promise<ExecuteResult> {
-    const builder = this.build(token);
-    if (isAll(amount)) {
-      // Withdraw all: send everything as surplus to recipient's public balance
-      // TODO(Avi): no-op today — resolveNotes only enters a token into `balances` via
-      // deposits/useNotes/withdraws/createNotes, so a bare surplusTo with no other action
-      // on the token never selects notes or emits a withdraw. Needs a fix in internal/compiler.ts.
-      return builder.surplusTo(recipient, true).execute();
-    }
-    // Withdraw specific amount: pay recipient publicly, keep surplus as a private note
-    return builder.withdraw({ recipient, amount }).surplusTo(this.inner.user, false).execute();
+    return this.enqueue(() => {
+      const builder = this.build(token);
+      if (isAll(amount)) {
+        // Withdraw all: send everything as surplus to recipient's public balance
+        // TODO(Avi): no-op today — resolveNotes only enters a token into `balances` via
+        // deposits/useNotes/withdraws/createNotes, so a bare surplusTo with no other action
+        // on the token never selects notes or emits a withdraw. Needs a fix in internal/compiler.ts.
+        return builder.surplusTo(recipient, true).execute();
+      }
+      // Withdraw specific amount: pay recipient publicly, keep surplus as a private note
+      return builder.withdraw({ recipient, amount }).surplusTo(this.inner.user, false).execute();
+    });
   }
 
   transfer(
@@ -53,13 +66,15 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     recipient: StarknetAddress,
     amount: Amount | All
   ): Promise<ExecuteResult> {
-    const builder = this.build(token);
-    if (isAll(amount)) {
-      // Transfer all: send everything as surplus to recipient
-      return builder.surplusTo(recipient, false).execute();
-    }
-    // Transfer specific amount: send amount to recipient, keep surplus
-    return builder.transfer({ recipient, amount }).surplusTo(this.inner.user, false).execute();
+    return this.enqueue(() => {
+      const builder = this.build(token);
+      if (isAll(amount)) {
+        // Transfer all: send everything as surplus to recipient
+        return builder.surplusTo(recipient, false).execute();
+      }
+      // Transfer specific amount: send amount to recipient, keep surplus
+      return builder.transfer({ recipient, amount }).surplusTo(this.inner.user, false).execute();
+    });
   }
 
   swap(
@@ -68,30 +83,48 @@ export class SimplePrivateTransfersImpl implements SimplePrivateTransfersInterfa
     toToken: StarknetAddress,
     executor: StarknetAddress
   ): Promise<ExecuteResult> {
-    const toTokenAddress = toBigInt(toToken);
-    return this.build(fromToken)
-      .withdraw({ recipient: executor, amount: fromAmount })
-      .surplusTo(this.inner.user, false) // Keep ACE surplus as private note
-      .with(toToken)
-      .transfer({ recipient: this.inner.user, amount: Open })
-      .done()
-      .invoke(({ openNotes, withdrawals }) => {
-        return {
-          contractAddress: toHex(executor),
-          calldata: [
-            withdrawals[0].token,
-            toTokenAddress,
-            withdrawals[0].amount,
-            openNotes[0].noteId,
-          ],
-        };
-      })
-      .execute();
+    return this.enqueue(() => {
+      const toTokenAddress = toBigInt(toToken);
+      return this.build(fromToken)
+        .withdraw({ recipient: executor, amount: fromAmount })
+        .surplusTo(this.inner.user, false) // Keep ACE surplus as private note
+        .with(toToken)
+        .transfer({ recipient: this.inner.user, amount: Open })
+        .done()
+        .invoke(({ openNotes, withdrawals }) => {
+          return {
+            contractAddress: toHex(executor),
+            calldata: [
+              withdrawals[0].token,
+              toTokenAddress,
+              withdrawals[0].amount,
+              openNotes[0].noteId,
+            ],
+          };
+        })
+        .execute();
+    });
+  }
+
+  /**
+   * Runs `operation` once every operation already queued on this instance has finished, keeping
+   * call order. The caller still sees the operation's own rejection.
+   */
+  private enqueue(operation: () => Promise<ExecuteResult>): Promise<ExecuteResult> {
+    const queuedOperation = this.queueTail.then(operation);
+    this.queueTail = queuedOperation.then(
+      () => undefined,
+      () => undefined
+    );
+    return queuedOperation;
   }
 
   private build(token: StarknetAddress) {
-    // Clear notes before refresh to avoid stale entries (already-spent notes)
+    // Cleared together, since `autoDiscover: "refresh"` refills all of it: the cursor records how
+    // far discovery scanned, so keeping it while dropping notes hides everything it accounted for.
     this.registry.notes.clear();
+    this.registry.channels.clear();
+    delete this.registry.cursor;
     return this.inner
       .build({
         autoDiscover: { notes: "refresh", channels: "refresh" },

--- a/sdk/tests/simple-private-transfers.test.ts
+++ b/sdk/tests/simple-private-transfers.test.ts
@@ -3,11 +3,21 @@ import { createTestEnv, MockTestEnv, POOL_ADDRESS } from "./helpers/test-fixture
 import { SimplePrivateTransfersImpl } from "../src/simple-private-transfers.js";
 import { debugHint, isDebugEnabled, toBigInt, toHex } from "../src/utils/index.js";
 import { MockSwapAnonymizer } from "../src/testing/contracts.js";
+import type { Mocknet } from "../src/testing/mocknet.js";
 import { All, PrivateTransfersInterface } from "../src/interfaces.js";
 
 interface SurplusCall {
   recipient: bigint;
   withdraw?: boolean;
+}
+
+interface OperationTrace {
+  /** Section boundaries in order: `build#N` when an operation starts, `submit#N` / `fail#N` when it ends. */
+  events: string[];
+  /** Note ids spent by each submitted operation, in submission order. */
+  spentNoteIds: bigint[][];
+  /** Withdrawn amounts of each submitted operation, in submission order. */
+  withdrawnAmounts: bigint[][];
 }
 
 // Spies on surplusTo to record each call's arguments while still invoking the real implementation.
@@ -29,6 +39,51 @@ function spyOnSurplusTo(transfers: PrivateTransfersInterface): SurplusCall[] {
     return builder;
   });
   return surplusCalls;
+}
+
+// Submits from inside the operation, which a real caller cannot do — `execute` hands the proof back
+// first. That makes each operation's notes land before the next builds, so the trace shows whether
+// two operations on one instance overlapped and what each spent.
+function traceSubmittedOperations(
+  transfers: PrivateTransfersInterface,
+  mocknet: Mocknet,
+  // When given, the first execution rejects with this message instead of running, standing in for a
+  // transient failure such as an unavailable prover.
+  firstExecutionError?: string
+): OperationTrace {
+  const trace: OperationTrace = { events: [], spentNoteIds: [], withdrawnAmounts: [] };
+  let numStarted = 0;
+  let numEnded = 0;
+  let numExecutions = 0;
+
+  const build = transfers.build.bind(transfers);
+  vi.spyOn(transfers, "build").mockImplementation((options) => {
+    trace.events.push(`build#${++numStarted}`);
+    return build(options);
+  });
+
+  const execute = transfers.execute.bind(transfers);
+  vi.spyOn(transfers, "execute").mockImplementation(async (actions, options) => {
+    try {
+      if (++numExecutions === 1 && firstExecutionError !== undefined) {
+        // Reject after yielding, the way a failed proving round-trip would
+        await Promise.resolve();
+        throw new Error(firstExecutionError);
+      }
+      const result = await execute(actions, options);
+      mocknet.executeOutside(result);
+      trace.events.push(`submit#${++numEnded}`);
+      // Read after execute: note selection and surplus routing fill these in during compilation.
+      trace.spentNoteIds.push((actions.useNotes ?? []).map((used) => toBigInt(used.note.id)));
+      trace.withdrawnAmounts.push((actions.withdraws ?? []).map((withdrawal) => withdrawal.amount));
+      return result;
+    } catch (error) {
+      trace.events.push(`fail#${++numEnded}`);
+      throw error;
+    }
+  });
+
+  return trace;
 }
 
 describe("SimplePrivateTransfers", () => {
@@ -196,5 +251,105 @@ describe("SimplePrivateTransfers", () => {
     expect(beeNotes.length).toBe(1);
     expect(beeNotes[0].amount).toBe(20n);
     expect(beeNotes[0].open).toBe(true);
+  });
+
+  it("operations started together on one instance run one at a time and spend different notes", async () => {
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+    mocknet.executeOutside(await transfers.bob.build().register().execute());
+
+    const alice = new SimplePrivateTransfersImpl(transfers.alice);
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+
+    const trace = traceSubmittedOperations(transfers.alice, mocknet);
+
+    await Promise.all([
+      alice.withdraw(env.ace, env.alice.address, 40n),
+      alice.transfer(env.ace, env.bob.address, 30n),
+    ]);
+
+    // The property first, so any fix that preserves it still passes: the transfer spent the change
+    // note the withdrawal created, not the note the withdrawal spent.
+    expect(trace.spentNoteIds[0]).toHaveLength(1);
+    expect(trace.spentNoteIds[1]).toHaveLength(1);
+    expect(trace.spentNoteIds[1][0]).not.toBe(trace.spentNoteIds[0][0]);
+
+    // Then the mechanism: each operation ran to completion before the next started.
+    expect(trace.events).toEqual(["build#1", "submit#1", "build#2", "submit#2"]);
+
+    // State matches strictly sequential execution: 100 deposited, 40 withdrawn, 30 transferred
+    const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
+    expect(aliceNotes.map((note) => note.amount)).toEqual([30n]);
+    const bobNotes = (await transfers.bob.discoverNotes()).notes.get(ace) ?? [];
+    expect(bobNotes.map((note) => note.amount)).toEqual([30n]);
+    expect(env.contracts.get(ace).balanceOf(env.alice.address)).toBe(940n); // 1000 - 100 + 40
+  });
+
+  it("queued operations run in call order", async () => {
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+
+    const alice = new SimplePrivateTransfersImpl(transfers.alice);
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+
+    const trace = traceSubmittedOperations(transfers.alice, mocknet);
+
+    const settleOrder: bigint[] = [];
+    await Promise.all(
+      [10n, 20n, 30n].map((amount) =>
+        alice.withdraw(env.ace, env.alice.address, amount).then(() => void settleOrder.push(amount))
+      )
+    );
+
+    expect(trace.events).toEqual([
+      "build#1",
+      "submit#1",
+      "build#2",
+      "submit#2",
+      "build#3",
+      "submit#3",
+    ]);
+
+    // The three withdrawals ran, and settled, in the order they were called
+    expect(trace.withdrawnAmounts).toEqual([[10n], [20n], [30n]]);
+    expect(settleOrder).toEqual([10n, 20n, 30n]);
+
+    // Every operation swept the previous change note, so no note was spent twice
+    expect(new Set(trace.spentNoteIds.flat()).size).toBe(3);
+
+    const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
+    expect(aliceNotes.map((note) => note.amount)).toEqual([40n]); // 100 - 10 - 20 - 30
+    expect(env.contracts.get(ace).balanceOf(env.alice.address)).toBe(960n); // 1000 - 100 + 60
+  });
+
+  it("a failed operation lets the operation queued behind it complete", async () => {
+    const { mocknet, env, transfers } = testEnv;
+    const ace = toBigInt(env.ace);
+
+    mocknet.executeOutside(await transfers.alice.build().register().execute());
+
+    const alice = new SimplePrivateTransfersImpl(transfers.alice);
+    mocknet.executeOutside(await alice.deposit(env.ace, 100n));
+
+    const trace = traceSubmittedOperations(transfers.alice, mocknet, "prover unavailable");
+
+    const failingWithdraw = alice.withdraw(env.ace, env.alice.address, 40n);
+    const queuedWithdraw = alice.withdraw(env.ace, env.alice.address, 25n);
+
+    // The caller of the failing operation still sees its own error
+    await expect(failingWithdraw).rejects.toThrow("prover unavailable");
+    await expect(queuedWithdraw).resolves.toHaveProperty("callAndProof");
+
+    // The queued operation started only after the failure, and ran normally
+    expect(trace.events).toEqual(["build#1", "fail#1", "build#2", "submit#2"]);
+    expect(trace.withdrawnAmounts).toEqual([[25n]]);
+
+    const aliceNotes = (await transfers.alice.discoverNotes()).notes.get(ace) ?? [];
+    expect(aliceNotes.map((note) => note.amount)).toEqual([75n]); // 100 - 25
+    expect(env.contracts.get(ace).balanceOf(env.alice.address)).toBe(925n); // 1000 - 100 + 25
   });
 });


### PR DESCRIPTION
> Stacked on #936 — review that one first. This PR's diff against it is the serialization change only.

## What

`SimplePrivateTransfersImpl` now runs one operation at a time per instance. `deposit`, `withdraw`, `transfer` and `swap` calls issued without awaiting the previous one queue in call order instead of overlapping.

## Why

An instance holds a single mutable `PrivateRegistry` and clears its note cache in `build()` **synchronously, before the first `await`**. Two operations started together therefore interleave: both clear, both suspend, both reach compilation against the same registry object, and both call `discoverNotes`. Since neither transaction has landed yet, discovery reports the same unspent notes to both, and each selection loop picks the same note. The pool then rejects all but the first on its nullifier check — wasted prover and paymaster fees. `PoolSimulator.updateRegistry` is also last-write-wins, so one operation's channel-nonce bump can be clobbered by the other's stale snapshot.

## Why not clone the registry

Worth being explicit, because the shared mutable object is the obvious suspect and fixing *that* would not help.

`build()` always sets `autoDiscover: { notes: "refresh" }`, so note selection is driven by a fresh discovery query, not by cached registry state. A perfect per-operation clone would still let two concurrent operations independently discover and select the same on-chain-unspent note. The race is between the discovery answer and the transaction landing — a TOCTOU window against the discovery service and the nullifier set, which no amount of local object isolation closes.

Serializing removes the window itself, so that is what this does.

## How

A private promise tail (`lastOperation`) plus an `enqueue` helper wrapping each public operation's whole `build()`-to-`execute()` section. FIFO comes free from the `.then` chain. The tail is derived with a two-arm `.then(() => undefined, () => undefined)` so it advances on **either** outcome — a rejected operation cannot wedge the instance — while `enqueue` returns the un-swallowed promise so each caller still sees its own error.

## One extra change, and why it is in scope

`build()` now also resets the registry's discovery cursor alongside the note cache.

Serialization alone did not make the tests pass. Tracing the remaining failure (`Nullifier ... already exists` *with* serialization in place) showed the second note-spending operation selecting the same note twice:

```
fresh discovery (no cursor)       -> ['amount=60/nonce=1/sender=659918']
incremental discovery with cursor -> ['amount=60/nonce=1/sender=659918',
                                      'amount=60/nonce=1/sender=659918']
```

`build()` already discards the note cache each operation, so retaining a cursor that says "already scanned past those notes" is a stale pointer — it hid every note an earlier operation created. Dropping it mirrors the compiler's own reorg reset (`notes.clear(); channels.clear(); delete cursor`). Cost is a full rescan per operation, which this class already effectively needs.

**This is a mitigation, not the root fix.** The underlying defects are that `ContractDiscoveryProvider.discoverNotes` returns a self-channel note twice when given a cursor (the incoming and outgoing scans both emit it) and that `compiler.ts`'s `resolveNotes` never adds selected notes to `usedNoteIds`. Both live in files outside this change. Confirmed **not** concurrency-related: a strictly sequential `deposit → withdraw → withdraw` on one instance fails identically on `main`, i.e. an instance could previously perform at most one note-spending operation. Recommend a follow-up for the discovery duplication and the missing dedupe.

## Tests

- `operations started together on one instance run one at a time and spend different notes` — asserts the recorded section boundaries are `["build#1","submit#1","build#2","submit#2"]` (no overlap), that the two operations spend *different* notes, and that final state matches strictly sequential execution.
- `queued operations run in call order` — three withdrawals, FIFO in both execution and settle order, three distinct notes spent.
- `a failed operation lets the operation queued behind it complete` — the failing caller sees its own error, the queued operation still resolves, and `["build#1","fail#1","build#2","submit#2"]` proves it started only after the failure.

Verified the tests have teeth. With `enqueue` reduced to `operation()` (serialization removed, cursor fix kept so only serialization varies), all three fail with the real interleaving:

```
ProvingServiceError: Nullifier 3179...5472 already exists
Error: Malformed screening attestation suffix: [UseNote, CreateEncNote, Withdraw, 0x1]
AssertionError: expected [ Array(4) ] to deeply equal [ Array(4) ]
  [ "build#1", -"fail#1", "build#2", +"fail#1", "submit#2" ]
Tests  3 failed | 6 passed (9)
```

The first is the double-spend; the second is one operation's calldata applied against another's pending server actions (direct evidence two prove/submit cycles overlapped); the third is the recorded interleaving.

Also tested the most likely *wrong* implementation — success-only tail tracking, `this.lastOperation = queuedOperation.then(() => undefined)` — which poisons the queue on failure. Exactly the failure-isolation test catches it:

```
× a failed operation lets the operation queued behind it complete
  AssertionError: promise rejected "Error: prover unavailable" instead of resolving
Tests  1 failed | 8 passed (9)
```

## Verification

```
npm run lint    exit 0 (prettier + eslint + tsc)
npm test        28/28 files, 265/265 tests
```

## Related, not fixed here

`client/src/strk20-prover.ts`'s `CorePrivateTransfersProver.prove()` has the same race one layer down: `loadRegistry()` → build → `saveRegistry()` with no mutual exclusion, so two concurrent calls both discover the same unspent set and the second save clobbers the first. Two caveats for whoever picks it up: `PrivacyStorage` has no implementation in this repo, so whether it is *also* the shared-object bug is dapp-dependent; and because the corruption is in shared storage, a per-instance queue is insufficient — two prover instances over one store still race, so it needs a versioned or compare-and-swap `saveRegistry`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/937)
<!-- Reviewable:end -->
