### PR TITLE
feat(proof-interceptor): screen the address an open-note deposit requires

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -40,7 +40,7 @@ The prover runs the screening round-trip in parallel with proving. The sidecar r
 
 | Category                      | Verdict                                             | When                                                                                                                                                                                                                                                                  |
 | ----------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Screened**                  | depends on Elliptic                                 | Single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` carrying a Deposit action. The depositor address (`user_addr`, `inner_calldata[0]`) is sent to elliptic-proxy.                                                                                                    |
+| **Screened**                  | depends on Elliptic                                 | Single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` that puts up an address: a Deposit's depositor (`user_addr`), the shadow account an interaction runs through, or an invoke target whose open-note policy is `Required`.                                                                                                    |
 | **Bypass (non-pool)**         | `allow`                                             | Multi-call INVOKEs, calls to contracts other than `SCREENING_POOL_ADDRESS`, and pool calls whose `calldata[0]`/address is non-canonically encoded (`"0x01"`, `"0X1"`, case-mismatched address). Set `SCREENING_BLOCK_NON_POOL_TX=true` to block all of these instead. |
 | **Bypass (pool, no Deposit)** | `allow`                                             | Pool calls with no Deposit action (withdraw-only) or whose action span fails to decode (most often ABI drift). **Not affected by `SCREENING_BLOCK_NON_POOL_TX`** — this toggle only changes the non-pool branch.                                                      |
 | **Blocked**                   | RPC error `10000`                                   | Sanctioned `user_addr`, screening-pipeline failure with fail-closed defaults, or any unhandled exception inside an interceptor (caught and converted to a block with the exception message as the reason).                                                            |
@@ -67,8 +67,10 @@ Required when screening is enabled (the production case):
 | `SCREENING_PARTNER_NAME`   | Partner identifier issued by the proxy operator.                                                                                                        |
 | `SCREENING_PARTNER_SECRET` | Base64-encoded HMAC key issued by the proxy operator.                                                                                                   |
 | `SCREENING_POOL_ADDRESS`   | Privacy-pool contract address — only direct calls to this address are screened.                                                                         |
+| `SCREENING_RPC_URL`        | Starknet JSON-RPC endpoint, used to read the pool's open-note screening policies.                                                                       |
+| `SCREENING_ANONYMIZER_ADDRESS` | Shadow account anonymizer. Its interactions are screened on the shadow account they run through, derived locally.                                    |
 
-Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. Optional knobs (`SCREENING_TIMEOUT_MS`, `SCREENING_TOTAL_TIMEOUT_MS`, `SCREENING_MAX_RETRIES`, `SCREENING_FAIL_OPEN`, `PORT`, `HOST`, `MAX_BODY_BYTES`, `TLS_CERT_PATH`/`TLS_KEY_PATH`) and their defaults are in `src/config.ts`. Note: `SCREENING_FAIL_OPEN` does **not** apply to the screening-v2 signing path — a deposit without a signature cannot proceed on-chain, so a signing failure always fails closed.
+Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. Optional knobs (`SCREENING_TIMEOUT_MS`, `SCREENING_TOTAL_TIMEOUT_MS`, `SCREENING_MAX_RETRIES`, `SCREENING_FAIL_OPEN`, `SCREENING_POLICY_TTL_MS`, `SCREENING_POLICY_TIMEOUT_MS`, `PORT`, `HOST`, `MAX_BODY_BYTES`, `TLS_CERT_PATH`/`TLS_KEY_PATH`) and their defaults are in `src/config.ts`. Note: `SCREENING_FAIL_OPEN` does **not** apply to the screening-v2 signing path — a deposit without a signature cannot proceed on-chain, so a signing failure always fails closed.
 
 ## HTTP endpoints
 
@@ -80,7 +82,7 @@ Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. O
 
 ### Request
 
-The body mirrors `starknet_proveTransaction` exactly (object or positional params). The screened shape is a single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` with `calldata = [call_count=1, contract_address=pool, selector, inner_len, user_addr, user_private_key, ...action_span]`. The action span is decoded against `PrivacyPoolABI`; only the Deposit variant triggers a screen. See `src/rpc.ts` for envelope validation and the calldata-layout comments above `isSinglePoolCall` in `src/pool-transaction.ts` for the field-by-field breakdown.
+The body mirrors `starknet_proveTransaction` exactly (object or positional params). The screened shape is a single direct INVOKE-v3 to `SCREENING_POOL_ADDRESS` with `calldata = [call_count=1, contract_address=pool, selector, inner_len, user_addr, user_private_key, ...action_span]`. The action span is decoded against `PrivacyPoolABI`. A Deposit triggers a screen of its depositor, and an invoke funding open notes triggers one of either the shadow account it runs through or the target itself, depending on the target's policy. See `src/rpc.ts` for envelope validation and the calldata-layout comments above `isSinglePoolCall` in `src/pool-transaction.ts` for the field-by-field breakdown.
 
 ### Response shapes
 
@@ -168,6 +170,8 @@ SCREENING_URL=https://<proxy-host> \
 SCREENING_PARTNER_NAME=<partner-name> \
 SCREENING_PARTNER_SECRET=<base64-secret> \
 SCREENING_POOL_ADDRESS=0x... \
+SCREENING_RPC_URL=https://<starknet-rpc> \
+SCREENING_ANONYMIZER_ADDRESS=0x... \
 PORT=8080 \
 npm start
 ```
@@ -184,6 +188,7 @@ npm start
 | `src/interceptor.ts`           | Parallel interceptor runner with first-block-wins semantics                                              |
 | `src/pool-transaction.ts`      | Pool-call gate and client-action decoding of a prove request's calldata                                  |
 | `src/shadow-account.ts`        | The shadow account interaction a transaction runs on the anonymizer, from its decoded actions            |
+| `src/screened-address.ts`      | The address a transaction is screened for: depositor, shadow account, or a `Required` invoke target      |
 | `src/screening-policy.ts`      | Open-note screening policies read from the pool over RPC, cached per depositor with an LRU TTL           |
 | `src/screening-interceptor.ts` | Deposit detection, address extraction, retry/timeout, HMAC-signed call to elliptic-proxy                 |
 | `src/types.ts`                 | JSON-RPC and `ProveTxnV3` types                                                                          |

--- a/proof-interceptor/src/config.ts
+++ b/proof-interceptor/src/config.ts
@@ -1,5 +1,9 @@
 // src/config.ts
 
+import {
+  DEFAULT_POLICY_TIMEOUT_MS,
+  DEFAULT_POLICY_TTL_MS,
+} from "./screening-policy.js";
 import type { ScreeningConfig } from "./screening-interceptor.js";
 
 export const DEFAULT_MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MB
@@ -42,6 +46,19 @@ export function loadConfig(): Config {
       maxRetries: parseIntEnv("SCREENING_MAX_RETRIES", 2),
       totalTimeoutMs: parseIntEnv("SCREENING_TOTAL_TIMEOUT_MS", 10000),
       poolAddress: requiredEnv("SCREENING_POOL_ADDRESS"),
+      // Screening reads the pool's open-note policies over RPC and derives shadow account addresses
+      // locally, so neither endpoint can be defaulted. Both are required as soon as screening is on,
+      // which fails at startup rather than per transaction.
+      rpcUrl: requiredEnv("SCREENING_RPC_URL"),
+      anonymizerAddress: requiredEnv("SCREENING_ANONYMIZER_ADDRESS"),
+      policyTtlMs: parseIntEnv(
+        "SCREENING_POLICY_TTL_MS",
+        DEFAULT_POLICY_TTL_MS
+      ),
+      policyTimeoutMs: parseIntEnv(
+        "SCREENING_POLICY_TIMEOUT_MS",
+        DEFAULT_POLICY_TIMEOUT_MS
+      ),
       blockNonPoolTx: process.env.SCREENING_BLOCK_NON_POOL_TX === "true",
     };
   }

