### PR TITLE
fix(discovery-service): decide block canonicality, not mere existence

### DIFF
--- a/crates/discovery-service/specs/05-security-considerations.md
+++ b/crates/discovery-service/specs/05-security-considerations.md
@@ -59,7 +59,7 @@ The following vectors have been identified and mitigated:
 The following request fields are validated by the service:
 
 - **max_reads:** Must be within allowed bounds (default 50, max 100). Zero is currently accepted but wastes work.
-- **last_known_block:** If provided, checked for canonical status (reorg detection). Returns `BLOCK_REORGED` if no longer canonical.
+- **last_known_block:** If provided, checked for canonical status (reorg detection). Returns `BLOCK_REORGED` if no longer canonical. Canonicity means the chain still carries that exact block at that height — not merely that the node still serves the hash — so a block replaced by a competing one is also reported as reorged (see §11.1).
 - **block_ref:** If provided, used as-is for querying. No separate existence check — an invalid hash surfaces as an RPC error.
 - **cursor:** Structural validation via serde deserialization. Malformed JSON results in `INVALID_REQUEST`. **Note:** cursor HashMap sizes (`channels`, `subchannels`) are NOT validated — an attacker can submit arbitrarily large maps that spawn unbounded concurrent tasks. Size caps MUST be enforced before task spawning.
 - **recipient_address:** Accepted as a Felt value without format validation.

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -47,6 +47,7 @@ The service works with soft finality to provide updates as soon as possible. All
 
 - Notes may appear that are later reorged out.
 - Clients should handle reorg errors gracefully and re-sync from scratch (simple strategy).
+- A `last_known_block` that left the chain is reported as `BLOCK_REORGED` whether the node dropped it or replaced it with a competing block at the same height (see §11.1).
 
 For use cases requiring stronger finality, clients should wait for L1 confirmation before acting on discovered notes.
 

--- a/crates/discovery-service/specs/11-reorg-handling.md
+++ b/crates/discovery-service/specs/11-reorg-handling.md
@@ -2,12 +2,39 @@
 
 Cache correctness requires explicit reorg handling in the indexer.
 
-## 11.1 Invariants
+§11.1 describes the canonicity check the service performs today. The sections
+after it describe the rollback design for the planned local cache.
+
+## 11.1 Canonicity Check (implemented)
+
+A request carrying `last_known_block` is answered by a **hash → height → hash
+round trip**: `starknet_getBlockWithTxHashes` resolves the hash to its block
+number, and a second call resolves that number to the block the node currently
+carries. The hashes must match.
+
+The second call is skipped when the first reports `ACCEPTED_ON_L1`: that block's
+state update is finalized on Ethereum, so no reorg can replace it and the height
+lookup cannot change the answer. Cursors older than L1 finality — measured at
+roughly 1.5k blocks behind head on Sepolia — therefore cost one round trip rather
+than two.
+
+Existence is deliberately not used as the test: a node keeps serving an orphaned
+block by hash while its storage holds it, so a block that was *replaced* rather
+than merely dropped would otherwise be reported as canonical. A height, by
+contrast, addresses exactly one block. Each check therefore costs two RPC round
+trips, each taking a request permit in turn.
+
+A height that resolves to a pre-confirmed block reports "not canonical", since a
+pre-confirmed block carries no hash and so can never be the hash asked about. An
+RPC failure is reported as an error rather than as either verdict, so a client is
+never told to re-sync because the node was unreachable.
+
+## 11.2 Invariants
 
 - Cache reflects a canonical chain state up to a chosen "safe head."
 - Reorgs roll back cache updates for orphaned blocks before applying new canonical blocks.
 
-## 11.2 Implementation Strategy
+## 11.3 Implementation Strategy
 
 1. **Maintain a canonical chain cursor:** Track `(block_number, block_hash, parent_hash)` for ingested blocks.
 2. **Detect reorg:** When the next block does not link to the current head by parent hash, a reorg is present.
@@ -17,7 +44,7 @@ Cache correctness requires explicit reorg handling in the indexer.
 
 This logic is required regardless of the ingestion mechanism.
 
