### PR TITLE
test(privacy): fold the block-timestamp cheat into the apply helpers

### DIFF
--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -26,7 +26,7 @@ use snforge_std::signature::KeyPairTrait;
 use snforge_std::signature::stark_curve::StarkCurveKeyPairImpl;
 use snforge_std::{
     CheatSpan, EventSpyTrait, EventsFilterTrait, TokenTrait, cheat_proof_facts, map_entry_address,
-    spy_events, start_cheat_block_timestamp, stop_cheat_block_timestamp,
+    spy_events,
 };
 use starknet::{ContractAddress, get_block_number};
 use starkware_utils::components::pausable::PausableComponent::Errors as PausableErrors;
@@ -2472,11 +2472,9 @@ fn test_deposit_wrong_screener_key_fails() {
 fn test_deposit_depositor_mismatch_fails() {
     let mut test: Test = Default::default();
     let token = test.new_token();
-    let depositor = test.new_user();
-    let other = test.new_user();
     let amount = constants::DEFAULT_AMOUNT;
-    depositor.increase_token_balance(:token, :amount);
-    depositor.approve(:token, amount: amount.into());
+    let depositor = test.new_funded_user(:token, :amount);
+    let other = test.new_user();
 
     let deposit = [depositor.deposit_action(:token, :amount)].span();
     // Attestation signed for a different depositor than the one actually depositing.
@@ -2503,14 +2501,14 @@ fn test_deposit_stale_screening_fails() {
     let attestation = sign_screening_attestation(
         depositor: user.address, issued_at: now - DEPOSITOR_VALIDATION_MAX_AGE - 1,
     );
-    start_cheat_block_timestamp(test.privacy.address, now);
-    let result = test
+    test
         .privacy
-        .safe_apply_actions_screened(
-            actions: deposit, screening: Some(attestation), caller: constants::PAYMASTER,
+        .assert_apply_fails_at(
+            :now,
+            actions: deposit,
+            screening: Some(attestation),
+            expected_error: errors::SCREENING_EXPIRED,
         );
-    stop_cheat_block_timestamp(test.privacy.address);
-    assert_panic_with_felt_error(:result, expected_error: errors::SCREENING_EXPIRED);
 }
 
 #[test]
@@ -2526,14 +2524,14 @@ fn test_deposit_future_dated_screening_fails() {
     let attestation = sign_screening_attestation(
         depositor: user.address, issued_at: now + DEPOSITOR_VALIDATION_MAX_FUTURE + 1,
     );
-    start_cheat_block_timestamp(test.privacy.address, now);
-    let result = test
+    test
         .privacy
-        .safe_apply_actions_screened(
-            actions: deposit, screening: Some(attestation), caller: constants::PAYMASTER,
+        .assert_apply_fails_at(
+            :now,
+            actions: deposit,
+            screening: Some(attestation),
+            expected_error: errors::SCREENING_FUTURE_DATED,
         );
-    stop_cheat_block_timestamp(test.privacy.address);
-    assert_panic_with_felt_error(:result, expected_error: errors::SCREENING_FUTURE_DATED);
 }
 
 #[test]
@@ -2549,13 +2547,7 @@ fn test_deposit_at_max_age_boundary_passes() {
     let attestation = sign_screening_attestation(
         depositor: user.address, issued_at: now - DEPOSITOR_VALIDATION_MAX_AGE,
     );
-    start_cheat_block_timestamp(test.privacy.address, now);
-    test
-        .privacy
-        .apply_actions_screened(
-            actions: deposit, screening: Some(attestation), caller: constants::PAYMASTER,
-        );
-    stop_cheat_block_timestamp(test.privacy.address);
+    test.privacy.apply_actions_screened_at(:now, actions: deposit, screening: Some(attestation));
     assert_eq!(token.balance_of(address: test.privacy.address), amount.into());
 }
 
@@ -2572,13 +2564,7 @@ fn test_deposit_within_future_tolerance_passes() {
     let attestation = sign_screening_attestation(
         depositor: user.address, issued_at: now + DEPOSITOR_VALIDATION_MAX_FUTURE,
     );
-    start_cheat_block_timestamp(test.privacy.address, now);
-    test
-        .privacy
-        .apply_actions_screened(
-            actions: deposit, screening: Some(attestation), caller: constants::PAYMASTER,
-        );
-    stop_cheat_block_timestamp(test.privacy.address);
+    test.privacy.apply_actions_screened_at(:now, actions: deposit, screening: Some(attestation));
     assert_eq!(token.balance_of(address: test.privacy.address), amount.into());
 }
 

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -70,6 +70,7 @@ use snforge_std::{
     CheatSpan, ContractClassTrait, DeclareResultTrait, MessageToL1, MessageToL1Spy,
     MessageToL1SpyTrait, Token, TokenTrait, cheat_proof_facts, cheat_resource_bounds, declare,
     declare_from_file, interact_with_state, map_entry_address, spy_messages_to_l1,
+    start_cheat_block_timestamp, stop_cheat_block_timestamp,
 };
 use starknet::account::Call;
 use starknet::deployment::DeploymentParams;
@@ -1597,6 +1598,36 @@ pub(crate) impl PrivacyCfgImpl of PrivacyCfgTrait {
         let screening = self._auto_screening(:actions);
         self._cheat_proof_facts(:proof_facts);
         self.safe_server.apply_actions(:actions, :screening)
+    }
+
+    /// Applies `actions` with a caller-supplied `screening` as the paymaster, with the pool's clock
+    /// reading `now` — for exercising attestation freshness.
+    fn apply_actions_screened_at(
+        self: @PrivacyCfg,
+        now: u64,
+        actions: Span<ServerAction>,
+        screening: Option<ScreeningAttestation>,
+    ) {
+        start_cheat_block_timestamp(*self.address, now);
+        self.apply_actions_screened(:actions, :screening, caller: constants::PAYMASTER);
+        stop_cheat_block_timestamp(*self.address);
+    }
+
+    /// Like `assert_apply_fails`, with the pool's clock reading `now`. The cheat is lifted before
+    /// the assertion, so a failing expectation cannot leave the clock frozen for later calls.
+    #[feature("safe_dispatcher")]
+    fn assert_apply_fails_at(
+        self: @PrivacyCfg,
+        now: u64,
+        actions: Span<ServerAction>,
+        screening: Option<ScreeningAttestation>,
+        expected_error: felt252,
+    ) {
+        start_cheat_block_timestamp(*self.address, now);
+        let result = self
+            .safe_apply_actions_screened(:actions, :screening, caller: constants::PAYMASTER);
+        stop_cheat_block_timestamp(*self.address);
+        assert_panic_with_felt_error(:result, :expected_error);
     }
 
     /// Applies `actions` with a caller-supplied `screening` as the paymaster and asserts the call


### PR DESCRIPTION
`apply_actions_screened_at` and `assert_apply_fails_at` wrap the start_cheat_block_timestamp / apply /
stop_cheat_block_timestamp sequence that each attestation-freshness test spelled out. Those tests need
a moved clock because a fresh test starts at timestamp 0, where "one second past the max age" is not
expressible, so they set a `now` and sign relative to it.

The helpers stop the cheat before asserting, which is what the four tests already did by hand — the
gain is that the ordering is now structural rather than per-test discipline, and a new freshness test
cannot leave the pool's clock frozen by forgetting the stop.

Also adopts the fixtures from the preceding commit at the two-user funding preamble they missed.

test_server.cairo loses 23 more lines. 77 tests, none renamed, no assertion changed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/948)
<!-- Reviewable:end -->
