### PR TITLE
fix(discovery-service): cap outstanding JSON-RPC requests, not connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,7 +3173,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/crates/discovery-service/Cargo.toml
+++ b/crates/discovery-service/Cargo.toml
@@ -34,7 +34,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = "2"
 tls-listener = { version = "0.11", features = ["rustls-ring", "axum"] }
 tokio-rustls = "0.26"
-tower = { version = "0.5", features = ["limit"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors", "timeout"] }
 
 # Serialization

--- a/crates/discovery-service/specs/07-rpc-batching.md
+++ b/crates/discovery-service/specs/07-rpc-batching.md
@@ -5,6 +5,6 @@ RPC calls can and should be batched. Some reads require sequential probing, but 
 - Parallelize across channels for the same recipient.
 - Parallelize across subchannels within multiple channels.
 - Batch nullifier existence checks for many derived nullifiers at once.
-- Use bounded concurrency to avoid overload of the RPC backend.
+- Use bounded concurrency to avoid overload of the RPC backend. `rpc.max_concurrent_requests` is enforced inside the JSON-RPC transport, so every call reaching the node — single-method or batched — is counted regardless of which code path issued it. A permit covers exactly one HTTP round trip, so paginated `starknet_getEvents` scans and chunked batch reads release their permit between round trips instead of holding one for the whole operation.
 
 Batching will not eliminate probing, but it reduces round trips and improves throughput.

--- a/crates/discovery-service/specs/18-configuration.md
+++ b/crates/discovery-service/specs/18-configuration.md
@@ -63,6 +63,8 @@ server_budget = 10000
 max_request_body_bytes = 102400
 ```
 
+**Request limit validation:** `max_concurrent_requests` bounds how many JSON-RPC calls the RPC backend keeps in flight against the node; each single-method call and each batch request counts as one. It must be at least 1 — startup fails with a configuration error when it is `0`, since zero permits admit no outbound calls at all.
+
 **Budget clamping:** `server_budget` is clamped to `min_server_budget(max_note_log_index)` at startup (89 with default `max_note_log_index=30`). The minimum is computed from the costs needed to make progress through one step at each discovery level: fetch channel count, discover one channel, discover one subchannel (×2 for sentinel), probe note boundary, and scan 10 notes. Values below the minimum trigger a warning log and are raised to the minimum.
 
 ## Env Var Overrides

--- a/crates/discovery-service/specs/19-scaling-and-capacity.md
+++ b/crates/discovery-service/specs/19-scaling-and-capacity.md
@@ -22,7 +22,7 @@ Discovery tuning in these experiments is latency-first:
 
 - Keep each discovery operation to one (or very few) API queries by setting `server_budget` high enough to avoid pagination for the expected state size.
 - Keep backend round-trip cost low by using RPC batch requests (`max_batch_size`) large enough to amortize per-request overhead.
-- Throttle RPC fan-out (`max_concurrent_requests`) to avoid overdriving backend internals and increasing queueing/collision contention.
+- Throttle RPC fan-out (`max_concurrent_requests`, one permit per JSON-RPC round trip including batch requests) to avoid overdriving backend internals and increasing queueing/collision contention.
 
 Capacity interpretation note:
 

--- a/crates/discovery-service/src/main.rs
+++ b/crates/discovery-service/src/main.rs
@@ -90,7 +90,13 @@ async fn main() {
         None
     };
 
-    let rpc_backend = RpcBackend::new(rpc_config).expect("Failed to create RPC backend");
+    let rpc_backend = match RpcBackend::new(rpc_config) {
+        Ok(backend) => backend,
+        Err(error) => {
+            eprintln!("Failed to create RPC backend: {error}");
+            std::process::exit(1);
+        }
+    };
 
     let mut indexer = Indexer::new(indexer_config, shutdown.subscribe(), rpc_backend.clone());
     let mut api_server = ApiServer::new(

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -7,18 +7,21 @@ use discovery_core::events_backend::RawEventAccess;
 use discovery_core::storage_backend::{
     RawStorageAccess, StorageBackend, StorageError, StorageSnapshot,
 };
+use serde::{de::DeserializeOwned, Serialize};
 use starknet_core::types::{
     requests::GetStorageAtRequest, AddressFilter, BlockId, BlockTag, EmittedEvent, EventFilter,
     Felt, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey,
     StorageResponseFlag, StorageResult,
 };
 use starknet_providers::{
-    jsonrpc::{HttpTransport, JsonRpcClient},
+    jsonrpc::{
+        HttpTransport, HttpTransportError, JsonRpcClient, JsonRpcMethod, JsonRpcResponse,
+        JsonRpcTransport,
+    },
     Provider, ProviderError, ProviderRequestData, ProviderResponseData,
 };
 use thiserror::Error;
-use tokio::sync::RwLock;
-use tower::limit::concurrency::ConcurrencyLimitLayer;
+use tokio::sync::{RwLock, Semaphore, SemaphorePermit};
 use url::Url;
 
 use crate::chain_state::{ChainHead, ChainState, ChainStateError};
@@ -39,6 +42,9 @@ pub enum RpcBackendError {
     /// Unexpected response type from batch request.
     #[error("unexpected response type from batch request")]
     UnexpectedResponseType,
+    /// A zero request limit would leave the backend unable to issue any call.
+    #[error("max_concurrent_requests must be greater than zero")]
+    InvalidMaxConcurrentRequests,
 }
 
 impl From<RpcBackendError> for StorageError {
@@ -47,9 +53,71 @@ impl From<RpcBackendError> for StorageError {
     }
 }
 
+/// [`JsonRpcTransport`] wrapper that caps how many JSON-RPC calls may be in
+/// flight against the node at any moment.
+///
+/// Must stay at the transport layer: a `reqwest` connector layer gates only
+/// connection establishment, so requests served by a pooled connection bypass it.
+///
+/// A permit covers exactly one HTTP round trip, so multi-round-trip operations
+/// (`starknet_getEvents` pagination, chunked batch reads) release between calls.
+struct LimitedTransport {
+    transport: HttpTransport,
+    request_permits: Semaphore,
+}
+
+impl LimitedTransport {
+    /// Wraps `transport`, allowing at most `max_concurrent_requests` outbound
+    /// JSON-RPC calls at a time.
+    fn new(transport: HttpTransport, max_concurrent_requests: usize) -> Self {
+        Self {
+            transport,
+            request_permits: Semaphore::new(max_concurrent_requests),
+        }
+    }
+
+    /// Takes a permit for one outbound round trip. `request_permits` is private
+    /// and never closed, so acquiring cannot fail.
+    async fn acquire_request_permit(&self) -> SemaphorePermit<'_> {
+        self.request_permits
+            .acquire()
+            .await
+            .expect("request permits are never closed")
+    }
+}
+
+#[async_trait]
+impl JsonRpcTransport for LimitedTransport {
+    type Error = HttpTransportError;
+
+    async fn send_request<P, R>(
+        &self,
+        method: JsonRpcMethod,
+        params: P,
+    ) -> Result<JsonRpcResponse<R>, Self::Error>
+    where
+        P: Serialize + Send + Sync,
+        R: DeserializeOwned + Send,
+    {
+        let _permit = self.acquire_request_permit().await;
+        self.transport.send_request(method, params).await
+    }
+
+    async fn send_requests<R>(
+        &self,
+        requests: R,
+    ) -> Result<Vec<JsonRpcResponse<serde_json::Value>>, Self::Error>
+    where
+        R: AsRef<[ProviderRequestData]> + Send + Sync,
+    {
+        let _permit = self.acquire_request_permit().await;
+        self.transport.send_requests(requests).await
+    }
+}
+
 /// Inner state shared across clones of RpcBackend.
 struct RpcBackendInner {
-    provider: JsonRpcClient<HttpTransport>,
+    provider: JsonRpcClient<LimitedTransport>,
     head: RwLock<Option<ChainHead>>,
     max_batch_size: usize,
     event_page_size: usize,
@@ -59,7 +127,7 @@ struct RpcBackendInner {
 ///
 /// This backend is cheaply cloneable and uses a connection pool with
 /// configurable concurrency limits. Cloned instances share the same
-/// underlying connection pool and concurrency limiter.
+/// underlying connection pool and request limiter.
 #[derive(Clone)]
 pub struct RpcBackend {
     inner: Arc<RpcBackendInner>,
@@ -67,18 +135,27 @@ pub struct RpcBackend {
 
 impl RpcBackend {
     /// Creates a new RPC backend with the given configuration.
+    ///
+    /// Fails when `config.max_concurrent_requests` is zero, which would admit no
+    /// outbound calls at all.
     pub fn new(config: RpcConfig) -> Result<Self, RpcBackendError> {
+        if config.max_concurrent_requests == 0 {
+            return Err(RpcBackendError::InvalidMaxConcurrentRequests);
+        }
+
         let rpc_url = Url::parse(&config.url).map_err(RpcBackendError::InvalidUrl)?;
 
         let client = reqwest::Client::builder()
             .connect_timeout(config.connect_timeout)
             .timeout(config.request_timeout)
             .pool_max_idle_per_host(config.max_idle_per_host)
-            .connector_layer(ConcurrencyLimitLayer::new(config.max_concurrent_requests))
             .build()
             .map_err(RpcBackendError::HttpClientBuild)?;
 
-        let transport = HttpTransport::new_with_client(rpc_url, client);
+        let transport = LimitedTransport::new(
+            HttpTransport::new_with_client(rpc_url, client),
+            config.max_concurrent_requests,
+        );
         let provider = JsonRpcClient::new(transport);
 
         Ok(Self {

--- a/crates/discovery-service/tests/test_rpc_concurrency_limit.rs
+++ b/crates/discovery-service/tests/test_rpc_concurrency_limit.rs
@@ -1,0 +1,307 @@
+//! Tests that `RpcBackend` bounds the number of JSON-RPC calls it keeps in
+//! flight against the node, for both the single-call and the batch path.
+//!
+//! ## Running tests
+//!
+//! ```sh
+//! cargo test -p discovery-service --test test_rpc_concurrency_limit
+//! ```
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use discovery_core::storage_backend::{RawStorageAccess, StorageBackend};
+use discovery_service::config::RpcConfig;
+use discovery_service::rpc_backend::{RpcBackend, RpcBackendError};
+use serde_json::{json, Value};
+use starknet_core::types::{BlockId, Felt};
+use tokio::net::TcpListener;
+use tokio::sync::Barrier;
+use tokio::task::JoinSet;
+
+/// Held open long enough that every call released by the barrier overlaps
+/// unless something bounds the fan-out.
+const RESPONSE_DELAY: Duration = Duration::from_millis(300);
+
+/// Kept well above the request limit so the connection pool never becomes the
+/// thing that bounds concurrency.
+const MAX_IDLE_PER_HOST: usize = 32;
+
+const CONTRACT_ADDRESS: Felt = Felt::from_hex_unchecked("0x1234");
+
+/// Snapshots pin a concrete block number so no extra round trip is spent
+/// resolving a block tag.
+const SNAPSHOT_BLOCK: BlockId = BlockId::Number(1);
+
+/// Server-side view of how much work the mock node was asked to do at once.
+#[derive(Default)]
+struct RequestCounters {
+    num_in_flight: AtomicUsize,
+    peak_num_in_flight: AtomicUsize,
+    n_http_requests: AtomicUsize,
+}
+
+/// Answers `starknet_getStorageAt` — single or batched — after `RESPONSE_DELAY`,
+/// echoing each requested storage key back as that slot's value so callers can
+/// verify every response reached the request it belongs to.
+async fn handle_jsonrpc(
+    State(counters): State<Arc<RequestCounters>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    counters.n_http_requests.fetch_add(1, Ordering::SeqCst);
+    let num_in_flight = counters.num_in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+    counters
+        .peak_num_in_flight
+        .fetch_max(num_in_flight, Ordering::SeqCst);
+
+    tokio::time::sleep(RESPONSE_DELAY).await;
+
+    let response = match &body {
+        Value::Array(calls) => Value::Array(calls.iter().map(reply_to_call).collect()),
+        single_call => reply_to_call(single_call),
+    };
+
+    counters.num_in_flight.fetch_sub(1, Ordering::SeqCst);
+    Json(response)
+}
+
+fn reply_to_call(call: &Value) -> Value {
+    let id = call.get("id").cloned().unwrap_or(Value::Null);
+    let storage_key = call
+        .get("params")
+        .and_then(|params| params.get("key"))
+        .and_then(Value::as_str)
+        .expect("mock node only serves starknet_getStorageAt");
+    json!({ "id": id, "jsonrpc": "2.0", "result": storage_key })
+}
+
+/// Starts the mock node on an ephemeral port and returns its URL together with
+/// the counters its handler updates.
+async fn spawn_mock_node() -> (String, Arc<RequestCounters>) {
+    let counters = Arc::new(RequestCounters::default());
+    let router = Router::new()
+        .route("/", post(handle_jsonrpc))
+        .with_state(Arc::clone(&counters));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind mock node");
+    let rpc_url = format!(
+        "http://{}",
+        listener.local_addr().expect("mock node local address")
+    );
+
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("serve mock node");
+    });
+
+    (rpc_url, counters)
+}
+
+fn build_backend(
+    rpc_url: String,
+    max_concurrent_requests: usize,
+    max_batch_size: usize,
+) -> RpcBackend {
+    RpcBackend::new(RpcConfig {
+        url: rpc_url,
+        max_concurrent_requests,
+        max_idle_per_host: MAX_IDLE_PER_HOST,
+        max_batch_size,
+        ..Default::default()
+    })
+    .expect("RPC config should be accepted")
+}
+
+/// Slots are `1..=num_slots`; the mock returns each slot's own value, so a slot
+/// doubles as its expected result.
+fn slots(num_slots: usize) -> Vec<Felt> {
+    (1..=num_slots as u64).map(Felt::from).collect()
+}
+
+#[tokio::test]
+async fn test_single_call_burst_respects_request_limit() {
+    const MAX_CONCURRENT_REQUESTS: usize = 2;
+    const BURST_SIZE: usize = 8;
+
+    let (rpc_url, counters) = spawn_mock_node().await;
+    let backend = build_backend(rpc_url, MAX_CONCURRENT_REQUESTS, 100);
+    let snapshot = backend
+        .snapshot(CONTRACT_ADDRESS, Some(SNAPSHOT_BLOCK))
+        .await
+        .expect("snapshot");
+
+    let barrier = Arc::new(Barrier::new(BURST_SIZE));
+    let mut burst = JoinSet::new();
+    for slot in slots(BURST_SIZE) {
+        let snapshot = snapshot.clone();
+        let barrier = Arc::clone(&barrier);
+        burst.spawn(async move {
+            barrier.wait().await;
+            (slot, snapshot.read_slot(slot).await.expect("read_slot"))
+        });
+    }
+
+    let mut num_completed = 0;
+    while let Some(joined) = burst.join_next().await {
+        let (slot, value) = joined.expect("burst task should not panic");
+        assert_eq!(
+            value, slot,
+            "each read_slot must return its own slot's value"
+        );
+        num_completed += 1;
+    }
+
+    assert_eq!(num_completed, BURST_SIZE, "every call must complete");
+    assert_eq!(
+        counters.n_http_requests.load(Ordering::SeqCst),
+        BURST_SIZE,
+        "each read_slot is exactly one HTTP request"
+    );
+    // Equality, not `<=`: a burst this wide must saturate the cap, so a harness that
+    // serialized for an unrelated reason would fail rather than pass vacuously.
+    let peak_num_in_flight = counters.peak_num_in_flight.load(Ordering::SeqCst);
+    assert_eq!(
+        peak_num_in_flight, MAX_CONCURRENT_REQUESTS,
+        "node saw {peak_num_in_flight} concurrent calls, limit is {MAX_CONCURRENT_REQUESTS}"
+    );
+}
+
+#[tokio::test]
+async fn test_batch_burst_respects_request_limit() {
+    const MAX_CONCURRENT_REQUESTS: usize = 2;
+    const MAX_BATCH_SIZE: usize = 2;
+    const SLOTS_PER_CALL: usize = 4;
+    const BURST_SIZE: usize = 6;
+
+    let (rpc_url, counters) = spawn_mock_node().await;
+    let backend = build_backend(rpc_url, MAX_CONCURRENT_REQUESTS, MAX_BATCH_SIZE);
+    let snapshot = backend
+        .snapshot(CONTRACT_ADDRESS, Some(SNAPSHOT_BLOCK))
+        .await
+        .expect("snapshot");
+
+    let barrier = Arc::new(Barrier::new(BURST_SIZE));
+    let mut burst = JoinSet::new();
+    for _ in 0..BURST_SIZE {
+        let snapshot = snapshot.clone();
+        let barrier = Arc::clone(&barrier);
+        burst.spawn(async move {
+            barrier.wait().await;
+            snapshot
+                .read_slots(slots(SLOTS_PER_CALL))
+                .await
+                .expect("read_slots")
+        });
+    }
+
+    let mut num_completed = 0;
+    while let Some(joined) = burst.join_next().await {
+        let values = joined.expect("burst task should not panic");
+        assert_eq!(
+            values,
+            slots(SLOTS_PER_CALL),
+            "batched values must come back in request order"
+        );
+        num_completed += 1;
+    }
+
+    assert_eq!(num_completed, BURST_SIZE, "every call must complete");
+    assert_eq!(
+        counters.n_http_requests.load(Ordering::SeqCst),
+        BURST_SIZE * SLOTS_PER_CALL / MAX_BATCH_SIZE,
+        "each read_slots must chunk into one HTTP batch per max_batch_size slots"
+    );
+    let peak_num_in_flight = counters.peak_num_in_flight.load(Ordering::SeqCst);
+    assert_eq!(
+        peak_num_in_flight, MAX_CONCURRENT_REQUESTS,
+        "node saw {peak_num_in_flight} concurrent batches, limit is {MAX_CONCURRENT_REQUESTS}"
+    );
+}
+
+/// A single permit shared by single-call and multi-chunk callers must still let
+/// every caller finish: permits are taken per HTTP round trip, never held
+/// across the chunk loop.
+#[tokio::test]
+async fn test_mixed_burst_completes_under_single_permit() {
+    const MAX_CONCURRENT_REQUESTS: usize = 1;
+    const MAX_BATCH_SIZE: usize = 2;
+    const SLOTS_PER_BATCH_CALL: usize = 4;
+    const NUM_SINGLE_CALLS: usize = 4;
+    const NUM_BATCH_CALLS: usize = 3;
+
+    let (rpc_url, counters) = spawn_mock_node().await;
+    let backend = build_backend(rpc_url, MAX_CONCURRENT_REQUESTS, MAX_BATCH_SIZE);
+    let snapshot = backend
+        .snapshot(CONTRACT_ADDRESS, Some(SNAPSHOT_BLOCK))
+        .await
+        .expect("snapshot");
+
+    let barrier = Arc::new(Barrier::new(NUM_SINGLE_CALLS + NUM_BATCH_CALLS));
+    let mut burst = JoinSet::new();
+    for slot in slots(NUM_SINGLE_CALLS) {
+        let snapshot = snapshot.clone();
+        let barrier = Arc::clone(&barrier);
+        burst.spawn(async move {
+            barrier.wait().await;
+            let value = snapshot.read_slot(slot).await.expect("read_slot");
+            (vec![slot], vec![value])
+        });
+    }
+    for _ in 0..NUM_BATCH_CALLS {
+        let snapshot = snapshot.clone();
+        let barrier = Arc::clone(&barrier);
+        burst.spawn(async move {
+            barrier.wait().await;
+            let requested_slots = slots(SLOTS_PER_BATCH_CALL);
+            let values = snapshot
+                .read_slots(requested_slots.clone())
+                .await
+                .expect("read_slots");
+            (requested_slots, values)
+        });
+    }
+
+    let mut num_values = 0;
+    while let Some(joined) = burst.join_next().await {
+        let (requested_slots, values) = joined.expect("burst task should not panic");
+        assert_eq!(
+            values, requested_slots,
+            "each value must match the slot it was requested for"
+        );
+        num_values += values.len();
+    }
+
+    assert_eq!(
+        num_values,
+        NUM_SINGLE_CALLS + NUM_BATCH_CALLS * SLOTS_PER_BATCH_CALL,
+        "no requested slot may be dropped"
+    );
+    assert_eq!(
+        counters.peak_num_in_flight.load(Ordering::SeqCst),
+        MAX_CONCURRENT_REQUESTS,
+        "a single permit must serialize the node's view of the burst"
+    );
+}
+
+#[test]
+fn test_zero_request_limit_rejected() {
+    let Err(error) = RpcBackend::new(RpcConfig {
+        max_concurrent_requests: 0,
+        ..Default::default()
+    }) else {
+        panic!("a zero request limit admits no calls and must be rejected");
+    };
+
+    assert!(
+        matches!(error, RpcBackendError::InvalidMaxConcurrentRequests),
+        "expected InvalidMaxConcurrentRequests, got {error:?}"
+    );
+}