-## 11.3 Reorg Depth Support
+## 11.4 Reorg Depth Support
 
 The current scheme supports arbitrary reorg depth because:
 
@@ -25,7 +52,7 @@ The current scheme supports arbitrary reorg depth because:
 - Rollback deletes all entries above the common ancestor.
 - During reorg reconciliation, the service falls back to RPC for any reads not yet re-indexed.
 
-## 11.4 Request Handling During Reorg
+## 11.5 Request Handling During Reorg
 
 When a reorg is in progress:
 
@@ -33,7 +60,7 @@ When a reorg is in progress:
 - Reads against not-yet-indexed new blocks fall back to RPC (with stricter budget).
 - Concurrent write operations are serialized at the indexer level.
 
-## 11.5 Reorg-Related Errors
+## 11.6 Reorg-Related Errors
 
 | Scenario | Error Code | Client Action |
 |----------|------------|---------------|

--- a/crates/discovery-service/src/chain_state.rs
+++ b/crates/discovery-service/src/chain_state.rs
@@ -30,11 +30,10 @@ pub trait ChainState: Send + Sync {
     /// Set the current chain head.
     async fn set_head(&self, head: ChainHead);
 
-    /// Check if a block hash is in the canonical chain.
+    /// Check whether `block_hash` is the block the chain carries at its height.
     ///
-    /// Returns `Ok(true)` if the block exists in the canonical chain,
-    /// `Ok(false)` if the block is not found (orphaned or non-existent),
-    /// and `Err` for RPC failures.
+    /// Canonicity is not existence: a node keeps serving an orphaned block by
+    /// hash. `Err` means the node could not answer, which is neither verdict.
     async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError>;
 }
 

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -9,9 +9,10 @@ use discovery_core::storage_backend::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use starknet_core::types::{
-    requests::GetStorageAtRequest, AddressFilter, BlockId, BlockTag, EmittedEvent, EventFilter,
-    Felt, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey,
-    StorageResponseFlag, StorageResult,
+    requests::GetStorageAtRequest, AddressFilter, BlockId, BlockStatus, BlockTag,
+    BlockWithTxHashes, EmittedEvent, EventFilter, Felt, GetStorageAtResult,
+    MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey, StorageResponseFlag,
+    StorageResult,
 };
 use starknet_providers::{
     jsonrpc::{
@@ -457,15 +458,37 @@ impl ChainState for RpcBackend {
     }
 
     async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
-        match self
-            .inner
-            .provider
-            .get_block_transaction_count(BlockId::Hash(block_hash))
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(false),
-            Err(e) => Err(ChainStateError::RpcError(e)),
+        // Two round trips: a height addresses exactly one block, so hash ->
+        // height -> hash decides canonicity where knowing the hash cannot.
+        let block = match self.block_by_id(BlockId::Hash(block_hash)).await? {
+            Some(block) => block,
+            None => return Ok(false),
+        };
+        // Except once the block is final: an L1-accepted block had its state
+        // update finalized on Ethereum, so no reorg can replace it and the
+        // second round trip cannot change the answer.
+        if block.status == BlockStatus::AcceptedOnL1 {
+            return Ok(true);
+        }
+        Ok(self
+            .block_by_id(BlockId::Number(block.block_number))
+            .await?
+            .is_some_and(|candidate| candidate.block_hash == block_hash))
+    }
+}
+
+impl RpcBackend {
+    /// Fetches the accepted block `block_id` addresses, or `None` when the node
+    /// has no such block. A pre-confirmed block is `None`: it carries no hash.
+    async fn block_by_id(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<BlockWithTxHashes>, ChainStateError> {
+        match self.inner.provider.get_block_with_tx_hashes(block_id).await {
+            Ok(MaybePreConfirmedBlockWithTxHashes::Block(block)) => Ok(Some(block)),
+            Ok(MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_)) => Ok(None),
+            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(None),
+            Err(error) => Err(ChainStateError::RpcError(error)),
         }
     }
 }

