### PR TITLE
feat(discovery-service): answer canonicity from reorg notifications

### DIFF
--- a/crates/discovery-service/specs/05-security-considerations.md
+++ b/crates/discovery-service/specs/05-security-considerations.md
@@ -59,7 +59,7 @@ The following vectors have been identified and mitigated:
 The following request fields are validated by the service:
 
 - **max_reads:** Must be within allowed bounds (default 50, max 100). Zero is currently accepted but wastes work.
-- **last_known_block:** If provided, checked for canonical status (reorg detection). Returns `BLOCK_REORGED` if no longer canonical.
+- **last_known_block:** If provided, checked for canonical status (reorg detection). Returns `BLOCK_REORGED` if no longer canonical. Canonicity means the chain still carries that exact block at that height — not merely that the node still serves the hash — so a block replaced by a competing one is also reported as reorged (see §11.1).
 - **block_ref:** If provided, used as-is for querying. No separate existence check — an invalid hash surfaces as an RPC error.
 - **cursor:** Structural validation via serde deserialization. Malformed JSON results in `INVALID_REQUEST`. **Note:** cursor HashMap sizes (`channels`, `subchannels`) are NOT validated — an attacker can submit arbitrarily large maps that spawn unbounded concurrent tasks. Size caps MUST be enforced before task spawning.
 - **recipient_address:** Accepted as a Felt value without format validation.

--- a/crates/discovery-service/specs/06-api-design.md
+++ b/crates/discovery-service/specs/06-api-design.md
@@ -47,6 +47,7 @@ The service works with soft finality to provide updates as soon as possible. All
 
 - Notes may appear that are later reorged out.
 - Clients should handle reorg errors gracefully and re-sync from scratch (simple strategy).
+- A `last_known_block` that left the chain is reported as `BLOCK_REORGED` whether the node dropped it or replaced it with a competing block at the same height (see §11.1).
 
 For use cases requiring stronger finality, clients should wait for L1 confirmation before acting on discovered notes.
 

--- a/crates/discovery-service/specs/11-reorg-handling.md
+++ b/crates/discovery-service/specs/11-reorg-handling.md
@@ -2,12 +2,39 @@
 
 Cache correctness requires explicit reorg handling in the indexer.
 
-## 11.1 Invariants
+§11.1 describes the canonicity check the service performs today. The sections
+after it describe the rollback design for the planned local cache.
+
+## 11.1 Canonicity Check (implemented)
+
+A request carrying `last_known_block` is answered by a **hash → height → hash
+round trip**: `starknet_getBlockWithTxHashes` resolves the hash to its block
+number, and a second call resolves that number to the block the node currently
+carries. The hashes must match.
+
+The second call is skipped when the first reports `ACCEPTED_ON_L1`: that block's
+state update is finalized on Ethereum, so no reorg can replace it and the height
+lookup cannot change the answer. Cursors older than L1 finality — measured at
+roughly 1.5k blocks behind head on Sepolia — therefore cost one round trip rather
+than two.
+
+Existence is deliberately not used as the test: a node keeps serving an orphaned
+block by hash while its storage holds it, so a block that was *replaced* rather
+than merely dropped would otherwise be reported as canonical. A height, by
+contrast, addresses exactly one block. Each check therefore costs two RPC round
+trips, each taking a request permit in turn.
+
+A height that resolves to a pre-confirmed block reports "not canonical", since a
+pre-confirmed block carries no hash and so can never be the hash asked about. An
+RPC failure is reported as an error rather than as either verdict, so a client is
+never told to re-sync because the node was unreachable.
+
+## 11.2 Invariants
 
 - Cache reflects a canonical chain state up to a chosen "safe head."
 - Reorgs roll back cache updates for orphaned blocks before applying new canonical blocks.
 
-## 11.2 Implementation Strategy
+## 11.3 Implementation Strategy
 
 1. **Maintain a canonical chain cursor:** Track `(block_number, block_hash, parent_hash)` for ingested blocks.
 2. **Detect reorg:** When the next block does not link to the current head by parent hash, a reorg is present.
@@ -17,7 +44,7 @@ Cache correctness requires explicit reorg handling in the indexer.
 
 This logic is required regardless of the ingestion mechanism.
 
-## 11.3 Reorg Depth Support
+## 11.4 Reorg Depth Support
 
 The current scheme supports arbitrary reorg depth because:
 
@@ -25,7 +52,7 @@ The current scheme supports arbitrary reorg depth because:
 - Rollback deletes all entries above the common ancestor.
 - During reorg reconciliation, the service falls back to RPC for any reads not yet re-indexed.
 
-## 11.4 Request Handling During Reorg
+## 11.5 Request Handling During Reorg
 
 When a reorg is in progress:
 
@@ -33,7 +60,7 @@ When a reorg is in progress:
 - Reads against not-yet-indexed new blocks fall back to RPC (with stricter budget).
 - Concurrent write operations are serialized at the indexer level.
 
-## 11.5 Reorg-Related Errors
+## 11.6 Reorg-Related Errors
 
 | Scenario | Error Code | Client Action |
 |----------|------------|---------------|

--- a/crates/discovery-service/specs/11-reorg-handling.md
+++ b/crates/discovery-service/specs/11-reorg-handling.md
@@ -7,27 +7,46 @@ after it describe the rollback design for the planned local cache.
 
 ## 11.1 Canonicity Check (implemented)
 
-A request carrying `last_known_block` is answered by a **hash → height → hash
-round trip**: `starknet_getBlockWithTxHashes` resolves the hash to its block
-number, and a second call resolves that number to the block the node currently
-carries. The hashes must match.
+A request carrying `last_known_block` is answered from two sources, in order.
 
-The second call is skipped when the first reports `ACCEPTED_ON_L1`: that block's
-state update is finalized on Ethereum, so no reorg can replace it and the height
-lookup cannot change the answer. Cursors older than L1 finality — measured at
-roughly 1.5k blocks behind head on Sepolia — therefore cost one round trip rather
-than two.
+1. **Reorg notifications.** The indexer's `starknet_subscribeNewHeads` subscription
+   delivers new headers and `starknet_subscriptionReorg`, which names the first and
+   last block of an orphaned range. Both feed a bounded window of recent block
+   hashes (1024 canonical + 1024 orphaned, hard capped since the node supplies
+   them). An announced hash is canonical; a hash inside a reported orphaned range
+   is not. Neither answer costs an RPC call.
 
-Existence is deliberately not used as the test: a node keeps serving an orphaned
-block by hash while its storage holds it, so a block that was *replaced* rather
-than merely dropped would otherwise be reported as canonical. A height, by
-contrast, addresses exactly one block. Each check therefore costs two RPC round
-trips, each taking a request permit in turn.
+   The window, and the cached head with it, is dropped when a subscription is
+   **lost** rather than when one starts: reorgs reach live subscribers only and
+   reconnection retries indefinitely, so anything the dead stream announced must go
+   back to the node for the whole outage.
 
-A height that resolves to a pre-confirmed block reports "not canonical", since a
-pre-confirmed block carries no hash and so can never be the hash asked about. An
-RPC failure is reported as an error rather than as either verdict, so a client is
-never told to re-sync because the node was unreachable.
+   **Trust assumption.** Treating an announced hash as canonical relies on the node
+   reporting every range it takes back. A node that silently reorgs and then
+   announces a header above the replaced height leaves the superseded entry
+   canonical until it is evicted. The negative answer and the round trip in (2)
+   carry no such assumption. Linking each header to the tracked entry below it by
+   `parent_hash` and cutting a divergent prefix would remove it; §11.3 already
+   tracks `parent_hash` for the planned cache.
+
+2. **Hash → height → hash round trip.** For hashes the window does not cover,
+   `starknet_getBlockWithTxHashes` resolves the hash to its block number, and a
+   second call resolves that number to the block the node currently carries. The
+   hashes must match. Existence is deliberately not the test: a node keeps serving
+   an orphaned block by hash while its storage holds it, so a block that was
+   *replaced* rather than dropped would otherwise read as canonical.
+
+   The second call is skipped when the first reports `ACCEPTED_ON_L1`: that block's
+   state update is finalized on Ethereum, so no reorg can replace it and the height
+   lookup cannot change the answer. Cursors older than L1 finality — roughly 1.5k
+   blocks behind head, measured on Sepolia — therefore cost one round trip. Newer
+   ones cost two, each taking a request permit in turn.
+
+An evicted hash is reported as unknown, never as orphaned, so eviction degrades to
+the round trip instead of forcing clients to re-sync. A height that resolves to a
+pre-confirmed block reports "not canonical", since a pre-confirmed block carries no
+hash. An RPC failure is an error rather than either verdict, so a client is never
+told to re-sync because the node was unreachable.
 
 ## 11.2 Invariants
 