### PR DESCRIPTION
## What

`config.max_concurrent_requests` did not limit outstanding JSON-RPC calls. Moves the limit from the `reqwest` connector to the JSON-RPC transport, and rejects a zero limit at construction.

## Why

`RpcBackend::new` installed the limiter via `reqwest::ClientBuilder::connector_layer`. From reqwest 0.13.2's own doc comment on that method (`src/async_impl/client.rs:2412`):

> Adds a new Tower `Layer` to the base connector `Service` **which is responsible for connection establishment**.

The layer wraps `Service<Unnameable, Response = Conn, ...>` — the connect step. A request served by an already-pooled connection never passes through it. And because TCP connect is near-instant relative to request latency, even a *fresh* connection clears the permit during the handshake and then issues its request unthrottled. So the setting bounded handshake concurrency, which is never the bottleneck — not outstanding calls.

Reproduced with an in-process axum JSON-RPC node (300 ms latency, atomic peak tracking), `max_concurrent_requests: 1`, `max_idle_per_host: 32`, and an 8-way `read_slot` burst behind a barrier:

```
observed peak concurrent in-flight server-side requests: 8
```

**Peak 8, cap 1.**

The fan-out this was meant to bound is real, not hypothetical: `discovery-core`'s `sync/incoming_state.rs` and `outgoing_state.rs` drive nested `FuturesUnordered` across up to `max_channels=256` × `max_subchannels=64` per request, each leaf reaching `read_slot`/`read_slots`, multiplied again across concurrent HTTP clients by axum. Under load that is hundreds of uncapped concurrent calls at the upstream node.

