### PR TITLE
fix(proof-interceptor): type-check the tests, not only what ships

### DIFF
--- a/.github/workflows/proxy-ci.yml
+++ b/.github/workflows/proxy-ci.yml
@@ -52,11 +52,17 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: proof-interceptor/package-lock.json
+          cache-dependency-path: |
+            proof-interceptor/package-lock.json
+            elliptic-proxy/package-lock.json
       - name: Build SDK (proof-interceptor depends on ABI)
         if: steps.filter.outputs.changed == 'true'
         working-directory: sdk
         run: npm ci && npm run build
+      - name: Install elliptic-proxy (its source is type-checked through tests/e2e.test.ts)
+        if: steps.filter.outputs.changed == 'true'
+        working-directory: elliptic-proxy
+        run: npm ci
       - name: Install
         if: steps.filter.outputs.changed == 'true'
         working-directory: proof-interceptor

--- a/proof-interceptor/README.md
+++ b/proof-interceptor/README.md
@@ -151,9 +151,10 @@ If `proof_interceptor_screening_results_total` stays at zero after real traffic,
 
 ```bash
 npm ci
-npm run build       # tsc → dist/
+(cd ../elliptic-proxy && npm ci)   # tests/e2e.test.ts imports its source, so lint resolves its deps
+npm run build       # tsc -p tsconfig.build.json → dist/
 npm test            # vitest run
-npm run lint        # prettier + eslint + tsc --noEmit
+npm run lint        # prettier + eslint + tsc --noEmit (src and tests)
 npm run format      # auto-fix
 ```
 

--- a/proof-interceptor/package.json
+++ b/proof-interceptor/package.json
@@ -8,9 +8,9 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
-    "dev": "tsc --watch",
+    "dev": "tsc -p tsconfig.build.json --watch",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "lint": "prettier --check src/ tests/ && eslint src/ tests/ && tsc --noEmit",

--- a/proof-interceptor/tests/e2e.test.ts
+++ b/proof-interceptor/tests/e2e.test.ts
@@ -10,6 +10,7 @@ import * as ff from "@google-cloud/functions-framework";
 import { getTestServer } from "@google-cloud/functions-framework/testing";
 import { createHandler } from "../src/proxy.js";
 import { ScreeningInterceptor } from "../src/screening-interceptor.js";
+import { ANONYMIZER_ADDR } from "./pool-call.js";
 
 import { createHandler as createEllipticHandler } from "../../elliptic-proxy/src/handler.js";
 import { forwardToElliptic } from "../../elliptic-proxy/src/elliptic.js";
@@ -112,6 +113,12 @@ async function startInterceptor(): Promise<void> {
     maxRetries: 0,
     totalTimeoutMs: 10000,
     poolAddress: "0xpool",
+    // Unreachable on purpose: a plain `Deposit` is screened on its own depositor, reading no policy.
+    rpcUrl: "http://127.0.0.1:1",
+    anonymizerAddress: ANONYMIZER_ADDR,
+    policyTtlMs: 60_000,
+    policyTimeoutMs: 50,
+    blockNonPoolTx: false,
   });
 
   const handler = createHandler({ interceptors: [interceptor] });

--- a/proof-interceptor/tests/pool-call.ts
+++ b/proof-interceptor/tests/pool-call.ts
@@ -151,8 +151,6 @@ export function computeAndInvokeAction(
 }
 
 /** Silences a fail-closed path's error log, and returns the spy to assert on. */
-export function silenceErrorLog(): ReturnType<
-  typeof vi.spyOn<typeof console, "error">
-> {
+export function silenceErrorLog() {
   return vi.spyOn(console, "error").mockImplementation(() => {});
 }

--- a/proof-interceptor/tests/screening-interceptor.test.ts
+++ b/proof-interceptor/tests/screening-interceptor.test.ts
@@ -1,5 +1,5 @@
 // tests/screening-interceptor.test.ts
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, type MockInstance } from "vitest";
 import { createHmac } from "node:crypto";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -565,7 +565,7 @@ describe("ScreeningInterceptor", () => {
 });
 
 function findLogEntry(
-  logSpy: ReturnType<typeof vi.spyOn<typeof console, "log">>,
+  logSpy: MockInstance<typeof console.log>,
   predicate: (entry: Record<string, unknown>) => boolean
 ): Record<string, unknown> | undefined {
   for (const call of logSpy.mock.calls) {

--- a/proof-interceptor/tests/screening-policy.test.ts
+++ b/proof-interceptor/tests/screening-policy.test.ts
@@ -118,9 +118,7 @@ function useMovableClock(): void {
 }
 
 /** Silences the line a pre-policy-pool read logs, and returns the spy to assert on. */
-function silencePolicyLog(): ReturnType<
-  typeof vi.spyOn<typeof console, "log">
-> {
+function silencePolicyLog() {
   return vi.spyOn(console, "log").mockImplementation(() => {});
 }
 

--- a/proof-interceptor/tsconfig.build.json
+++ b/proof-interceptor/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/proof-interceptor/tsconfig.json
+++ b/proof-interceptor/tsconfig.json
@@ -8,10 +8,12 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
-  "include": ["src"]
+  // Type checking covers the tests, not only what ships: `vitest` transpiles without checking, so a
+  // test left out of here is a test whose types nothing verifies. `tests/e2e.test.ts` imports
+  // `elliptic-proxy` source, so checking it needs that package's dependencies installed.
+  // `tsconfig.build.json` is the one that emits.
+  "include": ["src", "tests", "vitest.config.ts"]
 }


### PR DESCRIPTION
tsconfig.json declared "include": ["src"], so npm run lint's tsc --noEmit
never looked at tests/, and vitest transpiles without checking: every
"lint clean" claimed for a test file covered prettier and eslint only.
Four test files did not compile. Type checking now spans src, tests and
vitest.config.ts, and tsconfig.build.json is the one that emits.

Three of the four are the same construct, an explicit
ReturnType<typeof vi.spyOn<typeof console, "log">> on a console spy;
inference gives the right type where the spy is created, and the one
that annotates a parameter takes vitest's MockInstance instead.

The fourth is tests/e2e.test.ts, whose ScreeningConfig predates the five
fields the policy read added. Checking it needs elliptic-proxy's
dependencies resolvable, since it imports that package's source, so CI
installs them; excluding the file instead would have left the gate blind
exactly where the staleness was.

Also renames getScreenedAddress's policies parameter to policyReader,
after its type rather than a collection it does not hold.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/963)
<!-- Reviewable:end -->
