### PR TITLE
fix(proof-interceptor): stop refusing a delegated invoke that deposits nothing

### DIFF
--- a/proof-interceptor/src/screened-address.ts
+++ b/proof-interceptor/src/screened-address.ts
@@ -3,7 +3,7 @@ import { CairoCustomEnum, num } from "starknet";
 import { decodeClientActions, normalizeFelt } from "./pool-transaction.js";
 import type { PoolCallActions } from "./pool-transaction.js";
 import type { ProveTxnV3 } from "./types.js";
-import { getShadowAccountAddress } from "./shadow-account.js";
+import { createsOpenNotes, getShadowAccountAddress } from "./shadow-account.js";
 import type { OpenNoteScreeningPolicyClient } from "./screening-policy.js";
 
 type PolicyReader = Pick<OpenNoteScreeningPolicyClient, "getPolicy">;
@@ -21,7 +21,8 @@ type InvokeAction = "InvokeExternal" | "ComputeAndInvoke";
  */
 interface OpenNoteDepositor {
   address: string;
-  action: InvokeAction;
+  invokeVariant: InvokeAction;
+  action: CairoCustomEnum;
 }
 
 /** The pool takes one attestation per transaction, so a delegated depositor puts up at most one address. */
@@ -105,11 +106,18 @@ function getDelegatedAddress(
   { anonymizerAddress }: ScreenedAddressConfig
 ): DelegatedAddress {
   // A plain invoke is exempt under `Delegated`; only a compute-invoke puts up an address.
-  if (openNoteDepositor.action !== "ComputeAndInvoke") return { kind: "none" };
+  if (openNoteDepositor.invokeVariant !== "ComputeAndInvoke") {
+    return { kind: "none" };
+  }
 
   if (openNoteDepositor.address !== normalizeFelt(anonymizerAddress)) {
     console.error(JSON.stringify({ error: "unknown_delegated_depositor" }));
     return { kind: "unknownDelegate" };
+  }
+
+  // The pool assigns a subject only for an invoke that returns deposits.
+  if (!createsOpenNotes(openNoteDepositor.action)) {
+    return { kind: "none" };
   }
 
   const shadowAccount = getShadowAccountAddress(poolCall, anonymizerAddress);
@@ -139,7 +147,8 @@ function getOpenNoteDepositor(
     };
     return {
       address: normalizeFelt(num.toHex(contract_address)),
-      action: variant,
+      invokeVariant: variant,
+      action,
     };
   }
   return null;

