### PR TITLE
chore(proof-interceptor): ship only what the sidecar runs

### DIFF
--- a/deploy/proof-interceptor/Dockerfile
+++ b/deploy/proof-interceptor/Dockerfile
@@ -27,19 +27,29 @@ RUN cd proof-interceptor \
  && npm ci \
  && npm run build
 
-# Drop devDependencies once compilation is done; the runtime stage only
-# needs the production deps.
+# Drop devDependencies once compilation is done; the runtime stage only needs
+# the production deps. The SDK is pruned too — it is a file: dependency, so its
+# tree ships in the image rather than being flattened into the interceptor's.
 RUN cd proof-interceptor \
+ && npm prune --omit=dev \
+ && cd ../sdk \
  && npm prune --omit=dev
 
 # ---- runtime stage --------------------------------------------------------
 FROM node:22-slim
 WORKDIR /app/proof-interceptor
 
-# The SDK is a file: dependency, so the runtime needs both directories
-# present at the path npm resolved during install.
-COPY --from=build /app/sdk /app/sdk
-COPY --from=build /app/proof-interceptor /app/proof-interceptor
+# The SDK is a file: dependency, so the runtime needs both directories present
+# at the path npm resolved during install: the interceptor's
+# node_modules/@starkware-libs/starknet-privacy-sdk is a symlink to /app/sdk.
+# No first-party sources, tests or configs are copied. The node_modules trees are
+# not minimal: `--omit=dev` keeps optional peers and the SDK's own prod deps.
+COPY --from=build /app/sdk/package.json /app/sdk/package.json
+COPY --from=build /app/sdk/dist /app/sdk/dist
+COPY --from=build /app/sdk/node_modules /app/sdk/node_modules
+COPY --from=build /app/proof-interceptor/package.json /app/proof-interceptor/package.json
+COPY --from=build /app/proof-interceptor/dist /app/proof-interceptor/dist
+COPY --from=build /app/proof-interceptor/node_modules /app/proof-interceptor/node_modules
 
 ENV NODE_ENV=production
 ENV PORT=8080

--- a/deploy/proof-interceptor/Dockerfile.dockerignore
+++ b/deploy/proof-interceptor/Dockerfile.dockerignore
@@ -8,6 +8,7 @@
 **/.gitignore
 **/node_modules
 **/dist
+**/tests
 **/.cache
 **/coverage
 **/*.log


### PR DESCRIPTION
The runtime stage copied both package directories wholesale, so the image
carried each one's src, tests, tsconfigs and eslint config, and the SDK's
node_modules was never pruned: esbuild, eslint and the rest of its
devDependencies rode into production. Only the SDK was pruned, and only the
interceptor's own tree.

The build stage now prunes the SDK as well, the runtime copies package.json,
dist and node_modules for each package, and the build context drops tests.
Measured: 394.2 MB to 322.5 MB, with the SDK's node_modules down from 155 MB
to 70 MB. The image serves /health and answers a malformed prove request the
same as before.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/968)
<!-- Reviewable:end -->
