### PR TITLE
fix(ci): run the interceptor's tests when the SDK it links against changes

### DIFF
--- a/.github/workflows/proxy-ci.yml
+++ b/.github/workflows/proxy-ci.yml
@@ -46,7 +46,7 @@ jobs:
             changed:
               - 'proof-interceptor/**'
               - 'elliptic-proxy/**'
-              - 'sdk/src/internal/abi.ts'
+              - 'sdk/**'
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.filter.outputs.changed == 'true'
         with:


### PR DESCRIPTION
The proof-interceptor job gated its steps on `sdk/src/internal/abi.ts`, which is
one of three SDK files it imports. The shadow account derivation and
PRIMER_CLASS_HASH come from shadow-account-address.ts and the anonymizer ABI
from anonymizer-abi.ts, so a change to either skipped install, lint and tests
on a pull request that could not compile.

That is not hypothetical for the anonymizer ABI. It is generated, it was
regenerated once already for the invoke's new return shape, and the interceptor
reads its argument types out of it at module load — a missing method throws
there, before any test runs.

Two paths outside src/ break the link rather than the code: the root barrel
re-exports every symbol the interceptor imports, and package.json's exports map
declares the `./abi` subpath it resolves. The job also builds the SDK first, so
the lockfile and the build tsconfig are inputs too.

`sdk/**` covers all of it in one line that cannot go stale, and matches what
proof-interceptor-docker.yaml and e2e-devnet.yaml already watch. It costs a run
of this job on SDK-only changes, CHANGELOG edits included.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/975)
<!-- Reviewable:end -->