--- a/proof-interceptor/src/screened-address.ts
+++ b/proof-interceptor/src/screened-address.ts
@@ -1,0 +1,159 @@
+// src/screened-address.ts
+import { CairoCustomEnum, num } from "starknet";
+import { decodeClientActions, normalizeFelt } from "./pool-transaction.js";
+import type { PoolCallActions } from "./pool-transaction.js";
+import type { ProveTxnV3 } from "./types.js";
+import { getShadowAccountAddress } from "./shadow-account.js";
+import type { OpenNoteScreeningPolicyClient } from "./screening-policy.js";
+
+type PolicyReader = Pick<OpenNoteScreeningPolicyClient, "getPolicy">;
+
+export interface ScreenedAddressConfig {
+  poolAddress: string;
+  anonymizerAddress: string;
+}
+
+type InvokeAction = "InvokeExternal" | "ComputeAndInvoke";
+
+/**
+ * The contract whose invoke funds a transaction's open notes — the one the pool holds an open-note
+ * policy for — and the action it is driven through.
+ */
+interface OpenNoteDepositor {
+  address: string;
+  action: InvokeAction;
+}
+
+/** The pool takes one attestation per transaction, so a delegated depositor puts up at most one address. */
+type DelegatedAddress = Extract<
+  ScreenedAddress,
+  {
+    kind: "one" | "none" | "unknownDelegate" | "undeterminedShadowAccount";
+  }
+>;
+
+export type ScreenedAddress =
+  | { kind: "none" }
+  | { kind: "one"; address: string }
+  | { kind: "conflict" }
+  | { kind: "unreadablePolicy" }
+  | { kind: "unknownDelegate" }
+  | { kind: "undeterminedShadowAccount" };
+
+/**
+ * The address a prove request must be screened for.
+ *
+ * Screening an address the pool did not ask for is not a harmless extra: it rejects an attestation
+ * it has no subject for with `UNEXPECTED_SCREENING`.
+ */
+export async function getScreenedAddress(
+  transaction: ProveTxnV3,
+  config: ScreenedAddressConfig,
+  policyReader: PolicyReader
+): Promise<ScreenedAddress> {
+  // Calldata the pool cannot parse reverts on its own, so nothing in it needs screening.
+  const poolCall = decodeClientActions(transaction, config.poolAddress);
+  if (poolCall === null) return { kind: "none" };
+
+  const addresses = new Set<string>();
+
+  // A deposit is screened on its own depositor. The screening policy list does not apply to a
+  // `TransferFrom` the user signs for themselves.
+  if (poolCall.actions.some((action) => action.activeVariant() === "Deposit")) {
+    addresses.add(poolCall.userAddress);
+  }
+
+  const openNoteDepositor = getOpenNoteDepositor(poolCall.actions);
+  if (openNoteDepositor !== null) {
+    const policy = await policyReader.getPolicy(openNoteDepositor.address);
+    switch (policy) {
+      case "Exempt":
+        break;
+
+      case "Required":
+        addresses.add(openNoteDepositor.address);
+        break;
+
+      case "Delegated": {
+        const delegated = getDelegatedAddress(
+          poolCall,
+          openNoteDepositor,
+          config
+        );
+        if (delegated.kind === "one") addresses.add(delegated.address);
+        else if (delegated.kind !== "none") return delegated;
+        break;
+      }
+
+      case null:
+        return { kind: "unreadablePolicy" };
+
+      default:
+        return unscreenableUnderUnhandledPolicy(policy);
+    }
+  }
+
+  if (addresses.size > 1) return { kind: "conflict" };
+  const [address] = addresses;
+  return address === undefined ? { kind: "none" } : { kind: "one", address };
+}
+
+/** The address a delegated open-note depositor puts up for the deposits its invoke funds. */
+function getDelegatedAddress(
+  poolCall: PoolCallActions,
+  openNoteDepositor: OpenNoteDepositor,
+  { anonymizerAddress }: ScreenedAddressConfig
+): DelegatedAddress {
+  // A plain invoke is exempt under `Delegated`; only a compute-invoke puts up an address.
+  if (openNoteDepositor.action !== "ComputeAndInvoke") return { kind: "none" };
+
+  if (openNoteDepositor.address !== normalizeFelt(anonymizerAddress)) {
+    console.error(JSON.stringify({ error: "unknown_delegated_depositor" }));
+    return { kind: "unknownDelegate" };
+  }
+
+  const shadowAccount = getShadowAccountAddress(poolCall, anonymizerAddress);
+  if (shadowAccount === null) {
+    console.error(JSON.stringify({ error: "shadow_account_undetermined" }));
+    return { kind: "undeterminedShadowAccount" };
+  }
+  return { kind: "one", address: shadowAccount };
+}
+
+/**
+ * Under the invariant that an open note must be funded within the transaction that creates it, any
+ * transaction carrying a `CreateOpenNote` action has an open-note depositor.
+ */
+function getOpenNoteDepositor(
+  actions: CairoCustomEnum[]
+): OpenNoteDepositor | null {
+  if (!actions.some((action) => action.activeVariant() === "CreateOpenNote")) {
+    return null;
+  }
+  for (const action of actions) {
+    const variant = action.activeVariant();
+    if (variant !== "InvokeExternal" && variant !== "ComputeAndInvoke")
+      continue;
+    const { contract_address } = action.unwrap() as {
+      contract_address: bigint;
+    };
+    return {
+      address: normalizeFelt(num.toHex(contract_address)),
+      action: variant,
+    };
+  }
+  return null;
+}
+
+/**
+ * Refuses a policy the switch above does not handle, and fails closed if one reaches it at runtime.
+ * The `never` parameter is the point: `scripts/check_screening_policies.py` keeps
+ * {@link OpenNoteScreeningPolicy} tracking the Cairo enum, so a new variant fails to compile here
+ * instead of falling through and screening nobody.
+ */
+function unscreenableUnderUnhandledPolicy(policy: never): ScreenedAddress {
+  console.error(
+    JSON.stringify({ error: "screening_policy_unavailable", policy })
+  );
+  return { kind: "unreadablePolicy" };
+}

--- a/proof-interceptor/src/screening-interceptor.ts
+++ b/proof-interceptor/src/screening-interceptor.ts
@@ -5,7 +5,10 @@ import type {
   TransactionInterceptor,
   Verdict,
 } from "./interceptor.js";
