### PR TITLE
test(e2e): pin the Required default and a wrong-subject attestation on devnet

### DIFF
--- a/e2e/src/shadow-account-setup.ts
+++ b/e2e/src/shadow-account-setup.ts
@@ -71,6 +71,9 @@ export async function deployShadowAccountAnonymizer(
   admin: Account,
   node: RpcProvider,
   privacyAddress: string,
+  // A second deployment in one devnet needs its own salts, or the UDC addresses collide.
+  anonymizerSalt: string = "0x900",
+  mockDappSalt: string = "0x901",
 ): Promise<ShadowAccountAddresses> {
   const primerDirectory = join(repoRoot(), "artifacts");
   await declareClass(
@@ -106,7 +109,7 @@ export async function deployShadowAccountAnonymizer(
     node,
     anonymizerClassHash,
     [privacyAddress, shadowAccountClassHash, admin.address],
-    "0x900",
+    anonymizerSalt,
   );
 
   const mockDappClassHash = await declareTestBuildContract(
@@ -119,7 +122,7 @@ export async function deployShadowAccountAnonymizer(
     node,
     mockDappClassHash,
     [],
-    "0x901",
+    mockDappSalt,
   );
 
   return { anonymizer, mockDapp, anonymizerAbi };

--- a/e2e/tests/devnet/shadow-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/shadow-account-compute-invoke.test.ts
@@ -3,6 +3,7 @@ import {
   CallMockProofProvider,
   Devnet,
   IndexerDiscoveryProvider,
+  attestScreeningSubject,
   delegateOpenNoteDepositor,
   openNoteScreeningPolicyOf,
 } from "@starkware-libs/starknet-privacy-sdk/testing";
@@ -10,6 +11,8 @@ import {
   Open,
   createPrivateTransfers,
   type PrivateTransfersInterface,
+  type Proof,
+  type ProofInvocation,
 } from "@starkware-libs/starknet-privacy-sdk";
 import {
   CairoCustomEnum,
@@ -18,6 +21,7 @@ import {
   constants,
   hash,
   shortString,
+  type BlockIdentifier,
 } from "starknet";
 import { createE2eTestEnv, type E2eTestEnv } from "../../src/harness.js";
 import { deployTestTokens, type TokenAddresses } from "../../src/vesu-setup.js";
@@ -90,6 +94,7 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
   async function provePayoutCollection(
     transfers: PrivateTransfersInterface,
     seqNonce: bigint,
+    target: ShadowAccountAddresses,
   ) {
     const { env: de } = env;
 
@@ -97,7 +102,7 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
     const mintTx = await de.admin.execute({
       contractAddress: tokens.usdToken,
       entrypoint: "mint",
-      calldata: [shadowAccount.mockDapp, ...u256Calldata(payoutAmount)],
+      calldata: [target.mockDapp, ...u256Calldata(payoutAmount)],
     });
     await de.node.waitForTransaction(mintTx.transaction_hash);
 
@@ -126,12 +131,12 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
         // identity_commitment, which the pool prepends from the privacy_compute result. Compile
         // (calls, open_notes) via the anonymizer ABI and drop the leading commitment felt, so the
         // Array<Call>/Span lengths come from the ABI rather than hand-counted offsets.
-        const invokeAdditionalData = new CallData(shadowAccount.anonymizerAbi)
+        const invokeAdditionalData = new CallData(target.anonymizerAbi)
           .compile("privacy_invoke_with_computation", [
             0n, // identity_commitment placeholder — prepended by the pool; sliced off below
             [
               {
-                to: shadowAccount.mockDapp,
+                to: target.mockDapp,
                 selector: transferToCallerSelector,
                 calldata: CallData.compile([
                   usdToken,
@@ -151,7 +156,7 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
           .slice(1)
           .map((felt) => BigInt(felt));
         return {
-          contractAddress: shadowAccount.anonymizer,
+          contractAddress: target.anonymizer,
           computeAdditionalData: [dappName, seqNonce],
           invokeAdditionalData,
         };
@@ -165,7 +170,11 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
 
     const poolBalanceBefore = await balanceOf(de.privacy.address);
 
-    const { callAndProof } = await provePayoutCollection(transfers.alice, 0n);
+    const { callAndProof } = await provePayoutCollection(
+      transfers.alice,
+      0n,
+      shadowAccount,
+    );
     await devnet.executeOutside(callAndProof);
     await env.indexer.waitForBlock(devnet.url);
 
@@ -202,9 +211,92 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
     });
 
     await expect(
-      provePayoutCollection(unattestingAlice, 1n).then(({ callAndProof }) =>
-        devnet.executeOutside(callAndProof),
+      provePayoutCollection(unattestingAlice, 1n, shadowAccount).then(
+        ({ callAndProof }) => devnet.executeOutside(callAndProof),
       ),
     ).rejects.toThrow(/SCREENING_REQUIRED/);
+  });
+
+  it("pool rejects a collection attested for the wrong subject", async () => {
+    const { env: de } = env;
+
+    // Attests the anonymizer where the pool derives the shadow account. The attestation carries no
+    // address — the pool reconstructs the signed message over its own subject — so a signature for
+    // any other address must fail verification rather than pass as an attestation for it.
+    class WrongSubjectProofProvider extends CallMockProofProvider {
+      async prove(
+        invocation: ProofInvocation,
+        blockIdentifier?: BlockIdentifier,
+      ): Promise<Proof> {
+        const proof = await super.prove(invocation, blockIdentifier);
+        return attestScreeningSubject(
+          this.node,
+          proof,
+          shadowAccount.anonymizer,
+          blockIdentifier,
+        );
+      }
+    }
+    const wrongSubjectAlice = createPrivateTransfers({
+      account: de.alice,
+      viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
+      provingProvider: new WrongSubjectProofProvider(
+        de.node,
+        constants.StarknetChainId.SN_SEPOLIA,
+      ),
+      discoveryProvider: new IndexerDiscoveryProvider(
+        env.indexer.apiUrl,
+        de.privacy.address,
+      ),
+      poolContractAddress: de.privacy.address,
+    });
+
+    await expect(
+      provePayoutCollection(wrongSubjectAlice, 2n, shadowAccount).then(
+        ({ callAndProof }) => devnet.executeOutside(callAndProof),
+      ),
+    ).rejects.toThrow(/SCREENING_INVALID_SIGNATURE/);
+  });
+
+  it("collects through an unlisted anonymizer by attesting the anonymizer itself", async () => {
+    const { env: de, transfers } = env;
+    const { admin, node, privacy } = de;
+    const usdToken = BigInt(tokens.usdToken);
+
+    // A fresh anonymizer nobody lists holds the pool's default policy, so the pool demands an
+    // attestation naming the anonymizer itself rather than a shadow account.
+    const unlistedAnonymizer = await deployShadowAccountAnonymizer(
+      admin,
+      node,
+      privacy.address,
+      "0x902",
+      "0x903",
+    );
+    expect(
+      await openNoteScreeningPolicyOf(
+        node,
+        privacy.address,
+        unlistedAnonymizer.anonymizer,
+      ),
+    ).toBe("Required");
+
+    const usdNotesBefore = (await transfers.alice.discoverNotes()).notes.get(
+      usdToken,
+    );
+
+    const { callAndProof } = await provePayoutCollection(
+      transfers.alice,
+      0n,
+      unlistedAnonymizer,
+    );
+    await devnet.executeOutside(callAndProof);
+    await env.indexer.waitForBlock(devnet.url);
+
+    // The payout landed in a new open note, and nothing stayed behind.
+    const { notes } = await transfers.alice.discoverNotes();
+    const usdNotes = notes.get(usdToken) ?? [];
+    expect(usdNotes).toHaveLength((usdNotesBefore?.length ?? 0) + 1);
+    expect(await balanceOf(unlistedAnonymizer.mockDapp)).toBe(0n);
+    expect(await balanceOf(unlistedAnonymizer.anonymizer)).toBe(0n);
   });
 });


### PR DESCRIPTION
- New suite test: a compute-invoke through an anonymizer nobody lists is screened
  under the default `Required` policy — the pool demands and accepts an
  attestation naming the anonymizer itself.
- New negative: a validly signed attestation for the wrong subject reverts with
  `SCREENING_INVALID_SIGNATURE`. The attestation carries no address, so the pool
  reconstructs the signed message over the subject it derives, and a signature
  for any other address fails verification.
- `deployShadowAccountAnonymizer` takes its deploy salts as parameters, so a
  suite can deploy a second anonymizer without colliding with the first.

`UNEXPECTED_SCREENING` (an attestation the pool did not ask for) is deliberately
left to the Cairo tests: no real prover can produce one, so an e2e version would
only exercise a sabotaged harness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/976)
<!-- Reviewable:end -->
