### PR TITLE
feat(sdk): report an unreadable policy list as transient, not as a verdict

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- `screeningErrorFromProvingError` maps `screening_policy_unavailable` to `ScreeningUnavailable`:
+  the pool's policy list is as much a screening dependency as the screener, so a read the
+  interceptor could not complete is transient. The interceptor's `multiple_screening_subjects`,
+  `unknown_delegated_depositor` and `shadow_account_undetermined` are deliberately left
+  unmapped — terminal for the transaction as built, but silent about the address, so reporting them
+  as `ScreeningRejected` would tell a caller they are sanctioned.
 - `shadowAccountPartialCommitment`, `shadowAccountCommitment`, `shadowAccountAddress` and
   `PRIMER_CLASS_HASH`, the shadow account derivation as pure functions, so a caller holding the raw
   felts can predict a shadow account's address without deploying it or reading the chain.
@@ -25,6 +31,12 @@
   `Required`.
 - `generate-pool-interface` now maps Cairo enums to the `CairoCustomEnum` type starknet.js
   actually returns, instead of falling back to `unknown`.
+
+### Changed
+
+- `ScreeningRejected` and `ScreeningUnavailable` messages drop their `Deposit ` prefix. The screened
+  address is no longer always a deposit's depositor: it may be the shadow account an interaction
+  runs through, or an invoke target the pool requires screening for.
 
 ### Fixed
 

--- a/sdk/src/internal/errors.ts
+++ b/sdk/src/internal/errors.ts
@@ -9,35 +9,48 @@ export class ReorgError extends Error {
 }
 
 /**
- * The deposit's source address is on the sanctions list. Terminal — retrying
- * with the same address will not succeed.
+ * The address the pool screens for this transaction is on the sanctions list — a deposit's own
+ * depositor, the shadow account an interaction runs through, or an invoke target the pool requires
+ * screening for. Terminal: retrying with the same address will not succeed.
  */
 export class ScreeningRejected extends Error {
   override readonly name = "ScreeningRejected";
   constructor(reason?: string) {
-    super(reason ? `Deposit screening rejected: ${reason}` : "Deposit screening rejected");
+    super(reason ? `Screening rejected: ${reason}` : "Screening rejected");
   }
 }
 
 /**
- * Screening could not be completed (FPI cloud function or upstream unreachable).
- * Transient — the caller may retry later. Deposits fail closed: no signature
- * means no deposit.
+ * Screening could not be completed. It fails closed either way: no signature, no transaction.
+ *
+ * - The screener (FPI cloud function or upstream) or the pool's policy list could not be read.
+ *   Transient, so the caller may retry.
+ * - The pool answered a policy variant the interceptor's ABI cannot decode. Clears only once the
+ *   interceptor is upgraded.
  */
 export class ScreeningUnavailable extends Error {
   override readonly name = "ScreeningUnavailable";
   constructor(reason?: string) {
-    super(reason ? `Deposit screening unavailable: ${reason}` : "Deposit screening unavailable");
+    super(reason ? `Screening unavailable: ${reason}` : "Screening unavailable");
   }
 }
 
 /**
- * Opaque `data` reasons the proof interceptor emits on the screening checkpoint.
- * These are the *only* values that denote a screening verdict — a wire
- * contract with the proof interceptor; keep both sides in sync.
+ * Opaque `data` reasons the proof interceptor emits on the screening checkpoint. These are the
+ * *only* values that denote a screening verdict — a wire contract with the proof interceptor; keep
+ * both sides in sync.
+ *
+ * The interceptor also blocks with `multiple_screening_subjects`,
+ * `unknown_delegated_depositor` and `shadow_account_undetermined`. Those are deliberately not
+ * mapped: they are terminal for the transaction as built but say nothing about the address, so
+ * reporting them as {@link ScreeningRejected} would tell a caller they are sanctioned. They reach
+ * the caller as the prover's own error, whose message already carries the reason.
  */
 const SCREENING_BLOCKED_REASON = "address_blocked";
 const SCREENING_UNAVAILABLE_REASON = "screening_unavailable";
+// The pool's policy list is as much a screening dependency as the screener itself, so a read the
+// interceptor could not complete is transient rather than a verdict on the address.
+const SCREENING_POLICY_UNAVAILABLE_REASON = "screening_policy_unavailable";
 
 /**
  * Map a {@link ProvingServiceError} to a typed screening error, or `undefined`
@@ -57,7 +70,10 @@ export function screeningErrorFromProvingError(
   if (error.code !== TRANSACTION_REJECTED) {
     return undefined;
   }
-  if (error.data === SCREENING_UNAVAILABLE_REASON) {
+  if (
+    error.data === SCREENING_UNAVAILABLE_REASON ||
+    error.data === SCREENING_POLICY_UNAVAILABLE_REASON
+  ) {
     return new ScreeningUnavailable(error.data);
   }
   if (error.data === SCREENING_BLOCKED_REASON) {

--- a/sdk/tests/internal/screening.test.ts
+++ b/sdk/tests/internal/screening.test.ts
@@ -122,6 +122,29 @@ describe("screeningErrorFromProvingError", () => {
     expect(mapped).toBeInstanceOf(ScreeningRejected);
   });
 
+  it("maps code 10000 + screening_policy_unavailable to ScreeningUnavailable", () => {
+    const mapped = screeningErrorFromProvingError(
+      new ProvingServiceError(10000, "Transaction rejected", "screening_policy_unavailable")
+    );
+    expect(mapped).toBeInstanceOf(ScreeningUnavailable);
+  });
+
+  it("leaves the unresolved-subject reasons unmapped rather than calling them a rejection", () => {
+    // These are terminal for the transaction as built but say nothing about the address. Mapping
+    // them to ScreeningRejected would tell the caller they are sanctioned and must never retry; the
+    // caller rethrows the prover's own error instead, whose message already carries the reason.
+    for (const data of [
+      "multiple_screening_subjects",
+      "unknown_delegated_depositor",
+      "shadow_account_undetermined",
+    ]) {
+      const mapped = screeningErrorFromProvingError(
+        new ProvingServiceError(10000, "Transaction rejected", data)
+      );
+      expect(mapped).toBeUndefined();
+    }
+  });
+
   it("returns undefined for code 10000 with no data (not a screening verdict)", () => {
     const mapped = screeningErrorFromProvingError(
       new ProvingServiceError(10000, "Transaction rejected")


### PR DESCRIPTION
- `screening_policy_unavailable` maps to `ScreeningUnavailable`. The pool's policy
  list is a screening dependency, so a read the interceptor could not complete is
  transient rather than a verdict on the address.
- `multiple_screening_subjects`, `unknown_delegated_depositor` and
  `shadow_account_undetermined` stay unmapped: they say nothing about the address,
  so `ScreeningRejected` would tell a caller they are sanctioned. They reach the
  caller as the prover's own error, which already carries the reason.
- Both messages drop their `Deposit ` prefix; the screened address is not always
  a deposit's depositor.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/962)
<!-- Reviewable:end -->