--- a/crates/discovery-service/src/api/validators.rs
+++ b/crates/discovery-service/src/api/validators.rs
@@ -252,8 +252,10 @@ pub async fn validate_viewing_key<S: StorageSnapshot>(
 mod tests {
     use super::*;
     use crate::chain_state::mock::MockChainState;
+    use crate::chain_state::ChainHead;
     use discovery_core::discovery::{ChannelCursor, SubchannelCursor};
     use discovery_core::privacy_pool::types::SecretFelt;
+    use starknet_core::types::ReorgData;
 
     #[tokio::test]
     async fn test_none_resolves_to_head_hash() {
@@ -297,6 +299,42 @@ mod tests {
             validate_block_ref(Some(Felt::from_hex_unchecked("0x999")), None, &backend).await;
         assert!(result.is_err());
 
+        let (status, error) = result.unwrap_err();
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(error.error.code, error_codes::BLOCK_REORGED);
+    }
+
+    /// A reorg the node reported must turn into the 409 that tells the client to
+    /// discard its cursor, even though the block was announced as a head first.
+    #[tokio::test]
+    async fn test_reorged_announced_block_conflicts() {
+        let backend = MockChainState::new();
+        let announced_hash = Felt::from_hex_unchecked("0x456");
+        backend
+            .set_head(ChainHead {
+                block_number: 101,
+                block_hash: announced_hash,
+                timestamp: 1010,
+            })
+            .await;
+
+        assert!(
+            validate_block_ref(Some(announced_hash), None, &backend)
+                .await
+                .is_ok(),
+            "an announced head is accepted"
+        );
+
+        backend
+            .record_reorg(&ReorgData {
+                starting_block_hash: announced_hash,
+                starting_block_number: 101,
+                ending_block_hash: announced_hash,
+                ending_block_number: 101,
+            })
+            .await;
+
+        let result = validate_block_ref(Some(announced_hash), None, &backend).await;
         let (status, error) = result.unwrap_err();
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(error.error.code, error_codes::BLOCK_REORGED);

--- a/crates/discovery-service/src/chain_state.rs
+++ b/crates/discovery-service/src/chain_state.rs
@@ -30,11 +30,10 @@ pub trait ChainState: Send + Sync {
     /// Set the current chain head.
     async fn set_head(&self, head: ChainHead);
 
-    /// Check if a block hash is in the canonical chain.
+    /// Check whether `block_hash` is the block the chain carries at its height.
     ///
-    /// Returns `Ok(true)` if the block exists in the canonical chain,
-    /// `Ok(false)` if the block is not found (orphaned or non-existent),
-    /// and `Err` for RPC failures.
+    /// Canonicity is not existence: a node keeps serving an orphaned block by
+    /// hash. `Err` means the node could not answer, which is neither verdict.
     async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError>;
 }
 

--- a/crates/discovery-service/src/chain_state.rs
+++ b/crates/discovery-service/src/chain_state.rs
@@ -1,10 +1,22 @@
 //! Chain state tracking for the Starknet indexer.
 
+use std::collections::{BTreeMap, VecDeque};
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use starknet_core::types::Felt;
+use starknet_core::types::{Felt, ReorgData};
 use starknet_providers::ProviderError;
 use thiserror::Error;
+
+/// Canonical block hashes retained per new-heads subscription. At a few seconds
+/// per Starknet block this covers roughly the last hour of chain history — far
+/// deeper than any observed reorg — for roughly 40 KiB of hashes.
+pub const MAX_TRACKED_CANONICAL_BLOCKS: usize = 1024;
+
+/// Orphaned block hashes retained per new-heads subscription. Sized to absorb a
+/// reorg that orphans the entire tracked window; beyond that the oldest hashes
+/// are dropped and answered by the node instead.
+pub const MAX_TRACKED_ORPHANED_BLOCKS: usize = 1024;
 
 /// Represents the current chain head.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -12,6 +24,110 @@ pub struct ChainHead {
     pub block_number: u64,
     pub block_hash: Felt,
     pub timestamp: u64,
+}
+
+/// Bounded record of what a node's new-heads subscription said about the recent
+/// chain tip: the hash announced as canonical at each height, and the hashes
+/// since named in a reorg notification.
+///
+/// A hash the window does not cover is reported as unknown, never as orphaned —
+/// reporting an evicted entry as orphaned would force every client holding an
+/// older cursor to re-sync. Treating an announced hash as canonical assumes the
+/// node reports every range it takes back; see specs/11-reorg-handling.md §11.1.
+///
+/// Every value comes from an external node, so both collections are hard capped.
+#[derive(Debug, Default)]
+pub struct RecentBlockWindow {
+    /// Announced block hash per block number, ordered by height so the oldest
+    /// entry is the one evicted and a reorged range is cheap to cut out.
+    canonical_hashes: BTreeMap<u64, Felt>,
+    /// Hashes named by reorg notifications, oldest first.
+    orphaned_hashes: VecDeque<Felt>,
+}
+
+impl RecentBlockWindow {
+    /// Records `head` as the announced canonical block at its height.
+    ///
+    /// Entries at or above that height are superseded, and are dropped rather
+    /// than orphaned so they go back to being resolved against the node.
+    pub fn record_head(&mut self, head: &ChainHead) {
+        self.canonical_hashes.split_off(&head.block_number);
+        self.canonical_hashes
+            .insert(head.block_number, head.block_hash);
+        // An announcement outranks any earlier reorg naming the same hash.
+        self.orphaned_hashes
+            .retain(|orphaned_hash| *orphaned_hash != head.block_hash);
+
+        while self.canonical_hashes.len() > MAX_TRACKED_CANONICAL_BLOCKS {
+            self.canonical_hashes.pop_first();
+        }
+    }
+
+    /// Records the block range a reorg notification names as orphaned.
+    ///
+    /// Heights between the two named ends come from what the window already
+    /// tracks, so a range spanning the whole `u64` space costs no extra work.
+    pub fn record_reorg(&mut self, reorg: &ReorgData) {
+        let orphaned_block_numbers: Vec<u64> = self
+            .canonical_hashes
+            .range(lowest_orphaned_block_number(reorg)..=highest_orphaned_block_number(reorg))
+            .map(|(block_number, _)| *block_number)
+            .collect();
+
+        for block_number in orphaned_block_numbers {
+            if let Some(block_hash) = self.canonical_hashes.remove(&block_number) {
+                self.record_orphaned_hash(block_hash);
+            }
+        }
+        // Last, so the node's own hashes outlive window-inferred ones on eviction.
+        self.record_orphaned_hash(reorg.starting_block_hash);
+        self.record_orphaned_hash(reorg.ending_block_hash);
+    }
+
+    /// Forgets everything tracked.
+    pub fn clear(&mut self) {
+        self.canonical_hashes.clear();
+        self.orphaned_hashes.clear();
+    }
+
+    /// Canonicity of `block_hash` according to tracked notifications alone.
+    ///
+    /// - `Some(true)`: announced as the canonical block at its height and not
+    ///   named by a reorg since.
+    /// - `Some(false)`: named by a reorg notification.
+    /// - `None`: not covered by the window (never announced, or evicted), so the
+    ///   answer has to come from the node.
+    pub fn canonicity(&self, block_hash: Felt) -> Option<bool> {
+        if self.orphaned_hashes.contains(&block_hash) {
+            return Some(false);
+        }
+        self.canonical_hashes
+            .values()
+            .any(|canonical_hash| *canonical_hash == block_hash)
+            .then_some(true)
+    }
+
+    fn record_orphaned_hash(&mut self, block_hash: Felt) {
+        if self.orphaned_hashes.contains(&block_hash) {
+            return;
+        }
+        self.orphaned_hashes.push_back(block_hash);
+        while self.orphaned_hashes.len() > MAX_TRACKED_ORPHANED_BLOCKS {
+            self.orphaned_hashes.pop_front();
+        }
+    }
+}
+
+/// Lowest block number a reorg notification covers. The pair is taken as
+/// unordered, so an inverted range still yields a usable bound instead of
+/// panicking on a reversed lookup.
+pub fn lowest_orphaned_block_number(reorg: &ReorgData) -> u64 {
+    reorg.starting_block_number.min(reorg.ending_block_number)
+}
+
+/// Highest block number a reorg notification covers.
+fn highest_orphaned_block_number(reorg: &ReorgData) -> u64 {
+    reorg.starting_block_number.max(reorg.ending_block_number)
 }
 
 /// Errors that can occur during chain state operations.
@@ -27,8 +143,23 @@ pub trait ChainState: Send + Sync {
     /// Get the current chain head, if known.
     async fn get_head(&self) -> Option<ChainHead>;
 
-    /// Set the current chain head.
+    /// Set the current chain head, as announced by the node.
     async fn set_head(&self, head: ChainHead);
+
+    /// Record a reorg the node reported over its new-heads subscription.
+    ///
+    /// The reported range is the node's own verdict on which blocks left the
+    /// canonical chain, so the hashes it covers are answered by
+    /// [`ChainState::is_canonical`] without asking the node again.
+    async fn record_reorg(&self, reorg: &ReorgData);
+
+    /// Forget everything learned from a new-heads subscription, including the
+    /// cached head.
+    ///
+    /// Must be called when a subscription is lost, not when one starts: a block
+    /// orphaned while nothing was subscribed produces no notification, so every
+    /// hash the dead stream announced is unverifiable from that instant on.
+    async fn forget_recent_blocks(&self);
 
     /// Check whether `block_hash` is the block the chain carries at its height.
     ///
@@ -39,12 +170,16 @@ pub trait ChainState: Send + Sync {
 
 #[cfg(test)]
 pub mod mock {
+    use std::sync::Mutex;
+
     use super::*;
 
-    /// Mock chain state for testing.
+    /// Mock chain state for testing. `canonical_blocks` stands in for the node,
+    /// answering whatever the tracked window has no verdict on.
     pub struct MockChainState {
         head: Option<ChainHead>,
         canonical_blocks: Vec<Felt>,
+        recent_blocks: Mutex<RecentBlockWindow>,
     }
 
     impl MockChainState {
@@ -56,6 +191,7 @@ pub mod mock {
                     timestamp: 1000,
                 }),
                 canonical_blocks: vec![Felt::from_hex_unchecked("0x123")],
+                recent_blocks: Mutex::new(RecentBlockWindow::default()),
             }
         }
 
@@ -63,7 +199,12 @@ pub mod mock {
             Self {
                 head: None,
                 canonical_blocks: vec![],
+                recent_blocks: Mutex::new(RecentBlockWindow::default()),
             }
+        }
+
+        fn recent_blocks(&self) -> std::sync::MutexGuard<'_, RecentBlockWindow> {
+            self.recent_blocks.lock().expect("recent blocks lock")
         }
     }
 
@@ -79,12 +220,210 @@ pub mod mock {
             self.head
         }
 
-        async fn set_head(&self, _head: ChainHead) {
-            // No-op for mock
+        async fn set_head(&self, head: ChainHead) {
+            // The mock's head is fixed at construction; only tracking is exercised.
+            self.recent_blocks().record_head(&head);
+        }
+
+        async fn record_reorg(&self, reorg: &ReorgData) {
+            self.recent_blocks().record_reorg(reorg);
+        }
+
+        async fn forget_recent_blocks(&self) {
+            self.recent_blocks().clear();
         }
 
         async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
-            Ok(self.canonical_blocks.contains(&block_hash))
+            let tracked_canonicity = self.recent_blocks().canonicity(block_hash);
+            Ok(tracked_canonicity.unwrap_or_else(|| self.canonical_blocks.contains(&block_hash)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORPHANED_HASH: Felt = Felt::from_hex_unchecked("0xaaa");
+    const REPLACEMENT_HASH: Felt = Felt::from_hex_unchecked("0xbbb");
+
+    fn head_at(block_number: u64, block_hash: Felt) -> ChainHead {
+        ChainHead {
+            block_number,
+            block_hash,
+            timestamp: 1_700_000_000 + block_number,
+        }
+    }
+
+    fn reorg_between(
+        starting_block_number: u64,
+        starting_block_hash: Felt,
+        ending_block_number: u64,
+        ending_block_hash: Felt,
+    ) -> ReorgData {
+        ReorgData {
+            starting_block_hash,
+            starting_block_number,
+            ending_block_hash,
+            ending_block_number,
+        }
+    }
+
+    #[test]
+    fn test_announced_head_is_canonical() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), Some(true));
+    }
+
+    #[test]
+    fn test_unknown_hash_has_no_verdict() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        assert_eq!(window.canonicity(REPLACEMENT_HASH), None);
+    }
+
+    #[test]
+    fn test_reorg_marks_announced_hash_orphaned() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(99, REPLACEMENT_HASH));
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        window.record_reorg(&reorg_between(100, ORPHANED_HASH, 100, ORPHANED_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), Some(false));
+        assert_eq!(
+            window.canonicity(REPLACEMENT_HASH),
+            Some(true),
+            "blocks below the reorged range stay canonical"
+        );
+    }
+
+    #[test]
+    fn test_reorg_marks_named_hashes_never_announced() {
+        let mut window = RecentBlockWindow::default();
+
+        window.record_reorg(&reorg_between(100, ORPHANED_HASH, 105, REPLACEMENT_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), Some(false));
+        assert_eq!(window.canonicity(REPLACEMENT_HASH), Some(false));
+    }
+
+    #[test]
+    fn test_reorg_spanning_whole_number_space_is_bounded() {
+        let mut window = RecentBlockWindow::default();
+        for block_number in 0..10u64 {
+            window.record_head(&head_at(block_number, Felt::from(block_number)));
+        }
+
+        window.record_reorg(&reorg_between(0, ORPHANED_HASH, u64::MAX, REPLACEMENT_HASH));
+
+        for block_number in 0..10u64 {
+            assert_eq!(
+                window.canonicity(Felt::from(block_number)),
+                Some(false),
+                "block {block_number} is inside the reorged range"
+            );
+        }
+    }
+
+    #[test]
+    fn test_inverted_reorg_range_is_accepted() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        // The node is expected to order the pair; an inverted range must still
+        // be interpreted rather than panic on a reversed lookup.
+        window.record_reorg(&reorg_between(105, REPLACEMENT_HASH, 100, ORPHANED_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), Some(false));
+    }
+
+    #[test]
+    fn test_re_announced_head_clears_orphaned_verdict() {
+        let mut window = RecentBlockWindow::default();
+        window.record_reorg(&reorg_between(100, ORPHANED_HASH, 100, ORPHANED_HASH));
+
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), Some(true));
+    }
+
+    #[test]
+    fn test_superseded_height_loses_its_verdict() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(100, ORPHANED_HASH));
+
+        // A second announcement at the same height supersedes the first without
+        // proving it orphaned, so the old hash goes back to the node.
+        window.record_head(&head_at(100, REPLACEMENT_HASH));
+
+        assert_eq!(window.canonicity(ORPHANED_HASH), None);
+        assert_eq!(window.canonicity(REPLACEMENT_HASH), Some(true));
+    }
+
+    #[test]
+    fn test_window_evicts_oldest_and_stays_capped() {
+        let mut window = RecentBlockWindow::default();
+        let num_announced_heads = (MAX_TRACKED_CANONICAL_BLOCKS as u64) * 3;
+        for block_number in 0..num_announced_heads {
+            window.record_head(&head_at(block_number, Felt::from(block_number + 1)));
+        }
+
+        assert_eq!(
+            window.canonical_hashes.len(),
+            MAX_TRACKED_CANONICAL_BLOCKS,
+            "the window must stay at its cap however many heads arrive"
+        );
+        assert_eq!(
+            window.canonicity(Felt::from(1u64)),
+            None,
+            "an evicted hash must fall back to the node, not be called orphaned"
+        );
+        assert_eq!(
+            window.canonicity(Felt::from(num_announced_heads)),
+            Some(true),
+            "the newest announced head stays covered"
+        );
+    }
+
+    #[test]
+    fn test_orphaned_hashes_stay_capped() {
+        let mut window = RecentBlockWindow::default();
+        for block_number in 0..(MAX_TRACKED_ORPHANED_BLOCKS as u64) * 3 {
+            let block_hash = Felt::from(block_number + 1);
+            window.record_head(&head_at(block_number, block_hash));
+            window.record_reorg(&reorg_between(
+                block_number,
+                block_hash,
+                block_number,
+                block_hash,
+            ));
+        }
+
+        assert_eq!(
+            window.orphaned_hashes.len(),
+            MAX_TRACKED_ORPHANED_BLOCKS,
+            "orphaned hashes must stay at their cap however many reorgs arrive"
+        );
+        assert_eq!(
+            window.canonicity(Felt::from(1u64)),
+            None,
+            "an evicted orphaned hash falls back to the node"
+        );
+    }
+
+    #[test]
+    fn test_clear_drops_every_verdict() {
+        let mut window = RecentBlockWindow::default();
+        window.record_head(&head_at(100, REPLACEMENT_HASH));
+        window.record_reorg(&reorg_between(101, ORPHANED_HASH, 101, ORPHANED_HASH));
+
+        window.clear();
+
+        assert_eq!(window.canonicity(REPLACEMENT_HASH), None);
+        assert_eq!(window.canonicity(ORPHANED_HASH), None);
     }
 }

