### PR TITLE
feat(privacy): screen a Delegated depositor itself when its invoke returns no addresses

### DIFF
--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -573,13 +573,13 @@ pub trait IServer<T> {
     ///   - A target whose policy is `Required` (every unlisted address) makes the Invoke target
     ///   itself the tx's screening subject; a target that is `Exempt` raises no requirement. See
     ///   the screening errors above.
-    ///   - A depositor in `Delegated` mode provides the addresses associated with its deposits.
-    ///   The screening is performed on the associated addresses.
+    ///   - A depositor in `Delegated` mode is screened on the addresses returned after its
+    ///   deposits, or on itself when none follow.
     ///     - [`INVALID_ASSOCIATED_ADDRESSES`](privacy::errors::INVALID_ASSOCIATED_ADDRESSES):
-    ///       Thrown if no `Span<ContractAddress>` follows the deposits in the returned data, albeit
-    ///       expected. May indicate a depositor set to `Delegated` by mistake.
+    ///       Thrown if the data following the deposits is not a well-formed
+    ///       `Span<ContractAddress>`.
     ///     - [`NO_ASSOCIATED_ADDRESS`](privacy::errors::NO_ASSOCIATED_ADDRESS):
-    ///       Thrown when an associated address is required, but an empty span was provided.
+    ///       Thrown if that span is present but empty.
     ///     - [`INVALID_INVOKE_RETURN_DATA`](privacy::errors::INVALID_INVOKE_RETURN_DATA):
     ///       Thrown when the data returned from the call exceeds the expected one.
     ///
@@ -920,10 +920,9 @@ pub trait IAdmin<T> {
     /// default policy.
     /// - `Exempt`: the depositor's open-note deposits are exempted from screening.
     /// - `Delegated`: providing the addresses for screening is delegated to the depositor, which
-    /// lists them in the returned data following its deposits. The pool trusts the depositor to
-    /// report the associated addresses correctly.
-    /// See [`OpenNoteScreeningPolicy`](privacy::objects::OpenNoteScreeningPolicy) for how each
-    /// policy behaves per invoke kind.
+    /// lists them in the returned data following its deposits, falling back to screening the
+    /// depositor itself when none follow. The pool trusts the depositor to report the associated
+    /// addresses correctly.
     ///
     /// #### Parameters
     /// - `depositor` (`ContractAddress`): The depositor, e.g., an anonymizer contract. Must be

--- a/packages/privacy/src/objects.cairo
+++ b/packages/privacy/src/objects.cairo
@@ -99,14 +99,13 @@ pub struct Note {
     pub token: ContractAddress,
 }
 
-/// The table below details how the pool applies screening on open-note deposits, given the
-/// screening policy of the depositor and the actual invoke method used.
+/// The list below details how the pool applies screening on open-note deposits, given the
+/// screening policy of the depositor:
 ///
-/// | policy      | `privacy_invoke`     | `privacy_invoke_with_computation` |
-/// |-------------|----------------------|-----------------------------------|
-/// | `Required`  | screen the depositor | screen the depositor              |
-/// | `Exempt`    | no screening         | no screening                      |
-/// | `Delegated` | no screening         | screen the provided addresses     |
+/// - `Required`: screen the depositor.
+/// - `Exempt`: no screening.
+/// - `Delegated`: screen the addresses the invoke returns after the deposits, or the depositor
+///   itself when none are returned.
 ///
 /// No policy rejects a depositor outright. Under the default `Required`, a depositor the screening
 /// provider refuses gets no attestation, so its deposits are blocked anyway.

--- a/packages/privacy/src/privacy.cairo
+++ b/packages/privacy/src/privacy.cairo
@@ -983,9 +983,10 @@ pub mod Privacy {
         /// Executes the external invoke on `contract_address` with `selector`, emits an
         /// [`ExternalContractInvoked`](events::ExternalContractInvoked) event, and deposits the
         /// returned open notes. The return data is the deposits, optionally followed by the
-        /// addresses they are associated with; only a `Delegated` compute-invoke's addresses are
-        /// screened, but whatever follows the deposits must be a well-formed address span.
-        /// `selector` distinguishes a plain invoke from a compute-and-invoke; calldata is
+        /// addresses they are associated with; under a `Delegated` policy those addresses are
+        /// screened regardless of invoke kind, falling back to `contract_address` itself when
+        /// none follow the deposits. Whatever follows the deposits must be a well-formed address
+        /// span. `selector` distinguishes a plain invoke from a compute-and-invoke; calldata is
         /// intentionally not emitted, as it is already visible in the public call trace.
         fn _apply_invoke_and_deposits(
             ref self: ContractState,
@@ -1012,16 +1013,15 @@ pub mod Privacy {
                     ),
                     OpenNoteScreeningPolicy::Exempt => {},
                     OpenNoteScreeningPolicy::Delegated => {
-                        // Only a compute-invoke is delegated; a plain invoke is exempt.
-                        if selector == INVOKE_WITH_COMPUTATION_SELECTOR {
-                            let associated_addresses = associated_addresses
-                                .expect(errors::INVALID_ASSOCIATED_ADDRESSES);
+                        if let Some(associated_addresses) = associated_addresses {
                             assert(!associated_addresses.is_empty(), errors::NO_ASSOCIATED_ADDRESS);
                             for associated_address in associated_addresses {
                                 unify_address(
                                     ref screening_subject, reference: *associated_address,
                                 );
                             }
+                        } else {
+                            unify_address(ref screening_subject, reference: contract_address);
                         }
                     },
                 }

--- a/packages/privacy/src/tests/mock_delegated_screening.cairo
+++ b/packages/privacy/src/tests/mock_delegated_screening.cairo
@@ -2,12 +2,11 @@
 //! [`OpenNoteScreeningPolicy`](privacy::objects::OpenNoteScreeningPolicy) is `Delegated`.
 //!
 //! A delegated depositor returns the addresses its deposits are associated with after those
-//! deposits, in the same return data, so these mocks differ from an ordinary depositor only in
-//! what their compute-invoke returns.
+//! deposits, in the same return data, regardless of which invoke entry point funds them.
 //!
 //! [`MockDelegatedTarget`] implements both `privacy_invoke` and
-//! `privacy_invoke_with_computation`, standing in for a target that offers both: only the latter
-//! appends addresses, since only the latter is delegated.
+//! `privacy_invoke_with_computation`, appending the same addresses after either one's deposits.
+//! [`MockDelegatedWithoutAddresses`] implements both too, appending nothing after either.
 
 use privacy::objects::OpenNoteDeposit;
 use starknet::ContractAddress;
@@ -22,16 +21,18 @@ pub trait IMockDelegatedTarget<T> {
     fn privacy_invoke_with_computation(
         ref self: T, commitment: felt252, deposits: Span<OpenNoteDeposit>,
     ) -> (Span<OpenNoteDeposit>, Span<ContractAddress>);
-    /// Funds open notes without a computation — never delegated, so these deposits are exempt and
-    /// no addresses follow them.
-    fn privacy_invoke(ref self: T, deposits: Span<OpenNoteDeposit>) -> Span<OpenNoteDeposit>;
+    /// Funds open notes without a computation, followed by the same addresses as
+    /// `privacy_invoke_with_computation`.
+    fn privacy_invoke(
+        ref self: T, deposits: Span<OpenNoteDeposit>,
+    ) -> (Span<OpenNoteDeposit>, Span<ContractAddress>);
 }
 
 #[starknet::contract]
 pub mod MockDelegatedTarget {
     use privacy::objects::OpenNoteDeposit;
     use starknet::ContractAddress;
-    use starknet::storage::{MutableVecTrait, StoragePointerReadAccess, Vec};
+    use starknet::storage::{MutableVecTrait, StoragePointerReadAccess, Vec, VecTrait};
     use super::IMockDelegatedTarget;
 
     #[storage]
@@ -55,29 +56,37 @@ pub mod MockDelegatedTarget {
         fn privacy_invoke_with_computation(
             ref self: ContractState, commitment: felt252, deposits: Span<OpenNoteDeposit>,
         ) -> (Span<OpenNoteDeposit>, Span<ContractAddress>) {
-            let mut associated_addresses: Array<ContractAddress> = array![];
-            for index in 0..self.associated_addresses.len() {
-                associated_addresses.append(self.associated_addresses.at(index).read());
-            }
-            (deposits, associated_addresses.span())
+            (deposits, self.collect_associated_addresses())
         }
 
         fn privacy_invoke(
             ref self: ContractState, deposits: Span<OpenNoteDeposit>,
-        ) -> Span<OpenNoteDeposit> {
-            deposits
+        ) -> (Span<OpenNoteDeposit>, Span<ContractAddress>) {
+            (deposits, self.collect_associated_addresses())
+        }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn collect_associated_addresses(self: @ContractState) -> Span<ContractAddress> {
+            let mut associated_addresses: Array<ContractAddress> = array![];
+            for index in 0..self.associated_addresses.len() {
+                associated_addresses.append(self.associated_addresses.at(index).read());
+            }
+            associated_addresses.span()
         }
     }
 }
 
-/// A depositor listed `Delegated` that returns only its deposits — the misconfiguration the
-/// policy invites, since nothing stops a governor from listing a depositor that names nobody.
+/// A depositor listed `Delegated` that never names an associated address, on either invoke kind —
+/// the pool screens it on itself under the policy's fallback.
 #[starknet::interface]
 pub trait IMockDelegatedWithoutAddresses<T> {
     fn privacy_compute(self: @T, identity_key: felt252) -> felt252;
     fn privacy_invoke_with_computation(
         ref self: T, commitment: felt252, deposits: Span<OpenNoteDeposit>,
     ) -> Span<OpenNoteDeposit>;
+    fn privacy_invoke(ref self: T, deposits: Span<OpenNoteDeposit>) -> Span<OpenNoteDeposit>;
 }
 
 #[starknet::contract]
@@ -99,6 +108,12 @@ pub mod MockDelegatedWithoutAddresses {
 
         fn privacy_invoke_with_computation(
             ref self: ContractState, commitment: felt252, deposits: Span<OpenNoteDeposit>,
+        ) -> Span<OpenNoteDeposit> {
+            deposits
+        }
+
+        fn privacy_invoke(
+            ref self: ContractState, deposits: Span<OpenNoteDeposit>,
         ) -> Span<OpenNoteDeposit> {
             deposits
         }

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -2782,7 +2782,8 @@ fn test_delegated_target_screens_the_address_it_names() {
     assert_eq!(stored_amount, amount);
 }
 
-/// A queried target must name someone: silence is not exemption.
+/// An explicit empty address span is malformed, not a request to be screened as the target
+/// itself: the fallback applies only when nothing follows the deposits at all.
 #[test]
 fn test_delegated_target_naming_no_address_fails() {
     let mut test: Test = Default::default();
@@ -2875,38 +2876,89 @@ fn test_delegated_target_naming_the_zero_address_fails() {
         );
 }
 
-/// A `Delegated` target funding open notes through a plain Invoke names nobody: its plain invoke
-/// returns deposits alone, so the transaction landing at all proves the pool did not go looking for
-/// addresses behind them — had it looked, the missing span would have failed the apply.
+/// A compute-invoke returning no addresses is not silence: the pool falls back to screening the
+/// target itself, the same subject `Required` would have picked.
 #[test]
-fn test_delegated_target_names_no_addresses_on_a_plain_invoke() {
+fn test_delegated_target_without_addresses_screens_itself_on_a_compute_invoke() {
     let mut test: Test = Default::default();
     let token = test.new_token();
     let amount = constants::DEFAULT_AMOUNT;
-    let delegated_target = deploy_mock_delegated_target(
-        associated_addresses: array![test.new_user().address],
-    );
+    let delegated_target = deploy_mock_delegated_without_addresses();
     test.delegate_screening_to(depositor: delegated_target);
     let (_, note_id, actions) = test
-        .funded_open_note_from(depositor: delegated_target, :token, :amount);
+        .compute_funded_open_note_from(depositor: delegated_target, :token, :amount);
 
-    test.privacy.apply_actions_screened(:actions, screening: None, caller: constants::PAYMASTER);
+    test
+        .privacy
+        .assert_apply_fails(:actions, screening: None, expected_error: errors::SCREENING_REQUIRED);
+    test
+        .privacy
+        .apply_actions_screened(
+            :actions,
+            screening: Some(sign_screening_attestation(depositor: delegated_target, issued_at: 0)),
+            caller: constants::PAYMASTER,
+        );
 
     let (_, stored_amount) = unpack(packed_value: test.privacy.get_note(:note_id).packed_value);
     assert_eq!(stored_amount, amount);
 }
 
-/// Listing a depositor that names nobody as `Delegated` — the misconfiguration this policy
-/// invites — fails closed: with no address span behind its deposits there is nothing to screen,
-/// so they revert instead of going unscreened.
+/// The fallback does not depend on invoke kind: a plain invoke returning no addresses is screened
+/// on the target itself exactly like its compute-invoke counterpart.
 #[test]
-fn test_delegated_target_returning_no_addresses_fails() {
+fn test_delegated_target_without_addresses_screens_itself_on_a_plain_invoke() {
     let mut test: Test = Default::default();
+    let token = test.new_token();
+    let amount = constants::DEFAULT_AMOUNT;
     let delegated_target = deploy_mock_delegated_without_addresses();
+    test.delegate_screening_to(depositor: delegated_target);
+    let (_, note_id, actions) = test
+        .funded_open_note_from(depositor: delegated_target, :token, :amount);
+
     test
-        .assert_delegated_apply_fails(
-            :delegated_target, expected_error: errors::INVALID_ASSOCIATED_ADDRESSES,
+        .privacy
+        .assert_apply_fails(:actions, screening: None, expected_error: errors::SCREENING_REQUIRED);
+    test
+        .privacy
+        .apply_actions_screened(
+            :actions,
+            screening: Some(sign_screening_attestation(depositor: delegated_target, issued_at: 0)),
+            caller: constants::PAYMASTER,
         );
+
+    let (_, stored_amount) = unpack(packed_value: test.privacy.get_note(:note_id).packed_value);
+    assert_eq!(stored_amount, amount);
+}
+
+/// A named address is screened the same way regardless of invoke kind: the plain-invoke
+/// counterpart to `test_delegated_target_screens_the_address_it_names`.
+#[test]
+fn test_delegated_target_screens_the_address_it_names_on_a_plain_invoke() {
+    let mut test: Test = Default::default();
+    let token = test.new_token();
+    let amount = constants::DEFAULT_AMOUNT;
+    let named_address = test.new_user().address;
+    let delegated_target = test.new_delegated_target(associated_addresses: array![named_address]);
+    let (_, note_id, actions) = test
+        .funded_open_note_from(depositor: delegated_target, :token, :amount);
+
+    test
+        .privacy
+        .assert_apply_fails(
+            :actions,
+            screening: Some(sign_screening_attestation(depositor: delegated_target, issued_at: 0)),
+            expected_error: errors::SCREENING_INVALID_SIGNATURE,
+        );
+    test
+        .privacy
+        .apply_actions_screened(
+            :actions,
+            screening: Some(sign_screening_attestation(depositor: named_address, issued_at: 0)),
+            caller: constants::PAYMASTER,
+        );
+
+    let (_, stored_amount) = unpack(packed_value: test.privacy.get_note(:note_id).packed_value);
+    assert_eq!(stored_amount, amount);
 }
 
 /// A span promising more addresses than it carries is not a `Span<ContractAddress>` at all.

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -1365,8 +1365,8 @@ pub(crate) impl TestImpl of TestTrait {
         (user, note_id, actions)
     }
 
-    /// Like `funded_open_note_from`, but funding through the compute-invoke path — the one the
-    /// delegated policy acts on, so every delegated fixture funds this way.
+    /// Like `funded_open_note_from`, but funding through the compute-invoke path — one of the two
+    /// invoke kinds a `Delegated` depositor can fund through.
     fn compute_funded_open_note_from(
         ref self: Test, depositor: ContractAddress, token: Token, amount: u128,
     ) -> (User, felt252, Span<ServerAction>) {
@@ -1404,8 +1404,8 @@ pub(crate) impl TestImpl of TestTrait {
         delegated_target
     }
 
-    /// Lists `depositor` as `Delegated`, so the pool reads the addresses to screen from the return
-    /// data of the compute-invoke that funds its open notes.
+    /// Lists `depositor` as `Delegated`, so the pool reads the addresses to screen from whatever
+    /// return data follows the deposits `depositor`'s invoke returns.
     fn delegate_screening_to(self: @Test, depositor: ContractAddress) {
         self
             .privacy


### PR DESCRIPTION
- The Delegated arm no longer reads the invoke selector: the address span returned after the deposits is screened under both invoke kinds
- When nothing follows the deposits the depositor itself is screened, as under Required; an explicit empty span stays NO_ASSOCIATED_ADDRESS
- The policy enum, apply_actions, the setter and the invoke helper docs state the rule
- The delegated mocks answer both invoke kinds, so the tests cover invoke kind by returns-addresses

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/985)
<!-- Reviewable:end -->
