### PR TITLE
feat(proof-interceptor): derive the shadow account address of a prove request

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -80,7 +80,7 @@ Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. O
 
 ### Request
 
-The body mirrors `starknet_proveTransaction` exactly (object or positional params). The screened shape is a single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` with `calldata = [call_count=1, contract_address=pool, selector, inner_len, user_addr, user_private_key, ...action_span]`. The action span is decoded against `PrivacyPoolABI`; only the Deposit variant triggers a screen. See `src/rpc.ts` for envelope validation and the calldata-layout comments above `isSinglePoolCall` in `src/screening-interceptor.ts` for the field-by-field breakdown.
+The body mirrors `starknet_proveTransaction` exactly (object or positional params). The screened shape is a single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` with `calldata = [call_count=1, contract_address=pool, selector, inner_len, user_addr, user_private_key, ...action_span]`. The action span is decoded against `PrivacyPoolABI`; only the Deposit variant triggers a screen. See `src/rpc.ts` for envelope validation and the calldata-layout comments above `isSinglePoolCall` in `src/pool-transaction.ts` for the field-by-field breakdown.
 
 ### Response shapes
 
@@ -181,7 +181,9 @@ npm start
 | `src/proxy.ts`                 | Top-level request handler — routing (`/`, `/health`, `/metrics`), body limits, JSON-RPC error mapping    |
 | `src/rpc.ts`                   | JSON-RPC envelope and `starknet_checkTransaction` parameter validation                                   |
 | `src/interceptor.ts`           | Parallel interceptor runner with first-block-wins semantics                                              |
-| `src/screening-interceptor.ts` | Pool-call gate, deposit detection, address extraction, retry/timeout, HMAC-signed call to elliptic-proxy |
+| `src/pool-transaction.ts`      | Pool-call gate and client-action decoding of a prove request's calldata                                  |
+| `src/shadow-account.ts`        | The shadow account interaction a transaction runs on the anonymizer, from its decoded actions            |
+| `src/screening-interceptor.ts` | Deposit detection, address extraction, retry/timeout, HMAC-signed call to elliptic-proxy                 |
 | `src/types.ts`                 | JSON-RPC and `ProveTxnV3` types                                                                          |
 | `src/metrics.ts`               | Prometheus registry and metric definitions                                                               |
 | `src/shutdown.ts`              | SIGTERM/SIGINT handlers                                                                                  |