--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -88,7 +88,13 @@ impl<C: ChainState> Indexer<C> {
         info!("Indexer started");
 
         loop {
-            match self.run_inner().await {
+            let outcome = self.run_inner().await;
+            if outcome.is_err() {
+                // On loss, not on reconnect: a reconnect may be many backoff intervals
+                // away, and nothing notifies about the gap.
+                self.chain_state.forget_recent_blocks().await;
+            }
+            match outcome {
                 Ok(()) => {
                     info!("Indexer terminated");
                     return Ok(());
@@ -149,6 +155,7 @@ impl<C: ChainState> Indexer<C> {
                                 "Reorg detected: #{} -> #{}",
                                 reorg.starting_block_number, reorg.ending_block_number
                             );
+                            self.chain_state.record_reorg(&reorg).await;
                         }
                     }
                 }
@@ -167,5 +174,129 @@ impl<C: ChainState> Indexer<C> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use starknet_core::types::{Felt, ReorgData};
+
+    use super::*;
+    use crate::chain_state::{ChainStateError, RecentBlockWindow};
+
+    /// Keeps a real [`RecentBlockWindow`] and counts forget calls, so a test can
+    /// assert on the window's verdicts rather than only on the calls.
+    #[derive(Clone, Default)]
+    struct RecordingChainState {
+        recent_blocks: Arc<Mutex<RecentBlockWindow>>,
+        num_forget_calls: Arc<AtomicUsize>,
+    }
+
+    impl RecordingChainState {
+        fn canonicity(&self, block_hash: Felt) -> Option<bool> {
+            self.recent_blocks
+                .lock()
+                .expect("recent blocks lock")
+                .canonicity(block_hash)
+        }
+
+        fn num_forget_calls(&self) -> usize {
+            self.num_forget_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl ChainState for RecordingChainState {
+        async fn get_head(&self) -> Option<ChainHead> {
+            None
+        }
+
+        async fn set_head(&self, head: ChainHead) {
+            self.recent_blocks
+                .lock()
+                .expect("recent blocks lock")
+                .record_head(&head);
+        }
+
+        async fn record_reorg(&self, reorg: &ReorgData) {
+            self.recent_blocks
+                .lock()
+                .expect("recent blocks lock")
+                .record_reorg(reorg);
+        }
+
+        async fn forget_recent_blocks(&self) {
+            self.num_forget_calls.fetch_add(1, Ordering::SeqCst);
+            self.recent_blocks
+                .lock()
+                .expect("recent blocks lock")
+                .clear();
+        }
+
+        async fn is_canonical(&self, _block_hash: Felt) -> Result<bool, ChainStateError> {
+            unreachable!("the indexer never asks about canonicity")
+        }
+    }
+
+    /// Losing the stream must drop what it announced straight away; deferring to a
+    /// successful reconnect would answer the whole outage out of stale memory.
+    #[tokio::test]
+    async fn test_lost_subscription_forgets_announced_blocks_before_reconnecting() {
+        let announced_hash = Felt::from_hex_unchecked("0xabc");
+        let chain_state = RecordingChainState::default();
+        chain_state
+            .set_head(ChainHead {
+                block_number: 100,
+                block_hash: announced_hash,
+                timestamp: 1_700_000_000,
+            })
+            .await;
+        assert_eq!(
+            chain_state.canonicity(announced_hash),
+            Some(true),
+            "the announced head starts out covered by the window"
+        );
+
+        let (tx_shutdown, rx_shutdown) = broadcast::channel(1);
+        let mut indexer = Indexer::new(
+            IndexerConfig {
+                // Nothing listening, so the connect fails at once.
+                ws_url: "ws://127.0.0.1:1/ws".to_string(),
+                connect_timeout: Duration::from_secs(1),
+                // Long enough that the assertions below can only pass if the window
+                // was cleared on the failure rather than on a reconnect.
+                backoff_initial_interval: Duration::from_secs(600),
+                backoff_max_interval: Duration::from_secs(600),
+                backoff_max_elapsed_time: None,
+            },
+            rx_shutdown,
+            chain_state.clone(),
+        );
+        let indexer_task = tokio::spawn(async move { indexer.run().await });
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while chain_state.num_forget_calls() == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("a failed connect must forget the announced blocks");
+
+        assert_eq!(
+            chain_state.canonicity(announced_hash),
+            None,
+            "a hash announced by a dead subscription must go back to the node"
+        );
+
+        tx_shutdown.send(()).expect("shutdown receiver is alive");
+        indexer_task
+            .await
+            .expect("indexer task panicked")
+            .expect("shutdown during backoff is a clean exit");
     }
 }

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -9,9 +9,10 @@ use discovery_core::storage_backend::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use starknet_core::types::{
-    requests::GetStorageAtRequest, AddressFilter, BlockId, BlockTag, EmittedEvent, EventFilter,
-    Felt, GetStorageAtResult, MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey,
-    StorageResponseFlag, StorageResult,
+    requests::GetStorageAtRequest, AddressFilter, BlockId, BlockStatus, BlockTag,
+    BlockWithTxHashes, EmittedEvent, EventFilter, Felt, GetStorageAtResult,
+    MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey, StorageResponseFlag,
+    StorageResult,
 };
 use starknet_providers::{
     jsonrpc::{
@@ -457,15 +458,37 @@ impl ChainState for RpcBackend {
     }
 
     async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
-        match self
-            .inner
-            .provider
-            .get_block_transaction_count(BlockId::Hash(block_hash))
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(false),
-            Err(e) => Err(ChainStateError::RpcError(e)),
+        // Two round trips: a height addresses exactly one block, so hash ->
+        // height -> hash decides canonicity where knowing the hash cannot.
+        let block = match self.block_by_id(BlockId::Hash(block_hash)).await? {
+            Some(block) => block,
+            None => return Ok(false),
+        };
+        // Except once the block is final: an L1-accepted block had its state
+        // update finalized on Ethereum, so no reorg can replace it and the
+        // second round trip cannot change the answer.
+        if block.status == BlockStatus::AcceptedOnL1 {
+            return Ok(true);
+        }
+        Ok(self
+            .block_by_id(BlockId::Number(block.block_number))
+            .await?
+            .is_some_and(|candidate| candidate.block_hash == block_hash))
+    }
+}
+
+impl RpcBackend {
+    /// Fetches the accepted block `block_id` addresses, or `None` when the node
+    /// has no such block. A pre-confirmed block is `None`: it carries no hash.
+    async fn block_by_id(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<BlockWithTxHashes>, ChainStateError> {
+        match self.inner.provider.get_block_with_tx_hashes(block_id).await {
+            Ok(MaybePreConfirmedBlockWithTxHashes::Block(block)) => Ok(Some(block)),
+            Ok(MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(_)) => Ok(None),
+            Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => Ok(None),
+            Err(error) => Err(ChainStateError::RpcError(error)),
         }
     }
 }

--- a/crates/discovery-service/src/rpc_backend.rs
+++ b/crates/discovery-service/src/rpc_backend.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use starknet_core::types::{
     requests::GetStorageAtRequest, AddressFilter, BlockId, BlockStatus, BlockTag,
     BlockWithTxHashes, EmittedEvent, EventFilter, Felt, GetStorageAtResult,
-    MaybePreConfirmedBlockWithTxHashes, StarknetError, StorageKey, StorageResponseFlag,
+    MaybePreConfirmedBlockWithTxHashes, ReorgData, StarknetError, StorageKey, StorageResponseFlag,
     StorageResult,
 };
 use starknet_providers::{
@@ -25,7 +25,9 @@ use thiserror::Error;
 use tokio::sync::{RwLock, Semaphore, SemaphorePermit};
 use url::Url;
 
-use crate::chain_state::{ChainHead, ChainState, ChainStateError};
+use crate::chain_state::{
+    lowest_orphaned_block_number, ChainHead, ChainState, ChainStateError, RecentBlockWindow,
+};
 use crate::config::RpcConfig;
 
 /// Errors specific to the RPC backend.
@@ -120,6 +122,7 @@ impl JsonRpcTransport for LimitedTransport {
 struct RpcBackendInner {
     provider: JsonRpcClient<LimitedTransport>,
     head: RwLock<Option<ChainHead>>,
+    recent_blocks: RwLock<RecentBlockWindow>,
     max_batch_size: usize,
     event_page_size: usize,
 }
@@ -163,6 +166,7 @@ impl RpcBackend {
             inner: Arc::new(RpcBackendInner {
                 provider,
                 head: RwLock::new(None),
+                recent_blocks: RwLock::new(RecentBlockWindow::default()),
                 max_batch_size: config.max_batch_size,
                 event_page_size: config.event_page_size,
             }),
@@ -455,9 +459,37 @@ impl ChainState for RpcBackend {
 
     async fn set_head(&self, head: ChainHead) {
         *self.inner.head.write().await = Some(head);
+        self.inner.recent_blocks.write().await.record_head(&head);
+    }
+
+    async fn record_reorg(&self, reorg: &ReorgData) {
+        {
+            // An orphaned head must stop being handed out as the pin for new
+            // requests; dropping it sends `get_head` back to the node.
+            let mut cached_head = self.inner.head.write().await;
+            if cached_head
+                .is_some_and(|head| head.block_number >= lowest_orphaned_block_number(reorg))
+            {
+                *cached_head = None;
+            }
+        }
+        self.inner.recent_blocks.write().await.record_reorg(reorg);
+    }
+
+    async fn forget_recent_blocks(&self) {
+        // The cached head was announced by the same dead stream, so it is no more
+        // verifiable than the window.
+        *self.inner.head.write().await = None;
+        self.inner.recent_blocks.write().await.clear();
     }
 
     async fn is_canonical(&self, block_hash: Felt) -> Result<bool, ChainStateError> {
+        // Copied out before any await: no lock may be held across a node call.
+        let tracked_canonicity = self.inner.recent_blocks.read().await.canonicity(block_hash);
+        if let Some(is_canonical) = tracked_canonicity {
+            return Ok(is_canonical);
+        }
+
         // Two round trips: a height addresses exactly one block, so hash ->
         // height -> hash decides canonicity where knowing the hash cannot.
         let block = match self.block_by_id(BlockId::Hash(block_hash)).await? {

--- a/crates/discovery-service/tests/common/devnet.rs
+++ b/crates/discovery-service/tests/common/devnet.rs
@@ -36,6 +36,9 @@ pub struct DevnetConfig {
     pub accounts: u32,
     /// Optional port to use. If None, a free port will be found automatically.
     pub port: Option<u16>,
+    /// Keep the full state archive, which devnet requires before it will abort
+    /// blocks. Defaults to `false`, leaving devnet at its cheapest setting.
+    pub full_state_archive: bool,
 }
 
 pub struct DevnetClient {
@@ -49,6 +52,11 @@ impl DevnetClient {
     pub fn spawn(config: DevnetConfig) -> Result<Self> {
         let port = config.port.unwrap_or(find_free_port()?);
 
+        let state_archive_capacity = if config.full_state_archive {
+            "full"
+        } else {
+            "none"
+        };
         let mut process = Command::new("starknet-devnet")
             .args([
                 "--lite-mode",
@@ -61,7 +69,7 @@ impl DevnetClient {
                 "--block-generation-on",
                 "transaction",
                 "--state-archive-capacity",
-                "none",
+                state_archive_capacity,
                 "--l2-gas-price-fri",
                 "1",
                 "--data-gas-price-fri",
@@ -195,6 +203,32 @@ impl DevnetClient {
             .as_str()
             .map(String::from)
             .ok_or_else(|| anyhow::anyhow!("No block_hash in response"))
+    }
+
+    /// Orphan `starting_block_hash` and every block above it
+    /// (devnet_abortBlocks), which devnet answers only when it was spawned with
+    /// [`DevnetConfig::full_state_archive`].
+    ///
+    /// Devnet also pushes a `starknet_subscriptionReorg` notification to live
+    /// new-heads subscribers, and stops serving the aborted hashes.
+    pub async fn abort_blocks(&self, starting_block_hash: &str) -> Result<()> {
+        let resp: serde_json::Value = reqwest::Client::new()
+            .post(format!("{}/rpc", self.rpc_url()))
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "devnet_abortBlocks",
+                "params": { "starting_block_id": { "block_hash": starting_block_hash } }
+            }))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if let Some(error) = resp.get("error") {
+            bail!("devnet_abortBlocks failed: {}", error);
+        }
+        Ok(())
     }
 }
 

--- a/crates/discovery-service/tests/test_chain_state_canonicity.rs
+++ b/crates/discovery-service/tests/test_chain_state_canonicity.rs
@@ -1,0 +1,416 @@
+//! Tests that `RpcBackend` decides block canonicity — not mere existence — from
+//! reorg notifications and, when those do not cover a hash, from what the node
+//! currently carries at that hash's height.
+//!
+//! ## Running tests
+//!
+//! ```sh
+//! cargo test -p discovery-service --test test_chain_state_canonicity
+//! ```
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use discovery_service::chain_state::{ChainState, ChainStateError};
+use discovery_service::config::RpcConfig;
+use discovery_service::rpc_backend::RpcBackend;
+use serde_json::{json, Value};
+use starknet_core::types::{
+    BlockStatus, BlockWithTxHashes, Felt, L1DataAvailabilityMode,
+    MaybePreConfirmedBlockWithTxHashes, PreConfirmedBlockWithTxHashes, ResourcePrice,
+};
+use tokio::net::TcpListener;
+use tokio::task::JoinSet;
+
+/// Every test runs against a single request permit, so a canonicity check that
+/// held a permit across its second round trip would hang instead of pass.
+const MAX_CONCURRENT_REQUESTS: usize = 1;
+
+const ORPHANED_BLOCK_NUMBER: u64 = 100;
+const ORPHANED_HASH: Felt = Felt::from_hex_unchecked("0xa11ce");
+const REPLACEMENT_HASH: Felt = Felt::from_hex_unchecked("0xb0b");
+const UNKNOWN_HASH: Felt = Felt::from_hex_unchecked("0xdeadbeef");
+
+/// JSON-RPC error code outside the Starknet error set, so the client surfaces it
+/// as a transport-level failure rather than a `BlockNotFound`.
+const INTERNAL_ERROR_CODE: i64 = -32603;
+
+/// Named rather than a bare tuple so the two collections below cannot be read in
+/// the wrong order.
+#[derive(Clone, Copy)]
+struct BlockAtHeight {
+    block_number: u64,
+    block_hash: Felt,
+}
+
+/// A node that serves `starknet_getBlockWithTxHashes`.
+///
+/// `canonical_blocks` is what each height resolves to now; `addressable_blocks` is
+/// every block still reachable by hash, orphans included. The gap between the two
+/// is what a canonicity check has to see through.
+#[derive(Default)]
+struct MockNode {
+    canonical_blocks: Vec<BlockAtHeight>,
+    addressable_blocks: Vec<BlockAtHeight>,
+    /// Heights the node reports as a pre-confirmed block, which carries no hash.
+    pre_confirmed_block_numbers: Vec<u64>,
+    /// Heights the node reports as `ACCEPTED_ON_L1`, i.e. final.
+    l1_accepted_block_numbers: Vec<u64>,
+    /// When set, every call fails with this JSON-RPC error code.
+    error_code: Option<i64>,
+    n_block_requests: AtomicUsize,
+}
+
+impl MockNode {
+    fn block_number_of(&self, block_hash: Felt) -> Option<u64> {
+        self.addressable_blocks
+            .iter()
+            .find(|block| block.block_hash == block_hash)
+            .map(|block| block.block_number)
+    }
+
+    fn canonical_hash_at(&self, block_number: u64) -> Option<Felt> {
+        self.canonical_blocks
+            .iter()
+            .find(|block| block.block_number == block_number)
+            .map(|block| block.block_hash)
+    }
+
+    fn n_block_requests(&self) -> usize {
+        self.n_block_requests.load(Ordering::SeqCst)
+    }
+}
+
+async fn handle_jsonrpc(State(node): State<Arc<MockNode>>, Json(body): Json<Value>) -> Json<Value> {
+    node.n_block_requests.fetch_add(1, Ordering::SeqCst);
+
+    let request_id = body.get("id").cloned().unwrap_or(Value::Null);
+    assert_eq!(
+        body.get("method").and_then(Value::as_str),
+        Some("starknet_getBlockWithTxHashes"),
+        "a canonicity check must not call anything else"
+    );
+
+    if let Some(error_code) = node.error_code {
+        return Json(json!({
+            "id": request_id,
+            "jsonrpc": "2.0",
+            "error": { "code": error_code, "message": "mock node failure" },
+        }));
+    }
+
+    let block_id = body
+        .get("params")
+        .and_then(|params| params.get("block_id"))
+        .expect("block_id parameter");
+    let requested_hash = block_id
+        .get("block_hash")
+        .and_then(Value::as_str)
+        .map(|hash_text| Felt::from_hex(hash_text).expect("hex block hash"));
+
+    let block_number = match requested_hash {
+        Some(block_hash) => node.block_number_of(block_hash),
+        None => {
+            let requested_number = block_id
+                .get("block_number")
+                .and_then(Value::as_u64)
+                .expect("block_id names either a hash or a number");
+            (node.canonical_hash_at(requested_number).is_some()
+                || node.pre_confirmed_block_numbers.contains(&requested_number))
+            .then_some(requested_number)
+        }
+    };
+
+    let block = match block_number {
+        None => {
+            return Json(json!({
+                "id": request_id,
+                "jsonrpc": "2.0",
+                "error": { "code": 24, "message": "Block not found" },
+            }))
+        }
+        Some(block_number) if node.pre_confirmed_block_numbers.contains(&block_number) => {
+            pre_confirmed_block(block_number)
+        }
+        Some(block_number) => confirmed_block(
+            block_number,
+            requested_hash
+                .or_else(|| node.canonical_hash_at(block_number))
+                .expect("a confirmed block has a hash"),
+            node.l1_accepted_block_numbers.contains(&block_number),
+        ),
+    };
+
+    Json(json!({
+        "id": request_id,
+        "jsonrpc": "2.0",
+        "result": serde_json::to_value(block).expect("serialize block"),
+    }))
+}
+
+fn resource_price() -> ResourcePrice {
+    ResourcePrice {
+        price_in_fri: Felt::ONE,
+        price_in_wei: Felt::ONE,
+    }
+}
+
+fn confirmed_block(
+    block_number: u64,
+    block_hash: Felt,
+    is_l1_accepted: bool,
+) -> MaybePreConfirmedBlockWithTxHashes {
+    MaybePreConfirmedBlockWithTxHashes::Block(BlockWithTxHashes {
+        status: if is_l1_accepted {
+            BlockStatus::AcceptedOnL1
+        } else {
+            BlockStatus::AcceptedOnL2
+        },
+        block_hash,
+        parent_hash: Felt::ZERO,
+        block_number,
+        new_root: Felt::ZERO,
+        timestamp: 1_700_000_000 + block_number,
+        sequencer_address: Felt::ZERO,
+        l1_gas_price: resource_price(),
+        l2_gas_price: resource_price(),
+        l1_data_gas_price: resource_price(),
+        l1_da_mode: L1DataAvailabilityMode::Blob,
+        starknet_version: "0.14.0".to_string(),
+        event_commitment: Felt::ZERO,
+        transaction_commitment: Felt::ZERO,
+        receipt_commitment: Felt::ZERO,
+        state_diff_commitment: Felt::ZERO,
+        event_count: 0,
+        transaction_count: 0,
+        state_diff_length: 0,
+        transactions: vec![],
+    })
+}
+
+fn pre_confirmed_block(block_number: u64) -> MaybePreConfirmedBlockWithTxHashes {
+    MaybePreConfirmedBlockWithTxHashes::PreConfirmedBlock(PreConfirmedBlockWithTxHashes {
+        transactions: vec![],
+        block_number,
+        timestamp: 1_700_000_000 + block_number,
+        sequencer_address: Felt::ZERO,
+        l1_gas_price: resource_price(),
+        l2_gas_price: resource_price(),
+        l1_data_gas_price: resource_price(),
+        l1_da_mode: L1DataAvailabilityMode::Blob,
+        starknet_version: "0.14.0".to_string(),
+    })
+}
+
+/// Serves `node` on an ephemeral port and returns a backend pointed at it.
+async fn spawn_backend(node: MockNode) -> (RpcBackend, Arc<MockNode>) {
+    let node = Arc::new(node);
+    let router = Router::new()
+        .route("/", post(handle_jsonrpc))
+        .with_state(Arc::clone(&node));
+
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind mock node");
+    let rpc_url = format!(
+        "http://{}",
+        listener.local_addr().expect("mock node local address")
+    );
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("serve mock node");
+    });
+
+    let backend = RpcBackend::new(RpcConfig {
+        url: rpc_url,
+        max_concurrent_requests: MAX_CONCURRENT_REQUESTS,
+        ..Default::default()
+    })
+    .expect("RPC config should be accepted");
+    (backend, node)
+}
+
+/// The node still serves the orphaned block by hash, but its height now resolves
+/// to a different block. Existence alone would call this canonical.
+#[tokio::test]
+async fn test_orphaned_hash_at_reused_height_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: ORPHANED_HASH,
+            },
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: REPLACEMENT_HASH,
+            },
+        ],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(
+        !backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+        "a hash the node still serves is not canonical once its height carries another block"
+    );
+    assert_eq!(
+        node.n_block_requests(),
+        2,
+        "deciding this takes a hash -> height and a height -> hash call"
+    );
+}
+
+#[tokio::test]
+async fn test_canonical_hash_is_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(backend.is_canonical(REPLACEMENT_HASH).await.unwrap());
+    assert_eq!(node.n_block_requests(), 2);
+}
+
+/// An L1-accepted block is final, so its identity is settled by the first call and
+/// the height lookup is skipped.
+#[tokio::test]
+async fn test_l1_accepted_hash_is_canonical_in_one_call() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        l1_accepted_block_numbers: vec![ORPHANED_BLOCK_NUMBER],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(backend.is_canonical(REPLACEMENT_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "finality settles the answer, so the height lookup must be skipped"
+    );
+}
+
+/// A hash the node still serves as L1-accepted at a height that now carries another
+/// block would be a node contradicting itself; the short-circuit trusts finality.
+#[tokio::test]
+async fn test_unknown_hash_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode::default()).await;
+
+    assert!(!backend.is_canonical(UNKNOWN_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "a hash the node does not know needs no second call"
+    );
+}
+
+#[tokio::test]
+async fn test_rpc_failure_is_reported_as_error() {
+    let (backend, _node) = spawn_backend(MockNode {
+        error_code: Some(INTERNAL_ERROR_CODE),
+        ..Default::default()
+    })
+    .await;
+
+    let result = backend.is_canonical(REPLACEMENT_HASH).await;
+    assert!(
+        matches!(result, Err(ChainStateError::RpcError(_))),
+        "an unreachable node must leave canonicity unknown, not answer it"
+    );
+}
+
+/// A height the node serves as pre-confirmed carries no hash, so nothing can
+/// match it — and resolving it must not panic on the missing field.
+#[tokio::test]
+async fn test_pre_confirmed_height_is_not_canonical() {
+    let (backend, node) = spawn_backend(MockNode {
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: ORPHANED_HASH,
+        }],
+        pre_confirmed_block_numbers: vec![ORPHANED_BLOCK_NUMBER],
+        ..Default::default()
+    })
+    .await;
+
+    assert!(!backend.is_canonical(ORPHANED_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        1,
+        "a pre-confirmed answer to the hash lookup already settles the question"
+    );
+}
+
+/// Both round trips take a request permit in turn, so a burst of canonicity
+/// checks completes even when the node admits one call at a time.
+#[tokio::test]
+async fn test_canonicity_burst_completes_under_single_permit() {
+    const BURST_SIZE: usize = 8;
+
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: ORPHANED_HASH,
+            },
+            BlockAtHeight {
+                block_number: ORPHANED_BLOCK_NUMBER,
+                block_hash: REPLACEMENT_HASH,
+            },
+        ],
+        ..Default::default()
+    })
+    .await;
+
+    let mut burst = JoinSet::new();
+    for _ in 0..BURST_SIZE {
+        let backend = backend.clone();
+        burst.spawn(async move {
+            (
+                backend.is_canonical(REPLACEMENT_HASH).await.unwrap(),
+                backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+            )
+        });
+    }
+
+    let mut num_completed = 0;
+    while let Some(joined) = burst.join_next().await {
+        assert_eq!(
+            joined.expect("burst task should not panic"),
+            (true, false),
+            "every check must reach the same verdicts"
+        );
+        num_completed += 1;
+    }
+
+    assert_eq!(num_completed, BURST_SIZE, "every check must complete");
+    assert_eq!(node.n_block_requests(), BURST_SIZE * 4);
+}

