### PR TITLE
feat(proof-interceptor): read open-note screening policies from the pool

### DIFF
--- a/.github/workflows/check_formatting.yaml
+++ b/.github/workflows/check_formatting.yaml
@@ -25,6 +25,10 @@ jobs:
         run: |
           python3 scripts/check_primer_class_hash.py
 
+      - name: Check the open-note screening policies agree across Cairo, the ABI and the interceptor
+        run: |
+          python3 scripts/check_screening_policies.py
+
       - name: Check unused imports and variables
         run: |
           scarb cache clean

--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -126,6 +126,7 @@ Prometheus counters/histograms exported on `/metrics` (defined in `src/metrics.t
 
 - `proof_interceptor_screening_results_total{result}` — `allowed` / `blocked` / `unavailable`. The primary signal that screening is wired up at all.
 - `proof_interceptor_screening_retries_total` — retry attempts only (first attempts excluded).
+- `proof_interceptor_screening_policy_reads_total{result}` — open-note screening policies read from the pool: `Required` / `Exempt` / `Delegated`, or `unavailable` when the read failed and the flow fails closed.
 - `proof_interceptor_screening_duration_seconds{result}` — Elliptic round-trip latency.
 - `proof_interceptor_interceptor_verdicts_total{interceptor,verdict}` — per-interceptor verdicts.
 - `proof_interceptor_rpc_requests_total{action,method}` and `proof_interceptor_errors_total{type}` — request and error counters.
@@ -183,6 +184,7 @@ npm start
 | `src/interceptor.ts`           | Parallel interceptor runner with first-block-wins semantics                                              |
 | `src/pool-transaction.ts`      | Pool-call gate and client-action decoding of a prove request's calldata                                  |
 | `src/shadow-account.ts`        | The shadow account interaction a transaction runs on the anonymizer, from its decoded actions            |
+| `src/screening-policy.ts`      | Open-note screening policies read from the pool over RPC, cached per depositor with an LRU TTL           |
 | `src/screening-interceptor.ts` | Deposit detection, address extraction, retry/timeout, HMAC-signed call to elliptic-proxy                 |
 | `src/types.ts`                 | JSON-RPC and `ProveTxnV3` types                                                                          |
 | `src/metrics.ts`               | Prometheus registry and metric definitions                                                               |

--- a/proof-interceptor/package-lock.json
+++ b/proof-interceptor/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+        "lru-cache": "^11.3.2",
         "prom-client": "^15.1.3",
         "starknet": "^9.4.2"
       },
@@ -17,7 +18,6 @@
         "@google-cloud/functions-framework": "^5.0.2",
         "@types/node": "^22.19.17",
         "eslint": "^9.39.2",
-        "lru-cache": "^11.3.2",
         "prettier": "^3.7.4",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.51.0",
@@ -3603,7 +3603,6 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/proof-interceptor/package.json
+++ b/proof-interceptor/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
+    "lru-cache": "^11.3.2",
     "prom-client": "^15.1.3",
     "starknet": "^9.4.2"
   },
@@ -26,7 +27,6 @@
     "@google-cloud/functions-framework": "^5.0.2",
     "@types/node": "^22.19.17",
     "eslint": "^9.39.2",
-    "lru-cache": "^11.3.2",
     "prettier": "^3.7.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.51.0",

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -32,6 +32,13 @@ export const screeningResults = new Counter({
   registers: [registry],
 });
 
+export const screeningPolicyReads = new Counter({
+  name: "proof_interceptor_screening_policy_reads_total",
+  help: "Total open-note screening policies read from the pool, by policy or 'unavailable'",
+  labelNames: ["result"] as const,
+  registers: [registry],
+});
+
 export const screeningRetries = new Counter({
   name: "proof_interceptor_screening_retries_total",
   help: "Total screening retry attempts (not counting first attempt)",

--- a/proof-interceptor/src/pool-transaction.ts
+++ b/proof-interceptor/src/pool-transaction.ts
@@ -6,7 +6,8 @@ import type { ProveTxnV3 } from "./types.js";
 const ACTIONS_TYPE =
   "core::array::Span::<privacy::actions::ClientAction>" as const;
 
-const callDataDecoder = new CallData(PrivacyPoolABI);
+/** The pool ABI's coder, shared by every module that encodes or decodes pool calldata. */
+export const poolCallData = new CallData(PrivacyPoolABI);
 
 /**
  * Returns true iff the transaction is a single-call INVOKE whose target
@@ -77,7 +78,7 @@ export function decodeClientActions(
 
   const innerCalldata = calldata.slice(4, 4 + innerCalldataLength);
   try {
-    const actions = callDataDecoder.decodeParameters(
+    const actions = poolCallData.decodeParameters(
       ACTIONS_TYPE,
       innerCalldata.slice(2)
     ) as CairoCustomEnum[];

--- a/proof-interceptor/src/screening-policy.ts
+++ b/proof-interceptor/src/screening-policy.ts
@@ -1,0 +1,155 @@
+// src/screening-policy.ts
+import { LRUCache } from "lru-cache";
+import { CairoCustomEnum, RpcProvider } from "starknet";
+import { normalizeFelt, poolCallData } from "./pool-transaction.js";
+import { screeningPolicyReads } from "./metrics.js";
+
+/**
+ * The pool answers with a variant index, so this must match the Cairo enum in name and order.
+ * `scripts/check_screening_policies.py` fails a pull request where the two disagree.
+ */
+export type OpenNoteScreeningPolicy = "Required" | "Exempt" | "Delegated";
+
+export const MAX_CACHED_POLICIES = 1024;
+
+export const DEFAULT_POLICY_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * The policy read's own deadline. It is additive to the screening budget rather than carved out of
+ * it: a prove request can spend this window and then the screening one, so a deployment tightening
+ * the end-to-end latency has to lower both.
+ */
+export const DEFAULT_POLICY_TIMEOUT_MS = 10_000;
+
+const POLICY_TYPE = "privacy::objects::OpenNoteScreeningPolicy";
+
+export interface PolicyClientConfig {
+  /** A Starknet JSON-RPC endpoint. The client calls one view on it and nothing else. */
+  rpcUrl: string;
+  poolAddress: string;
+  /** How long a read is reused. {@link DEFAULT_POLICY_TTL_MS} is the value a deployment gets. */
+  ttlMs: number;
+  /** One read's deadline. {@link DEFAULT_POLICY_TIMEOUT_MS} is the value a deployment gets. */
+  timeoutMs: number;
+}
+
+/**
+ * Reads open-note screening policies from the pool over RPC, so a governance change reaches the
+ * interceptor without a paired config update.
+ */
+export class OpenNoteScreeningPolicyClient {
+  private readonly cachedPolicies: LRUCache<string, OpenNoteScreeningPolicy>;
+  /**
+   * The read in flight per address, so concurrent callers for one address share it instead of each
+   * issuing their own call. Every entry is removed as its read settles, so the map holds at most one
+   * entry per address being read right now — the cap belongs on the cache, which outlives the reads.
+   */
+  private readonly pendingReads = new Map<
+    string,
+    Promise<OpenNoteScreeningPolicy | null>
+  >();
+  private readonly provider: RpcProvider;
+
+  constructor(private readonly config: PolicyClientConfig) {
+    this.cachedPolicies = new LRUCache({
+      max: MAX_CACHED_POLICIES,
+      ttl: config.ttlMs,
+      // Age entries by the wall clock, so the TTL is a window of real time.
+      perf: { now: () => Date.now() },
+    });
+    this.provider = new RpcProvider({
+      nodeUrl: config.rpcUrl,
+      // The provider takes no timeout of its own, so every request it makes carries one from here.
+      baseFetch: (url, init) =>
+        fetch(url, { ...init, signal: AbortSignal.timeout(config.timeoutMs) }),
+    });
+  }
+
+  /**
+   * The pool's open-note screening policy for `depositor`, from the cache, a read already in flight
+   * for the same address, or a fresh read; or `null` when the read fails, times out or answers with
+   * something that is not a policy. A failed read is never cached, and an expired entry is never
+   * served.
+   */
+  async getPolicy(depositor: string): Promise<OpenNoteScreeningPolicy | null> {
+    const address = normalizeFelt(depositor);
+    // `allowStale` is off by default, so an entry past its TTL reads as absent.
+    const cached = this.cachedPolicies.get(address);
+    if (cached !== undefined) return cached;
+
+    const policy = await this.readOnce(address);
+    if (policy === null) return null;
+    this.cachedPolicies.set(address, policy);
+    return policy;
+  }
+
+  /** One read per address at a time: a caller arriving mid-flight awaits the read already running. */
+  private readOnce(address: string): Promise<OpenNoteScreeningPolicy | null> {
+    const inFlight = this.pendingReads.get(address);
+    if (inFlight !== undefined) return inFlight;
+
+    const read = this.readPolicy(address).finally(() =>
+      this.pendingReads.delete(address)
+    );
+    this.pendingReads.set(address, read);
+    return read;
+  }
+
+  private async readPolicy(
+    depositor: string
+  ): Promise<OpenNoteScreeningPolicy | null> {
+    try {
+      const felts = await this.provider.callContract(
+        {
+          contractAddress: this.config.poolAddress,
+          entrypoint: "get_open_note_screening_policy",
+          calldata: [depositor],
+        },
+        // The policy has to come from a block the pool's own execution will see. A change is
+        // visible here once it is in `latest`, and to a cached read one TTL after that.
+        "latest"
+      );
+      const policy = parsePolicy(felts);
+      if (policy === null) throw new Error("the pool returned no policy");
+      screeningPolicyReads.inc({ result: policy });
+      return policy;
+    } catch (error) {
+      // No address goes into the log, as on the rest of this path.
+      console.error(
+        JSON.stringify({
+          error: "screening_policy_unavailable",
+          message: error instanceof Error ? error.message : String(error),
+        })
+      );
+      screeningPolicyReads.inc({ result: "unavailable" });
+      return null;
+    }
+  }
+}
+
+/**
+ * The pool answers with one felt, the variant index of its policy enum, decoded through the
+ * committed ABI.
+ */
+function parsePolicy(felts: unknown): OpenNoteScreeningPolicy | null {
+  if (!Array.isArray(felts) || felts.length !== 1) return null;
+  if (typeof felts[0] !== "string") return null;
+
+  try {
+    const decoded = poolCallData.decodeParameters(
+      POLICY_TYPE,
+      felts as string[]
+    ) as CairoCustomEnum;
+    const variant = decoded.activeVariant();
+    return isPolicy(variant) ? variant : null;
+  } catch {
+    // `decodeParameters` rejects a variant index the enum does not have.
+    return null;
+  }
+}
+
+function isPolicy(variant: string): variant is OpenNoteScreeningPolicy {
+  return (
+    variant === "Required" || variant === "Exempt" || variant === "Delegated"
+  );
+}

--- a/proof-interceptor/tests/pool-call.ts
+++ b/proof-interceptor/tests/pool-call.ts
@@ -1,4 +1,5 @@
 // tests/pool-call.ts
+import { vi } from "vitest";
 import { CairoCustomEnum, CallData, num } from "starknet";
 import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import { ShadowAccountAnonymizerABI } from "@starkware-libs/starknet-privacy-sdk";
@@ -74,4 +75,11 @@ export function poolCallTransaction(actions: CairoCustomEnum[]): ProveTxnV3 {
     nonce_data_availability_mode: "L1",
     fee_data_availability_mode: "L1",
   } as unknown as ProveTxnV3;
+}
+
+/** Silences a fail-closed path's error log, and returns the spy to assert on. */
+export function silenceErrorLog(): ReturnType<
+  typeof vi.spyOn<typeof console, "error">
+> {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
 }

--- a/proof-interceptor/tests/screening-policy.test.ts
+++ b/proof-interceptor/tests/screening-policy.test.ts
@@ -1,0 +1,361 @@
+// tests/screening-policy.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
+import { silenceErrorLog } from "./pool-call.js";
+import {
+  DEFAULT_POLICY_TIMEOUT_MS,
+  DEFAULT_POLICY_TTL_MS,
+  MAX_CACHED_POLICIES,
+  OpenNoteScreeningPolicyClient,
+  type OpenNoteScreeningPolicy,
+} from "../src/screening-policy.js";
+
+const POOL_ADDR = "0x9001";
+const DEPOSITOR = "0xa11ce";
+// keccak("get_open_note_screening_policy"), masked to a selector. Committed here so a typo in the
+// entrypoint name the client asks for fails this test instead of every policy read in production.
+const GET_POLICY_SELECTOR =
+  "0x19ffd9b0ff9d97560bf4426e5a7682651f5f7a4210dab7771376b52e6720e";
+
+const POLICIES: OpenNoteScreeningPolicy[] = ["Required", "Exempt", "Delegated"];
+
+/** What the fake node does with one `starknet_call`: answer a body, an HTTP status, or nothing. */
+type RpcAnswer = { body: unknown } | { status: number } | "no answer";
+
+/** The answer to the `requestNumber`-th call the fake node receives, counting from 1. */
+type RpcResponder = (requestNumber: number) => RpcAnswer;
+
+let rpcServer: Server;
+let rpcUrl: string;
+let requests: unknown[];
+let respond: RpcResponder;
+
+/** A `starknet_call` result carrying `policy`, serialized as the pool's enum is: its variant index. */
+function policyAnswer(policy: OpenNoteScreeningPolicy): RpcAnswer {
+  const index = POLICIES.indexOf(policy);
+  return {
+    body: { jsonrpc: "2.0", id: 1, result: ["0x" + index.toString(16)] },
+  };
+}
+
+beforeEach(async () => {
+  requests = [];
+  respond = () => policyAnswer("Exempt");
+  rpcServer = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => (body += chunk));
+    request.on("end", () => {
+      requests.push(JSON.parse(body));
+      const answer = respond(requests.length);
+      if (answer === "no answer") return;
+      if ("status" in answer) {
+        response.writeHead(answer.status);
+        response.end();
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(answer.body));
+    });
+  });
+  await new Promise<void>((resolve) => rpcServer.listen(0, resolve));
+  rpcUrl = `http://127.0.0.1:${(rpcServer.address() as AddressInfo).port}`;
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await new Promise<void>((resolve, reject) =>
+    rpcServer.close((error) => (error ? reject(error) : resolve()))
+  );
+});
+
+function newClient(
+  overrides: { ttlMs?: number; timeoutMs?: number } = {}
+): OpenNoteScreeningPolicyClient {
+  return new OpenNoteScreeningPolicyClient({
+    rpcUrl,
+    poolAddress: POOL_ADDR,
+    ttlMs: DEFAULT_POLICY_TTL_MS,
+    timeoutMs: DEFAULT_POLICY_TIMEOUT_MS,
+    ...overrides,
+  });
+}
+
+const OVERFLOW_DEPOSITOR = "0xfffffff";
+/** These tests run on the client's own default TTL, so the advances below are relative to it. */
+const TTL_MS = DEFAULT_POLICY_TTL_MS;
+
+/** Caches one policy per slot, leaving the cache full and "0x1" its least recently used entry. */
+async function fillCache(client: OpenNoteScreeningPolicyClient): Promise<void> {
+  for (let entry = 1; entry <= MAX_CACHED_POLICIES; entry++) {
+    await client.getPolicy("0x" + entry.toString(16));
+  }
+}
+
+/**
+ * Starts a test on a clock it can move. The cache ages entries by `Date.now()`, so faking time
+ * expires them without waiting; the local HTTP the client talks to is I/O, and runs regardless.
+ */
+function useMovableClock(): void {
+  vi.useFakeTimers({ now: Date.now() });
+}
+
+describe("OpenNoteScreeningPolicyClient", () => {
+  it("resolves every policy the pool can answer with", async () => {
+    for (const policy of POLICIES) {
+      respond = () => policyAnswer(policy);
+      // A fresh client per policy: one client would answer the second one from its cache.
+      expect(await newClient().getPolicy(DEPOSITOR)).toBe(policy);
+    }
+  });
+
+  it("asks the pool for the depositor's policy at the latest block", async () => {
+    await newClient().getPolicy(DEPOSITOR);
+
+    expect(requests).toEqual([
+      {
+        jsonrpc: "2.0",
+        // starknet.js numbers its own requests.
+        id: expect.any(Number),
+        method: "starknet_call",
+        params: {
+          request: {
+            contract_address: POOL_ADDR,
+            entry_point_selector: GET_POLICY_SELECTOR,
+            calldata: [DEPOSITOR],
+          },
+          block_id: "latest",
+        },
+      },
+    ]);
+  });
+
+  it("declares exactly the policies the pool ABI does", () => {
+    // The union is hand-written while the decode reads the ABI, so they are pinned to each other
+    // here; `scripts/check_screening_policies.py` pins both to the Cairo enum that owns the list.
+    const abi = PrivacyPoolABI as readonly {
+      type: string;
+      name?: string;
+      variants?: readonly { name: string; type: string }[];
+    }[];
+    const policyEnum = abi.find(
+      (item) =>
+        item.type === "enum" &&
+        item.name === "privacy::objects::OpenNoteScreeningPolicy"
+    );
+
+    expect(policyEnum?.variants?.map((variant) => variant.name)).toEqual(
+      POLICIES
+    );
+    // None of them carries data, which is why one felt is the whole answer.
+    expect(policyEnum?.variants?.map((variant) => variant.type)).toEqual([
+      "()",
+      "()",
+      "()",
+    ]);
+  });
+
+  it("keys the cache by the normalized address", async () => {
+    const client = newClient();
+    expect(await client.getPolicy("0x0000a11ce")).toBe("Exempt");
+    expect(await client.getPolicy("0xA11CE")).toBe("Exempt");
+
+    expect(requests).toHaveLength(1);
+  });
+
+  it("reads a policy once per depositor within the TTL", async () => {
+    const client = newClient();
+    await client.getPolicy(DEPOSITOR);
+    await client.getPolicy(DEPOSITOR);
+    await client.getPolicy("0xb0b");
+
+    expect(requests).toHaveLength(2);
+  });
+
+  it("reads again once the TTL expires, so a policy change propagates", async () => {
+    useMovableClock();
+    respond = (requestNumber) =>
+      policyAnswer(requestNumber === 1 ? "Exempt" : "Required");
+    const client = newClient();
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Required");
+    expect(requests).toHaveLength(2);
+  });
+
+  it("holds a policy for the whole TTL, not a moment less", async () => {
+    useMovableClock();
+    respond = (requestNumber) =>
+      policyAnswer(requestNumber === 1 ? "Exempt" : "Required");
+    const client = newClient();
+    await client.getPolicy(DEPOSITOR);
+
+    await vi.advanceTimersByTimeAsync(TTL_MS - 1);
+
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+    expect(requests).toHaveLength(1);
+  });
+
+  it("evicts the least recently used policy once the cache is full", async () => {
+    const client = newClient();
+    await fillCache(client);
+    // One depositor more than the cache holds, so the least recently used entry is evicted.
+    await client.getPolicy(OVERFLOW_DEPOSITOR);
+    const readsBeforeEviction = requests.length;
+
+    await client.getPolicy("0x1");
+    await client.getPolicy(OVERFLOW_DEPOSITOR);
+
+    expect(requests).toHaveLength(readsBeforeEviction + 1);
+  });
+
+  it("keeps a policy that keeps being read over one that stopped being read", async () => {
+    // What least-recently-used buys over evicting in insertion order: a flood of transactions to
+    // distinct targets costs re-reads of itself, not of the few targets real deposits go through.
+    const client = newClient();
+    await fillCache(client);
+    await client.getPolicy("0x1");
+    await client.getPolicy(OVERFLOW_DEPOSITOR);
+    const readsBeforeEviction = requests.length;
+
+    // "0x1" was read last of the filled entries, so "0x2" is the one that went.
+    await client.getPolicy("0x1");
+    expect(requests).toHaveLength(readsBeforeEviction);
+    await client.getPolicy("0x2");
+    expect(requests).toHaveLength(readsBeforeEviction + 1);
+  });
+
+  it("issues one read for concurrent calls on the same depositor", async () => {
+    const client = newClient();
+
+    const policies = await Promise.all(
+      Array.from({ length: 10 }, () => client.getPolicy(DEPOSITOR))
+    );
+
+    expect(policies).toEqual(Array(10).fill("Exempt"));
+    expect(requests).toHaveLength(1);
+  });
+
+  it("keeps concurrent reads for different depositors apart", async () => {
+    respond = (requestNumber) =>
+      policyAnswer(requestNumber === 1 ? "Exempt" : "Delegated");
+    const client = newClient();
+
+    const [first, second] = await Promise.all([
+      client.getPolicy(DEPOSITOR),
+      client.getPolicy("0xb0b"),
+    ]);
+
+    // Coalescing is per address: sharing one read across addresses would answer both the same.
+    expect([first, second]).toEqual(["Exempt", "Delegated"]);
+    expect(requests).toHaveLength(2);
+  });
+
+  it("reads again after a shared read fails, rather than reusing the failure", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = (requestNumber) =>
+      requestNumber === 1 ? { status: 503 } : policyAnswer("Required");
+    const client = newClient();
+
+    const failed = await Promise.all([
+      client.getPolicy(DEPOSITOR),
+      client.getPolicy(DEPOSITOR),
+    ]);
+    expect(failed).toEqual([null, null]);
+    expect(requests).toHaveLength(1);
+
+    // The in-flight entry is cleared when the read settles, failure included, so the next caller
+    // starts a new one instead of awaiting a promise that already resolved to null.
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Required");
+    expect(requests).toHaveLength(2);
+    errorSpy.mockRestore();
+  });
+
+  it("returns null on an RPC error response", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = () => ({
+      body: {
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: 40, message: "Contract error" },
+      },
+    });
+
+    expect(await newClient().getPolicy(DEPOSITOR)).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = () => ({ status: 503 });
+
+    expect(await newClient().getPolicy(DEPOSITOR)).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("returns null for a variant index the pool's enum does not have", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = () => ({ body: { jsonrpc: "2.0", id: 1, result: ["0x7"] } });
+
+    expect(await newClient().getPolicy(DEPOSITOR)).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("returns null for a result that is not one felt of policy", async () => {
+    const errorSpy = silenceErrorLog();
+    for (const result of [[], ["0x1", "0x1"], "Exempt", [1], null]) {
+      respond = () => ({ body: { jsonrpc: "2.0", id: 1, result } });
+      expect(await newClient().getPolicy(DEPOSITOR)).toBeNull();
+    }
+    errorSpy.mockRestore();
+  });
+
+  it("returns null when the RPC does not answer within the timeout", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = () => "no answer";
+
+    expect(await newClient({ timeoutMs: 50 }).getPolicy(DEPOSITOR)).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("does not cache a failed read", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = (requestNumber) =>
+      requestNumber === 1 ? { status: 503 } : policyAnswer("Delegated");
+    const client = newClient();
+
+    expect(await client.getPolicy(DEPOSITOR)).toBeNull();
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Delegated");
+    errorSpy.mockRestore();
+  });
+
+  it("reports a policy it can no longer read as unresolvable, not as its last value", async () => {
+    const errorSpy = silenceErrorLog();
+    useMovableClock();
+    respond = (requestNumber) =>
+      requestNumber === 1 ? policyAnswer("Exempt") : { status: 503 };
+    const client = newClient();
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+
+    expect(await client.getPolicy(DEPOSITOR)).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it("keeps the depositor out of the log when a read fails", async () => {
+    const errorSpy = silenceErrorLog();
+    respond = () => ({ status: 503 });
+
+    await newClient().getPolicy(DEPOSITOR);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = String(errorSpy.mock.calls[0][0]);
+    expect(logged).toContain("screening_policy_unavailable");
+    expect(logged).not.toContain("a11ce");
+    errorSpy.mockRestore();
+  });
+});

--- a/scripts/check_screening_policies.py
+++ b/scripts/check_screening_policies.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3.10
+"""Asserts the `OpenNoteScreeningPolicy` enum agrees across Cairo, the committed pool ABI and the
+proof interceptor. Not the policy list itself, which is pool storage: the set of policies and the
+order they are declared in.
+
+The pool answers with a variant index, so a name's position is what turns it back into a policy: a
+reorder makes both sides read a policy the pool never meant. Nothing else connects the three copies,
+since no CI job regenerates the ABI from Cairo.
+
+Runs unfiltered on every pull request, so a change to any of the three is checked against the others.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CAIRO_SOURCE = REPO_ROOT / "packages/privacy/src/objects.cairo"
+ABI_SOURCE = REPO_ROOT / "sdk/src/internal/abi.ts"
+INTERCEPTOR_SOURCE = REPO_ROOT / "proof-interceptor/src/screening-policy.ts"
+
+ENUM_NAME = "OpenNoteScreeningPolicy"
+ABI_ENUM_NAME = f"privacy::objects::{ENUM_NAME}"
+
+CAIRO_PATTERN = re.compile(rf"pub enum {ENUM_NAME} \{{(.*?)\n\}}", re.DOTALL)
+CAIRO_VARIANT_PATTERN = re.compile(r"^\s{4}([A-Z]\w*),", re.MULTILINE)
+UNION_PATTERN = re.compile(rf'export type {ENUM_NAME} =([^;]*);', re.DOTALL)
+UNION_MEMBER_PATTERN = re.compile(r'"(\w+)"')
+
+
+def cairo_variants() -> list[str]:
+    body = CAIRO_PATTERN.search(CAIRO_SOURCE.read_text())
+    if body is None:
+        sys.exit(f"{CAIRO_SOURCE}: `pub enum {ENUM_NAME}` not found. Did it move or change shape?")
+    return CAIRO_VARIANT_PATTERN.findall(body.group(1))
+
+
+def abi_variants() -> list[str]:
+    # The ABI is a TypeScript file wrapping one JSON array; take the array and parse it as JSON.
+    text = ABI_SOURCE.read_text()
+    start, end = text.find("["), text.rfind("]")
+    if start == -1 or end == -1:
+        sys.exit(f"{ABI_SOURCE}: no JSON array found. Did the generated file change shape?")
+    for item in json.loads(text[start : end + 1]):
+        if item.get("type") == "enum" and item.get("name") == ABI_ENUM_NAME:
+            return [variant["name"] for variant in item["variants"]]
+    sys.exit(f"{ABI_SOURCE}: {ABI_ENUM_NAME} is missing. Regenerate it with `npm run generate:abi`.")
+
+
+def union_members() -> list[str]:
+    union = UNION_PATTERN.search(INTERCEPTOR_SOURCE.read_text())
+    if union is None:
+        sys.exit(f"{INTERCEPTOR_SOURCE}: `export type {ENUM_NAME}` not found. Did it move?")
+    return UNION_MEMBER_PATTERN.findall(union.group(1))
+
+
+def main() -> None:
+    policies = {
+        CAIRO_SOURCE: cairo_variants(),
+        ABI_SOURCE: abi_variants(),
+        INTERCEPTOR_SOURCE: union_members(),
+    }
+    if len(set(map(tuple, policies.values()))) > 1:
+        listed = "\n".join(
+            f"  {source.relative_to(REPO_ROOT)}: {names}" for source, names in policies.items()
+        )
+        sys.exit(
+            "The open-note screening policies disagree, in name or in order:\n"
+            f"{listed}\n"
+            "Order is the serde index the pool answers with, so it has to match too. Cairo owns the "
+            "list: regenerate the ABI with `npm run generate:abi` in sdk/, then update the "
+            "interceptor's union and the policies it screens on."
+        )
+    print(f"Open-note screening policies agree: {policies[CAIRO_SOURCE]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The interceptor needs a target's open-note screening policy to know whether to
screen it, and reads it from the pool over RPC rather than from config, so a
governance change needs no paired deploy. An unresolvable read is null, never a
guessed policy: the caller must fail closed, since an assumed Exempt lets a
deposit through unscreened and an assumed Required mints an attestation the pool
rejects. The default timeout matches this service's elliptic-proxy budget, the
other outbound call between a prove request and its answer; discovery-service's
30s RpcConfig::request_timeout is the closer protocol match but belongs to a
background indexer. check_screening_policies.py exists because no CI job
regenerates the pool ABI from Cairo, so nothing else connects the policy list
Cairo owns to the union this decode narrows to.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/955)
<!-- Reviewable:end -->