--- a/proof-interceptor/src/pool-transaction.ts
+++ b/proof-interceptor/src/pool-transaction.ts
@@ -1,0 +1,113 @@
+// src/pool-transaction.ts
+import { CairoCustomEnum, CallData } from "starknet";
+import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
+import type { ProveTxnV3 } from "./types.js";
+
+const ACTIONS_TYPE =
+  "core::array::Span::<privacy::actions::ClientAction>" as const;
+
+const callDataDecoder = new CallData(PrivacyPoolABI);
+
+/**
+ * Returns true iff the transaction is a single-call INVOKE whose target
+ * contract matches `poolAddress`.
+ *
+ * Expected calldata layout for a single-call INVOKE:
+ *   [0] call_count          — must normalize to "0x1"
+ *   [1] contract_address    — must match `poolAddress`
+ *   [2] selector             — entrypoint selector (not checked here)
+ *   [3] inner_calldata_len   — length of inner calldata
+ *   [4..] inner calldata
+ *
+ * Multi-call batches (call_count !== 1) are not considered pool
+ * transactions even if one of the inner calls targets the pool, because
+ * single-call shape is required to decode the inner calldata.
+ *
+ * All hex felts are normalized before comparison so attackers can't bypass
+ * the check with variants like "0X1", "0x01", "0x001", or mixed-case digits.
+ */
+export function isSinglePoolCall(
+  transaction: ProveTxnV3,
+  poolAddress: string
+): boolean {
+  const calldata = transaction.calldata;
+  if (calldata.length < 7 || normalizeFelt(calldata[0]) !== "0x1") return false;
+  return normalizeFelt(calldata[1]) === normalizeFelt(poolAddress);
+}
+
+/** A pool call's decoded inner calldata: `[user_addr, user_private_key, ...client actions]`. */
+export interface PoolCallActions {
+  /** `user_addr`, normalized. */
+  userAddress: string;
+  /**
+   * `user_private_key`, the user's viewing key, which the pool feeds to `compute_identity_key`. It is
+   * `null` when that felt does not parse. Only shadow account derivation reads it, so an unparseable
+   * one costs only that derivation.
+   *
+   * A secret: it identifies the user and derives their shadow accounts, so it must never be logged,
+   * echoed into a verdict, or forwarded anywhere.
+   */
+  viewingKey: bigint | null;
+  /** The client actions the pool is asked to compile, one enum per action. */
+  actions: CairoCustomEnum[];
+}
+
+/**
+ * Decodes the client actions of a single direct call to the pool, using the
+ * contract ABI from the SDK.
+ *
+ * Returns `null` for a transaction that is not such a call, and for calldata
+ * that does not decode. Screening garbage is pointless, since a transaction the
+ * pool cannot parse reverts on its own.
+ *
+ * The length prefix and the action span are read here rather than through the SDK's own
+ * `extractExecuteViewCalldata`, which converts the prefix with an unguarded `Number(BigInt(...))`.
+ * Every felt below is caller-supplied, so each one is checked before it is used: a prefix that is
+ * not a number, or shorter than the two leading felts, ends the decode instead of slicing.
+ */
+export function decodeClientActions(
+  transaction: ProveTxnV3,
+  poolAddress: string
+): PoolCallActions | null {
+  if (!isSinglePoolCall(transaction, poolAddress)) return null;
+
+  const calldata = transaction.calldata;
+  const innerCalldataLength = parseInt(calldata[3], 16);
+  if (Number.isNaN(innerCalldataLength) || innerCalldataLength < 3) return null;
+
+  const innerCalldata = calldata.slice(4, 4 + innerCalldataLength);
+  try {
+    const actions = callDataDecoder.decodeParameters(
+      ACTIONS_TYPE,
+      innerCalldata.slice(2)
+    ) as CairoCustomEnum[];
+    return {
+      userAddress: normalizeFelt(innerCalldata[0]),
+      viewingKey: parseFelt(innerCalldata[1]),
+      actions,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The felt as a bigint, or `null` if it does not parse. */
+export function parseFelt(value: string): bigint | null {
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canonicalizes a hex felt252 string for equality comparison. Lowercases the
+ * input (so "0X" / "0x" prefixes and "ABC" / "abc" digits all normalize the
+ * same), strips the optional "0x" prefix, removes leading zeros, then
+ * re-attaches "0x". Returns "0x0" for the zero value.
+ */
+export function normalizeFelt(value: string): string {
+  const lower = value.toLowerCase();
+  const hex = lower.startsWith("0x") ? lower.slice(2) : lower;
+  return "0x" + (hex.replace(/^0+/, "") || "0");
+}

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -1,12 +1,11 @@
 // src/screening-interceptor.ts
 import { createHmac } from "node:crypto";
-import { CallData } from "starknet";
-import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import type {
   ScreeningSignature,
   TransactionInterceptor,
   Verdict,
 } from "./interceptor.js";
+import { decodeClientActions, isSinglePoolCall } from "./pool-transaction.js";
 import type { ProveTxnV3 } from "./types.js";
 import {
   screeningResults,
@@ -33,47 +32,13 @@ export interface ScreeningConfig {
   blockNonPoolTx: boolean;
 }
 
-const ACTIONS_TYPE =
-  "core::array::Span::<privacy::actions::ClientAction>" as const;
-
-const callDataDecoder = new CallData(PrivacyPoolABI);
-
 // 0x-hex felt, at most 64 hex digits (the zero-padded address width).
 const HEX_FELT = /^0x[0-9a-fA-F]{1,64}$/;
 
 /**
- * Returns true iff the transaction is a single-call INVOKE whose target
- * contract matches `poolAddress`.
- *
- * Expected calldata layout for a single-call INVOKE:
- *   [0] call_count          — must normalize to "0x1"
- *   [1] contract_address    — must match `poolAddress`
- *   [2] selector             — entrypoint selector (not checked here)
- *   [3] inner_calldata_len   — length of inner calldata
- *   [4..] inner calldata
- *
- * Multi-call batches (call_count !== 1) are not considered pool
- * transactions even if one of the inner calls targets the pool, because
- * single-call shape is required for the screening logic to extract the
- * deposit action and user address.
- *
- * All hex felts are normalized before comparison so attackers can't bypass
- * the check with variants like "0X1", "0x01", "0x001", or mixed-case digits.
- */
-export function isSinglePoolCall(
-  transaction: ProveTxnV3,
-  poolAddress: string
-): boolean {
-  const calldata = transaction.calldata;
-  if (calldata.length < 7 || normalizeFelt(calldata[0]) !== "0x1") return false;
-  return normalizeFelt(calldata[1]) === normalizeFelt(poolAddress);
-}
-
-/**
  * Extracts addresses that need screening from a privacy pool transaction,
  * but only if the transaction is a single direct call to the pool and
- * contains a Deposit action. The inner calldata is decoded using the
- * contract ABI from the SDK.
+ * contains a Deposit action.
  *
  * Returns `[]` for non-pool transactions and for pool transactions that
  * carry no Deposit action (e.g., Withdraw-only). Whether non-pool
@@ -84,48 +49,12 @@ export function getScreenedAddresses(
   transaction: ProveTxnV3,
   poolAddress: string
 ): string[] {
-  if (!isSinglePoolCall(transaction, poolAddress)) return [];
-
-  const calldata = transaction.calldata;
-  const innerCalldataLength = parseInt(calldata[3], 16);
-  if (Number.isNaN(innerCalldataLength) || innerCalldataLength < 3) return [];
-
-  const innerCalldata = calldata.slice(4, 4 + innerCalldataLength);
-
-  // innerCalldata[0] = user_addr, [1] = user_private_key, [2..] = actions span
-  const actionsCalldata = innerCalldata.slice(2);
-  if (!hasDepositAction(actionsCalldata)) return [];
-
-  return [normalizeFelt(innerCalldata[0])];
-}
-
-/**
- * Decodes serialized client actions using the contract ABI and checks for Deposit.
- * Returns false if the calldata is malformed (fail-open: don't screen garbage).
- */
-function hasDepositAction(actionsCalldata: string[]): boolean {
-  try {
-    const decoded = callDataDecoder.decodeParameters(
-      ACTIONS_TYPE,
-      actionsCalldata
-    ) as Array<{ activeVariant: () => string }>;
-
-    return decoded.some((action) => action.activeVariant() === "Deposit");
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Canonicalizes a hex felt252 string for equality comparison. Lowercases the
- * input (so "0X" / "0x" prefixes and "ABC" / "abc" digits all normalize the
- * same), strips the optional "0x" prefix, removes leading zeros, then
- * re-attaches "0x". Returns "0x0" for the zero value.
- */
-function normalizeFelt(value: string): string {
-  const lower = value.toLowerCase();
-  const hex = lower.startsWith("0x") ? lower.slice(2) : lower;
-  return "0x" + (hex.replace(/^0+/, "") || "0");
+  const poolCall = decodeClientActions(transaction, poolAddress);
+  if (poolCall === null) return [];
+  const hasDeposit = poolCall.actions.some(
+    (action) => action.activeVariant() === "Deposit"
+  );
+  return hasDeposit ? [poolCall.userAddress] : [];
 }
 
 type SignOutcome =

--- a/proof-interceptor/src/shadow-account.ts
+++ b/proof-interceptor/src/shadow-account.ts
@@ -1,0 +1,152 @@
+// src/shadow-account.ts
+import { CairoCustomEnum, CallData, num } from "starknet";
+import {
+  ShadowAccountAnonymizerABI,
+  shadowAccountAddress,
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "@starkware-libs/starknet-privacy-sdk";
+import {
+  normalizeFelt,
+  parseFelt,
+  type PoolCallActions,
+} from "./pool-transaction.js";
+
+const anonymizerDecoder = new CallData(ShadowAccountAnonymizerABI);
+
+/**
+ * The parameters of `privacy_compute` and `privacy_invoke_with_computation` that
+ * a `ComputeAndInvoke` action supplies, which is all but the leading one of
+ * each. The pool prepends the identity key to the first, and to the second the
+ * identity commitment `privacy_compute` returned.
+ */
+const COMPUTE_ARGUMENT_TYPES = anonymizerArgumentTypes("privacy_compute");
+const INVOKE_ARGUMENT_TYPES = anonymizerArgumentTypes(
+  "privacy_invoke_with_computation"
+);
+
+/**
+ * A shadow account interaction: an invoke the pool runs on the anonymizer that
+ * settles at least one open note, and so funds a deposit.
+ *
+ * The fields are the anonymizer's `privacy_compute` arguments. Together with
+ * the identity key the pool derives from the user, they determine the identity
+ * commitment, and through it the one shadow account holding the dapp's funds
+ * until they reach an open note. That account is the address to screen.
+ */
+export interface ShadowAccountInteraction {
+  dappName: bigint;
+  nonce: bigint;
+}
+
+/**
+ * The address of the shadow account a pool call's interaction runs through, or `null` when the call
+ * runs none, or when a felt the derivation needs does not parse. It is the address to screen for the
+ * open notes that interaction funds.
+ *
+ * The derivation is local, using the SDK's formulas, so it resolves even for an account that is not
+ * deployed yet. The anonymizer salts the deploy by the identity commitment and cements
+ * `PRIMER_CLASS_HASH`, which keeps the address independent of chain state, and a deployed account
+ * sits at the same address.
+ *
+ * `poolCall.viewingKey` is a secret and stays inside this derivation.
+ */
+export function getShadowAccountAddress(
+  poolCall: PoolCallActions,
+  anonymizerAddress: string
+): string | null {
+  if (poolCall.viewingKey === null) return null;
+  const interaction = getShadowAccountInteraction(
+    poolCall.actions,
+    anonymizerAddress
+  );
+  if (interaction === null) return null;
+  const userAddress = parseFelt(poolCall.userAddress);
+  if (userAddress === null) return null;
+
+  const anonymizer = BigInt(normalizeFelt(anonymizerAddress));
+  const commitment = shadowAccountCommitment(
+    shadowAccountPartialCommitment(
+      userAddress,
+      poolCall.viewingKey,
+      anonymizer,
+      interaction.dappName
+    ),
+    interaction.nonce
+  );
+  return normalizeFelt(num.toHex(shadowAccountAddress(commitment, anonymizer)));
+}
+
+/**
+ * The shadow account interaction among `actions`, or `null` when they run
+ * none: no `ComputeAndInvoke` targets `anonymizerAddress`, the one that does
+ * settles no open note (nothing is deposited, so nobody is screened), or its
+ * data does not decode.
+ *
+ * Undecodable data counts as no interaction rather than as an error, since the
+ * pool cannot execute it either and the transaction reverts on its own.
+ *
+ * The pool accepts at most one invoke-phase action per transaction, so a second
+ * `ComputeAndInvoke` makes a transaction the pool rejects whatever this returns.
+ * The first one wins here.
+ */
+export function getShadowAccountInteraction(
+  actions: CairoCustomEnum[],
+  anonymizerAddress: string
+): ShadowAccountInteraction | null {
+  for (const action of actions) {
+    if (action.activeVariant() !== "ComputeAndInvoke") continue;
+    const input = action.unwrap() as {
+      contract_address: bigint;
+      compute_additional_data: bigint[];
+      invoke_additional_data: bigint[];
+    };
+    if (
+      normalizeFelt(num.toHex(input.contract_address)) !==
+      normalizeFelt(anonymizerAddress)
+    ) {
+      continue;
+    }
+    return shadowAccountInteraction(input);
+  }
+  return null;
+}
+
+function shadowAccountInteraction(input: {
+  compute_additional_data: bigint[];
+  invoke_additional_data: bigint[];
+}): ShadowAccountInteraction | null {
+  try {
+    if (
+      input.compute_additional_data.length !== COMPUTE_ARGUMENT_TYPES.length
+    ) {
+      return null;
+    }
+    const [dappName, nonce] = anonymizerDecoder.decodeParameters(
+      COMPUTE_ARGUMENT_TYPES,
+      input.compute_additional_data.map(num.toHex)
+    ) as bigint[];
+    // `calls` is unread: which shadow account acts is what decides the address
+    // to screen, not what it does.
+    const [, openNotes] = anonymizerDecoder.decodeParameters(
+      INVOKE_ARGUMENT_TYPES,
+      input.invoke_additional_data.map(num.toHex)
+    ) as [unknown, unknown[]];
+    return openNotes.length === 0 ? null : { dappName, nonce };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The types of `name`'s arguments after its first one, read from the committed
+ * anonymizer ABI. A Cairo-side rename of a parameter's type therefore reaches
+ * this decode through the ABI generated from it.
+ */
+function anonymizerArgumentTypes(name: string): string[] {
+  const method = anonymizerDecoder.parser.getMethod(name);
+  if (method === undefined) {
+    throw new Error(`${name} is missing from the anonymizer ABI`);
+  }
+  return method.inputs.slice(1).map((input) => input.type);
+}

--- a/proof-interceptor/tests/pool-call.ts
+++ b/proof-interceptor/tests/pool-call.ts
@@ -1,0 +1,77 @@
+// tests/pool-call.ts
+import { CairoCustomEnum, CallData, num } from "starknet";
+import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
+import { ShadowAccountAnonymizerABI } from "@starkware-libs/starknet-privacy-sdk";
+import type { ProveTxnV3 } from "../src/types.js";
+
+export const POOL_ADDR = "0x9001";
+export const USER_ADDR = "0xaaa111";
+export const PRIVATE_KEY = "0xbbb222";
+export const TOKEN = "0xdead";
+export const ANONYMIZER_ADDR = "0x5678";
+export const DAPP_NAME = 0x646170n;
+export const NONCE = 7n;
+
+const poolCallData = new CallData(PrivacyPoolABI);
+const anonymizerCallData = new CallData(ShadowAccountAnonymizerABI);
+
+/** One dapp call, standing in for whatever the shadow account is asked to run. */
+export const DAPP_CALLS = [{ to: TOKEN, selector: "0x1", calldata: ["0x2"] }];
+
+/** One open note, collecting the shadow account's whole balance of `TOKEN`. */
+export const OPEN_NOTES = [
+  {
+    note_id: "0x3",
+    token: TOKEN,
+    collect_policy: new CairoCustomEnum({ All: {} }),
+  },
+];
+
+/**
+ * The `invoke_additional_data` the SDK's shadow account builder produces: the anonymizer's
+ * `privacy_invoke_with_computation` calldata without its leading `identity_commitment`, which the
+ * pool prepends from the compute result. Compiled through the anonymizer ABI, so a Cairo-side
+ * change to those arguments reaches these tests instead of leaving hand-written felts that still
+ * decode into something.
+ */
+export function invokeAdditionalData(openNotes: unknown[]): string[] {
+  return anonymizerCallData
+    .compile("privacy_invoke_with_computation", [0n, DAPP_CALLS, openNotes])
+    .slice(1);
+}
+
+export function depositAction(): CairoCustomEnum {
+  return new CairoCustomEnum({ Deposit: { token: TOKEN, amount: "0x64" } });
+}
+
+/**
+ * A prove request calling the pool's `compile_actions`: a single-call INVOKE
+ * whose inner calldata is `[user_addr, user_private_key, ...client actions]`.
+ * The pool ABI serializes the actions, so a test reads the calldata a client
+ * really sends instead of felts written out by hand.
+ */
+export function poolCallTransaction(actions: CairoCustomEnum[]): ProveTxnV3 {
+  const innerCalldata = poolCallData
+    .compile("compile_actions", [USER_ADDR, PRIVATE_KEY, actions])
+    .map((felt) => num.toHex(felt));
+  return {
+    type: "INVOKE",
+    version: "0x3",
+    sender_address: "0xcontract",
+    calldata: [
+      "0x1", // 1 call
+      POOL_ADDR,
+      "0xselector",
+      num.toHex(innerCalldata.length),
+      ...innerCalldata,
+    ],
+    signature: ["0x1"],
+    nonce: "0x0",
+    resource_bounds: {},
+    tip: "0x0",
+    paymaster_data: [],
+    account_deployment_data: [],
+    nonce_data_availability_mode: "L1",
+    fee_data_availability_mode: "L1",
+  } as unknown as ProveTxnV3;
+}

--- a/proof-interceptor/tests/pool-transaction.test.ts
+++ b/proof-interceptor/tests/pool-transaction.test.ts
@@ -1,0 +1,50 @@
+// tests/pool-transaction.test.ts
+import { describe, it, expect } from "vitest";
+import { decodeClientActions } from "../src/pool-transaction.js";
+import { getScreenedAddresses } from "../src/screening-interceptor.js";
+import {
+  POOL_ADDR,
+  PRIVATE_KEY,
+  USER_ADDR,
+  depositAction,
+  poolCallTransaction,
+} from "./pool-call.js";
+
+describe("decodeClientActions", () => {
+  it("decodes the user address and the actions of a pool call", () => {
+    const poolCall = decodeClientActions(
+      poolCallTransaction([depositAction()]),
+      POOL_ADDR
+    );
+    expect(poolCall?.userAddress).toBe(USER_ADDR);
+    expect(poolCall?.actions.map((action) => action.activeVariant())).toEqual([
+      "Deposit",
+    ]);
+  });
+
+  it("returns null for a call to another contract", () => {
+    const transaction = poolCallTransaction([depositAction()]);
+    expect(decodeClientActions(transaction, "0x4321")).toBeNull();
+  });
+
+  it("carries the viewing key the pool derives identity keys from", () => {
+    const poolCall = decodeClientActions(
+      poolCallTransaction([depositAction()]),
+      POOL_ADDR
+    );
+    expect(poolCall?.viewingKey).toBe(BigInt(PRIVATE_KEY));
+  });
+
+  it("still screens the deposit when only the viewing key is unparseable", () => {
+    // The key felt is caller-controlled, and only shadow account derivation reads it. Voiding the
+    // whole decode over it would drop the transaction out of screening altogether, which for a
+    // deposit means letting it through unscreened.
+    const transaction = poolCallTransaction([depositAction()]);
+    transaction.calldata[5] = "not-a-felt";
+
+    const poolCall = decodeClientActions(transaction, POOL_ADDR);
+    expect(poolCall?.userAddress).toBe(USER_ADDR);
+    expect(poolCall?.viewingKey).toBeNull();
+    expect(getScreenedAddresses(transaction, POOL_ADDR)).toEqual([USER_ADDR]);
+  });
+});

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -5,9 +5,9 @@ import { createServer, type Server } from "node:http";
 import {
   ScreeningInterceptor,
   getScreenedAddresses,
-  isSinglePoolCall,
   type ScreeningConfig,
 } from "../src/screening-interceptor.js";
+import { isSinglePoolCall } from "../src/pool-transaction.js";
 import type { ProveTxnV3 } from "../src/types.js";
 
 // Test addresses and values — must be valid hex for ABI decoding

--- a/proof-interceptor/tests/shadow-account.test.ts
+++ b/proof-interceptor/tests/shadow-account.test.ts
@@ -1,0 +1,192 @@
+// tests/shadow-account.test.ts
+import { describe, it, expect } from "vitest";
+import { CairoCustomEnum, type BigNumberish } from "starknet";
+import {
+  shadowAccountAddress,
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "@starkware-libs/starknet-privacy-sdk";
+import { decodeClientActions } from "../src/pool-transaction.js";
+import {
+  getShadowAccountAddress,
+  getShadowAccountInteraction,
+} from "../src/shadow-account.js";
+import {
+  ANONYMIZER_ADDR,
+  DAPP_NAME,
+  NONCE,
+  OPEN_NOTES,
+  POOL_ADDR,
+  PRIVATE_KEY,
+  USER_ADDR,
+  depositAction,
+  invokeAdditionalData,
+  poolCallTransaction,
+} from "./pool-call.js";
+
+function computeAndInvoke(input: {
+  contract_address?: string;
+  compute_additional_data?: BigNumberish[];
+  invoke_additional_data?: BigNumberish[];
+}): CairoCustomEnum {
+  return new CairoCustomEnum({
+    ComputeAndInvoke: {
+      contract_address: input.contract_address ?? ANONYMIZER_ADDR,
+      compute_additional_data: input.compute_additional_data ?? [
+        DAPP_NAME,
+        NONCE,
+      ],
+      invoke_additional_data:
+        input.invoke_additional_data ?? invokeAdditionalData(OPEN_NOTES),
+    },
+  });
+}
+
+function interactionOf(
+  actions: CairoCustomEnum[],
+  anonymizerAddress = ANONYMIZER_ADDR
+) {
+  const poolCall = decodeClientActions(poolCallTransaction(actions), POOL_ADDR);
+  expect(poolCall).not.toBeNull();
+  return getShadowAccountInteraction(poolCall!.actions, anonymizerAddress);
+}
+
+function addressOf(
+  actions: CairoCustomEnum[],
+  anonymizerAddress = ANONYMIZER_ADDR
+) {
+  const poolCall = decodeClientActions(poolCallTransaction(actions), POOL_ADDR);
+  expect(poolCall).not.toBeNull();
+  return getShadowAccountAddress(poolCall!, anonymizerAddress);
+}
+
+describe("getShadowAccountInteraction", () => {
+  it("returns the dapp name and nonce of an interaction settling an open note", () => {
+    expect(interactionOf([computeAndInvoke({})])).toEqual({
+      dappName: DAPP_NAME,
+      nonce: NONCE,
+    });
+  });
+
+  it("returns null when the interaction settles no open note", () => {
+    const action = computeAndInvoke({
+      invoke_additional_data: invokeAdditionalData([]),
+    });
+    expect(interactionOf([action])).toBeNull();
+  });
+
+  it("returns null when the compute-invoke targets another contract", () => {
+    const action = computeAndInvoke({ contract_address: "0x4321" });
+    expect(interactionOf([action])).toBeNull();
+  });
+
+  it("matches the anonymizer regardless of leading zeros and case", () => {
+    const action = computeAndInvoke({ contract_address: "0x0000005678" });
+    expect(interactionOf([action], "0X5678")).toEqual({
+      dappName: DAPP_NAME,
+      nonce: NONCE,
+    });
+  });
+
+  it("returns null when no action is a compute-invoke", () => {
+    expect(interactionOf([depositAction()])).toBeNull();
+  });
+
+  it("finds the interaction alongside a deposit in the same transaction", () => {
+    expect(interactionOf([depositAction(), computeAndInvoke({})])).toEqual({
+      dappName: DAPP_NAME,
+      nonce: NONCE,
+    });
+  });
+
+  it("returns null when the invoke data is truncated", () => {
+    const truncated = invokeAdditionalData(OPEN_NOTES).slice(0, 2);
+    expect(
+      interactionOf([computeAndInvoke({ invoke_additional_data: truncated })])
+    ).toBeNull();
+  });
+
+  it("returns null when the invoke data claims more open notes than it carries", () => {
+    const data = invokeAdditionalData(OPEN_NOTES);
+    // The open notes follow the calls; their length prefix is the felt after them.
+    const openNotesLengthIndex = data.length - 1 - 3;
+    data[openNotesLengthIndex] = "2";
+    expect(
+      interactionOf([computeAndInvoke({ invoke_additional_data: data })])
+    ).toBeNull();
+  });
+
+  it("returns null when the compute data is not a dapp name and a nonce", () => {
+    for (const computeData of [[DAPP_NAME], [DAPP_NAME, NONCE, 1n]]) {
+      const action = computeAndInvoke({ compute_additional_data: computeData });
+      expect(interactionOf([action])).toBeNull();
+    }
+  });
+});
+
+describe("getShadowAccountAddress", () => {
+  it("derives the address the anonymizer would deploy the interaction's account to", () => {
+    // Composed here from the transaction's own felts, so the test fails if the derivation reads the
+    // wrong ones: a swapped user and viewing key, or the pool address in place of the anonymizer.
+    const expected = shadowAccountAddress(
+      shadowAccountCommitment(
+        shadowAccountPartialCommitment(
+          BigInt(USER_ADDR),
+          BigInt(PRIVATE_KEY),
+          BigInt(ANONYMIZER_ADDR),
+          DAPP_NAME
+        ),
+        NONCE
+      ),
+      BigInt(ANONYMIZER_ADDR)
+    );
+    expect(addressOf([computeAndInvoke({})])).toBe(
+      "0x" + expected.toString(16)
+    );
+  });
+
+  it("returns null for an unparseable user address instead of throwing", () => {
+    // `user_addr` is caller-controlled and reaches the derivation as a bigint. An unparseable one
+    // must void the derivation, not escape as an exception: the interceptor turns a thrown error
+    // into a block whose reason is the exception text, where reasons are opaque codes.
+    const transaction = poolCallTransaction([computeAndInvoke({})]);
+    transaction.calldata[4] = "not-a-felt";
+    const poolCall = decodeClientActions(transaction, POOL_ADDR);
+
+    expect(poolCall).not.toBeNull();
+    expect(getShadowAccountAddress(poolCall!, ANONYMIZER_ADDR)).toBeNull();
+  });
+
+  it("returns null when the transaction runs no interaction", () => {
+    expect(addressOf([depositAction()])).toBeNull();
+    expect(
+      addressOf([
+        computeAndInvoke({ invoke_additional_data: invokeAdditionalData([]) }),
+      ])
+    ).toBeNull();
+  });
+
+  it("gives each nonce its own address", () => {
+    const first = addressOf([
+      computeAndInvoke({ compute_additional_data: [DAPP_NAME, 1n] }),
+    ]);
+    const second = addressOf([
+      computeAndInvoke({ compute_additional_data: [DAPP_NAME, 2n] }),
+    ]);
+    expect(first).not.toBeNull();
+    expect(first).not.toBe(second);
+  });
+
+  it("gives each dapp its own address", () => {
+    const other = addressOf([
+      computeAndInvoke({ compute_additional_data: [DAPP_NAME + 1n, NONCE] }),
+    ]);
+    expect(addressOf([computeAndInvoke({})])).not.toBe(other);
+  });
+
+  it("finds the interaction alongside a deposit", () => {
+    expect(addressOf([depositAction(), computeAndInvoke({})])).toBe(
+      addressOf([computeAndInvoke({})])
+    );
+  });
+});


### PR DESCRIPTION
A prove request's ComputeAndInvoke on the anonymizer determines the shadow
account its open notes fund, so the interceptor derives that address locally —
the SDK's shared formulas over the request's own felts (user, viewing key, dapp
name, nonce) — rather than reading the chain. The viewing key is a secret: it
never leaves the derivation and an unparseable one costs only it, never the
screening of the rest of the transaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/954)
<!-- Reviewable:end -->
