### PR TITLE
fix(sdk): add on-chain shadow account address derivation for pre-primer anonymizers

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,6 +9,15 @@
   felts can predict a shadow account's address without deploying it or reading the chain.
   `shadowAccounts(dapp).partialCommitment()` / `.commitment(nonce)` now delegate to them, and a
   committed cross-language vector pins all three against the anonymizer's Cairo.
+- `shadowAccountAddressOnChain(commitment, anonymizerAddress, provider)`, which looks `commitment`
+  up in the anonymizer's `get_shadow_account` registry first (authoritative, and era-agnostic, once
+  something is deployed) and only falls back to `shadowAccountAddress`'s `PRIMER_CLASS_HASH` formula
+  when nothing is deployed yet. `shadowAccountAddress` predicts the wrong address for an anonymizer
+  deployed before the primer pattern, because it deploys the shadow account class directly, and
+  there is no on-chain view that tells the two generations apart ahead of deployment. Also adds
+  `shadowAccountAddressFromClassHash(commitment, classHash, anonymizerAddress)`, the address formula
+  generalized to an explicit class hash, for a caller who knows out of band that
+  `anonymizerAddress` predates the primer pattern and has its shadow account class hash in hand.
 - Regenerated `ShadowAccountAnonymizerABI` against the anonymizer's new
   `privacy_invoke_with_computation` return shape, `(Span<OpenNoteDeposit>, Span<ContractAddress>)`.
   The invoke now returns the shadow account its deposits passed through, which is the address the

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -5,6 +5,8 @@ export { ShadowAccountAnonymizerABI } from "./internal/anonymizer-abi.js";
 export {
   PRIMER_CLASS_HASH,
   shadowAccountAddress,
+  shadowAccountAddressFromClassHash,
+  shadowAccountAddressOnChain,
   shadowAccountCommitment,
   shadowAccountPartialCommitment,
 } from "./internal/shadow-account-address.js";

--- a/sdk/src/internal/shadow-account-address.ts
+++ b/sdk/src/internal/shadow-account-address.ts
@@ -1,6 +1,7 @@
+import type { ProviderInterface } from "starknet";
 import { hash as starknetHash } from "starknet";
 
