### PR TITLE
discovery-core: make unused starknet-providers optional behind a default-on feature

### DIFF
--- a/crates/discovery-core/Cargo.toml
+++ b/crates/discovery-core/Cargo.toml
@@ -3,6 +3,10 @@ name = "discovery-core"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["providers"]
+providers = ["dep:starknet-providers"]
+
 [dependencies]
 thiserror = "1.0"
 async-trait = "0.1"
@@ -10,7 +14,7 @@ num-traits = "0.2"
 starknet-core = { package = "starknet-rust-core", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-crypto = { package = "starknet-rust-crypto", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
 starknet-types-core = { version = "0.2", features = ["curve", "serde"] }
-starknet-providers = { package = "starknet-rust-providers", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe" }
+starknet-providers = { package = "starknet-rust-providers", git = "https://github.com/software-mansion/starknet-rust.git", rev = "7caedfe", optional = true }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 url = "2"


### PR DESCRIPTION
`starknet-providers` is declared as a dependency of `discovery-core` but is not referenced anywhere under `crates/discovery-core/src` or its `tests`: `grep -rn 'starknet.providers' crates/discovery-core/src crates/discovery-core/tests` returns nothing.

This makes it `optional = true` behind a `providers` feature that is enabled by default.

**Source-compatible for every existing consumer.** The feature is on unless explicitly disabled, and no public API of the crate mentions the provider types, so the dependency graph resolves identically for anyone who does nothing.

**What it buys.** Consumers building `discovery-core` for a constrained target can pass `default-features = false`. On `wasm32-unknown-unknown` the graph drops from 142 to 118 crates, removing `starknet-providers`, `reqwest`, `web-sys`, `wasm-bindgen-futures` and the `ethereum-types`/`primitive-types` stack.

**To be precise about what this is not:** `discovery-core` already builds for `wasm32-unknown-unknown` with default features today. This is a reduction in dependency surface, not a fix for a broken target.

No lines under `crates/discovery-core/src` are changed — the diff is five lines of `Cargo.toml`.

Context: we run the engine unmodified inside a keyless note indexer (https://github.com/kfastov/strk20-indexer) and are packaging the consumer half for the browser, which is where the smaller graph matters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/984)
<!-- Reviewable:end -->
