### PR TITLE
feat(sdk): derive a shadow account's address off-chain

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -21,6 +21,10 @@ jobs:
         run: |
           scarb fmt -w --check
 
+      - name: Check the Primer class hash agrees between Cairo and TypeScript
+        run: |
+          python3 scripts/check_primer_class_hash.py
+
       - name: Check unused imports and variables
         run: |
           scarb cache clean

--- a/packages/shadow_account_anonymizer/src/tests/test_shadow_account_anonymizer.cairo
+++ b/packages/shadow_account_anonymizer/src/tests/test_shadow_account_anonymizer.cairo
@@ -9,11 +9,12 @@ use shadow_account_anonymizer::shadow_account_anonymizer::{
     commitment_from_partial, errors, partial_commitment,
 };
 use shadow_account_anonymizer::tests::test_utils::{
-    Components, ComponentsTrait, PRIVACY, anonymizer_disp, deploy_components,
-    deploy_shadow_account_anonymizer, deploy_token, transfer_to_caller_call,
+    Components, ComponentsTrait, GOVERNANCE_ADMIN, PRIVACY, anonymizer_disp, declare_primer,
+    deploy_components, deploy_shadow_account_anonymizer, deploy_token, transfer_to_caller_call,
 };
 use snforge_std::{
-    DeclareResultTrait, EventSpyTrait, EventsFilterTrait, TokenTrait, declare, spy_events,
+    ContractClassTrait, DeclareResultTrait, EventSpyTrait, EventsFilterTrait, TokenTrait, declare,
+    spy_events,
 };
 use starknet::account::Call;
 use starknet::syscalls::call_contract_syscall;
@@ -832,4 +833,43 @@ fn test_invoke_return_data_is_the_deposits_then_the_addresses() {
     assert_eq!(deposits.len(), 1);
     assert_eq!(associated_addresses.len(), 1);
     assert_eq!(*associated_addresses[0], anonymizer.get_shadow_account(identity_commitment));
+}
+
+
+/// A committed cross-language vector. The SDK's `shadow-account-address` test derives the same
+/// felts from the same inputs, so the off-chain derivation cannot drift from the contract's. This
+/// test deploys the anonymizer at the vector's own address and goes through its entry points, so
+/// the expected felts pin the deployed contract rather than restate its recipe.
+#[test]
+fn test_shadow_account_derivation_matches_the_committed_vector() {
+    let anonymizer_address: ContractAddress = 0x444.try_into().unwrap();
+    declare_primer();
+    let shadow_account_class_hash = *declare("ShadowAccount")
+        .unwrap_syscall()
+        .contract_class()
+        .class_hash;
+    declare("ShadowAccountAnonymizer")
+        .unwrap_syscall()
+        .contract_class()
+        .deploy_at(
+            @array![PRIVACY.into(), shadow_account_class_hash.into(), GOVERNANCE_ADMIN.into()],
+            anonymizer_address,
+        )
+        .unwrap_syscall();
+    let anonymizer = anonymizer_disp(anonymizer_address);
+
+    let partial = partial_commitment(identity_key: 0x111, dapp_name: 0x222);
+    assert_eq!(partial, 0xdbb320724c2f71919310007cc2ee821e9b234b98535d24dae197124c2ef4fb);
+
+    let commitment = anonymizer.privacy_compute(identity_key: 0x111, dapp_name: 0x222, nonce: 0x3);
+    assert_eq!(commitment, 0x418bf56bebf218ffa365531394e68b3336a9557b5b8be8ad6a21f44e79833b);
+
+    let shadow_accounts = anonymizer
+        .get_shadow_accounts(
+            partial_commitment: partial, start_nonce: 3, end_nonce: 4, until_undeployed: false,
+        );
+    assert_eq!(
+        *shadow_accounts[0].address,
+        0x5e1a753154c6cbb012b819c0362921b7040df54b90bb9241f54e7d946cf9708.try_into().unwrap(),
+    );
 }