-import { decodeClientActions, isSinglePoolCall } from "./pool-transaction.js";
+import { isSinglePoolCall } from "./pool-transaction.js";
+import { OpenNoteScreeningPolicyClient } from "./screening-policy.js";
+import { getScreenedAddress } from "./screened-address.js";
+import type { ScreenedAddress } from "./screened-address.js";
 import type { ProveTxnV3 } from "./types.js";
 import {
   screeningResults,
@@ -26,6 +29,10 @@ export interface ScreeningConfig {
   maxRetries: number;
   totalTimeoutMs: number;
   poolAddress: string;
+  rpcUrl: string;
+  anonymizerAddress: string;
+  policyTtlMs: number;
+  policyTimeoutMs: number;
   // When true, transactions that are not a single direct INVOKE call to
   // `poolAddress` are blocked outright. When false (default), such transactions
   // bypass screening and are allowed through.
@@ -36,26 +43,19 @@ export interface ScreeningConfig {
 const HEX_FELT = /^0x[0-9a-fA-F]{1,64}$/;
 
 /**
- * Extracts addresses that need screening from a privacy pool transaction,
- * but only if the transaction is a single direct call to the pool and
- * contains a Deposit action.
- *
- * Returns `[]` for non-pool transactions and for pool transactions that
- * carry no Deposit action (e.g., Withdraw-only). Whether non-pool
- * transactions are then allowed through or blocked is decided by the
- * caller via `ScreeningConfig.blockNonPoolTx`.
+ * The opaque code each unresolved screening subject blocks with: they reach the client as JSON-RPC
+ * error `data`, so they must not reveal an address. Keying by the kinds makes a new one a compile
+ * error rather than a kind that falls through to being screened.
  */
-export function getScreenedAddresses(
-  transaction: ProveTxnV3,
-  poolAddress: string
-): string[] {
-  const poolCall = decodeClientActions(transaction, poolAddress);
-  if (poolCall === null) return [];
-  const hasDeposit = poolCall.actions.some(
-    (action) => action.activeVariant() === "Deposit"
-  );
-  return hasDeposit ? [poolCall.userAddress] : [];
-}
+const UNRESOLVED_SUBJECT_REASONS: Record<
+  Exclude<ScreenedAddress["kind"], "one" | "none">,
+  string
+> = {
+  conflict: "multiple_screening_subjects",
+  unreadablePolicy: "screening_policy_unavailable",
+  unknownDelegate: "unknown_delegated_depositor",
+  undeterminedShadowAccount: "shadow_account_undetermined",
+};
 
 type SignOutcome =
   | { result: "allowed"; signature: ScreeningSignature }
@@ -65,7 +65,16 @@ type SignOutcome =
 export class ScreeningInterceptor implements TransactionInterceptor {
   readonly name = "screening";
 
-  constructor(private readonly config: ScreeningConfig) {}
+  private readonly policies: OpenNoteScreeningPolicyClient;
+
+  constructor(private readonly config: ScreeningConfig) {
+    this.policies = new OpenNoteScreeningPolicyClient({
+      rpcUrl: config.rpcUrl,
+      poolAddress: config.poolAddress,
+      ttlMs: config.policyTtlMs,
+      timeoutMs: config.policyTimeoutMs,
+    });
+  }
 
   async intercept(transaction: ProveTxnV3): Promise<Verdict> {
     if (!isSinglePoolCall(transaction, this.config.poolAddress)) {
@@ -86,18 +95,21 @@ export class ScreeningInterceptor implements TransactionInterceptor {
       return { action: "allow" };
     }
 
-    const addresses = getScreenedAddresses(
+    const screened = await getScreenedAddress(
       transaction,
-      this.config.poolAddress
+      this.config,
+      this.policies
     );
-    if (addresses.length === 0) return { action: "allow" };
+    if (screened.kind === "none") return { action: "allow" };
+    if (screened.kind !== "one") {
+      return {
+        action: "block",
+        reason: UNRESOLVED_SUBJECT_REASONS[screened.kind],
+      };
+    }
 
-    // A deposit yields exactly one screened address: the depositor (user_addr),
-    // which the contract binds to the proven TransferFrom.from_addr. Screen and
-    // sign it in one /screen call. Reasons are opaque codes — they surface to
-    // the client as JSON-RPC error `data` and must not reveal the depositor.
-    const depositor = addresses[0];
-    const outcome = await this.screenAndSign(depositor);
+    // One address per transaction, screened and signed in one `/screen` call.
+    const outcome = await this.screenAndSign(screened.address);
     if (outcome.result === "blocked") {
       return { action: "block", reason: "address_blocked" };
     }

--- a/proof-interceptor/tests/config.test.ts
+++ b/proof-interceptor/tests/config.test.ts
@@ -1,6 +1,20 @@
 // tests/config.test.ts
 import { describe, it, expect, beforeEach } from "vitest";
 import { loadConfig } from "../src/config.js";
+import {
+  DEFAULT_POLICY_TIMEOUT_MS,
+  DEFAULT_POLICY_TTL_MS,
+} from "../src/screening-policy.js";
+
+/** The env every screening test needs: `loadConfig` requires all of these once screening is on. */
+function setScreeningEnv(): void {
+  process.env.SCREENING_URL = "http://elliptic-proxy:3000";
+  process.env.SCREENING_PARTNER_NAME = "test-partner";
+  process.env.SCREENING_PARTNER_SECRET = "c2VjcmV0";
+  process.env.SCREENING_POOL_ADDRESS = "0xpool";
+  process.env.SCREENING_RPC_URL = "http://starknet-rpc:5050";
+  process.env.SCREENING_ANONYMIZER_ADDRESS = "0xanonymizer";
+}
 
 describe("loadConfig", () => {
   const originalEnv = process.env;
@@ -14,6 +28,8 @@ describe("loadConfig", () => {
     delete process.env.MAX_BODY_BYTES;
     delete process.env.TLS_CERT_PATH;
     delete process.env.TLS_KEY_PATH;
+    delete process.env.SCREENING_POLICY_TTL_MS;
+    delete process.env.SCREENING_POLICY_TIMEOUT_MS;
   });
 
   it("loads config from env vars", () => {
@@ -76,10 +92,7 @@ describe("loadConfig", () => {
   });
 
   it("loads screening config when SCREENING_URL is set", () => {
-    process.env.SCREENING_URL = "http://elliptic-proxy:3000";
-    process.env.SCREENING_PARTNER_NAME = "test-partner";
-    process.env.SCREENING_PARTNER_SECRET = "c2VjcmV0";
-    process.env.SCREENING_POOL_ADDRESS = "0xpool";
+    setScreeningEnv();
 
     const config = loadConfig();
     expect(config.screening).toEqual({
@@ -91,15 +104,38 @@ describe("loadConfig", () => {
       maxRetries: 2,
       totalTimeoutMs: 10000,
       poolAddress: "0xpool",
+      rpcUrl: "http://starknet-rpc:5050",
+      anonymizerAddress: "0xanonymizer",
+      policyTtlMs: DEFAULT_POLICY_TTL_MS,
+      policyTimeoutMs: DEFAULT_POLICY_TIMEOUT_MS,
       blockNonPoolTx: false,
     });
   });
 
+  it.each(["SCREENING_RPC_URL", "SCREENING_ANONYMIZER_ADDRESS"])(
+    "refuses to start with screening on and %s missing",
+    (missing) => {
+      // Failing at startup beats failing per transaction: without either value the interceptor
+      // cannot resolve a policy or derive a shadow account, so every affected flow would block.
+      setScreeningEnv();
+      delete process.env[missing];
+
+      expect(() => loadConfig()).toThrow(`${missing} env var is required`);
+    }
+  );
+
+  it("takes the policy TTL and timeout from the env", () => {
+    setScreeningEnv();
+    process.env.SCREENING_POLICY_TTL_MS = "5000";
+    process.env.SCREENING_POLICY_TIMEOUT_MS = "250";
+
+    const config = loadConfig();
+    expect(config.screening?.policyTtlMs).toBe(5000);
+    expect(config.screening?.policyTimeoutMs).toBe(250);
+  });
+
   it("enables blockNonPoolTx when SCREENING_BLOCK_NON_POOL_TX is 'true'", () => {
-    process.env.SCREENING_URL = "http://elliptic-proxy:3000";
-    process.env.SCREENING_PARTNER_NAME = "test-partner";
-    process.env.SCREENING_PARTNER_SECRET = "c2VjcmV0";
-    process.env.SCREENING_POOL_ADDRESS = "0xpool";
+    setScreeningEnv();
     process.env.SCREENING_BLOCK_NON_POOL_TX = "true";
 
     const config = loadConfig();
@@ -107,10 +143,7 @@ describe("loadConfig", () => {
   });
 
   it("leaves blockNonPoolTx false for any value other than 'true'", () => {
-    process.env.SCREENING_URL = "http://elliptic-proxy:3000";
-    process.env.SCREENING_PARTNER_NAME = "test-partner";
-    process.env.SCREENING_PARTNER_SECRET = "c2VjcmV0";
-    process.env.SCREENING_POOL_ADDRESS = "0xpool";
+    setScreeningEnv();
     process.env.SCREENING_BLOCK_NON_POOL_TX = "1";
 
     const config = loadConfig();

--- a/proof-interceptor/tests/pool-call.ts
+++ b/proof-interceptor/tests/pool-call.ts
@@ -1,19 +1,20 @@
 // tests/pool-call.ts
 import { vi } from "vitest";
 import { CairoCustomEnum, CallData, num } from "starknet";
-import { PrivacyPoolABI } from "@starkware-libs/starknet-privacy-sdk/abi";
 import { ShadowAccountAnonymizerABI } from "@starkware-libs/starknet-privacy-sdk";
+import { poolCallData } from "../src/pool-transaction.js";
 import type { ProveTxnV3 } from "../src/types.js";
 
 export const POOL_ADDR = "0x9001";
 export const USER_ADDR = "0xaaa111";
 export const PRIVATE_KEY = "0xbbb222";
 export const TOKEN = "0xdead";
+export const AMOUNT = "0x64";
 export const ANONYMIZER_ADDR = "0x5678";
+export const SWAP_EXECUTOR = "0xe0e0";
 export const DAPP_NAME = 0x646170n;
 export const NONCE = 7n;
 
-const poolCallData = new CallData(PrivacyPoolABI);
 const anonymizerCallData = new CallData(ShadowAccountAnonymizerABI);
 
 /** One dapp call, standing in for whatever the shadow account is asked to run. */
@@ -75,6 +76,78 @@ export function poolCallTransaction(actions: CairoCustomEnum[]): ProveTxnV3 {
     nonce_data_availability_mode: "L1",
     fee_data_availability_mode: "L1",
   } as unknown as ProveTxnV3;
+}
+
+/**
+ * A prove request written as raw felts, so a test can express calldata no compiler would produce:
+ * a bad length prefix, an unprefixed address, a call count other than one.
+ */
+export function rawPoolCallTransaction(
+  calldataOverride?: string[]
+): ProveTxnV3 {
+  return {
+    type: "INVOKE",
+    version: "0x3",
+    sender_address: "0xcontract",
+    calldata: calldataOverride ?? [
+      "0x1", // 1 call
+      POOL_ADDR, // call.to
+      "0xselector", // call.selector (not decoded)
+      "0x6", // inner calldata length
+      USER_ADDR,
+      PRIVATE_KEY,
+      "0x1", // 1 action
+      "0x5", // Deposit variant
+      TOKEN,
+      AMOUNT,
+    ],
+    signature: ["0x1"],
+    nonce: "0x0",
+    resource_bounds: {},
+    tip: "0x0",
+    paymaster_data: [],
+    account_deployment_data: [],
+    nonce_data_availability_mode: "L1",
+    fee_data_availability_mode: "L1",
+  } as unknown as ProveTxnV3;
+}
+
+/** The client action that creates the open note an invoke then funds. */
+export function createOpenNoteAction(): CairoCustomEnum {
+  return new CairoCustomEnum({
+    CreateOpenNote: {
+      recipient_addr: USER_ADDR,
+      recipient_public_key: "0x9",
+      token: TOKEN,
+      index: 0,
+      random: "0xa",
+    },
+  });
+}
+
+/** A plain invoke on `target`, the shape a swap or lending executor is driven through. */
+export function invokeExternalAction(target: string): CairoCustomEnum {
+  return new CairoCustomEnum({
+    InvokeExternal: { contract_address: target, calldata: ["0x1"] },
+  });
+}
+
+/**
+ * A `ComputeAndInvoke` on `target` settling `openNotes`. The invoke data is compiled through the
+ * anonymizer ABI, so a Cairo-side change to its arguments reaches these tests instead of leaving
+ * hand-written felts that still decode into something.
+ */
+export function computeAndInvokeAction(
+  target = ANONYMIZER_ADDR,
+  openNotes: unknown[] = OPEN_NOTES
+): CairoCustomEnum {
+  return new CairoCustomEnum({
+    ComputeAndInvoke: {
+      contract_address: target,
+      compute_additional_data: [DAPP_NAME, NONCE],
+      invoke_additional_data: invokeAdditionalData(openNotes),
+    },
+  });
 }
 
 /** Silences a fail-closed path's error log, and returns the spy to assert on. */

--- a/proof-interceptor/tests/pool-transaction.test.ts
+++ b/proof-interceptor/tests/pool-transaction.test.ts
@@ -1,13 +1,18 @@
 // tests/pool-transaction.test.ts
 import { describe, it, expect } from "vitest";
-import { decodeClientActions } from "../src/pool-transaction.js";
-import { getScreenedAddresses } from "../src/screening-interceptor.js";
 import {
+  decodeClientActions,
+  isSinglePoolCall,
+} from "../src/pool-transaction.js";
+import {
+  AMOUNT,
   POOL_ADDR,
   PRIVATE_KEY,
+  TOKEN,
   USER_ADDR,
   depositAction,
   poolCallTransaction,
+  rawPoolCallTransaction,
 } from "./pool-call.js";
 
 describe("decodeClientActions", () => {
@@ -35,16 +40,355 @@ describe("decodeClientActions", () => {
     expect(poolCall?.viewingKey).toBe(BigInt(PRIVATE_KEY));
   });
 
-  it("still screens the deposit when only the viewing key is unparseable", () => {
-    // The key felt is caller-controlled, and only shadow account derivation reads it. Voiding the
+  it("survives an unparseable viewing key, keeping the rest of the decode", () => {
+    // The key felt is caller-controlled and only shadow account derivation reads it. Voiding the
     // whole decode over it would drop the transaction out of screening altogether, which for a
-    // deposit means letting it through unscreened.
+    // deposit means letting it through unscreened. `screened-address.test.ts` pins that end.
     const transaction = poolCallTransaction([depositAction()]);
     transaction.calldata[5] = "not-a-felt";
 
     const poolCall = decodeClientActions(transaction, POOL_ADDR);
     expect(poolCall?.userAddress).toBe(USER_ADDR);
     expect(poolCall?.viewingKey).toBeNull();
-    expect(getScreenedAddresses(transaction, POOL_ADDR)).toEqual([USER_ADDR]);
   });
+});
+
+describe("decodeClientActions on raw calldata", () => {
+  it("decodes user_addr from a deposit transaction", () => {
+    const poolCall = decodeClientActions(rawPoolCallTransaction(), POOL_ADDR);
+    expect(poolCall?.userAddress).toBe(USER_ADDR);
+  });
+
+  it("returns empty when contract address does not match pool address", () => {
+    const poolCall = decodeClientActions(rawPoolCallTransaction(), "0xother");
+    expect(poolCall).toBeNull();
+  });
+
+  it("matches pool address regardless of leading zeros", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction([
+        "0x1",
+        "0x00000abc",
+        "0xsel",
+        "0x6",
+        USER_ADDR,
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]),
+      "0xabc"
+    );
+    expect(poolCall?.userAddress).toBe(USER_ADDR);
+  });
+
+  it("returns empty for short calldata", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction(["0x1", POOL_ADDR, "0xsel"]),
+      POOL_ADDR
+    );
+    expect(poolCall).toBeNull();
+  });
+
+  it("normalizes addresses by stripping leading zeros", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction([
+        "0x1",
+        POOL_ADDR,
+        "0xsel",
+        "0x6",
+        "0x00004a1b2c",
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]),
+      POOL_ADDR
+    );
+    expect(poolCall?.userAddress).toBe("0x4a1b2c");
+  });
+
+  it("normalizes all-zero address to 0x0", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction([
+        "0x1",
+        POOL_ADDR,
+        "0xsel",
+        "0x6",
+        "0x0000000000",
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]),
+      POOL_ADDR
+    );
+    expect(poolCall?.userAddress).toBe("0x0");
+  });
+
+  it("returns empty when inner_calldata_len is too small", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction(["0x1", POOL_ADDR, "0xsel", "0x2", "0x1", "0x2"]),
+      POOL_ADDR
+    );
+    expect(poolCall).toBeNull();
+  });
+
+  it("returns empty when inner_calldata_len is not valid hex", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction(["0x1", POOL_ADDR, "0xsel", "not-hex", "0x1"]),
+      POOL_ADDR
+    );
+    expect(poolCall).toBeNull();
+  });
+
+  it("handles address without 0x prefix", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction([
+        "0x1",
+        POOL_ADDR,
+        "0xsel",
+        "0x6",
+        "4a1b2c",
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]),
+      POOL_ADDR
+    );
+    expect(poolCall?.userAddress).toBe("0x4a1b2c");
+  });
+
+  it("returns empty when calldata[0] is not 0x1", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction(["0x2", POOL_ADDR, "0xsel", "0x6", "0x1"]),
+      POOL_ADDR
+    );
+    expect(poolCall).toBeNull();
+  });
+
+  // Attackers must not be able to dodge the single-pool-call check by
+  // submitting equivalent encodings of 1 (uppercase prefix, leading zeros,
+  // bare "1" with no prefix). All of these are the same felt value.
+  it.each([["0X1"], ["0x01"], ["0x001"], ["0x0001"], ["1"]])(
+    "treats %s as a single-call count (no normalization bypass)",
+    (callCount) => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          callCount,
+          POOL_ADDR,
+          "0xselector",
+          "0x6",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x1",
+          "0x5",
+          TOKEN,
+          AMOUNT,
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.userAddress).toBe(USER_ADDR);
+    }
+  );
+
+  it("matches pool address regardless of 0X vs 0x prefix casing", () => {
+    const poolCall = decodeClientActions(
+      rawPoolCallTransaction([
+        "0x1",
+        "0XABC",
+        "0xselector",
+        "0x6",
+        USER_ADDR,
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]),
+      "0xabc"
+    );
+    expect(poolCall?.userAddress).toBe(USER_ADDR);
+  });
+
+  describe("deposit-only screening", () => {
+    it("decodes a transaction whose only action is SetViewingKey", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0x5",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x1", // 1 action
+          "0x0", // SetViewingKey
+          "0xabc", // random
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.actions.map((action) => action.activeVariant())).toEqual(
+        ["SetViewingKey"]
+      );
+    });
+
+    it("decodes a transaction whose only action is Withdraw", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0x8",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x1", // 1 action
+          "0x7", // Withdraw
+          "0x111", // to_addr
+          TOKEN,
+          AMOUNT,
+          "0xabc", // random
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.actions.map((action) => action.activeVariant())).toEqual(
+        ["Withdraw"]
+      );
+    });
+
+    it("decodes user_addr when a deposit follows other actions", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0x8",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x2", // 2 actions
+          "0x0", // SetViewingKey
+          "0xabc",
+          "0x5", // Deposit
+          TOKEN,
+          AMOUNT,
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.userAddress).toBe(USER_ADDR);
+    });
+
+    it("decodes user_addr past an InvokeExternal action", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0xc",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x2", // 2 actions
+          "0x8", // InvokeExternal
+          "0x222", // contract_address
+          "0x2",
+          "0xa",
+          "0xb", // Span<felt252> len=2
+          "0x5", // Deposit
+          TOKEN,
+          AMOUNT,
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.userAddress).toBe(USER_ADDR);
+    });
+
+    it("decodes a transaction carrying no actions", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0x3",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x0", // 0 actions
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall?.actions.map((action) => action.activeVariant())).toEqual(
+        []
+      );
+    });
+
+    it("returns null on malformed calldata, so nothing is screened", () => {
+      const poolCall = decodeClientActions(
+        rawPoolCallTransaction([
+          "0x1",
+          POOL_ADDR,
+          "0xsel",
+          "0x4",
+          USER_ADDR,
+          PRIVATE_KEY,
+          "0x1", // 1 action
+          "0xff", // invalid variant index
+        ]),
+        POOL_ADDR
+      );
+      expect(poolCall).toBeNull();
+    });
+  });
+});
+
+describe("isSinglePoolCall", () => {
+  it("returns true for a single-call INVOKE targeting the pool", () => {
+    expect(isSinglePoolCall(rawPoolCallTransaction(), POOL_ADDR)).toBe(true);
+  });
+
+  it("returns false when the target contract is not the pool", () => {
+    expect(isSinglePoolCall(rawPoolCallTransaction(), "0xother")).toBe(false);
+  });
+
+  it("returns false for multi-call transactions", () => {
+    const transaction = rawPoolCallTransaction([
+      "0x2", // 2 calls
+      POOL_ADDR,
+      "0xsel",
+      "0x0",
+      "0xother",
+      "0xsel",
+      "0x0",
+    ]);
+    expect(isSinglePoolCall(transaction, POOL_ADDR)).toBe(false);
+  });
+
+  it("returns false for short calldata", () => {
+    expect(
+      isSinglePoolCall(
+        rawPoolCallTransaction(["0x1", POOL_ADDR, "0xsel"]),
+        POOL_ADDR
+      )
+    ).toBe(false);
+  });
+
+  it.each([["0X1"], ["0x01"], ["0x001"]])(
+    "returns true when call_count is %s (normalized to 0x1)",
+    (callCount) => {
+      const transaction = rawPoolCallTransaction([
+        callCount,
+        POOL_ADDR,
+        "0xsel",
+        "0x6",
+        USER_ADDR,
+        PRIVATE_KEY,
+        "0x1",
+        "0x5",
+        TOKEN,
+        AMOUNT,
+      ]);
+      expect(isSinglePoolCall(transaction, POOL_ADDR)).toBe(true);
+    }
+  );
 });