-import { hash as poseidonHash, toBigInt } from "../utils/index.js";
+import { hash as poseidonHash, toBigInt, toHex } from "../utils/index.js";
 import { compute_identity_key } from "../utils/hashes.js";
 
 /**
@@ -40,20 +41,80 @@ export function shadowAccountCommitment(partialCommitment: bigint, nonce: bigint
 
 /**
  * The address the anonymizer deploys the shadow account of `commitment` to, salted by that
- * commitment.
+ * commitment, assuming the primer pattern.
  *
  * The anonymizer deploys with `deploy_from_zero: false` and no constructor arguments, so the
- * address derives from (commitment, `PRIMER_CLASS_HASH`, empty calldata, the anonymizer). Callers
- * that need the address of an *already deployed* account can read it from the anonymizer's
- * `get_shadow_account` view instead. The two agree for anything deployed under the primer pattern.
+ * address derives from (commitment, `PRIMER_CLASS_HASH`, empty calldata, the anonymizer). This is
+ * correct for a current-generation anonymizer, but an anonymizer deployed *before* the primer
+ * pattern existed deploys the shadow account class directly, so this returns the wrong address for
+ * it. There is no on-chain way to tell the two apart ahead of deployment: `PRIMER_CLASS_HASH` is a
+ * Cairo constant, not exposed by any view, so nothing on `anonymizerAddress` itself says whether it
+ * uses the primer pattern.
+ *
+ * For an *already deployed* account, read the anonymizer's `get_shadow_account` view instead, or
+ * use {@link shadowAccountAddressOnChain}, which does that lookup and falls back to this formula
+ * only when nothing is deployed for `commitment` yet. For an anonymizer known out of band to
+ * predate the primer pattern, pass its shadow account class hash (its `get_shadow_account_class_hash`
+ * view) to {@link shadowAccountAddressFromClassHash} instead of calling this function.
  */
 export function shadowAccountAddress(commitment: bigint, anonymizerAddress: bigint): bigint {
+  return shadowAccountAddressFromClassHash(commitment, PRIMER_CLASS_HASH, anonymizerAddress);
+}
+
+/**
+ * The address a shadow account of `commitment` deploys to from `classHash`, salted by that
+ * commitment: the same derivation {@link shadowAccountAddress} uses with `PRIMER_CLASS_HASH`,
+ * generalized to an explicit class hash.
+ *
+ * For an anonymizer known out of band to predate the primer pattern (see
+ * {@link shadowAccountAddress}), pass its shadow account class hash here directly rather than
+ * relying on the primer formula, which is wrong for that generation. There is no on-chain
+ * discriminator to make this choice automatically; the caller must know which generation
+ * `anonymizerAddress` is.
+ */
+export function shadowAccountAddressFromClassHash(
+  commitment: bigint,
+  classHash: bigint,
+  anonymizerAddress: bigint
+): bigint {
   return toBigInt(
-    starknetHash.calculateContractAddressFromHash(
-      commitment,
-      PRIMER_CLASS_HASH,
-      [],
-      anonymizerAddress
-    )
+    starknetHash.calculateContractAddressFromHash(commitment, classHash, [], anonymizerAddress)
   );
+}
+
+/**
+ * The address the anonymizer deploys the shadow account of `commitment` to, resolved against the
+ * chain rather than assumed off-chain.
+ *
+ * Looks up `commitment` in the anonymizer's `get_shadow_account` registry first. If a shadow
+ * account is already deployed for it, the registry's stored address is authoritative regardless of
+ * which class the anonymizer deploys from — a pre-primer anonymizer's registry is exactly as
+ * trustworthy as a primer-pattern one's, so this needs no class hash at all in that case.
+ *
+ * If nothing is deployed yet, there is no on-chain way to tell which class this anonymizer *will*
+ * deploy from: as {@link shadowAccountAddress} explains, the primer pattern's class hash is a Cairo
+ * constant with no corresponding view, so a pre-primer anonymizer is indistinguishable on-chain from
+ * a primer-pattern one before something is actually deployed. This falls back to
+ * {@link shadowAccountAddress}'s primer formula in that case — correct for a current-generation
+ * anonymizer, but a guess that is wrong for one that predates the primer pattern. Do not fund a
+ * predicted, not-yet-deployed address on an anonymizer whose generation you have not verified out
+ * of band; a caller who knows they are targeting an older anonymizer should read its
+ * `get_shadow_account_class_hash` and call {@link shadowAccountAddressFromClassHash} explicitly
+ * instead of relying on this fallback.
+ */
+export async function shadowAccountAddressOnChain(
+  commitment: bigint,
+  anonymizerAddress: bigint,
+  provider: ProviderInterface
+): Promise<bigint> {
+  const [deployed] = await provider.callContract({
+    contractAddress: toHex(anonymizerAddress),
+    entrypoint: "get_shadow_account",
+    calldata: [toHex(commitment)],
+  });
+  const deployedAddress = toBigInt(deployed);
+  if (deployedAddress !== 0n) {
+    return deployedAddress;
+  }
+  return shadowAccountAddress(commitment, anonymizerAddress);
 }

--- a/sdk/tests/internal/shadow-account-address.test.ts
+++ b/sdk/tests/internal/shadow-account-address.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
+import type { ProviderInterface } from "starknet";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   PRIMER_CLASS_HASH,
   shadowAccountAddress,
+  shadowAccountAddressFromClassHash,
+  shadowAccountAddressOnChain,
   shadowAccountCommitment,
   shadowAccountPartialCommitment,
 } from "../../src/internal/shadow-account-address.js";
@@ -22,6 +25,22 @@ const ANONYMIZER = 0x444n;
 const PARTIAL_COMMITMENT = 0xdbb320724c2f71919310007cc2ee821e9b234b98535d24dae197124c2ef4fbn;
 const COMMITMENT = 0x418bf56bebf218ffa365531394e68b3336a9557b5b8be8ad6a21f44e79833bn;
 const ADDRESS = 0x5e1a753154c6cbb012b819c0362921b7040df54b90bb9241f54e7d946cf9708n;