--- a/crates/discovery-service/tests/common/devnet.rs
+++ b/crates/discovery-service/tests/common/devnet.rs
@@ -36,6 +36,9 @@ pub struct DevnetConfig {
     pub accounts: u32,
     /// Optional port to use. If None, a free port will be found automatically.
     pub port: Option<u16>,
+    /// Keep the full state archive, which devnet requires before it will abort
+    /// blocks. Defaults to `false`, leaving devnet at its cheapest setting.
+    pub full_state_archive: bool,
 }
 
 pub struct DevnetClient {
@@ -49,6 +52,11 @@ impl DevnetClient {
     pub fn spawn(config: DevnetConfig) -> Result<Self> {
         let port = config.port.unwrap_or(find_free_port()?);
 
+        let state_archive_capacity = if config.full_state_archive {
+            "full"
+        } else {
+            "none"
+        };
         let mut process = Command::new("starknet-devnet")
             .args([
                 "--lite-mode",
@@ -61,7 +69,7 @@ impl DevnetClient {
                 "--block-generation-on",
                 "transaction",
                 "--state-archive-capacity",
-                "none",
+                state_archive_capacity,
                 "--l2-gas-price-fri",
                 "1",
                 "--data-gas-price-fri",
@@ -195,6 +203,32 @@ impl DevnetClient {
             .as_str()
             .map(String::from)
             .ok_or_else(|| anyhow::anyhow!("No block_hash in response"))
+    }
+
+    /// Orphan `starting_block_hash` and every block above it
+    /// (devnet_abortBlocks), which devnet answers only when it was spawned with
+    /// [`DevnetConfig::full_state_archive`].
+    ///
+    /// Devnet also pushes a `starknet_subscriptionReorg` notification to live
+    /// new-heads subscribers, and stops serving the aborted hashes.
+    pub async fn abort_blocks(&self, starting_block_hash: &str) -> Result<()> {
+        let resp: serde_json::Value = reqwest::Client::new()
+            .post(format!("{}/rpc", self.rpc_url()))
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "devnet_abortBlocks",
+                "params": { "starting_block_id": { "block_hash": starting_block_hash } }
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(error) = resp.get("error") {
+            bail!("devnet_abortBlocks failed: {}", error);
+        }
+        Ok(())
     }
 }
 

--- a/crates/discovery-service/tests/test_chain_state_canonicity.rs
+++ b/crates/discovery-service/tests/test_chain_state_canonicity.rs
@@ -1,0 +1,416 @@
+//! Tests that `RpcBackend` decides block canonicity — not mere existence — from
+//! reorg notifications and, when those do not cover a hash, from what the node
+//! currently carries at that hash's height.
+//!
+//! ## Running tests
+//!
+//! ```sh
+//! cargo test -p discovery-service --test test_chain_state_canonicity
+//! ```
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use discovery_service::chain_state::{ChainState, ChainStateError};
+use discovery_service::config::RpcConfig;
+use discovery_service::rpc_backend::RpcBackend;
+use serde_json::{json, Value};
+use starknet_core::types::{
+    BlockStatus, BlockWithTxHashes, Felt, L1DataAvailabilityMode,
+    MaybePreConfirmedBlockWithTxHashes, PreConfirmedBlockWithTxHashes, ResourcePrice,
+};
+use tokio::net::TcpListener;
+use tokio::task::JoinSet;
+
+/// Every test runs against a single request permit, so a canonicity check that
+/// held a permit across its second round trip would hang instead of pass.
+const MAX_CONCURRENT_REQUESTS: usize = 1;
+
+const ORPHANED_BLOCK_NUMBER: u64 = 100;
+const ORPHANED_HASH: Felt = Felt::from_hex_unchecked("0xa11ce");
+const REPLACEMENT_HASH: Felt = Felt::from_hex_unchecked("0xb0b");
+const UNKNOWN_HASH: Felt = Felt::from_hex_unchecked("0xdeadbeef");
+
+/// JSON-RPC error code outside the Starknet error set, so the client surfaces it
+/// as a transport-level failure rather than a `BlockNotFound`.
+const INTERNAL_ERROR_CODE: i64 = -32603;
+
+/// Named rather than a bare tuple so the two collections below cannot be read in
+/// the wrong order.
+#[derive(Clone, Copy)]
+struct BlockAtHeight {
+    block_number: u64,
+    block_hash: Felt,
+}
+
+/// A node that serves `starknet_getBlockWithTxHashes`.
+///
+/// `canonical_blocks` is what each height resolves to now; `addressable_blocks` is
+/// every block still reachable by hash, orphans included. The gap between the two
+/// is what a canonicity check has to see through.
+#[derive(Default)]
+struct MockNode {
+    canonical_blocks: Vec<BlockAtHeight>,
+    addressable_blocks: Vec<BlockAtHeight>,
+    /// Heights the node reports as a pre-confirmed block, which carries no hash.
+    pre_confirmed_block_numbers: Vec<u64>,
+    /// Heights the node reports as `ACCEPTED_ON_L1`, i.e. final.
+    l1_accepted_block_numbers: Vec<u64>,
+    /// When set, every call fails with this JSON-RPC error code.
+    error_code: Option<i64>,
+    n_block_requests: AtomicUsize,
+}
+
+impl MockNode {
+    fn block_number_of(&self, block_hash: Felt) -> Option<u64> {
+        self.addressable_blocks
+            .iter()
+            .find(|block| block.block_hash == block_hash)
+            .map(|block| block.block_number)
+    }
+
+    fn canonical_hash_at(&self, block_number: u64) -> Option<Felt> {
+        self.canonical_blocks
+            .iter()
+            .find(|block| block.block_number == block_number)
+            .map(|block| block.block_hash)
+    }
+
+    fn n_block_requests(&self) -> usize {
+        self.n_block_requests.load(Ordering::SeqCst)
+    }
+}
+
+async fn handle_jsonrpc(State(node): State<Arc<MockNode>>, Json(body): Json<Value>) -> Json<Value> {
+    node.n_block_requests.fetch_add(1, Ordering::SeqCst);
+
+    let request_id = body.get("id").cloned().unwrap_or(Value::Null);
+    assert_eq!(
+        body.get("method").and_then(Value::as_str),
+        Some("starknet_getBlockWithTxHashes"),
+        "a canonicity check must not call anything else"
+    );
+
+    if let Some(error_code) = node.error_code {
+        return Json(json!({
+            "id": request_id,
+            "jsonrpc": "2.0",
+            "error": { "code": error_code, "message": "mock node failure" },
+        }));
+    }
+
+    let block_id = body
+        .get("params")
+        .and_then(|params| params.get("block_id"))
+        .expect("block_id parameter");
+    let requested_hash = block_id
+        .get("block_hash")
+        .and_then(Value::as_str)
+        .map(|hash_text| Felt::from_hex(hash_text).expect("hex block hash"));
+
+    let block_number = match requested_hash {
+        Some(block_hash) => node.block_number_of(block_hash),
+        None => {
+            let requested_number = block_id
+                .get("block_number")
+                .and_then(Value::as_u64)
+                .expect("block_id names either a hash or a number");
+            (node.canonical_hash_at(requested_number).is_some()
+                || node.pre_confirmed_block_numbers.contains(&requested_number))
+            .then_some(requested_number)
+        }
+    };
+
+    let block = match block_number {
+        None => {
+            return Json(json!({
+                "id": request_id,
+                "jsonrpc": "2.0",
+                "error": { "code": 24, "message": "Block not found" },
+            }))
+        }
+        Some(block_number) if node.pre_confirmed_block_numbers.contains(&block_number) => {
+            pre_confirmed_block(block_number)
+        }
+        Some(block_number) => confirmed_block(
+            block_number,
+            requested_hash
+                .or_else(|| node.canonical_hash_at(block_number))
+                .expect("a confirmed block has a hash"),
+            node.l1_accepted_block_numbers.contains(&block_number),
+        ),
+    };
+
+    Json(json!({
+        "id": request_id,
+        "jsonrpc": "2.0",
+        "result": serde_json::to_value(block).expect("serialize block"),
+    }))
+}
+
+fn resource_price() -> ResourcePrice {
+    ResourcePrice {
+        price_in_fri: Felt::ONE,
+        price_in_wei: Felt::ONE,
+    }
+}
+
+fn confirmed_block(
+    block_number: u64,
+    block_hash: Felt,
+    is_l1_accepted: bool,
+) -> MaybePreConfirmedBlockWithTxHashes {
+    MaybePreConfirmedBlockWithTxHashes::Block(BlockWithTxHashes {
+        status: if is_l1_accepted {
+            BlockStatus::AcceptedOnL1
+        } else {
+            BlockStatus::AcceptedOnL2
+        },
+        block_hash,
+        parent_hash: Felt::ZERO,
+        block_number,
+        new_root: Felt::ZERO,
+        timestamp: 1_700_000_000 + block_number,
+        sequencer_address: Felt::ZERO,
+        l1_gas_price: resource_price(),
+        l2_gas_price: resource_price(),
+        l1_data_gas_price: resource_price(),
+        l1_da_mode: L1DataAvailabilityMode::Blob,
+        starknet_version: "0.14.0".to_string(),
+        event_commitment: Felt::ZERO,
+        transaction_commitment: Felt::ZERO,
+        receipt_commitment: Felt::ZERO,
+        state_diff_commitment: Felt::ZERO,
+        event_count: 0,
+        transaction_count: 0,
+        state_diff_length: 0,
+        transactions: vec![],
+    })
+}
+
+fn pre_confirmed_block(block_number: u64) -> MaybePreConfirmedBlockWithTxHashes {
+    MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(PreConfirmedBlockWithTxHashes {
+        transactions: vec![],
+        block_number,
+        timestamp: 1_700_000_000 + block_number,
+        sequencer_address: Felt::ZERO,
+        l1_gas_price: resource_price(),
+        l2_gas_price: resource_price(),
+        l1_data_gas_price: resource_price(),
+        l1_da_mode: L1DataAvailabilityMode::Blob,
+        starknet_version: "0.14.0".to_string(),
+    })
+}
+
+/// Serves `node` on an ephemeral port and returns a backend pointed at it.
+async fn spawn_backend(node: MockNode) -> (RpcBackend, Arc<MockNode>) {
+    let node = Arc::new(node);
+    let router = Router::new()
+        .route("/", post(handle_jsonrpc))
+        .with_state(Arc::clone(&node));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind mock node");
+    let rpc_url = format!(
+        "http://{}",
+        listener.local_addr().expect("mock node local address")
+    );
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("serve mock node");
+    });
+
+    let backend = RpcBackend::new(RpcConfig {
+        url: rpc_url,
+        max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
+        ..Default::default()
+    })
+    .expect("RPC config should be accepted");
+    (backend, node)
+}
+
+/// The node still serves the orphaned block by hash, but its height now resolves
+/// to a different block. Existence alone would call this canonical.
+#[tokio::test]
+async fn test_orphaned_hash_at_reused_height_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: ORPHANED_HASH,
+            },
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: REPLACEMENT_HASH,
+            },
+        ],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(
+        !backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+        "a hash the node still serves is not canonical once its height carries another block"
+    );
+    assert_eq!(
+        node.n_block_requests(),
+        2,
+        "deciding this takes a hash -> height and a height -> hash call"
+    );
+}
+
+#[tokio::test]
+async fn test_canonical_hash_is_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(backend.is_canonical(REPLACEMENT_HASH).await.unwrap());
+    assert_eq!(node.n_block_requests(), 2);
+}
+
+/// An L1-accepted block is final, so its identity is settled by the first call and
+/// the height lookup is skipped.
+#[tokio::test]
+async fn test_l1_accepted_hash_is_canonical_in_one_call() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        l1_accepted_block_numbers: vec![ORPHANED_BLOCK_NUMBER],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(backend.is_canonical(REPLACEMENT_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "finality settles the answer, so the height lookup must be skipped"
+    );
+}
+
+/// A hash the node still serves as L1-accepted at a height that now carries another
+/// block would be a node contradicting itself; the short-circuit trusts finality.
+#[tokio::test]
+async fn test_unknown_hash_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode::default()).await;
+
+    assert!(!backend.is_canonical(UNKNOWN_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "a hash the node does not know needs no second call"
+    );
+}
+
+#[tokio::test]
+async fn test_rpc_failure_is_reported_as_error() {
+    let (backend, _node) = spawn_backend(MockNode {
+        error_code: Some(INTERNAL_ERROR_CODE),
+        ..Default::default()
+    })
+    .await;
+
+    let result = backend.is_canonical(REPLACEMENT_HASH).await;
+    assert!(
+        matches!(result, Err(ChainStateError::RpcError(_))),
+        "an unreachable node must leave canonicity unknown, not answer it"
+    );
+}
+
+/// A height the node serves as pre-confirmed carries no hash, so nothing can
+/// match it — and resolving it must not panic on the missing field.
+#[tokio::test]
+async fn test_pre_confirmed_height_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: ORPHANED_HASH,
+        }],
+        pre_confirmed_block_numbers: vec![ORPHANED_BLOCK_NUMBER],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(!backend.is_canonical(ORPHANED_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "a pre-confirmed answer to the hash lookup already settles the question"
+    );
+}
+
+/// Both round trips take a request permit in turn, so a burst of canonicity
+/// checks completes even when the node admits one call at a time.
+#[tokio::test]
+async fn test_canonicity_burst_completes_under_single_permit() {
+    const BURST_SIZE: usize = 8;
+
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: ORPHANED_HASH,
+            },
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: REPLACEMENT_HASH,
+            },
+        ],
+        ..Default::default()
+    })
+    .await;
+
+    let mut burst = JoinSet::new();
+    for _ in 0..BURST_SIZE {
+        let backend = backend.clone();
+        burst.spawn(async move {
+            (
+                backend.is_canonical(REPLACEMENT_HASH).await.unwrap(),
+                backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+            )
+        });
+    }
+
+    let mut num_completed = 0;
+    while let Some(joined) = burst.join_next().await {
+        assert_eq!(
+            joined.expect("burst task should not panic"),
+            (true, false),
+            "every check must reach the same verdicts"
+        );
+        num_completed += 1;
+    }
+
+    assert_eq!(num_completed, BURST_SIZE, "every check must complete");
+    assert_eq!(node.n_block_requests(), BURST_SIZE * 4);
+}

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -15,7 +15,7 @@
 
 mod common;
 