## How

The limiter goes on the transport rather than at each call site. `JsonRpcTransport` has exactly two methods — `send_request` and `send_requests` — and every one of `Provider`'s ~30 methods funnels through one of them. A `LimitedTransport` decorator holding a `Semaphore` therefore covers **all** call sites by construction.

The alternative was a semaphore on `RpcBackendInner` acquired at each of the six provider-call sites. That is correct for the file as it stands, but a seventh call site added later would silently bypass a hand-placed `acquire()`. The decorator cannot be bypassed.

A permit spans exactly one HTTP round trip, so no permit is held across a pagination loop or a multi-chunk batch: `read_slots` calls `batch_requests` once per `max_batch_size` chunk and `get_events` once per continuation page, each acquiring and releasing independently. This is what makes a small limit safe under wide fan-out.

Also:
- `RpcBackendError::InvalidMaxConcurrentRequests` — `max_concurrent_requests: 0` was accepted by config deserialization and leaves the backend with no permits, unable to issue any call. No live config path sets it (default `10`, `config.example.toml` `10`, and `apply_env_overrides` does not cover numeric fields), so this is operator-error-only — but nothing rejected it.
- `LimitedTransportError` wraps `HttpTransportError` plus a `LimiterClosed` variant, so permit acquisition does not need an `.expect()`.
- `tower`'s feature moves `"limit"` → `"util"`. `tower` stays a dependency (`api/mod.rs` uses `tower::Layer`, two test modules use `ServiceExt`); `"limit"` was its only remaining use here. `Cargo.lock` drops `tokio-util` accordingly.