+
+/**
+ * Live Starknet Sepolia vector for anonymizer 0x010a2285...9fe8d9b147, which predates the primer
+ * pattern: it has no `get_primer_class_hash` entrypoint at all (RPC error 21, "Requested entry
+ * point does not exist") and deploys shadow accounts with its `get_shadow_account_class_hash()`
+ * class directly. `deployedOnSepolia` is the address `get_shadow_account(commitment)` actually
+ * returns on-chain (`ShadowAccountDeployed` event, tx 0x48ccd889292f406734d97a27c53db53910fb0f9ef
+ * 3c056668bd64e20ccb111b, block 14130089) — the primer formula predicts a different, wrong address
+ * for the same commitment, because this anonymizer never deploys a Primer at all.
+ */
+const SEPOLIA = {
+  commitment: 0x72c7cef4c82933a9107758dc7385e8378c306c866269cdc814a446fb71a874cn,
+  anonymizer: 0x010a2285310c107c731d997afc147afb7495daff6397c2d242133d9fe8d9b147n,
+  shadowAccountClassHash: 0x70e76435b6ddb74b11665d3bc3264aaf354f59329976f3ffcb03b2ab992b78fn,
+  deployedOnSepolia: 0x5070c79c08b1146ec188f9e5f21c58cf83358f786b23d64d7c66b4c1ba477c9n,
+};
 
 describe("shadow account derivation", () => {
   it("matches the committed Cairo vector", () => {
@@ -66,4 +85,71 @@ describe("shadow account derivation", () => {
       0x00123e6bc1c14ae9934e933d3f64916a6116dd6b036a922b2b1f0815e0d1d300n
     );
   });
+});
+
+describe("shadowAccountAddressFromClassHash", () => {
+  it("agrees with shadowAccountAddress when passed PRIMER_CLASS_HASH", () => {
+    expect(shadowAccountAddressFromClassHash(COMMITMENT, PRIMER_CLASS_HASH, ANONYMIZER)).toBe(
+      shadowAccountAddress(COMMITMENT, ANONYMIZER)
+    );
+  });
+
+  it(
+    "reproduces the address a pre-primer anonymizer actually deployed on Sepolia, given its " +
+      "shadow account class hash",
+    () => {
+      const { commitment, anonymizer, shadowAccountClassHash, deployedOnSepolia } = SEPOLIA;
+
+      expect(
+        shadowAccountAddressFromClassHash(commitment, shadowAccountClassHash, anonymizer)
+      ).toBe(deployedOnSepolia);
+      // The primer formula alone gets this wrong: this anonymizer never deploys a Primer at all.
+      expect(shadowAccountAddress(commitment, anonymizer)).not.toBe(deployedOnSepolia);
+    }
+  );
+});
+
+describe("shadowAccountAddressOnChain", () => {
+  /** A minimal `ProviderInterface` stub: only `callContract` is exercised. */
+  function mockProvider(callContract: ProviderInterface["callContract"]): ProviderInterface {
+    return { callContract } as unknown as ProviderInterface;
+  }
+
+  it(
+    "returns the anonymizer's registered address once one is deployed, even for a pre-primer " +
+      "anonymizer (real Sepolia vector)",
+    async () => {
+      const { commitment, anonymizer, deployedOnSepolia } = SEPOLIA;
+      const callContract = vi.fn().mockImplementation(async (call) => {
+        expect(call.entrypoint).toBe("get_shadow_account");
+        expect(call.contractAddress).toBe(`0x${anonymizer.toString(16)}`);
+        expect(call.calldata).toEqual([`0x${commitment.toString(16)}`]);
+        return [`0x${deployedOnSepolia.toString(16)}`];
+      });
+
+      await expect(
+        shadowAccountAddressOnChain(commitment, anonymizer, mockProvider(callContract))
+      ).resolves.toBe(deployedOnSepolia);
+      expect(callContract).toHaveBeenCalledTimes(1);
+      // The registry lookup is authoritative regardless of generation: the primer formula alone
+      // would have gotten this one wrong.
+      expect(shadowAccountAddress(commitment, anonymizer)).not.toBe(deployedOnSepolia);
+    }
+  );
+
+  it(
+    "falls back to the primer formula when the registry has nothing deployed for this " +
+      "commitment yet",
+    async () => {
+      const callContract = vi.fn().mockImplementation(async (call) => {
+        expect(call.entrypoint).toBe("get_shadow_account");
+        return ["0x0"];
+      });
+
+      await expect(
+        shadowAccountAddressOnChain(COMMITMENT, ANONYMIZER, mockProvider(callContract))
+      ).resolves.toBe(shadowAccountAddress(COMMITMENT, ANONYMIZER));
+      expect(callContract).toHaveBeenCalledTimes(1);
+    }
+  );
 });


### PR DESCRIPTION
## Problem

`shadowAccountAddress(commitment, anonymizerAddress)` in `sdk/src/internal/shadow-account-address.ts` unconditionally derives the address using the hardcoded `PRIMER_CLASS_HASH` — the class of the `Primer` contract the anonymizer deploys from before replacing its class with the shadow account's. That formula is correct for anonymizers deployed under the primer pattern, but **anonymizers deployed before the primer pattern existed deploy the shadow account class directly**, with no on-chain check that a given anonymizer actually uses the primer. For those, `shadowAccountAddress` silently returns an address the anonymizer will never deploy to.

### Live evidence (Starknet Sepolia)

- Anonymizer `0x010a2285310c107c731d997afc147afb7495daff6397c2d242133d9fe8d9b147` has **no** `get_primer_class_hash` entrypoint (RPC error 21, "Requested entry point does not exist") — in fact this entrypoint doesn't exist on *any* anonymizer in this codebase; `PRIMER_CLASS_HASH` is a Cairo constant (`packages/shadow_account_anonymizer/src/shadow_account_anonymizer.cairo`), never exposed by a view. It does answer `get_shadow_account_class_hash()` → `0x70e76435b6ddb74b11665d3bc3264aaf354f59329976f3ffcb03b2ab992b78f`, and `get_shadow_account(commitment)` → the deployed address once one exists.
- For commitment `0x72c7cef4c82933a9107758dc7385e8378c306c866269cdc814a446fb71a874c`:
  - The primer formula (current `shadowAccountAddress`) predicts `0x46b08f2e2ac5e91359a747810e361f3f236731bee2333c920f1fb9375a94628`.
  - `get_shadow_account_class_hash` combined with the same salt formula predicts `0x5070c79c08b1146ec188f9e5f21c58cf83358f786b23d64d7c66b4c1ba477c9`, which is the address **actually deployed** on chain (`ShadowAccountDeployed` event, tx [`0x48ccd889292f406734d97a27c53db53910fb0f9ef3c056668bd64e20ccb111b`](https://sepolia.voyager.online/tx/0x48ccd889292f406734d97a27c53db53910fb0f9ef3c056668bd64e20ccb111b), block 14130089, SUCCEEDED) — and `get_shadow_account(commitment)` returns this same address directly, as a registry read.
- Consequence for integrators: funding the address `shadowAccountAddress` predicts sends funds to an address the anonymizer never deploys; the subsequent spend reverts inside the shadow account with `ERC20: insufficient balance` — a silent fund-misdirection shape, not a loud failure.

Found while integrating shadow accounts into a private-neobank build on Sepolia.

## The substantive finding for maintainers: registry vs. predictor, and no on-chain discriminator

`get_shadow_account(commitment)` is authoritative and era-agnostic once something is deployed — it correctly returned the real deployed address above regardless of which class the anonymizer used. But it is a *registry*, not a *predictor*: for a commitment nothing has been deployed against yet, it returns the zero address (verified against undeployed commitments on the same anonymizer), so it cannot answer the pre-funding question on its own.

That leaves a real gap for the pre-funding case: **there is no on-chain way to tell a pre-primer anonymizer apart from a primer-pattern one before something is deployed.** `PRIMER_CLASS_HASH` is a Cairo constant with no corresponding view, so nothing about `anonymizerAddress` itself says which generation it is. This PR does not (and cannot) close that gap — it makes the registry-authoritative case correct and the ambiguous case explicit and opt-in rather than a silent wrong guess.

As a possible follow-up, it might be worth maintainers considering exposing either a `get_primer_class_hash` view or a `predict_shadow_account_address(commitment)` view on the anonymizer itself, so a caller could resolve the pre-deployment case on-chain too instead of needing to know an anonymizer's generation out of band. Raising this as a question, not a demand — happy to help if there's interest.

## Fix

Small, additive, non-breaking:

- Adds `shadowAccountAddressOnChain(commitment, anonymizerAddress, provider)` alongside the existing sync `shadowAccountAddress`. It looks `commitment` up in the anonymizer's `get_shadow_account` registry first; if a shadow account is already deployed, that stored address is returned directly (authoritative, era-agnostic). Only if nothing is deployed yet does it fall back to the existing primer formula — correct for current-generation anonymizers, a guess for older ones, exactly as `shadowAccountAddress` already documents.
- Adds `shadowAccountAddressFromClassHash(commitment, classHash, anonymizerAddress)`, the address formula generalized to an explicit class hash, so a caller who knows out of band that they're targeting a pre-primer anonymizer (and has read its `get_shadow_account_class_hash`) can opt in deliberately instead of the library guessing for them.
- Exports both new helpers from `sdk/src/index.ts`.
- Does **not** change `PRIMER_CLASS_HASH` and does **not** change the behavior of the existing sync `shadowAccountAddress` — its primer-pattern assumption is correct for current deployments; the gap is only the pre-funding case for anonymizers that predate it.
- Updates the JSDoc on `shadowAccountAddress` to state plainly that it assumes the primer pattern, that there is no on-chain view to discover an anonymizer's generation before deployment, and points callers at `shadowAccountAddressOnChain` (post-deployment, or as a documented fallback) or `shadowAccountAddressFromClassHash` (deliberate opt-in for a known pre-primer anonymizer).
- No blanket `try`/`catch` anywhere: a provider error from the registry read propagates to the caller rather than silently falling through to a guess.
- Adds unit tests (mocked provider, no network): registry-hit returns the authoritative address (verified against the real Sepolia vector above, including the assertion that the primer formula alone would have gotten it wrong); registry-miss falls back to the primer formula; `shadowAccountAddressFromClassHash` reproduces the real Sepolia address from the commitment and class hash directly, and agrees with `shadowAccountAddress` when passed `PRIMER_CLASS_HASH`.
- Adds a `CHANGELOG.md` entry under `sdk/CHANGELOG.md` matching the existing "Added" style for this file.

## Test plan

- [x] `npx vitest run tests/internal/shadow-account-address.test.ts --coverage.enabled=false` — 9/9 pass (5 existing + 4 new)
- [x] Broke the Sepolia-address constant and, separately, the registry-precedence logic in source; confirmed each relevant test goes red; restored both; confirmed green again
- [x] `npx eslint src/ tests/` — clean
- [x] `npx tsc --noEmit -p tsconfig.build.json` — clean
- [x] `npx tsc -p tsconfig.build.json` (build) — clean
- [x] `npm run check:fast` (build + lint + fast test suite) — 264/264 tests pass
- [x] `python3 scripts/check_primer_class_hash.py` — still agrees (unchanged)

Only `sdk/` files touched; no Cairo changes.

---

**Edit:** an earlier revision of this PR had `shadowAccountAddressOnChain` try `get_primer_class_hash` first with a catch-all fallback to `get_shadow_account_class_hash` on any failure — Copilot's automated review correctly flagged that a blanket catch could silently swap derivation paths on a transient RPC error, not just on "entrypoint not found". That whole shape is now gone: `get_primer_class_hash` doesn't exist on any anonymizer in this codebase, so it was dead code that always fell through anyway, and always risked the exact failure mode described above for a primer-pattern anonymizer. The current design (above) reads the authoritative `get_shadow_account` registry instead, with no fallback branch and no swallowed errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/977)
<!-- Reviewable:end -->
