### PR TITLE
feat(proof-interceptor): treat a pool without the policy list as exempting open-note depositors

### DIFF
--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -55,6 +55,7 @@ Defaults are deployment-friendly, not security-strict. Apply these for productio
 - **Choose listener binding deliberately.** The service has no application-level authentication, so the host binding is the security boundary. Prefer `HOST=127.0.0.1` (loopback-only, in-pod sidecar) when metrics can be relayed by the prover or a co-located collector. Use `HOST=0.0.0.0` only when direct Prometheus scraping of the Pod IP is required, and pair it with a NetworkPolicy restricting ingress to the prover and the approved scraper. Co-location in the same Pod is _not_ by itself the boundary: with `HOST=0.0.0.0`, the listener is reachable from any Pod that can route to this Pod's IP.
 - **`TLS_CERT_PATH`/`TLS_KEY_PATH` are server-side TLS only.** They encrypt the prover↔sidecar connection but do _not_ authenticate the client (no `requestCert`/`ca` is configured in `src/server.ts`). For real mTLS, put a service mesh or proxy in front of the sidecar.
 - **Verify `SCREENING_URL` is set.** Without it, the service runs as a no-op pass-through that always returns `allowed: true` — `/health` still reports OK. Confirm `proof_interceptor_screening_results_total` is non-zero on `/metrics`.
+- **Point `SCREENING_RPC_URL` at an endpoint serving JSON-RPC spec ≥ 0.9.** The pre-policy-pool fallback keys on the dedicated entrypoint-miss error (21); an older endpoint reports a generic contract error instead, so every policy read fails closed and open-note deposits block.
 - **Pin `@starkware-libs/starknet-privacy-sdk`** to a version whose `PrivacyPoolABI` matches the deployed pool contract. ABI drift causes silent fail-open on Deposit detection.
 
 ## Configuration
@@ -67,7 +68,7 @@ Required when screening is enabled (the production case):
 | `SCREENING_PARTNER_NAME`   | Partner identifier issued by the proxy operator.                                                                                                        |
 | `SCREENING_PARTNER_SECRET` | Base64-encoded HMAC key issued by the proxy operator.                                                                                                   |
 | `SCREENING_POOL_ADDRESS`   | Privacy-pool contract address — only direct calls to this address are screened.                                                                         |
-| `SCREENING_RPC_URL`        | Starknet JSON-RPC endpoint, used to read the pool's open-note screening policies.                                                                       |
+| `SCREENING_RPC_URL`        | Starknet JSON-RPC endpoint, used to read the pool's open-note screening policies. A pool without the policy entrypoint predates the list and enforces its own block list on chain, so every read answers `Exempt` and this service can deploy before the pool upgrades. |
 | `SCREENING_ANONYMIZER_ADDRESS` | Shadow account anonymizer. Its interactions are screened on the shadow account they run through, derived locally.                                    |
 
 Plus the production toggle `SCREENING_BLOCK_NON_POOL_TX=true` discussed above. Optional knobs (`SCREENING_TIMEOUT_MS`, `SCREENING_TOTAL_TIMEOUT_MS`, `SCREENING_MAX_RETRIES`, `SCREENING_FAIL_OPEN`, `SCREENING_POLICY_TTL_MS`, `SCREENING_POLICY_TIMEOUT_MS`, `PORT`, `HOST`, `MAX_BODY_BYTES`, `TLS_CERT_PATH`/`TLS_KEY_PATH`) and their defaults are in `src/config.ts`. Note: `SCREENING_FAIL_OPEN` does **not** apply to the screening-v2 signing path — a deposit without a signature cannot proceed on-chain, so a signing failure always fails closed.
