### PR TITLE
refactor(e2e): read devnet's chain id from devnet instead of naming it

### DIFF
--- a/e2e/src/harness.ts
+++ b/e2e/src/harness.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import { join } from "path";
-import { constants, hash, type Account } from "starknet";
+import { hash, type Account } from "starknet";
 import { nodeOf, repoRoot } from "./utils.js";
 import {
   Devnet,
@@ -118,7 +118,7 @@ export async function createE2eTestEnv(
   config?: E2eTestEnvConfig,
 ): Promise<E2eTestEnv> {
   const env = await devnet.initialize();
-  const chainId = constants.StarknetChainId.SN_SEPOLIA;
+  const chainId = env.chainId;
 
   const indexer = await IndexerClient.spawn({
     wsUrl: devnet.wsUrl,

--- a/e2e/src/signing-client.ts
+++ b/e2e/src/signing-client.ts
@@ -31,8 +31,6 @@ import type {
  * seam differ between tests, so those stay in each test.
  */
 
-const CHAIN_ID = constants.StarknetChainId.SN_SEPOLIA;
-
 export interface CoreProverParams {
   signer: SignerInterface;
   address: StarknetAddress;
@@ -40,6 +38,7 @@ export interface CoreProverParams {
   node: ProviderInterface;
   indexerApiUrl: string;
   poolAddress: string;
+  chainId: constants.StarknetChainId;
   /**
    * Only needed when the flow calls `shadowAccounts(...)`; unused otherwise. Supplying it also
    * selects the interceptor-backed prover, which is what a `Delegated` anonymizer needs — the
@@ -63,8 +62,8 @@ export function makeCoreProver(
     ),
     prover:
       params.shadowAccountAnonymizerAddress === undefined
-        ? new ScreeningCallMockProofProvider(params.node, CHAIN_ID)
-        : new InterceptorSubjectProofProvider(params.node, CHAIN_ID, {
+        ? new ScreeningCallMockProofProvider(params.node, params.chainId)
+        : new InterceptorSubjectProofProvider(params.node, params.chainId, {
             poolAddress: params.poolAddress,
           }),
     poolContractAddress: params.poolAddress,

--- a/e2e/tests/devnet/ohttp-relay.test.ts
+++ b/e2e/tests/devnet/ohttp-relay.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants } from "starknet";
 import {
   Devnet,
   ScreeningCallMockProofProvider,
@@ -85,7 +84,7 @@ describe("E2E OHTTP via relay", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
@@ -122,7 +121,7 @@ describe("E2E OHTTP via relay", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,

--- a/e2e/tests/devnet/ohttp.test.ts
+++ b/e2e/tests/devnet/ohttp.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants } from "starknet";
 import {
   Devnet,
   ScreeningCallMockProofProvider,
@@ -81,7 +80,7 @@ describe("E2E OHTTP", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,
@@ -115,7 +114,7 @@ describe("E2E OHTTP", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: ohttpDiscovery,
       poolContractAddress: de.privacy.address,

--- a/e2e/tests/devnet/pagination-discovery.test.ts
+++ b/e2e/tests/devnet/pagination-discovery.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants } from "starknet";
 import {
   Devnet,
   ScreeningCallMockProofProvider,
@@ -72,7 +71,7 @@ describe("Discovery pagination with small budget", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
@@ -106,7 +105,7 @@ describe("Discovery pagination with small budget", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,
@@ -123,7 +122,7 @@ describe("Discovery pagination with small budget", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: discovery,
       poolContractAddress: de.privacy.address,

--- a/e2e/tests/devnet/payment-service-discovery.test.ts
+++ b/e2e/tests/devnet/payment-service-discovery.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants } from "starknet";
 import type { DevnetEnvironment } from "@starkware-libs/starknet-privacy-sdk/testing";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -41,7 +40,7 @@ describe("Payment Service Discovery", () => {
     env = await createE2eTestEnv(devnet, { indexer: { logFile: INDEXER_LOG } });
 
     const { env: de } = env;
-    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const chainId = env.env.chainId;
     const indexerDiscovery = new IndexerDiscoveryProvider(
       env.indexer.apiUrl,
       de.privacy.address,
@@ -222,7 +221,7 @@ describe("Payment Service Discovery", () => {
       env.indexer.apiUrl,
       de.privacy.address,
     );
-    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const chainId = env.env.chainId;
 
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
@@ -251,7 +250,7 @@ describe("Payment Service Discovery", () => {
       env.indexer.apiUrl,
       de.privacy.address,
     );
-    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const chainId = env.env.chainId;
 
     const aliceDiscover = createPrivateTransfers({
       account: de.alice,
@@ -278,7 +277,7 @@ describe("Payment Service Discovery", () => {
       env.indexer.apiUrl,
       de.privacy.address,
     );
-    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const chainId = env.env.chainId;
 
     for (let i = 0; i < users.length; i++) {
       const userDiscover = createPrivateTransfers({
@@ -305,7 +304,7 @@ describe("Payment Service Discovery", () => {
       env.indexer.apiUrl,
       de.privacy.address,
     );
-    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const chainId = env.env.chainId;
 
     for (let i = 0; i < users.length; i++) {
       const userDiscover = createPrivateTransfers({

--- a/e2e/tests/devnet/shadow-account-compute-invoke.test.ts
+++ b/e2e/tests/devnet/shadow-account-compute-invoke.test.ts
@@ -18,7 +18,6 @@ import {
   CairoCustomEnum,
   CallData,
   cairo,
-  constants,
   hash,
   shortString,
   type BlockIdentifier,
@@ -199,10 +198,7 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
     const unattestingAlice = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new CallMockProofProvider(
-        de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
-      ),
+      provingProvider: new CallMockProofProvider(de.node, env.env.chainId),
       discoveryProvider: new IndexerDiscoveryProvider(
         env.indexer.apiUrl,
         de.privacy.address,
@@ -240,10 +236,7 @@ describe("shadow account anonymizer compute-and-invoke on devnet", () => {
     const wrongSubjectAlice = createPrivateTransfers({
       account: de.alice,
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
-      provingProvider: new WrongSubjectProofProvider(
-        de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
-      ),
+      provingProvider: new WrongSubjectProofProvider(de.node, env.env.chainId),
       discoveryProvider: new IndexerDiscoveryProvider(
         env.indexer.apiUrl,
         de.privacy.address,

--- a/e2e/tests/devnet/shadow-account-invoke.test.ts
+++ b/e2e/tests/devnet/shadow-account-invoke.test.ts
@@ -92,6 +92,7 @@ describe("dapp client: shadowAccounts(dappName).invoke + addresses on devnet", (
       node: node,
       indexerApiUrl: env.indexer.apiUrl,
       poolAddress: privacy.address,
+      chainId: env.env.chainId,
       shadowAccountAnonymizerAddress: shadowAccount.anonymizer,
     });
     const wallet = {

--- a/e2e/tests/devnet/signing-evm.test.ts
+++ b/e2e/tests/devnet/signing-evm.test.ts
@@ -164,6 +164,7 @@ describe("dapp client: Eth712Account (EVM) deposit on devnet", () => {
       node,
       indexerApiUrl: env.indexer.apiUrl,
       poolAddress: privacy.address,
+      chainId: env.env.chainId,
       paymaster: efoMockPaymaster(),
     });
   }

--- a/e2e/tests/devnet/signing.test.ts
+++ b/e2e/tests/devnet/signing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants, ec, num } from "starknet";
+import { ec, num } from "starknet";
 import type { TypedData } from "starknet";
 import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
 import type {
@@ -146,7 +146,7 @@ describe("dapp client: SNIP-12 CallSet signer deposit on devnet", () => {
     const { alice, privacy, node } = env.env;
     const signer = new Snip12CallSetSigner({
       accountAddress: alice.address,
-      chainId: constants.StarknetChainId.SN_SEPOLIA,
+      chainId: env.env.chainId,
       sign: (messageHash) =>
         ec.starkCurve.sign(num.toHex(messageHash), signingKey),
     });
@@ -157,6 +157,7 @@ describe("dapp client: SNIP-12 CallSet signer deposit on devnet", () => {
       node,
       indexerApiUrl: env.indexer.apiUrl,
       poolAddress: privacy.address,
+      chainId: env.env.chainId,
       paymaster: mockPaymaster(),
     });
   }

--- a/e2e/tests/devnet/smoke.test.ts
+++ b/e2e/tests/devnet/smoke.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { constants } from "starknet";
 import {
   Devnet,
   ScreeningCallMockProofProvider,
@@ -70,7 +69,7 @@ describe("E2E Smoke", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xA11CE") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,
@@ -101,7 +100,7 @@ describe("E2E Smoke", () => {
       viewingKeyProvider: { getViewingKey: async () => BigInt("0xB0B") },
       provingProvider: new ScreeningCallMockProofProvider(
         de.node,
-        constants.StarknetChainId.SN_SEPOLIA,
+        env.env.chainId,
       ),
       discoveryProvider: indexerDiscovery,
       poolContractAddress: de.privacy.address,

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -44,6 +44,8 @@ import { AddressMap } from "../utils/maps.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+export const DEVNET_CHAIN_ID = "TESTNET";
+
 // Contract paths
 const CONTRACT_CLASS_PATH = join(
   __dirname,
@@ -86,6 +88,8 @@ export interface DevnetEnvironment {
   eth: string;
   privacy: PrivacyPoolContract;
   node: RpcProvider;
+  /** The chain devnet reports, read from it rather than named, so a suite cannot pin a stale one. */
+  chainId: constants.StarknetChainId;
 }
 
 export class Devnet {
@@ -135,7 +139,7 @@ export class Devnet {
       "--dump-on",
       "request", // Enable devnet_dump RPC (no-op unless explicitly called)
       "--chain-id",
-      "TESTNET",
+      DEVNET_CHAIN_ID,
       "--proof-mode",
       "none",
     ];
@@ -167,7 +171,6 @@ export class Devnet {
       nodeUrl: this.devnet.provider.url,
       transactionRetryIntervalFallback: 50,
       batch: 0,
-      chainId: "0x534e5f5345504f4c4941",
     });
     // Get predeployed accounts using JSON-RPC directly
     const response = await fetch(this.devnet.provider.url, {
@@ -250,6 +253,7 @@ export class Devnet {
       eth,
       privacy,
       node: this.node,
+      chainId: (await this.node.getChainId()) as constants.StarknetChainId,
     };
 
     debugLog("devnet", "initialize", () =>
@@ -488,7 +492,7 @@ export async function createDevnetTestEnv(
   config?: DevnetTestEnvConfig
 ): Promise<DevnetTestEnv> {
   const env = await devnet.initialize();
-  const chainId = constants.StarknetChainId.SN_SEPOLIA;
+  const chainId = env.chainId;
 
   // The pool screens deposits, so use a proving provider that signs each deposit's attestation
   // with the screener key the pool was deployed with.
@@ -523,7 +527,7 @@ export function createUnattestedAliceTransfers(env: DevnetEnvironment): PrivateT
   return createPrivateTransfers({
     account: env.alice,
     viewingKeyProvider: { getViewingKey: async () => toBigInt("0xA11CE") },
-    provingProvider: new CallMockProofProvider(env.node, constants.StarknetChainId.SN_SEPOLIA),
+    provingProvider: new CallMockProofProvider(env.node, env.chainId),
     discoveryProvider: new ContractDiscoveryProvider(env.privacy),
     poolContractAddress: env.privacy.address,
   });

--- a/sdk/src/testing/index.ts
+++ b/sdk/src/testing/index.ts
@@ -51,6 +51,7 @@ export {
 } from "./concurrency-profiler.js";
 export {
   Devnet,
+  DEVNET_CHAIN_ID,
   createDevnetTestEnv,
   createUnattestedAliceTransfers,
   type DevnetConfig,


### PR DESCRIPTION
- `DevnetEnvironment` carries the `chainId` the node reports, and `--chain-id`
  comes from one exported `DEVNET_CHAIN_ID`. Nothing downstream names a chain any
  more: the harness, `makeCoreProver` (now a required `chainId` param) and all
  twenty-odd suite call sites read `env.env.chainId`.
- The felt is never written down. Devnet resolves the launch name through its own
  alias table (`TESTNET` is `SN_SEPOLIA`) and nothing here can derive one from the
  other, so the provider stops pinning `chainId` and reads it from the node like
  everything else — one constant, nothing to drift against.
- The value is unchanged, so this is a refactor. It removes the class of bug where
  devnet's chain id moves and the proof facts every suite builds keep naming the
  old one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/980)
<!-- Reviewable:end -->