--- a/scripts/check_primer_class_hash.py
+++ b/scripts/check_primer_class_hash.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3.10
+"""Asserts the Primer class hash agrees between Cairo and TypeScript.
+
+Every shadow account address derives from this class hash, so the anonymizer cements it and the SDK
+mirrors it to predict addresses off-chain. If the two drift, the SDK predicts addresses that hold no
+funds and the proof interceptor screens the wrong one, and nothing fails loudly.
+
+Runs unfiltered on every pull request, so a change to either side is checked against the other.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CAIRO_SOURCE = REPO_ROOT / "packages/shadow_account_anonymizer/src/shadow_account_anonymizer.cairo"
+TS_SOURCE = REPO_ROOT / "sdk/src/internal/shadow-account-address.ts"
+
+CAIRO_PATTERN = re.compile(
+    r"pub const PRIMER_CLASS_HASH: ClassHash\s*=\s*(0x[0-9a-fA-F_]+)", re.MULTILINE
+)
+TS_PATTERN = re.compile(r"export const PRIMER_CLASS_HASH\s*=\s*(0x[0-9a-fA-F_]+)n", re.MULTILINE)
+
+
+def extract(source: Path, pattern: re.Pattern) -> int:
+    match = pattern.search(source.read_text())
+    if match is None:
+        sys.exit(f"{source}: PRIMER_CLASS_HASH not found. Did the declaration change shape?")
+    return int(match.group(1).replace("_", ""), 16)
+
+
+def main() -> None:
+    cairo_class_hash = extract(CAIRO_SOURCE, CAIRO_PATTERN)
+    ts_class_hash = extract(TS_SOURCE, TS_PATTERN)
+    if cairo_class_hash != ts_class_hash:
+        sys.exit(
+            "PRIMER_CLASS_HASH disagrees between Cairo and TypeScript:\n"
+            f"  {CAIRO_SOURCE.relative_to(REPO_ROOT)}: {cairo_class_hash:#066x}\n"
+            f"  {TS_SOURCE.relative_to(REPO_ROOT)}: {ts_class_hash:#066x}\n"
+            "Every off-chain shadow account address derives from this value; update both."
+        )
+    print(f"PRIMER_CLASS_HASH agrees: {cairo_class_hash:#066x}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `shadowAccountPartialCommitment`, `shadowAccountCommitment`, `shadowAccountAddress` and
+  `PRIMER_CLASS_HASH`, the shadow account derivation as pure functions, so a caller holding the raw
+  felts can predict a shadow account's address without deploying it or reading the chain.
+  `shadowAccounts(dapp).partialCommitment()` / `.commitment(nonce)` now delegate to them, and a
+  committed cross-language vector pins all three against the anonymizer's Cairo.
 - Regenerated `ShadowAccountAnonymizerABI` against the anonymizer's new
   `privacy_invoke_with_computation` return shape, `(Span<OpenNoteDeposit>, Span<ContractAddress>)`.
   The invoke now returns the shadow account its deposits passed through, which is the address the

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,6 +2,12 @@ export * from "./interfaces.js";
 export { AddressMap } from "./utils/index.js";
 export { createPrivateTransfers } from "./factory.js";
 export { ShadowAccountAnonymizerABI } from "./internal/anonymizer-abi.js";
+export {
+  PRIMER_CLASS_HASH,
+  shadowAccountAddress,
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "./internal/shadow-account-address.js";
 export { SimplePrivateTransfersImpl } from "./simple-private-transfers.js";
 export {
   ProvingService,

--- a/sdk/src/internal/shadow-account-address.ts
+++ b/sdk/src/internal/shadow-account-address.ts
@@ -1,0 +1,59 @@
+import { hash as starknetHash } from "starknet";
+
+import { hash as poseidonHash, toBigInt } from "../utils/index.js";
+import { compute_identity_key } from "../utils/hashes.js";
+
+/**
+ * Class hash of the `Primer` contract every shadow account is deployed from, before the anonymizer
+ * replaces its class with the shadow account's. Mirrors `PRIMER_CLASS_HASH` in
+ * `packages/shadow_account_anonymizer/src/shadow_account_anonymizer.cairo`, cemented there so a
+ * shadow account's address does not move when the shadow account class changes.
+ *
+ * A mismatch with the Cairo constant makes every address below wrong, so CI asserts the two agree.
+ */
+export const PRIMER_CLASS_HASH =
+  0x00123e6bc1c14ae9934e933d3f64916a6116dd6b036a922b2b1f0815e0d1d300n;
+
+/**
+ * The user+dapp half of a shadow account's identity commitment,
+ * `hash(compute_identity_key(user, viewingKey, anonymizer), dappName)`.
+ *
+ * Mirrors `partial_commitment` in the anonymizer. `dappName` is a felt, so encode a short string
+ * before calling.
+ */
+export function shadowAccountPartialCommitment(
+  user: bigint,
+  viewingKey: bigint,
+  anonymizerAddress: bigint,
+  dappName: bigint
+): bigint {
+  return poseidonHash(compute_identity_key(user, viewingKey, anonymizerAddress), dappName);
+}
+
+/**
+ * The full identity commitment of one shadow account, `hash(partialCommitment, nonce)`. Mirrors
+ * `commitment_from_partial` in the anonymizer.
+ */
+export function shadowAccountCommitment(partialCommitment: bigint, nonce: bigint): bigint {
+  return poseidonHash(partialCommitment, nonce);
+}
+
+/**
+ * The address the anonymizer deploys the shadow account of `commitment` to, salted by that
+ * commitment.
+ *
+ * The anonymizer deploys with `deploy_from_zero: false` and no constructor arguments, so the
+ * address derives from (commitment, `PRIMER_CLASS_HASH`, empty calldata, the anonymizer). Callers
+ * that need the address of an *already deployed* account can read it from the anonymizer's
+ * `get_shadow_account` view instead. The two agree for anything deployed under the primer pattern.
+ */
+export function shadowAccountAddress(commitment: bigint, anonymizerAddress: bigint): bigint {
+  return toBigInt(
+    starknetHash.calculateContractAddressFromHash(
+      commitment,
+      PRIMER_CLASS_HASH,
+      [],
+      anonymizerAddress
+    )
+  );
+}

--- a/sdk/src/internal/shadow-accounts.ts
+++ b/sdk/src/internal/shadow-accounts.ts
@@ -9,8 +9,11 @@ import type {
   ViewingKey,
 } from "../interfaces.js";
 import { ShadowAccountAnonymizerABI } from "./anonymizer-abi.js";
-import { hash as poseidonHash, toBigInt, toHex } from "../utils/index.js";
-import { compute_identity_key } from "../utils/hashes.js";
+import { toBigInt, toHex } from "../utils/index.js";
+import {
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "./shadow-account-address.js";
 
 /** Encodes a dapp name to a felt: a string is a Cairo short string, a felt passes through. */
 function encodeDappName(dappName: string | BigNumberish): bigint {
@@ -74,17 +77,16 @@ export class ShadowAccountsBuilderImpl implements ShadowAccountsBuilder {
   }
 
   async partialCommitment(): Promise<bigint> {
-    const viewingKey = await this.params.getViewingKey();
-    const identityKey = compute_identity_key(
+    return shadowAccountPartialCommitment(
       this.params.user,
-      toBigInt(viewingKey),
-      this.shadowAccountAnonymizerAddress
+      toBigInt(await this.params.getViewingKey()),
+      this.shadowAccountAnonymizerAddress,
+      this.dappName
     );
-    return poseidonHash(identityKey, this.dappName);
   }
 
   async commitment(nonce: BigNumberish): Promise<bigint> {
-    return poseidonHash(await this.partialCommitment(), toBigInt(nonce));
+    return shadowAccountCommitment(await this.partialCommitment(), toBigInt(nonce));
   }
 }
 

--- a/sdk/tests/internal/shadow-account-address.test.ts
+++ b/sdk/tests/internal/shadow-account-address.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PRIMER_CLASS_HASH,
+  shadowAccountAddress,
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "../../src/internal/shadow-account-address.js";
+import { compute_identity_key } from "../../src/utils/hashes.js";
+import { hash as poseidonHash } from "../../src/utils/index.js";
+
+/**
+ * The committed cross-language vector. Cairo asserts the same inputs and the same three expected
+ * felts in `test_shadow_account_derivation_matches_the_committed_vector`, so a change to either
+ * implementation fails on one side. Without it these tests would only prove the SDK agrees with
+ * itself.
+ */
+const IDENTITY_KEY = 0x111n;
+const DAPP_NAME = 0x222n;
+const NONCE = 0x3n;
+const ANONYMIZER = 0x444n;
+const PARTIAL_COMMITMENT = 0xdbb320724c2f71919310007cc2ee821e9b234b98535d24dae197124c2ef4fbn;
+const COMMITMENT = 0x418bf56bebf218ffa365531394e68b3336a9557b5b8be8ad6a21f44e79833bn;
+const ADDRESS = 0x5e1a753154c6cbb012b819c0362921b7040df54b90bb9241f54e7d946cf9708n;
+
+describe("shadow account derivation", () => {
+  it("matches the committed Cairo vector", () => {
+    expect(poseidonHash(IDENTITY_KEY, DAPP_NAME)).toBe(PARTIAL_COMMITMENT);
+    expect(shadowAccountCommitment(PARTIAL_COMMITMENT, NONCE)).toBe(COMMITMENT);
+    expect(shadowAccountAddress(COMMITMENT, ANONYMIZER)).toBe(ADDRESS);
+  });
+
+  it("reaches the same commitment from the user's own inputs", () => {
+    const user = 0x999n;
+    const viewingKey = 0x888n;
+    const partial = shadowAccountPartialCommitment(user, viewingKey, ANONYMIZER, DAPP_NAME);
+    // The anonymizer goes into the identity key, not only into the address, so a partial commitment
+    // belongs to the anonymizer it was derived for.
+    expect(partial).toBe(
+      poseidonHash(compute_identity_key(user, viewingKey, ANONYMIZER), DAPP_NAME)
+    );
+    expect(partial).not.toBe(shadowAccountPartialCommitment(user, viewingKey, 0x445n, DAPP_NAME));
+  });
+
+  it("gives every nonce its own address", () => {
+    const partial = shadowAccountPartialCommitment(0x999n, 0x888n, ANONYMIZER, DAPP_NAME);
+    const addresses = [0n, 1n, 2n].map((nonce) =>
+      shadowAccountAddress(shadowAccountCommitment(partial, nonce), ANONYMIZER)
+    );
+    expect(new Set(addresses).size).toBe(addresses.length);
+  });
+
+  it("salts by the commitment and deploys from the anonymizer", () => {
+    // Both matter: the salt separates one shadow account from the next, and the deployer keeps two
+    // anonymizers from colliding on one address.
+    expect(shadowAccountAddress(COMMITMENT, ANONYMIZER)).not.toBe(
+      shadowAccountAddress(COMMITMENT + 1n, ANONYMIZER)
+    );
+    expect(shadowAccountAddress(COMMITMENT, ANONYMIZER)).not.toBe(
+      shadowAccountAddress(COMMITMENT, ANONYMIZER + 1n)
+    );
+  });
+
+  it("pins the Primer class hash the anonymizer cements", () => {
+    expect(PRIMER_CLASS_HASH).toBe(
+      0x00123e6bc1c14ae9934e933d3f64916a6116dd6b036a922b2b1f0815e0d1d300n
+    );
+  });
+});


### PR DESCRIPTION
The shadow account derivation moves from a builder method into pure functions
(partial commitment, commitment, address) so callers holding raw felts — the
proof interceptor now, the SDK's mock prover next — share one formula with the
builder. A committed cross-language vector pins all three felts against the
anonymizer's own entry points, and CI asserts PRIMER_CLASS_HASH agrees between
Cairo and TS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/953)
<!-- Reviewable:end -->
