### PR TITLE
chore(proof-interceptor): align starknet.js with the SDK on 10.5.0

### DIFF
--- a/proof-interceptor/package-lock.json
+++ b/proof-interceptor/package-lock.json
@@ -11,7 +11,7 @@
         "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
         "lru-cache": "11.3.5",
         "prom-client": "15.1.3",
-        "starknet": "9.4.2",
+        "starknet": "10.5.0",
         "zod": "3.24.0"
       },
       "devDependencies": {
@@ -1290,17 +1290,37 @@
         "ox": "^0.4.4"
       }
     },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
+      "name": "@starknet-io/get-starknet-wallet-standard",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.2.tgz",
+      "integrity": "sha512-jCnLFNPw4IGgmkwDlHszKbnyEbQKu3pE7cZHyVMFwyvRG98IA9FZKykrTNH7Nq3BILf6EcOZ5SgYUQE/gtqraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@starknet-io/types-js": "^0.10.3",
+        "@wallet-standard/base": "^1.1.1",
+        "@wallet-standard/features": "^1.1.1",
+        "ox": "^0.4.4"
+      }
+    },
     "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT"
     },
-    "node_modules/@starknet-io/starknet-types-010": {
+    "node_modules/@starknet-io/starknet-types-0101": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
-      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.2.tgz",
+      "integrity": "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-0103": {
+      "name": "@starknet-io/types-js",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {
@@ -1308,6 +1328,12 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.9.2.tgz",
       "integrity": "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/types-js": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.3.tgz",
+      "integrity": "sha512-WtTGjqgyjqYSaSks/CQrpERGiLlwhr1TTD4llsr8IKEZHb78OJEmEhzrb/LxJV1SIz+MEsB1pioG62BOmFKYLA==",
       "license": "MIT"
     },
     "node_modules/@starkware-libs/starknet-privacy-sdk": {
@@ -1850,24 +1876,24 @@
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@wallet-standard/features": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wallet-standard/base": "^1.1.0"
+        "@wallet-standard/base": "^1.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/abi-wan-kanabi": {
@@ -3877,12 +3903,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4555,9 +4575,9 @@
       "license": "MIT"
     },
     "node_modules/starknet": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.4.2.tgz",
-      "integrity": "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-10.5.0.tgz",
+      "integrity": "sha512-hHKW39sVFLCGPC8QKdQksbs8qo10Rjb6Zdpv3nKMYQUeXDtffvI1SOa62aX8+WcnpfG7Te4UBx5NTomz/X7ZpA==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.7.0",
@@ -4565,12 +4585,12 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
-        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.2",
+        "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
+        "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
         "abi-wan-kanabi": "2.2.4",
-        "lossless-json": "^4.2.0",
-        "pako": "^2.0.4",
-        "ts-mixer": "^6.0.3"
+        "lossless-json": "^4.2.0"
       },
       "engines": {
         "node": ">=22"
@@ -4757,12 +4777,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-mixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/proof-interceptor/package.json
+++ b/proof-interceptor/package.json
@@ -20,7 +20,7 @@
     "@starkware-libs/starknet-privacy-sdk": "file:../sdk",
     "lru-cache": "11.3.5",
     "prom-client": "15.1.3",
-    "starknet": "9.4.2",
+    "starknet": "10.5.0",
     "zod": "3.24.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The package asked for ^9.4.2 while the SDK it links pins 10.5.0, so a build
shipped two copies of starknet.js and the interceptor decoded pool calldata
with a different one than the SDK whose ABI it borrows.

This package's suite passes on 10.5.0. The screening work in flight adds a
pre-policy-pool fallback that rests on RpcError.isType("ENTRYPOINT_NOT_FOUND"),
which had only ever been measured on 9.4.2; it was checked against 10.5.0
before this change was split out — the five tests driving a mock node that
answers JSON-RPC error 21 pass, and swapping the checked type to
CONTRACT_NOT_FOUND fails exactly those five. Whichever of the two series merges
second should re-run them, since neither exercises that pairing alone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/967)
<!-- Reviewable:end -->
