### PR TITLE
feat(e2e): run devnet on its own chain id, so nothing it signs replays on Sepolia

### DIFF
--- a/e2e/tests/devnet/eth712-account.test.ts
+++ b/e2e/tests/devnet/eth712-account.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { CallData, hash, num, shortString, type Call } from "starknet";
+import {
+  CairoFelt252,
+  CallData,
+  hash,
+  num,
+  shortString,
+  type Call,
+} from "starknet";
 import {
   Devnet,
   type DevnetEnvironment,
@@ -47,7 +54,9 @@ describe("StarknetEth712Account custom-signature validation on devnet", () => {
       const approveCalldata = ["0x1234", "0x1f4", "0x0"];
       const signer = new Eip712HashSigner({
         accountAddress: account.address,
-        snChainName: "SN_SEPOLIA", // devnet chain id — keccak'd into the EIP-712 domain name
+        // The account decodes the domain name from `get_tx_info().chain_id`, so read it from the
+        // chain rather than naming it.
+        snChainName: new CairoFelt252(env.chainId).decodeUtf8(),
         evmChainId: 1n,
         sign: secp256k1SignFn(EVM_KEY),
       });

--- a/e2e/tests/devnet/signing-evm.test.ts
+++ b/e2e/tests/devnet/signing-evm.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { CallData, num, shortString, type TypedData } from "starknet";
+import {
+  CairoFelt252,
+  CallData,
+  num,
+  shortString,
+  type TypedData,
+} from "starknet";
 import { Devnet } from "@starkware-libs/starknet-privacy-sdk/testing";
 import type {
   Paymaster,
@@ -96,10 +102,10 @@ describe("dapp client: Eth712Account (EVM) deposit on devnet", () => {
           calls: build.calls,
         };
         // Build the OutsideExecution typed data with the real domain the account verifies against
-        // (SN_SEPOLIA / evm chain 1 / this account) — the signer now reads the domain from here.
+        // (this chain / evm chain 1 / this account) — the signer now reads the domain from here.
         const typedData = outsideExecutionTypedData({
           accountAddress: account.address,
-          snChainName: "SN_SEPOLIA",
+          snChainName: new CairoFelt252(env.env.chainId).decodeUtf8(),
           evmChainId: 1n,
           calls: outsideExecution.calls.map((call) => ({
             address: call.to,
@@ -153,7 +159,7 @@ describe("dapp client: Eth712Account (EVM) deposit on devnet", () => {
     const { privacy, node } = env.env;
     const signer = new Eip712HashSigner({
       accountAddress: account.address,
-      snChainName: "SN_SEPOLIA",
+      snChainName: new CairoFelt252(env.env.chainId).decodeUtf8(),
       evmChainId: 1n,
       sign: secp256k1SignFn(EVM_KEY),
     });

--- a/sdk/src/testing/devnet.ts
+++ b/sdk/src/testing/devnet.ts
@@ -44,7 +44,7 @@ import { AddressMap } from "../utils/maps.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export const DEVNET_CHAIN_ID = "TESTNET";
+export const DEVNET_CHAIN_ID = "SN_DEVNET";
 
 // Contract paths
 const CONTRACT_CLASS_PATH = join(


### PR DESCRIPTION
`DEVNET_CHAIN_ID` becomes `SN_DEVNET`. The devnet pool is deployed with the
canonical test screener key, whose private half is public in this repo, so an
attestation minted here used to verify against any Sepolia pool holding the same
key. The chain id is bound into the attestation's SNIP-12 domain, so the two
domains now hash differently and a devnet signature is worthless off devnet.

The three EIP-712 sites decode the domain name from the chain id rather than
naming `SN_SEPOLIA`. The account derives it from `get_tx_info().chain_id`, so
hardcoding it made the domain separator diverge — those three suites failed until
they read the chain instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/981)
<!-- Reviewable:end -->