--- a/crates/discovery-service/tests/test_chain_state_canonicity.rs
+++ b/crates/discovery-service/tests/test_chain_state_canonicity.rs
@@ -15,13 +15,15 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::routing::post;
 use axum::{Json, Router};
-use discovery_service::chain_state::{ChainState, ChainStateError};
+use discovery_service::chain_state::{
+    ChainHead, ChainState, ChainStateError, MAX_TRACKED_CANONICAL_BLOCKS,
+};
 use discovery_service::config::RpcConfig;
 use discovery_service::rpc_backend::RpcBackend;
 use serde_json::{json, Value};
 use starknet_core::types::{
     BlockStatus, BlockWithTxHashes, Felt, L1DataAvailabilityMode,
-    MaybePreConfirmedBlockWithTxHashes, PreConfirmedBlockWithTxHashes, ResourcePrice,
+    MaybePreConfirmedBlockWithTxHashes, PreConfirmedBlockWithTxHashes, ReorgData, ResourcePrice,
 };
 use tokio::net::TcpListener;
 use tokio::task::JoinSet;
@@ -235,6 +237,23 @@ async fn spawn_backend(node: MockNode) -> (RpcBackend, Arc<MockNode>) {
     (backend, node)
 }
 
+fn head_at(block_number: u64, block_hash: Felt) -> ChainHead {
+    ChainHead {
+        block_number,
+        block_hash,
+        timestamp: 1_700_000_000 + block_number,
+    }
+}
+
+fn reorg_of(block_number: u64, block_hash: Felt) -> ReorgData {
+    ReorgData {
+        starting_block_hash: block_hash,
+        starting_block_number: block_number,
+        ending_block_hash: block_hash,
+        ending_block_number: block_number,
+    }
+}
+
 /// The node still serves the orphaned block by hash, but its height now resolves
 /// to a different block. Existence alone would call this canonical.
 #[tokio::test]