--- a/proof-interceptor/tests/screened-address.test.ts
+++ b/proof-interceptor/tests/screened-address.test.ts
@@ -1,0 +1,349 @@
+// tests/screened-address.test.ts
+import { describe, it, expect } from "vitest";
+import { CairoCustomEnum } from "starknet";
+import {
+  shadowAccountAddress,
+  shadowAccountCommitment,
+  shadowAccountPartialCommitment,
+} from "@starkware-libs/starknet-privacy-sdk";
+import type { OpenNoteScreeningPolicy } from "../src/screening-policy.js";
+import { getScreenedAddress } from "../src/screened-address.js";
+import {
+  ANONYMIZER_ADDR,
+  DAPP_NAME,
+  NONCE,
+  POOL_ADDR,
+  PRIVATE_KEY,
+  SWAP_EXECUTOR,
+  USER_ADDR,
+  computeAndInvokeAction,
+  createOpenNoteAction,
+  depositAction,
+  invokeExternalAction,
+  poolCallTransaction,
+  rawPoolCallTransaction,
+  silenceErrorLog,
+} from "./pool-call.js";
+
+/**
+ * A policy reader answering from `policies`, recording what it was asked. An address absent from
+ * `policies` reads as unresolvable, which is what an RPC failure looks like to the resolver.
+ */
+function fakePolicies(policies: Record<string, OpenNoteScreeningPolicy>) {
+  const asked: string[] = [];
+  return {
+    asked,
+    getPolicy: async (depositor: string) => {
+      asked.push(depositor);
+      return policies[depositor] ?? null;
+    },
+  };
+}
+
+const CONFIG = {
+  poolAddress: POOL_ADDR,
+  anonymizerAddress: ANONYMIZER_ADDR,
+};
+
+async function subjectOf(
+  actions: CairoCustomEnum[],
+  policies: Record<string, OpenNoteScreeningPolicy> = {}
+) {
+  const reader = fakePolicies(policies);
+  const screened = await getScreenedAddress(
+    poolCallTransaction(actions),
+    CONFIG,
+    reader
+  );
+  return { screened, asked: reader.asked };
+}
+
+describe("getScreenedAddress", () => {
+  it("screens the depositor of a plain deposit", async () => {
+    const { screened, asked } = await subjectOf([depositAction()]);
+
+    expect(screened).toEqual({ kind: "one", address: USER_ADDR });
+    // No invoke, so no policy to read: a deposit is screened without touching the pool.
+    expect(asked).toEqual([]);
+  });
+
+  it("screens the depositor even when the viewing key does not parse", async () => {
+    // Only shadow account derivation reads that felt, so a caller cannot drop their own deposit out
+    // of screening by corrupting it.
+    const transaction = poolCallTransaction([depositAction()]);
+    transaction.calldata[5] = "not-a-felt";
+
+    const screened = await getScreenedAddress(
+      transaction,
+      CONFIG,
+      fakePolicies({})
+    );
+
+    expect(screened).toEqual({ kind: "one", address: USER_ADDR });
+  });
+
+  it("screens nobody for a call to a contract other than the pool", async () => {
+    const screened = await getScreenedAddress(
+      poolCallTransaction([depositAction()]),
+      { poolAddress: "0x4321", anonymizerAddress: ANONYMIZER_ADDR },
+      fakePolicies({})
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("screens nobody for calldata that does not decode", async () => {
+    // A transaction the pool cannot parse reverts on its own, so there is nothing to screen for it.
+    const screened = await getScreenedAddress(
+      rawPoolCallTransaction([
+        "0x1",
+        POOL_ADDR,
+        "0xselector",
+        "0x4",
+        USER_ADDR,
+        "0xbbb222",
+        "0x1",
+        "0xff", // no such action variant
+      ]),
+      CONFIG,
+      fakePolicies({})
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("screens nobody when the transaction neither deposits nor invokes", async () => {
+    const { screened } = await subjectOf([createOpenNoteAction()]);
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("screens an unlisted invoke target, which the pool defaults to Required", async () => {
+    const { screened, asked } = await subjectOf(
+      [createOpenNoteAction(), invokeExternalAction(SWAP_EXECUTOR)],
+      { [SWAP_EXECUTOR]: "Required" }
+    );
+
+    expect(screened).toEqual({ kind: "one", address: SWAP_EXECUTOR });
+    expect(asked).toEqual([SWAP_EXECUTOR]);
+  });
+
+  it("screens nobody for an Exempt invoke target", async () => {
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), invokeExternalAction(SWAP_EXECUTOR)],
+      { [SWAP_EXECUTOR]: "Exempt" }
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("screens the shadow account of a Delegated interaction, not the anonymizer", async () => {
+    // Composed here from the transaction's own felts rather than asserted to be "not the
+    // anonymizer": only the value pins which felts the derivation reads, so feeding it the wrong
+    // user address or nonce fails this.
+    const expected = shadowAccountAddress(
+      shadowAccountCommitment(
+        shadowAccountPartialCommitment(
+          BigInt(USER_ADDR),
+          BigInt(PRIVATE_KEY),
+          BigInt(ANONYMIZER_ADDR),
+          DAPP_NAME
+        ),
+        NONCE
+      ),
+      BigInt(ANONYMIZER_ADDR)
+    );
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction()],
+      { [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({
+      kind: "one",
+      address: "0x" + expected.toString(16),
+    });
+  });
+
+  it("screens nobody when the anonymizer is not listed Delegated", async () => {
+    // The devnet suites and the middle of the rollout run the anonymizer as `Exempt`. Screening its
+    // shadow account then is not a harmless extra: the pool has no subject, so the attestation the
+    // prover would attach makes it revert with `UNEXPECTED_SCREENING`.
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction()],
+      { [ANONYMIZER_ADDR]: "Exempt" }
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("screens an unlisted anonymizer as itself, not its shadow account", async () => {
+    // Unlisted is `Required`, under which the pool asks for the target's own address.
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction()],
+      { [ANONYMIZER_ADDR]: "Required" }
+    );
+
+    expect(screened).toEqual({ kind: "one", address: ANONYMIZER_ADDR });
+  });
+
+  it("cannot determine a shadow account for an interaction that settles no open note", async () => {
+    // The open note is created here, so the empty note list is what the resolver reacts to rather
+    // than the missing `CreateOpenNote`. The policy is still read — the invoke is the transaction's
+    // open-note depositor — but the interaction settles nothing, so no shadow account acts and the
+    // pool is left asking for a subject the interceptor cannot name.
+    const { screened, asked } = await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction(ANONYMIZER_ADDR, [])],
+      { [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "undeterminedShadowAccount" });
+    expect(asked).toEqual([ANONYMIZER_ADDR]);
+  });
+
+  it("reads no policy for a transaction that creates no open note", async () => {
+    // The policy list is consulted only for a transaction carrying a `CreateOpenNote`.
+    const { screened, asked } = await subjectOf([computeAndInvokeAction()]);
+
+    expect(screened).toEqual({ kind: "none" });
+    expect(asked).toEqual([]);
+  });
+
+  it("fails closed when the target's policy cannot be read", async () => {
+    const { screened } = await subjectOf([
+      createOpenNoteAction(),
+      invokeExternalAction(SWAP_EXECUTOR),
+    ]);
+
+    expect(screened).toEqual({ kind: "unreadablePolicy" });
+  });
+
+  it("refuses a delegated compute-invoke whose address it cannot compute", async () => {
+    const errorSpy = silenceErrorLog();
+    // Only the anonymizer's shadow account is derivable here. For any other delegated target the
+    // pool asks for an address nothing off chain can name, so refuse rather than let the
+    // transaction reach the pool unattested.
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction(SWAP_EXECUTOR)],
+      { [SWAP_EXECUTOR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "unknownDelegate" });
+    errorSpy.mockRestore();
+  });
+
+  it("screens nobody for a delegated target driven through a plain invoke", async () => {
+    // The pool reads addresses only from a compute-invoke, so a plain invoke from a delegated
+    // depositor is exempt there and must be exempt here too.
+    const { screened } = await subjectOf(
+      [createOpenNoteAction(), invokeExternalAction(SWAP_EXECUTOR)],
+      { [SWAP_EXECUTOR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("never screens a shadow account under another target's policy", async () => {
+    const errorSpy = silenceErrorLog();
+    // Two invoke-phase actions is a transaction the pool rejects, but the interceptor sees it before
+    // the pool does. Both are compute-invokes, so only comparing the funding invoke's own target
+    // keeps the anonymizer's shadow account from riding in on the swap executor's listing: the
+    // derivation would otherwise scan on and find the anonymizer's action by itself.
+    const { screened, asked } = await subjectOf(
+      [
+        createOpenNoteAction(),
+        computeAndInvokeAction(SWAP_EXECUTOR),
+        computeAndInvokeAction(),
+      ],
+      { [SWAP_EXECUTOR]: "Delegated", [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(asked).toEqual([SWAP_EXECUTOR]);
+    expect(screened).toEqual({ kind: "unknownDelegate" });
+    errorSpy.mockRestore();
+  });
+
+  it("says the delegated depositor is unknown when it refuses, without revealing an address", async () => {
+    const errorSpy = silenceErrorLog();
+
+    await subjectOf(
+      [createOpenNoteAction(), computeAndInvokeAction(SWAP_EXECUTOR)],
+      { [SWAP_EXECUTOR]: "Delegated" }
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = String(errorSpy.mock.calls[0][0]);
+    expect(logged).toContain("unknown_delegated_depositor");
+    expect(logged).not.toContain(SWAP_EXECUTOR);
+    errorSpy.mockRestore();
+  });
+
+  it("refuses separately when the anonymizer's shadow account cannot be determined", async () => {
+    // The depositor is one this does know how to resolve; the transaction is what gives it nothing
+    // to resolve from. An unparseable viewing key is a different failure from an unsupported
+    // contract, and the verdict says so.
+    const errorSpy = silenceErrorLog();
+    const transaction = poolCallTransaction([
+      createOpenNoteAction(),
+      computeAndInvokeAction(),
+    ]);
+    transaction.calldata[5] = "not-a-felt";
+
+    const screened = await getScreenedAddress(transaction, CONFIG, {
+      getPolicy: async () => "Delegated" as const,
+    });
+
+    expect(screened).toEqual({ kind: "undeterminedShadowAccount" });
+    expect(String(errorSpy.mock.calls[0][0])).toContain(
+      "shadow_account_undetermined"
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("screens nobody when a plain invoke funds the notes for a delegated target", async () => {
+    const { screened } = await subjectOf(
+      [
+        createOpenNoteAction(),
+        invokeExternalAction(SWAP_EXECUTOR),
+        computeAndInvokeAction(),
+      ],
+      { [SWAP_EXECUTOR]: "Delegated", [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "none" });
+  });
+
+  it("reports a conflict when a deposit and an invoke target disagree", async () => {
+    const { screened } = await subjectOf(
+      [
+        depositAction(),
+        createOpenNoteAction(),
+        invokeExternalAction(SWAP_EXECUTOR),
+      ],
+      { [SWAP_EXECUTOR]: "Required" }
+    );
+
+    expect(screened).toEqual({ kind: "conflict" });
+  });
+
+  it("reports a conflict when a deposit and a shadow account disagree", async () => {
+    const { screened } = await subjectOf(
+      [depositAction(), createOpenNoteAction(), computeAndInvokeAction()],
+      { [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "conflict" });
+  });
+
+  it("dedups an invoke target that is also the depositor", async () => {
+    const { screened } = await subjectOf(
+      [
+        depositAction(),
+        createOpenNoteAction(),
+        invokeExternalAction(USER_ADDR),
+      ],
+      { [USER_ADDR]: "Required" }
+    );
+
+    expect(screened).toEqual({ kind: "one", address: USER_ADDR });
+  });
+});

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -2,20 +2,25 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createHmac } from "node:crypto";
 import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import {
   ScreeningInterceptor,
-  getScreenedAddresses,
   type ScreeningConfig,
 } from "../src/screening-interceptor.js";
-import { isSinglePoolCall } from "../src/pool-transaction.js";
-import type { ProveTxnV3 } from "../src/types.js";
+import {
+  ANONYMIZER_ADDR,
+  POOL_ADDR,
+  SWAP_EXECUTOR,
+  computeAndInvokeAction,
+  createOpenNoteAction,
+  depositAction,
+  invokeExternalAction,
+  poolCallTransaction,
+  rawPoolCallTransaction,
+} from "./pool-call.js";
 
 // Test addresses and values — must be valid hex for ABI decoding
-const USER_ADDR = "0xaaa111";
-const PRIVATE_KEY = "0xbbb222";
-const TOKEN = "0xdead";
-const AMOUNT = "0x64";
-const POOL_ADDR = "0xpool";
+// A real felt: unlike the placeholders above, this one is serialized into an action and decoded.
 
 // The interceptor relays the /screen signature verbatim without verifying it,
 // so a well-shaped (not cryptographically valid) signature is enough here.
@@ -33,317 +38,6 @@ const ALLOW_RESPONSE = {
   signature: MOCK_SIGNATURE,
 };
 const BLOCKED_RESPONSE = { blocked: true, source: "blocklist" };
-
-function sampleTransaction(calldataOverride?: string[]): ProveTxnV3 {
-  return {
-    type: "INVOKE",
-    version: "0x3",
-    sender_address: "0xcontract",
-    calldata: calldataOverride ?? [
-      "0x1", // 1 call
-      "0xpool", // call.to (not decoded)
-      "0xselector", // call.selector (not decoded)
-      "0x6", // inner calldata length
-      USER_ADDR,
-      PRIVATE_KEY,
-      "0x1", // 1 action
-      "0x5", // Deposit variant
-      TOKEN,
-      AMOUNT,
-    ],
-    signature: ["0x1"],
-    nonce: "0x0",
-    resource_bounds: {},
-    tip: "0x0",
-    paymaster_data: [],
-    account_deployment_data: [],
-    nonce_data_availability_mode: "L1",
-    fee_data_availability_mode: "L1",
-  } as unknown as ProveTxnV3;
-}
-
-describe("getScreenedAddresses", () => {
-  it("extracts user_addr when transaction contains a deposit", () => {
-    const addresses = getScreenedAddresses(sampleTransaction(), POOL_ADDR);
-    expect(addresses).toEqual(["0xaaa111"]);
-  });
-
-  it("returns empty when contract address does not match pool address", () => {
-    const addresses = getScreenedAddresses(sampleTransaction(), "0xother");
-    expect(addresses).toEqual([]);
-  });
-
-  it("matches pool address regardless of leading zeros", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction([
-        "0x1",
-        "0x00000abc",
-        "0xsel",
-        "0x6",
-        USER_ADDR,
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]),
-      "0xabc"
-    );
-    expect(addresses).toEqual(["0xaaa111"]);
-  });
-
-  it("returns empty for short calldata", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction(["0x1", POOL_ADDR, "0xsel"]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual([]);
-  });
-
-  it("normalizes addresses by stripping leading zeros", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction([
-        "0x1",
-        POOL_ADDR,
-        "0xsel",
-        "0x6",
-        "0x00004a1b2c",
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual(["0x4a1b2c"]);
-  });
-
-  it("normalizes all-zero address to 0x0", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction([
-        "0x1",
-        POOL_ADDR,
-        "0xsel",
-        "0x6",
-        "0x0000000000",
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual(["0x0"]);
-  });
-
-  it("returns empty when inner_calldata_len is too small", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction(["0x1", POOL_ADDR, "0xsel", "0x2", "0x1", "0x2"]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual([]);
-  });
-
-  it("returns empty when inner_calldata_len is not valid hex", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction(["0x1", POOL_ADDR, "0xsel", "not-hex", "0x1"]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual([]);
-  });
-
-  it("handles address without 0x prefix", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction([
-        "0x1",
-        POOL_ADDR,
-        "0xsel",
-        "0x6",
-        "4a1b2c",
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual(["0x4a1b2c"]);
-  });
-
-  it("returns empty when calldata[0] is not 0x1", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction(["0x2", POOL_ADDR, "0xsel", "0x6", "0x1"]),
-      POOL_ADDR
-    );
-    expect(addresses).toEqual([]);
-  });
-
-  // Attackers must not be able to dodge the single-pool-call check by
-  // submitting equivalent encodings of 1 (uppercase prefix, leading zeros,
-  // bare "1" with no prefix). All of these are the same felt value.
-  it.each([["0X1"], ["0x01"], ["0x001"], ["0x0001"], ["1"]])(
-    "treats %s as a single-call count (no normalization bypass)",
-    (callCount) => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          callCount,
-          POOL_ADDR,
-          "0xselector",
-          "0x6",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x1",
-          "0x5",
-          TOKEN,
-          AMOUNT,
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual(["0xaaa111"]);
-    }
-  );
-
-  it("matches pool address regardless of 0X vs 0x prefix casing", () => {
-    const addresses = getScreenedAddresses(
-      sampleTransaction([
-        "0x1",
-        "0XABC",
-        "0xselector",
-        "0x6",
-        USER_ADDR,
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]),
-      "0xabc"
-    );
-    expect(addresses).toEqual(["0xaaa111"]);
-  });
-
-  describe("deposit-only screening", () => {
-    it("returns empty when actions contain only SetViewingKey (variant 0)", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0x5",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x1", // 1 action
-          "0x0", // SetViewingKey
-          "0xabc", // random
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual([]);
-    });
-
-    it("returns empty when actions contain only Withdraw (variant 7)", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0x8",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x1", // 1 action
-          "0x7", // Withdraw
-          "0x111", // to_addr
-          TOKEN,
-          AMOUNT,
-          "0xabc", // random
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual([]);
-    });
-
-    it("returns address when deposit appears after other actions", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0x8",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x2", // 2 actions
-          "0x0", // SetViewingKey
-          "0xabc",
-          "0x5", // Deposit
-          TOKEN,
-          AMOUNT,
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual(["0xaaa111"]);
-    });
-
-    it("handles InvokeExternal before deposit", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0xc",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x2", // 2 actions
-          "0x8", // InvokeExternal
-          "0x222", // contract_address
-          "0x2",
-          "0xa",
-          "0xb", // Span<felt252> len=2
-          "0x5", // Deposit
-          TOKEN,
-          AMOUNT,
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual(["0xaaa111"]);
-    });
-
-    it("returns empty when action count is zero", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0x3",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x0", // 0 actions
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual([]);
-    });
-
-    it("returns empty on malformed calldata (fail-open)", () => {
-      const addresses = getScreenedAddresses(
-        sampleTransaction([
-          "0x1",
-          POOL_ADDR,
-          "0xsel",
-          "0x4",
-          USER_ADDR,
-          PRIVATE_KEY,
-          "0x1", // 1 action
-          "0xff", // invalid variant index
-        ]),
-        POOL_ADDR
-      );
-      expect(addresses).toEqual([]);
-    });
-  });
-});
 
 // Helper to start a mock elliptic-proxy
 let mockServer: Server;
@@ -383,61 +77,16 @@ function makeConfig(overrides?: Partial<ScreeningConfig>): ScreeningConfig {
     maxRetries: 0,
     totalTimeoutMs: 10000,
     poolAddress: POOL_ADDR,
+    // Unreachable on purpose: none of these transactions runs an invoke, so no policy is read. A
+    // test that reached for one would fail closed instead of silently screening the wrong address.
+    rpcUrl: "http://127.0.0.1:1",
+    anonymizerAddress: ANONYMIZER_ADDR,
+    policyTtlMs: 60_000,
+    policyTimeoutMs: 50,
     blockNonPoolTx: false,
     ...overrides,
   };
 }
-
-describe("isSinglePoolCall", () => {
-  it("returns true for a single-call INVOKE targeting the pool", () => {
-    expect(isSinglePoolCall(sampleTransaction(), POOL_ADDR)).toBe(true);
-  });
-
-  it("returns false when the target contract is not the pool", () => {
-    expect(isSinglePoolCall(sampleTransaction(), "0xother")).toBe(false);
-  });
-
-  it("returns false for multi-call transactions", () => {
-    const transaction = sampleTransaction([
-      "0x2", // 2 calls
-      POOL_ADDR,
-      "0xsel",
-      "0x0",
-      "0xother",
-      "0xsel",
-      "0x0",
-    ]);
-    expect(isSinglePoolCall(transaction, POOL_ADDR)).toBe(false);
-  });
-
-  it("returns false for short calldata", () => {
-    expect(
-      isSinglePoolCall(
-        sampleTransaction(["0x1", POOL_ADDR, "0xsel"]),
-        POOL_ADDR
-      )
-    ).toBe(false);
-  });
-
-  it.each([["0X1"], ["0x01"], ["0x001"]])(
-    "returns true when call_count is %s (normalized to 0x1)",
-    (callCount) => {
-      const transaction = sampleTransaction([
-        callCount,
-        POOL_ADDR,
-        "0xsel",
-        "0x6",
-        USER_ADDR,
-        PRIVATE_KEY,
-        "0x1",
-        "0x5",
-        TOKEN,
-        AMOUNT,
-      ]);
-      expect(isSinglePoolCall(transaction, POOL_ADDR)).toBe(true);
-    }
-  );
-});
 
 describe("ScreeningInterceptor", () => {
   it("attaches the signature to the verdict on an allowed deposit", async () => {
@@ -448,7 +97,7 @@ describe("ScreeningInterceptor", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
 
     const logCall = logSpy.mock.calls.find((call) => {
@@ -471,7 +120,7 @@ describe("ScreeningInterceptor", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       // Opaque code — must NOT leak the depositor address.
@@ -505,7 +154,7 @@ describe("ScreeningInterceptor", () => {
 
     const config = makeConfig();
     const interceptor = new ScreeningInterceptor(config);
-    await interceptor.intercept(sampleTransaction());
+    await interceptor.intercept(rawPoolCallTransaction());
 
     expect(receivedUrl).toBe("/screen");
     expect(receivedHeaders["x-access-key"]).toBe("test-partner");
@@ -534,7 +183,7 @@ describe("ScreeningInterceptor", () => {
 
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(config);
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -558,7 +207,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(config);
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -574,7 +223,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -597,7 +246,7 @@ describe("ScreeningInterceptor", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
     expect(requestCount).toBe(3);
 
@@ -621,7 +270,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -639,7 +288,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -655,7 +304,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -679,7 +328,7 @@ describe("ScreeningInterceptor", () => {
 
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig());
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict.action).toBe("block");
     if (verdict.action === "block") {
       expect(verdict.reason).toBe("screening_unavailable");
@@ -697,7 +346,7 @@ describe("ScreeningInterceptor", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict).toEqual({ action: "block", reason: "address_blocked" });
     // A terminal block short-circuits before the signature check and is never
     // retried, even though maxRetries allows it.
@@ -720,14 +369,14 @@ describe("ScreeningInterceptor", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const interceptor = new ScreeningInterceptor(makeConfig({ maxRetries: 2 }));
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict).toEqual({ action: "block", reason: "address_blocked" });
     expect(requestCount).toBe(3);
     logSpy.mockRestore();
   });
 
   it("allows (no signature) when there is no extractable deposit address", async () => {
-    const transaction = sampleTransaction(["0x0"]);
+    const transaction = rawPoolCallTransaction(["0x0"]);
     const interceptor = new ScreeningInterceptor(
       makeConfig({ ellipticProxyUrl: "http://127.0.0.1:1" })
     );
@@ -743,7 +392,7 @@ describe("ScreeningInterceptor", () => {
         poolAddress: "0xdifferent",
       })
     );
-    const verdict = await interceptor.intercept(sampleTransaction());
+    const verdict = await interceptor.intercept(rawPoolCallTransaction());
     expect(verdict).toEqual({ action: "allow" });
 
     const logEntry = findLogEntry(
@@ -758,6 +407,80 @@ describe("ScreeningInterceptor", () => {
     logSpy.mockRestore();
   });
 
+  describe("screening subjects beyond the depositor", () => {
+    /** A node answering every `starknet_call` with `Delegated`, the anonymizer's production policy. */
+    async function startDelegatedPolicyNode(): Promise<{
+      url: string;
+      close: () => Promise<void>;
+    }> {
+      const node = createServer((request, response) => {
+        request.resume();
+        request.on("end", () => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({ jsonrpc: "2.0", id: 1, result: ["0x2"] })
+          );
+        });
+      });
+      await new Promise<void>((resolve) => node.listen(0, resolve));
+      const { port } = node.address() as AddressInfo;
+      return {
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((resolve) => node.close(() => resolve())),
+      };
+    }
+
+    it("blocks a transaction putting up two addresses", async () => {
+      // A deposit screens its depositor, and the delegated interaction screens its shadow account.
+      // The pool takes one attestation per transaction, so this cannot be satisfied and must not be
+      // signed.
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const policyNode = await startDelegatedPolicyNode();
+      const interceptor = new ScreeningInterceptor(
+        makeConfig({ poolAddress: POOL_ADDR, rpcUrl: policyNode.url })
+      );
+
+      const verdict = await interceptor.intercept(
+        poolCallTransaction([
+          depositAction(),
+          createOpenNoteAction(),
+          computeAndInvokeAction(),
+        ])
+      );
+
+      expect(verdict.action).toBe("block");
+      if (verdict.action === "block") {
+        expect(verdict.reason).toBe("multiple_screening_subjects");
+      }
+      await policyNode.close();
+      logSpy.mockRestore();
+    });
+
+    it("blocks when an invoke target's policy cannot be read", async () => {
+      // `rpcUrl` is unreachable in these tests, so the policy read fails and the flow fails closed
+      // rather than guessing the target is exempt.
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const interceptor = new ScreeningInterceptor(
+        makeConfig({ poolAddress: POOL_ADDR })
+      );
+      const verdict = await interceptor.intercept(
+        poolCallTransaction([
+          createOpenNoteAction(),
+          invokeExternalAction(SWAP_EXECUTOR),
+        ])
+      );
+
+      expect(verdict.action).toBe("block");
+      if (verdict.action === "block") {
+        expect(verdict.reason).toBe("screening_policy_unavailable");
+      }
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
   describe("blockNonPoolTx flag", () => {
     it("blocks transactions whose target is not the pool", async () => {
       const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -768,7 +491,7 @@ describe("ScreeningInterceptor", () => {
           blockNonPoolTx: true,
         })
       );
-      const verdict = await interceptor.intercept(sampleTransaction());
+      const verdict = await interceptor.intercept(rawPoolCallTransaction());
       expect(verdict.action).toBe("block");
       if (verdict.action === "block") {
         expect(verdict.reason).toContain(
@@ -789,7 +512,7 @@ describe("ScreeningInterceptor", () => {
     });
 
     it("blocks multi-call transactions even if a call targets the pool", async () => {
-      const transaction = sampleTransaction([
+      const transaction = rawPoolCallTransaction([
         "0x2", // 2 calls
         POOL_ADDR,
         "0xsel",
@@ -826,7 +549,7 @@ describe("ScreeningInterceptor", () => {
       const interceptor = new ScreeningInterceptor(
         makeConfig({ blockNonPoolTx: true })
       );
-      const verdict = await interceptor.intercept(sampleTransaction());
+      const verdict = await interceptor.intercept(rawPoolCallTransaction());
       expect(verdict).toEqual({ action: "allow", signature: MOCK_SIGNATURE });
 
       // Pool deposits should not emit the "non_pool_tx" log line — they go


### PR DESCRIPTION
Each address is gated on the policy that makes the pool ask for it, because an
attestation the pool has no subject for reverts with UNEXPECTED_SCREENING: a
deposit screens its own depositor, a Required open-note depositor screens
itself, and a Delegated one screens the shadow account its compute-invoke runs
through. Deriving that address is per-contract work implemented for the
anonymizer alone, so any other delegated depositor is refused rather than left
to revert unattested, as is a policy the pool cannot be read for.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/957)
<!-- Reviewable:end -->