--- a/proof-interceptor/src/shadow-account.ts
+++ b/proof-interceptor/src/shadow-account.ts
@@ -79,9 +79,8 @@ export function getShadowAccountAddress(
 
 /**
  * The shadow account interaction among `actions`, or `null` when they run
- * none: no `ComputeAndInvoke` targets `anonymizerAddress`, the one that does
- * settles no open note (nothing is deposited, so nobody is screened), or its
- * data does not decode.
+ * none: no `ComputeAndInvoke` targets `anonymizerAddress`, or its data does not
+ * decode.
  *
  * Undecodable data counts as no interaction rather than as an error, since the
  * pool cannot execute it either and the transaction reverts on its own.
@@ -114,7 +113,6 @@ export function getShadowAccountInteraction(
 
 function shadowAccountInteraction(input: {
   compute_additional_data: bigint[];
-  invoke_additional_data: bigint[];
 }): ShadowAccountInteraction | null {
   try {
     if (
@@ -126,15 +124,27 @@ function shadowAccountInteraction(input: {
       COMPUTE_ARGUMENT_TYPES,
       input.compute_additional_data.map(num.toHex)
     ) as bigint[];
+    return { dappName, nonce };
+  } catch {
+    return null;
+  }
+}
+
+/** Whether `action`, a `ComputeAndInvoke`, creates any open note. Undecodable data creates none. */
+export function createsOpenNotes(action: CairoCustomEnum): boolean {
+  const { invoke_additional_data: invokeData } = action.unwrap() as {
+    invoke_additional_data: bigint[];
+  };
+  try {
     // `calls` is unread: which shadow account acts is what decides the address
     // to screen, not what it does.
     const [, openNotes] = anonymizerDecoder.decodeParameters(
       INVOKE_ARGUMENT_TYPES,
-      input.invoke_additional_data.map(num.toHex)
+      invokeData.map(num.toHex)
     ) as [unknown, unknown[]];
-    return openNotes.length === 0 ? null : { dappName, nonce };
+    return openNotes.length > 0;
   } catch {
-    return null;
+    return false;
   }
 }
 

--- a/proof-interceptor/tests/screened-address.test.ts
+++ b/proof-interceptor/tests/screened-address.test.ts
@@ -186,18 +186,43 @@ describe("getScreenedAddress", () => {
     expect(screened).toEqual({ kind: "one", address: ANONYMIZER_ADDR });
   });
 
-  it("cannot determine a shadow account for an interaction that settles no open note", async () => {
-    // The open note is created here, so the empty note list is what the resolver reacts to rather
-    // than the missing `CreateOpenNote`. The policy is still read — the invoke is the transaction's
-    // open-note depositor — but the interaction settles nothing, so no shadow account acts and the
-    // pool is left asking for a subject the interceptor cannot name.
+  it("screens nobody for an interaction that creates no open note", async () => {
+    // The `CreateOpenNote` is here, so the empty note list is what the resolver reacts to.
     const { screened, asked } = await subjectOf(
       [createOpenNoteAction(), computeAndInvokeAction(ANONYMIZER_ADDR, [])],
       { [ANONYMIZER_ADDR]: "Delegated" }
     );
 
-    expect(screened).toEqual({ kind: "undeterminedShadowAccount" });
+    expect(screened).toEqual({ kind: "none" });
     expect(asked).toEqual([ANONYMIZER_ADDR]);
+  });
+
+  it("still screens a deposit riding an interaction that creates no open note", async () => {
+    const { screened } = await subjectOf(
+      [
+        depositAction(),
+        createOpenNoteAction(),
+        computeAndInvokeAction(ANONYMIZER_ADDR, []),
+      ],
+      { [ANONYMIZER_ADDR]: "Delegated" }
+    );
+
+    expect(screened).toEqual({ kind: "one", address: USER_ADDR });
+  });
+
+  it("screens nobody when a transaction creating no open note is otherwise underivable", async () => {
+    // The note count is read before the felts the derivation needs.
+    const transaction = poolCallTransaction([
+      createOpenNoteAction(),
+      computeAndInvokeAction(ANONYMIZER_ADDR, []),
+    ]);
+    transaction.calldata[5] = "not-a-felt";
+
+    const screened = await getScreenedAddress(transaction, CONFIG, {
+      getPolicy: async () => "Delegated" as const,
+    });
+
+    expect(screened).toEqual({ kind: "none" });
   });
 
   it("reads no policy for a transaction that creates no open note", async () => {

--- a/proof-interceptor/tests/shadow-account.test.ts
+++ b/proof-interceptor/tests/shadow-account.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@starkware-libs/starknet-privacy-sdk";
 import { decodeClientActions } from "../src/pool-transaction.js";
 import {
+  createsOpenNotes,
   getShadowAccountAddress,
   getShadowAccountInteraction,
 } from "../src/shadow-account.js";
@@ -68,11 +69,15 @@ describe("getShadowAccountInteraction", () => {
     });
   });
 
-  it("returns null when the interaction settles no open note", () => {
+  it("returns the compute arguments even when the invoke creates no open note", () => {
+    // The identity commitment determines the address; the note count does not enter it.
     const action = computeAndInvoke({
       invoke_additional_data: invokeAdditionalData([]),
     });
-    expect(interactionOf([action])).toBeNull();
+    expect(interactionOf([action])).toEqual({
+      dappName: DAPP_NAME,
+      nonce: NONCE,
+    });
   });
 
   it("returns null when the compute-invoke targets another contract", () => {
@@ -97,23 +102,6 @@ describe("getShadowAccountInteraction", () => {
       dappName: DAPP_NAME,
       nonce: NONCE,
     });
-  });
-
-  it("returns null when the invoke data is truncated", () => {
-    const truncated = invokeAdditionalData(OPEN_NOTES).slice(0, 2);
-    expect(
-      interactionOf([computeAndInvoke({ invoke_additional_data: truncated })])
-    ).toBeNull();
-  });
-
-  it("returns null when the invoke data claims more open notes than it carries", () => {
-    const data = invokeAdditionalData(OPEN_NOTES);
-    // The open notes follow the calls; their length prefix is the felt after them.
-    const openNotesLengthIndex = data.length - 1 - 3;
-    data[openNotesLengthIndex] = "2";
-    expect(
-      interactionOf([computeAndInvoke({ invoke_additional_data: data })])
-    ).toBeNull();
   });
 
   it("returns null when the compute data is not a dapp name and a nonce", () => {
@@ -159,11 +147,14 @@ describe("getShadowAccountAddress", () => {
 
   it("returns null when the transaction runs no interaction", () => {
     expect(addressOf([depositAction()])).toBeNull();
+  });
+
+  it("derives the address even when the invoke creates no open note", () => {
     expect(
       addressOf([
         computeAndInvoke({ invoke_additional_data: invokeAdditionalData([]) }),
       ])
-    ).toBeNull();
+    ).toBe(addressOf([computeAndInvoke({})]));
   });
 
   it("gives each nonce its own address", () => {
@@ -188,5 +179,36 @@ describe("getShadowAccountAddress", () => {
     expect(addressOf([depositAction(), computeAndInvoke({})])).toBe(
       addressOf([computeAndInvoke({})])
     );
+  });
+});
+
+describe("createsOpenNotes", () => {
+  it("is true for an interaction carrying an open note", () => {
+    expect(createsOpenNotes(computeAndInvoke({}))).toBe(true);
+  });
+
+  it("is false for an interaction carrying none", () => {
+    expect(
+      createsOpenNotes(
+        computeAndInvoke({ invoke_additional_data: invokeAdditionalData([]) })
+      )
+    ).toBe(false);
+  });
+
+  it("is false when the invoke data does not decode", () => {
+    const truncated = invokeAdditionalData(OPEN_NOTES).slice(0, 2);
+    expect(
+      createsOpenNotes(computeAndInvoke({ invoke_additional_data: truncated }))
+    ).toBe(false);
+  });
+
+  it("is false when the invoke data claims more open notes than it carries", () => {
+    const data = invokeAdditionalData(OPEN_NOTES);
+    // The open notes follow the calls; their length prefix is the felt after them.
+    const openNotesLengthIndex = data.length - 1 - 3;
+    data[openNotesLengthIndex] = "2";
+    expect(
+      createsOpenNotes(computeAndInvoke({ invoke_additional_data: data }))
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
The pool assigns a screening subject only for an invoke that returns deposits:
the policy read and the whole Delegated branch sit inside `if !deposits
.is_empty()` in `_apply_invoke_and_deposits`, and the anonymizer returns one
deposit per open note it is handed. An interaction settling none leaves the pool
asking for nobody, and an attestation sent anyway is rejected with
UNEXPECTED_SCREENING.

The resolver refused those transactions instead, blocking with
shadow_account_undetermined, because the derivation collapsed three outcomes
into one null: no interaction, data that does not decode, and an interaction
settling no open note. Only the first two are undetermined. The third is a
determination — nobody — and it also returned early, discarding a deposit's own
depositor when one rode along, so a transaction the pool would have screened on
its depositor was refused outright.

The derivation now answers address, noOpenNotes or undetermined, and the
delegated path maps noOpenNotes to no subject. The open notes are read before
the felts the derivation needs, so an invoke depositing nothing puts up nobody
whatever the rest of the call looks like — the pool never reads those felts
either. undetermined keeps failing closed, and no wire reason changes:
shadow_account_undetermined stops covering a case the pool does not ask about.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/973)
<!-- Reviewable:end -->
