### PR TITLE
chore(proof-interceptor): pin dependencies exactly and drop the unused vite

### DIFF
--- a/proof-interceptor/package-lock.json
+++ b/proof-interceptor/package-lock.json
@@ -9,21 +9,20 @@
       "version": "0.1.0",
       "dependencies": {
         "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
-        "lru-cache": "^11.3.2",
-        "prom-client": "^15.1.3",
-        "starknet": "^9.4.2",
+        "lru-cache": "11.3.5",
+        "prom-client": "15.1.3",
+        "starknet": "9.4.2",
         "zod": "3.24.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.2",
-        "@google-cloud/functions-framework": "^5.0.2",
-        "@types/node": "^22.19.17",
-        "eslint": "^9.39.2",
-        "prettier": "^3.7.4",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.51.0",
-        "vite": "^6.4.2",
-        "vitest": "^3.2.1"
+        "@eslint/js": "9.39.4",
+        "@google-cloud/functions-framework": "5.0.2",
+        "@types/node": "22.19.17",
+        "eslint": "9.39.4",
+        "prettier": "3.8.3",
+        "typescript": "5.9.3",
+        "typescript-eslint": "8.58.2",
+        "vitest": "3.2.4"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/proof-interceptor/package.json
+++ b/proof-interceptor/package.json
@@ -18,20 +18,19 @@
   },
   "dependencies": {
     "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
-    "lru-cache": "^11.3.2",
-    "prom-client": "^15.1.3",
-    "starknet": "^9.4.2",
+    "lru-cache": "11.3.5",
+    "prom-client": "15.1.3",
+    "starknet": "9.4.2",
     "zod": "3.24.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
-    "@google-cloud/functions-framework": "^5.0.2",
-    "@types/node": "^22.19.17",
-    "eslint": "^9.39.2",
-    "prettier": "^3.7.4",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.51.0",
-    "vite": "^6.4.2",
-    "vitest": "^3.2.1"
+    "@eslint/js": "9.39.4",
+    "@google-cloud/functions-framework": "5.0.2",
+    "@types/node": "22.19.17",
+    "eslint": "9.39.4",
+    "prettier": "3.8.3",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.58.2",
+    "vitest": "3.2.4"
   }
 }


### PR DESCRIPTION
The manifest declared vite, which nothing imports: vitest.config.ts loads
defineConfig from vitest/config, and vitest brings its own vite. The lockfile
is unchanged by the removal, so this only stops the package claiming a
dependency it does not have.

@google-cloud/functions-framework stays, contrary to the same review note:
tests/e2e.test.ts hosts the elliptic-proxy handler through it, so it is a real
devDependency.

Ranges become exact versions. A screening sidecar that fails closed should
deploy the tree it was tested against, and a caret makes the image's contents
depend on when it was built.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/966)
<!-- Reviewable:end -->