@@ -340,6 +359,146 @@ async fn test_rpc_failure_is_reported_as_error() {
     assert!(
         matches!(result, Err(ChainStateError::RpcError(_))),
         "an unreachable node must leave canonicity unknown, not answer it"
+    );
+}
+
+/// A reported orphaned range settles those hashes without asking the node.
+#[tokio::test]
+async fn test_reorg_notification_answers_without_calling_node() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: ORPHANED_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: ORPHANED_HASH,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    backend
+        .set_head(head_at(ORPHANED_BLOCK_NUMBER, ORPHANED_HASH))
+        .await;
+    assert!(
+        backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+        "an announced head is canonical"
+    );
+
+    backend
+        .record_reorg(&reorg_of(ORPHANED_BLOCK_NUMBER, ORPHANED_HASH))
+        .await;
+
+    assert!(
+        !backend.is_canonical(ORPHANED_HASH).await.unwrap(),
+        "the reorg notification settles the announced hash"
+    );
+    assert_eq!(
+        node.n_block_requests(),
+        0,
+        "neither answer may cost a call: the node has already stated both"
+    );
+}
+
+/// A reorg covering the cached head must stop that head being handed out as the
+/// pin for new requests.
+#[tokio::test]
+async fn test_reorg_drops_the_cached_head() {
+    let (backend, _node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    backend
+        .set_head(head_at(ORPHANED_BLOCK_NUMBER, ORPHANED_HASH))
+        .await;
+    backend
+        .record_reorg(&reorg_of(ORPHANED_BLOCK_NUMBER, ORPHANED_HASH))
+        .await;
+
+    // With no cached head, `get_head` resolves the tip against the node, which
+    // serves no `latest` block, so nothing stale is reported.
+    assert!(backend.get_head().await.is_none());
+}
+
+/// Reorgs reach live subscribers only, so a subscription restart has to send
+/// every previously announced hash back to the node.
+#[tokio::test]
+async fn test_forgetting_recent_blocks_returns_to_node() {
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: ORPHANED_BLOCK_NUMBER,
+            block_hash: REPLACEMENT_HASH,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    backend
+        .set_head(head_at(ORPHANED_BLOCK_NUMBER, REPLACEMENT_HASH))
+        .await;
+    backend.forget_recent_blocks().await;
+
+    assert!(backend.is_canonical(REPLACEMENT_HASH).await.unwrap());
+    assert_eq!(
+        node.n_block_requests(),
+        2,
+        "a forgotten hash is resolved against the node again"
+    );
+}
+
+/// Eviction must degrade to a node round trip. Answering `false` for an evicted
+/// hash would make every client holding an older cursor re-sync.
+#[tokio::test]
+async fn test_evicted_announced_head_falls_back_to_node() {
+    // Filler heads are hashed from their own height, offset clear of the hash
+    // under test so no filler can accidentally match it.
+    let filler_hash = |block_number: u64| Felt::from(block_number + 0x10_0000);
+    let evicted_block_number = 1;
+    let evicted_hash = Felt::from_hex_unchecked("0xe1");
+    let (backend, node) = spawn_backend(MockNode {
+        canonical_blocks: vec![BlockAtHeight {
+            block_number: evicted_block_number,
+            block_hash: evicted_hash,
+        }],
+        addressable_blocks: vec![BlockAtHeight {
+            block_number: evicted_block_number,
+            block_hash: evicted_hash,
+        }],
+        ..Default::default()
+    })
+    .await;
+
+    backend
+        .set_head(head_at(evicted_block_number, evicted_hash))
+        .await;
+    for block_number in 2..=(MAX_TRACKED_CANONICAL_BLOCKS as u64 + 2) {
+        backend
+            .set_head(head_at(block_number, filler_hash(block_number)))
+            .await;
+    }
+
+    assert!(
+        backend.is_canonical(evicted_hash).await.unwrap(),
+        "the node still carries the evicted block at its height"
+    );
+    assert_eq!(
+        node.n_block_requests(),
+        2,
+        "an evicted hash is resolved against the node, not answered from memory"
     );
 }
 

--- a/crates/discovery-service/tests/test_rpc_backend.rs
+++ b/crates/discovery-service/tests/test_rpc_backend.rs
@@ -15,7 +15,7 @@
 
 mod common;
 
-use common::setup_devnet_with_dump;
+use common::{setup_devnet_with_dump, DevnetClient, DevnetConfig};
 use discovery_core::privacy_pool::events::{IEvents, PrivacyPoolEventContent};
 use discovery_core::privacy_pool::storage_slots;
 use discovery_core::privacy_pool::views::IViews;
@@ -169,6 +169,47 @@ async fn test_withdrawal_events_empty_for_non_recipient() {
         .unwrap();
 
     assert!(withdrawals.is_empty());
+}
+
+/// A block that left the chain must be reported non-canonical against real devnet.
+///
+/// This cannot separate canonicity from existence: devnet drops an aborted block
+/// rather than keeping it addressable, and its `--lite-mode` hashes are derived
+/// from the block number, so a replacement at the vacated height would reuse the
+/// same hash. The retained-orphan case is covered in
+/// `test_chain_state_canonicity.rs`; do not cite this test for it.
+#[tokio::test]
+async fn test_aborted_block_is_not_canonical() {
+    let devnet = DevnetClient::spawn(DevnetConfig {
+        full_state_archive: true,
+        ..Default::default()
+    })
+    .expect("Failed to spawn devnet");
+
+    let backend = RpcBackend::new(RpcConfig {
+        url: devnet.rpc_url(),
+        ..Default::default()
+    })
+    .unwrap();
+
+    devnet.create_block().await.unwrap();
+    let aborted_block_hash_text = devnet.create_block().await.unwrap();
+    let aborted_block_hash = Felt::from_hex(&aborted_block_hash_text).unwrap();
+
+    assert!(
+        backend.is_canonical(aborted_block_hash).await.unwrap(),
+        "a block the chain currently carries is canonical"
+    );
+
+    devnet
+        .abort_blocks(&aborted_block_hash_text)
+        .await
+        .expect("devnet should abort blocks");
+
+    assert!(
+        !backend.is_canonical(aborted_block_hash).await.unwrap(),
+        "a block the chain no longer carries is not canonical"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
> Stacked on #939 — review that one first. This PR's diff against it is the notification window only.
>
> Split out of #939, which is now just the canonicality fix. That PR makes `is_canonical` correct; this one makes it cheap.

## What

**The bigger find is adjacent**: the indexer already subscribes to `subscribe_new_heads` and receives `starknet_subscriptionReorg` — which names the orphaned range exactly — and threw it away into a `warn!`. The node was telling us precisely what we needed.

This tracks announced headers and reorg notifications in a bounded window and answers canonicity from it, falling back to #939's round trip only for hashes it does not cover. A window hit costs **zero** RPC calls; the fallback costs two, or one when #939's L1-finality short-circuit applies.

## How

1. **`RecentBlockWindow`** in `chain_state.rs` — `BTreeMap<u64, Felt>` of announced heights plus a FIFO `VecDeque<Felt>` of node-named orphaned hashes. `is_canonical` consults it first. New `ChainState::record_reorg` / `forget_recent_blocks`; the indexer calls `record_reorg` on the `Reorg` arm.
2. **A reorg covering the cached head drops it**, so `get_head` stops handing out an orphaned pin.

## Invalidation is on subscription loss, not reconnect

The load-bearing detail, and the one worth reviewing closely. Reorgs reach *live* subscribers only, so a block orphaned while nothing is subscribed produces no notification — every hash the dead stream announced becomes unverifiable from that instant.

Clearing the window on `subscribe` — the obvious placement, and where this started — leaves the whole outage answered out of stale memory: `run_inner` only reaches that line after a *successful* reconnect, and with `backoff_max_elapsed_time: None` reconnection retries forever while the API keeps serving. A reorged `last_known_block` would get a 200 instead of a 409 `BLOCK_REORGED` for an unbounded window, reintroducing exactly what #939 fixes by a different route.

It is therefore cleared in `run()` the moment `run_inner` returns an error, along with the cached head, which the same dead stream announced.

## Bounds and safety

`MAX_TRACKED_CANONICAL_BLOCKS` = `MAX_TRACKED_ORPHANED_BLOCKS` = **1024**, hard constants — this data comes from an external node. Roughly the last hour of chain history at current block times, far deeper than any observed reorg, for ~40 KiB of hashes.

**Eviction and misses return no verdict, never `false`** — an aged-out hash falls back to the node rather than wrongly 409-ing every client holding an older cursor. `test_evicted_announced_head_falls_back_to_node` asserts this. Reorg ranges are walked via `BTreeMap::range` over *tracked* entries only, so a claimed `0..u64::MAX` range costs at most 1024 steps, and an inverted range is normalized rather than panicking `BTreeMap::range`.

**No deadlock at `max_concurrent_requests: 1`** (relevant given #938): the `RwLock` read guard is copied into a local `Option<bool>` and dropped before any RPC. Cost on a miss is unchanged from #939 (2 permits sequentially, or 1 for an L1-accepted block); hits cost 0.

**Scope, now that #939 short-circuits on finality.** The two mechanisms cover opposite halves of the distribution: this window holds the last 1024 announced blocks and so helps clients that synced *recently*, while #939's L1 short-circuit already reduces *old* cursors — which always miss this window — to one call. What remains for this PR is the band between the head and L1 finality (~1.5k blocks on Sepolia, measured). Whether that band is where real cursors land is the open question; I have no production data on cursor-age distribution, and it is the input that should decide whether this PR is worth its complexity.

## Design assumption worth a reviewer's attention

Announced headers are trusted as canonical for the lifetime of one subscription. This matches the existing design, which already pins reads to the WS-announced head hash.

Residual risk: a node that accepts a `newHeads` subscription but never emits `starknet_subscriptionReorg`, or that silently reorgs and then announces a header *above* the replaced height, would leave positives stale until eviction. I verified empirically that devnet's `devnet_abortBlocks` **does** emit it (`{"starting_block_hash":"0x2","starting_block_number":2,"ending_block_hash":"0x3","ending_block_number":3}`). The negative answer and #939's round trip carry no such assumption.

Two ways out if you would rather not depend on it: consult only the orphaned set and always round-trip for positives (a one-line change), or link each announced header to the tracked entry below it by `parent_hash` and cut a divergent prefix — §11.3 already tracks `parent_hash` for the planned cache. Documented in `specs/11-reorg-handling.md` §11.1 and deliberately left open.

## Tests

17 new. Eleven `RecentBlockWindow` unit tests (caps, eviction, `u64::MAX` range, inverted range, re-announced head clearing an orphan verdict, superseded heights losing their verdict), four integration tests against the mock node that serves orphans by hash, `test_reorged_announced_block_conflicts` at the validator layer, and the indexer invalidation test.

Verified the tests have teeth. Reducing `RpcBackend::record_reorg` and `forget_recent_blocks` to no-ops — the old warn-and-discard behaviour:

```
test test_reorg_notification_answers_without_calling_node ... FAILED
test test_reorg_drops_the_cached_head ... FAILED
test test_forgetting_recent_blocks_returns_to_node ... FAILED
test result: FAILED. 7 passed; 3 failed
```

The other seven are #939's, which do not depend on the window. At the validator layer, with only the mock's `record_reorg` reduced to warn-and-discard:

```
test api::validators::tests::test_reorged_announced_block_conflicts ... FAILED
```

And moving the invalidation back to post-subscribe:

```
test indexer::tests::test_lost_subscription_forgets_announced_blocks_before_reconnecting ... FAILED
  panicked: a failed connect must forget the announced blocks: Elapsed(())
```

## Verification

```
cargo fmt --check                  exit 0
cargo clippy --all-targets         0 warnings
cargo test -p discovery-service    103 passed, 0 failed
```

## Specs

`11-reorg-handling.md` §11.1 gains the notification source, the invalidation-on-loss rule, and the trust assumption above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/941)
<!-- Reviewable:end -->