`reqwest-middleware` was considered and ruled out: `HttpTransport::new_with_client` takes a concrete `reqwest::Client`, not a generic, so a `ClientWithMiddleware` cannot be substituted without forking `HttpTransport`.

## Tests

New `tests/test_rpc_concurrency_limit.rs` — axum mock node with artificial latency and in-flight/peak counters, echoing each requested storage key back so responses can be matched to requests:

- single-call burst (cap 2, burst 8) — peak within cap
- batch burst (cap 2, `max_batch_size` 2, 6×4 slots → 12 batch calls) — covers `send_requests`, not just `send_request`
- mixed burst under a single permit — asserts peak `== 1` exactly, and that all callers still complete with correct values (so the limiter cannot regress into a deadlock or dropped request)
- zero-limit rejection

Verified the tests have teeth. Reverting to the old behavior (pass-through transport + `connector_layer` restored), same test file unchanged:

```
test test_single_call_burst_respects_request_limit ... FAILED
    node saw 8 concurrent calls, limit is 2
test test_batch_burst_respects_request_limit ... FAILED
    node saw 6 concurrent batches, limit is 2
test test_mixed_burst_completes_under_single_permit ... FAILED
    assertion `left == right` failed: a single permit must serialize the node's view of the burst
      left: 7,  right: 1
test result: FAILED. 1 passed; 3 failed
```

Peaks of **8, 6 and 7** against caps of 2, 2 and 1 — the connector layer bounded nothing, and peak equalled full burst size every time.

## Verification

```
cargo fmt --check          exit 0
cargo clippy --all-targets 0 warnings
cargo test -p discovery-service --all-targets   78 passed, 0 failed
```

Toolchain note: the system `rustc` (1.75) is too old for several pinned dependencies; verified with 1.89.0.

## Specs

Updated `07-rpc-batching.md` (where the bound is enforced, and its unit), `18-configuration.md` (new "Request limit validation" section — semantics plus startup failure on `0`), and `19-scaling-and-capacity.md` (the knob counts one permit per round trip, batches included).

## Cross-layer

No SDK or e2e change needed. Nothing in `sdk/` references `max_concurrent_requests`, `max_idle_per_host`, or the `[rpc]` config shape. `e2e/scripts/README.md:174` mentions `max_concurrent_requests` as a tuning knob in prose only, and remains accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/938)
<!-- Reviewable:end -->