@@ -128,7 +129,7 @@ Prometheus counters/histograms exported on `/metrics` (defined in `src/metrics.t
 
 - `proof_interceptor_screening_results_total{result}` — `allowed` / `blocked` / `unavailable`. The primary signal that screening is wired up at all.
 - `proof_interceptor_screening_retries_total` — retry attempts only (first attempts excluded).
-- `proof_interceptor_screening_policy_reads_total{result}` — open-note screening policies read from the pool: `Required` / `Exempt` / `Delegated`, or `unavailable` when the read failed and the flow fails closed.
+- `proof_interceptor_screening_policy_reads_total{result}` — open-note screening policies read from the pool: `Required` / `Exempt` / `Delegated`; `pre_policy_pool` when the pool has no policy entrypoint and every open-note depositor reads as exempt; or `unavailable` when the read failed and the flow fails closed.
 - `proof_interceptor_screening_duration_seconds{result}` — Elliptic round-trip latency.
 - `proof_interceptor_interceptor_verdicts_total{interceptor,verdict}` — per-interceptor verdicts.
 - `proof_interceptor_rpc_requests_total{action,method}` and `proof_interceptor_errors_total{type}` — request and error counters.

--- a/proof-interceptor/src/metrics.ts
+++ b/proof-interceptor/src/metrics.ts
@@ -34,7 +34,7 @@ export const screeningResults = new Counter({
 
 export const screeningPolicyReads = new Counter({
   name: "proof_interceptor_screening_policy_reads_total",
-  help: "Total open-note screening policies read from the pool, by policy or 'unavailable'",
+  help: "Total open-note screening policies read from the pool, by policy, 'pre_policy_pool' (a pool without the entrypoint, exempt) or 'unavailable'",
   labelNames: ["result"] as const,
   registers: [registry],
 });

--- a/proof-interceptor/src/screening-policy.ts
+++ b/proof-interceptor/src/screening-policy.ts
@@ -1,6 +1,6 @@
 // src/screening-policy.ts
 import { LRUCache } from "lru-cache";
-import { CairoCustomEnum, RpcProvider } from "starknet";
+import { CairoCustomEnum, RpcError, RpcProvider } from "starknet";
 import { normalizeFelt, poolCallData } from "./pool-transaction.js";
 import { screeningPolicyReads } from "./metrics.js";
 
@@ -70,6 +70,11 @@ export class OpenNoteScreeningPolicyClient {
    * for the same address, or a fresh read; or `null` when the read fails, times out or answers with
    * something that is not a policy. A failed read is never cached, and an expired entry is never
    * served.
+   *
+   * A pool without the policy entrypoint answers `Exempt` for every depositor: such a pool predates
+   * the policy list, asks for no open-note attestations, and enforces its own depositor block list
+   * on chain. The answer is cached like any other, so an upgrade that adds the entrypoint is honored
+   * within one TTL.
    */
   async getPolicy(depositor: string): Promise<OpenNoteScreeningPolicy | null> {
     const address = normalizeFelt(depositor);
@@ -114,6 +119,13 @@ export class OpenNoteScreeningPolicyClient {
       screeningPolicyReads.inc({ result: policy });
       return policy;
     } catch (error) {
+      if (error instanceof RpcError && error.isType("ENTRYPOINT_NOT_FOUND")) {
+        console.log(
+          JSON.stringify({ screening: "pre_policy_pool", policy: "Exempt" })
+        );
+        screeningPolicyReads.inc({ result: "pre_policy_pool" });
+        return "Exempt";
+      }
       // No address goes into the log, as on the rest of this path.
       console.error(
         JSON.stringify({

--- a/proof-interceptor/tests/screening-policy.test.ts
+++ b/proof-interceptor/tests/screening-policy.test.ts
@@ -21,6 +21,22 @@ const GET_POLICY_SELECTOR =
 
 const POLICIES: OpenNoteScreeningPolicy[] = ["Required", "Exempt", "Delegated"];
 
+/**
+ * What a node answers when the called contract has no such entrypoint: dedicated JSON-RPC error 21
+ * (`ENTRYPOINT_NOT_FOUND`), distinct from 20 (no contract) and 40 (a revert). A pool answering it
+ * predates the policy list.
+ */
+const ENTRYPOINT_NOT_FOUND_ANSWER: RpcAnswer = {
+  body: {
+    jsonrpc: "2.0",
+    id: 1,
+    error: {
+      code: 21,
+      message: "Requested entrypoint does not exist in the contract",
+    },
+  },
+};
+
 /** What the fake node does with one `starknet_call`: answer a body, an HTTP status, or nothing. */
 type RpcAnswer = { body: unknown } | { status: number } | "no answer";
 
@@ -99,6 +115,13 @@ async function fillCache(client: OpenNoteScreeningPolicyClient): Promise<void> {
  */
 function useMovableClock(): void {
   vi.useFakeTimers({ now: Date.now() });
+}
+
+/** Silences the line a pre-policy-pool read logs, and returns the spy to assert on. */
+function silencePolicyLog(): ReturnType<
+  typeof vi.spyOn<typeof console, "log">
+> {
+  return vi.spyOn(console, "log").mockImplementation(() => {});
 }
 
 describe("OpenNoteScreeningPolicyClient", () => {
@@ -271,6 +294,77 @@ describe("OpenNoteScreeningPolicyClient", () => {
     // starts a new one instead of awaiting a promise that already resolved to null.
     expect(await client.getPolicy(DEPOSITOR)).toBe("Required");
     expect(requests).toHaveLength(2);
+    errorSpy.mockRestore();
+  });
+
+  it("answers Exempt for every depositor of a pool without the policy entrypoint", async () => {
+    const errorSpy = silenceErrorLog();
+    const logSpy = silencePolicyLog();
+    respond = () => ENTRYPOINT_NOT_FOUND_ANSWER;
+    const client = newClient();
+
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+    expect(await client.getPolicy("0xb0b")).toBe("Exempt");
+    // A missing entrypoint is an answer, not a failure: nothing goes to the error log.
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it("caches the missing-entrypoint answer like a policy", async () => {
+    const logSpy = silencePolicyLog();
+    respond = () => ENTRYPOINT_NOT_FOUND_ANSWER;
+    const client = newClient();
+
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+    expect(requests).toHaveLength(1);
+    logSpy.mockRestore();
+  });
+
+  it("keeps the depositor out of the pre-policy-pool log", async () => {
+    const logSpy = silencePolicyLog();
+    respond = () => ENTRYPOINT_NOT_FOUND_ANSWER;
+
+    await newClient().getPolicy(DEPOSITOR);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = String(logSpy.mock.calls[0][0]);
+    expect(logged).toContain("pre_policy_pool");
+    expect(logged).not.toContain("a11ce");
+    logSpy.mockRestore();
+  });
+
+  it("honors a pool upgrade that adds the policy entrypoint within one TTL", async () => {
+    const logSpy = silencePolicyLog();
+    useMovableClock();
+    respond = (requestNumber) =>
+      requestNumber === 1
+        ? ENTRYPOINT_NOT_FOUND_ANSWER
+        : policyAnswer("Required");
+    const client = newClient();
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Exempt");
+
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+
+    expect(await client.getPolicy(DEPOSITOR)).toBe("Required");
+    expect(requests).toHaveLength(2);
+    logSpy.mockRestore();
+  });
+
+  it("fails closed when no contract answers at the pool address", async () => {
+    // Only the entrypoint miss reads as a pre-policy pool. An undeployed address is a
+    // misconfiguration, not an old pool, and stays a failed read.
+    const errorSpy = silenceErrorLog();
+    respond = () => ({
+      body: {
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: 20, message: "Contract not found" },
+      },
+    });
+
+    expect(await newClient().getPolicy(DEPOSITOR)).toBeNull();
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
A pool that answers the policy read with ENTRYPOINT_NOT_FOUND (JSON-RPC
error 21) predates the policy list: it asks for no open-note
attestations and enforces its own depositor block list on chain. The
policy client now answers Exempt for every depositor of such a pool,
cached like any policy read, so the interceptor can deploy before the
pool upgrades and honors the upgrade within one TTL. Every other read
failure stays fail-closed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/958)
<!-- Reviewable:end -->
