### PR TITLE
fix(discovery-service): return typed errors, and pin the Rust toolchain

### DIFF
--- a/crates/discovery-service/src/indexer.rs
+++ b/crates/discovery-service/src/indexer.rs
@@ -84,7 +84,7 @@ impl<C: ChainState> Indexer<C> {
     ///
     /// Only recoverable errors (connection, subscription, receive) trigger a retry.
     /// Non-recoverable errors (unsubscribe, close) cause immediate failure.
-    pub async fn run(&mut self) -> Result<(), ()> {
+    pub async fn run(&mut self) -> Result<(), IndexerError> {
         info!("Indexer started");
 
         loop {
@@ -108,7 +108,7 @@ impl<C: ChainState> Indexer<C> {
                 }
                 Err(e) => {
                     error!("Indexer error (non-recoverable): {}", e);
-                    return Err(());
+                    return Err(e);
                 }
             }
         }

--- a/crates/discovery-service/src/shutdown.rs
+++ b/crates/discovery-service/src/shutdown.rs
@@ -1,10 +1,22 @@
 //! Graceful shutdown helper.
 
+use thiserror::Error;
 use tokio::{
     signal::unix::{signal, SignalKind},
     sync::broadcast,
 };
 use tracing::info;
+
+/// Errors that can occur while waiting to broadcast a shutdown.
+#[derive(Debug, Error)]
+pub enum ShutdownError {
+    /// A signal handler could not be registered, so the process cannot observe SIGTERM or SIGINT.
+    #[error("failed to register signal handler: {0}")]
+    SignalHandler(#[from] std::io::Error),
+    /// The signal arrived but every subscriber had already dropped its receiver.
+    #[error("no subscriber left to notify")]
+    NoSubscribers,
+}
 
 /// Manages graceful shutdown by listening for SIGTERM and SIGINT signals
 /// and broadcasting shutdown notifications to subscribers.
@@ -25,15 +37,49 @@ impl Shutdown {
         self.tx_shutdown.subscribe()
     }
 
-    pub async fn run(&self) -> Result<(), ()> {
-        let mut sigterm = signal(SignalKind::terminate()).map_err(|_| ())?;
-        let mut sigint = signal(SignalKind::interrupt()).map_err(|_| ())?;
+    pub async fn run(&self) -> Result<(), ShutdownError> {
+        let mut sigterm = signal(SignalKind::terminate())?;
+        let mut sigint = signal(SignalKind::interrupt())?;
 
         tokio::select! {
             _ = sigterm.recv() => info!("Received SIGTERM, initiating shutdown..."),
             _ = sigint.recv() => info!("Received SIGINT, initiating shutdown..."),
         };
 
-        self.tx_shutdown.send(()).map(|_| ()).map_err(|_| ())
+        self.notify()
+    }
+
+    /// Broadcasts the shutdown notification. Separate from the signal wait so both outcomes are
+    /// reachable in a test.
+    fn notify(&self) -> Result<(), ShutdownError> {
+        self.tx_shutdown
+            .send(())
+            .map(|_| ())
+            .map_err(|_| ShutdownError::NoSubscribers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notify_reaches_a_subscriber() {
+        let shutdown = Shutdown::default();
+        let mut receiver = shutdown.subscribe();
+
+        shutdown.notify().expect("a live subscriber accepts it");
+
+        assert!(receiver.try_recv().is_ok());
+    }
+
+    #[test]
+    fn notify_reports_that_nobody_is_listening() {
+        let shutdown = Shutdown::default();
+        drop(shutdown.subscribe());
+
+        let error = shutdown.notify().expect_err("nobody is left to receive");
+
+        assert!(matches!(error, ShutdownError::NoSubscribers));
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.91.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
`Format & Clippy` is failing on pull requests that contain no Rust — 953 among them. Clippy 1.91 added `result_unit_err`, and two public functions in `discovery-service` return `Result<(), ()>`.

**The lints.** `Indexer::run` and `Shutdown::run` both discarded the error they were holding. The indexer already had an `IndexerError` in hand and threw it away one line before returning; it now returns it. The shutdown listener gets a `ShutdownError` naming its two real failures: a signal handler that could not be registered, and a notification with no subscriber left to receive it. Both now match `ApiServer::run`, which has returned its own error type all along.

Callers are unchanged — `main.rs` routes all three through `flatten()`, which is generic over the error type and erases it.

**The pin.** These lints arrived with a toolchain release, not with a change: the workflows use `dtolnay/rust-toolchain@stable`, so a new clippy turns whichever pull request is open at the time red. `rust-toolchain.toml` pins 1.91.0 with `rustfmt` and `clippy`, which rustup reads in CI and locally. Bumping it becomes a deliberate commit that can carry its own lint fixes, instead of an unrelated branch absorbing them.

**Verified** on 1.91.0: `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --lib --bins` 212 passed. The two new `Shutdown::notify` tests were mutation-proven — replacing the error mapping with `.or(Ok(()))` fails `notify_reports_that_nobody_is_listening` and only that one. Devnet-backed integration tests were not run locally; CI covers them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/970)
<!-- Reviewable:end -->