-use common::setup_devnet_with_dump;
+use common::{setup_devnet_with_dump, DevnetClient, DevnetConfig};
 use discovery_core::privacy_pool::events::{IEvents, PrivacyPoolEventContent};
 use discovery_core::privacy_pool::storage_slots;
 use discovery_core::privacy_pool::views::IViews;
@@ -169,6 +169,47 @@ async fn test_withdrawal_events_empty_for_non_recipient() {
         .unwrap();
 
     assert!(withdrawals.is_empty());
+}
+
+/// A block that left the chain must be reported non-canonical against real devnet.
+///
+/// This cannot separate canonicity from existence: devnet drops an aborted block
+/// rather than keeping it addressable, and its `--lite-mode` hashes are derived
+/// from the block number, so a replacement at the vacated height would reuse the
+/// same hash. The retained-orphan case is covered in
+/// `test_chain_state_canonicity.rs`; do not cite this test for it.
+#[tokio::test]
+async fn test_aborted_block_is_not_canonical() {
+    let devnet = DevnetClient::spawn(DevnetConfig {
+        full_state_archive: true,
+        ..Default::default()
+    })
+    .expect("Failed to spawn devnet");
+
+    let backend = RpcBackend::new(RpcConfig {
+        url: devnet.rpc_url(),
+        ..Default::default()
+    })
+    .unwrap();
+
+    devnet.create_block().await.unwrap();
+    let aborted_block_hash_text = devnet.create_block().await.unwrap();
+    let aborted_block_hash = Felt::from_hex(&aborted_block_hash_text).unwrap();
+
+    assert!(
+        backend.is_canonical(aborted_block_hash).await.unwrap(),
+        "a block the chain currently carries is canonical"
+    );
+
+    devnet
+        .abort_blocks(&aborted_block_hash_text)
+        .await
+        .expect("devnet should abort blocks");
+
+    assert!(
+        !backend.is_canonical(aborted_block_hash).await.unwrap(),
+        "a block the chain no longer carries is not canonical"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
> Stacked on #938 — review that one first. This PR's diff against it is the canonicality change only.
>
> Split: this PR is the canonicality fix. Answering it from the node's reorg notifications, and everything that entails, moved to #941.

## What

`ChainState::is_canonical` promised canonical-chain membership but `RpcBackend` implemented an existence check. Answers canonicality from a hash→height→hash round trip instead.

## Why

```rust
match self.inner.provider.get_block_transaction_count(BlockId::Hash(block_hash)).await {
    Ok(_) => Ok(true),
    Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(false),
    Err(e) => Err(ChainStateError::RpcError(e)),
}
```

"The node can still serve this hash" is not "this hash is on the chain". `api/validators.rs` relies on `is_canonical` to answer `409` / `BLOCK_REORGED` when a client's `last_known_block` was reorged out; with an existence check the reorged cursor is accepted and the client keeps extending state built on notes that have left the chain.

**Being precise about the scope, because I tested the premise and it is narrower than it looks.** Against this repo's own devnet, after `devnet_abortBlocks` the aborted hash immediately returns `BlockNotFound` — so once a node has locally processed a reorg, the existence check answers *correctly*. The real gap is the transient window before that specific endpoint has processed the fork, during which its storage legitimately still holds the old block. Structurally Pathfinder and Juno must behave the same way, since both key storage by height.

Impact is also bounded: `validate_block_ref` uses `last_known_block` only to decide whether to 409 — when it is supplied and `block_ref` is omitted, the query `BlockId` is `get_head()`, not `last_known_block`. So a false "canonical" verdict does not pin queries to orphaned data; it fails to fire the resync signal. A doomed spend still fails safely at the contract's nullifier check. And Starknet reorgs are incident-level rare — one documented mainnet case ([Jan 5 2026](https://www.starknet.io/blog/starknet-incident-report-january-5-2026/), an 18-minute reversion to height 5,187,263).

## How

1. **Hash→height→hash.** `BlockId::Number` addresses exactly one block, so comparing the hash the node currently carries at that height is a true canonicality test. New private `block_by_id` reuses the `Block`/`PreConfirmedBlock` match shape already in `resolve_block_number`; a pre-confirmed block reports `None` since it carries no hash.
2. **L1-finality short-circuit.** The second call is skipped when the first reports `ACCEPTED_ON_L1` — that block's state update is finalized on Ethereum, so no reorg can replace it and the height lookup cannot change the answer. `status` is already on the block being fetched, so this costs nothing to read.
3. **Docstring corrected** to describe what is implemented, including the pre-confirmed case and that `Err` means "unknown", not a verdict.

## Cost

Two RPC round trips per check instead of one — but only for cursors newer than L1 finality. Measured against hosted Sepolia:

```
head-0      13246784   ACCEPTED_ON_L2     2 calls
head-500    13246284   ACCEPTED_ON_L2     2 calls
head-5000   13241784   ACCEPTED_ON_L1     1 call
l1_accepted 13245300   (~1484 blocks behind head)
```

So anything older than roughly 1.5k blocks costs one round trip. The payload does grow — `getBlockTransactionCount` returns 35 B where `getBlockWithTxHashes` returns 1283–1354 B on those blocks (≈ 1143 B + 70 B per transaction) — but at ~310 ms round-trip latency the size difference was ~8 ms, i.e. noise. The dominant cost is the extra RTT, which the short-circuit removes for old cursors and #941 removes for recent ones.

The check runs only on first requests carrying `last_known_block` (`validators.rs:26`), never on pagination, and never for `SimplePrivateTransfers`, which drops its cursor in `build()`.

## Bounds and safety

**No deadlock at `max_concurrent_requests: 1`** (relevant given #938): no permit is held between the two calls — each round trip acquires and releases inside the transport. Every test in the new file runs with a single permit, and `test_canonicity_burst_completes_under_single_permit` drives 8 concurrent double-checks (16 calls) through it.

## Tests

Why this shipped unnoticed: `test_api.rs`'s `test_incoming_sync_block_reorged` and the e2e `reorg-recovery.test.ts` both simulate a reorg with a hash that **never existed** (`0xdeadbeef…`), which only exercises the `BlockNotFound` path — trivially correct before and after.

New `tests/test_chain_state_canonicity.rs` (7 tests, mock node) covers: orphaned-at-reused-height → false (2 calls); canonical → true (2 calls); L1-accepted → true in **1 call**; `BlockNotFound` → false (1 call); RPC error → `Err`; pre-confirmed height → false without panicking; single-permit burst. The mock deliberately keeps *what each height resolves to now* separate from *every block still reachable by hash* — that gap is what a canonicity check has to see through, and what a node's storage looks like right after a reorg.

Verified the tests have teeth. Restoring the old existence check verbatim fails **6 of 7** — though partly because the mock pins the method it serves, so `get_block_transaction_count` is rejected outright. Isolating just the verdict, by keeping `get_block_with_tx_hashes` but returning `is_some()`:

```
test test_orphaned_hash_at_reused_height_is_not_canonical ... FAILED
  panicked: a hash the node still serves is not canonical once its height carries another block
test test_canonical_hash_is_canonical ... FAILED
test test_canonicity_burst_completes_under_single_permit ... FAILED
test result: FAILED. 4 passed; 3 failed
```

**3 of 7**, and the first is the semantic case this PR exists for. The four that still pass do not distinguish the two behaviours: an unknown hash and a pre-confirmed height are `false` either way, and an RPC failure is `Err` regardless. `test_l1_accepted_hash_is_canonical_in_one_call` also passes it — an existence check happens to return true in one call too — so that test pins the **call count**, not the verdict; the verdict is guarded by the tests above it. Removing the short-circuit alone fails it with `left: 2, right: 1`.

Honest caveat: `test_aborted_block_is_not_canonical` (real devnet, `devnet_abortBlocks`) also passes against the *old* code — devnet stops serving the aborted hash, so `BlockNotFound` answers it either way. Refilling the vacated height would not help either: devnet runs in `--lite-mode`, where a block's hash is derived from its number, so the replacement reuses the same hash (measured: both `0x2`). It is there to validate the round trip against a real node's payloads, not to catch this regression, and its docstring now says so.

## Verification

```
cargo fmt --check                  exit 0
cargo clippy --all-targets         0 warnings
cargo test -p discovery-service    86 passed, 0 failed
```

Includes #938's `test_rpc_concurrency_limit.rs` (4 tests), untouched and passing.

## Specs

`11-reorg-handling.md` gains §11.1 "Canonicity Check (implemented)" with the old §11.1–11.5 renumbered, marking the boundary between today's behavior and the planned local cache; `05-security-considerations.md` §5.4 and `06-api-design.md` §6.4 updated. §11.2–11.6 and the `reorgs_handled` metric remain aspirational — no cache exists yet, so I labelled the boundary rather than rewriting them.

## Cross-layer

No SDK change needed: it already sends `last_known_block` and maps 409/`BLOCK_REORGED` to `ReorgError` → resync. The only delta clients see is that a `last_known_block` replaced by a competing block at the same height now 409s where it previously returned 200 — which is what the existing SDK wiring wants.

## Follow-up

`e2e/reorg-recovery.test.ts` still uses the never-existed hash. Worth upgrading to create a block, use its hash as `last_known_block`, then `devnet_abortBlocks` (needs `--state-archive-capacity full`). e2e was out of scope here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/939)
<!-- Reviewable:end -->

