### PR TITLE
refactor(privacy): drop the zero-address check from the screening subject

### DIFF
--- a/packages/privacy/src/interface.cairo
+++ b/packages/privacy/src/interface.cairo
@@ -537,8 +537,6 @@ pub trait IServer<T> {
     /// the tx's actions require screening of more than one distinct address — two deposits with
     /// different `from_addr`, a deposit combined with an Invoke whose target requires screening of
     /// its own address, or a delegated target naming two addresses.
-    /// - [`ZERO_CONTRACT_ADDRESS`](privacy::errors::ZERO_CONTRACT_ADDRESS): Thrown if a screening
-    /// subject is the zero address.
     /// - [`SCREENING_REQUIRED`](privacy::errors::SCREENING_REQUIRED): Thrown if the tx's actions
     /// require screening but `screening` is [`Option::None`].
     /// - [`UNEXPECTED_SCREENING`](privacy::errors::UNEXPECTED_SCREENING): Thrown if `screening` is

--- a/packages/privacy/src/tests/test_server.cairo
+++ b/packages/privacy/src/tests/test_server.cairo
@@ -2841,38 +2841,15 @@ fn test_delegated_target_naming_two_addresses_fails() {
         );
 }
 
-/// The zero-address guard sits in the accumulator so it covers every requirement source, not only
-/// the delegated answer: a regular deposit from the zero address reaches it too. Without a test
-/// driving this path, moving the guard into the query would pass the whole suite while quietly
-/// dropping it for regular deposits.
+/// Zero is a screening subject like any other: no screener attests to it, so the deposits a
+/// delegated target names it for stay blocked rather than exempted.
 #[test]
-fn test_regular_deposit_from_the_zero_address_fails() {
-    let mut test: Test = Default::default();
-    let token = test.new_token();
-    let amount = constants::DEFAULT_AMOUNT;
-    let deposit = [
-        ServerAction::TransferFrom(
-            TransferFromInput { from_addr: Zero::zero(), token: token.contract_address(), amount },
-        ),
-    ]
-        .span();
-
-    test
-        .privacy
-        .assert_apply_fails(
-            actions: deposit, screening: None, expected_error: errors::ZERO_CONTRACT_ADDRESS,
-        );
-}
-
-/// The zero address is how the pool says "nothing to screen", so a target may not name it as
-/// something to screen — an attestation over `0x0` would attest to no one.
-#[test]
-fn test_delegated_target_naming_the_zero_address_fails() {
+fn test_delegated_target_naming_the_zero_address_still_requires_screening() {
     let mut test: Test = Default::default();
     let delegated_target = deploy_mock_delegated_target(associated_addresses: array![Zero::zero()]);
     test
         .assert_delegated_apply_fails(
-            :delegated_target, expected_error: errors::ZERO_CONTRACT_ADDRESS,
+            :delegated_target, expected_error: errors::SCREENING_REQUIRED,
         );
 }
 

--- a/packages/privacy/src/tests/test_utils.cairo
+++ b/packages/privacy/src/tests/test_utils.cairo
@@ -337,15 +337,6 @@ fn test_unify_address_dedups_same_screening_subject() {
     assert_eq!(screening_subject, Some(address));
 }
 
-/// The zero address already means "nothing to screen" as a `None` requirement, so it can never be
-/// a requirement itself.
-#[test]
-#[should_panic(expected: 'ZERO_CONTRACT_ADDRESS')]
-fn test_unify_address_rejects_the_zero_address() {
-    let mut screening_subject: Option<ContractAddress> = None;
-    unify_address(ref screening_subject, reference: Zero::zero());
-}
-
 #[test]
 #[should_panic(expected: 'MULTIPLE_SCREENING_SUBJECTS')]
 fn test_unify_address_rejects_distinct_screening_subject() {

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -604,7 +604,6 @@ pub(crate) fn deserialize_invoke_return_data(
 /// Unifies `subject` with `reference`: binds it on the first application, and requires equality on
 /// every later one.
 pub(crate) fn unify_address(ref subject: Option<ContractAddress>, reference: ContractAddress) {
-    assert(reference.is_non_zero(), errors::ZERO_CONTRACT_ADDRESS);
     if let Some(already_set) = subject {
         assert(already_set == reference, errors::MULTIPLE_SCREENING_SUBJECTS);
     } else {


### PR DESCRIPTION
- A zero subject is Some(0), not None: it demands an attestation over zero, which no screener issues, so the check only changed which error a failing input got
- The delegated-names-zero test keeps that property as SCREENING_REQUIRED
- ZERO_CONTRACT_ADDRESS stays for the policy setter and compile-time invoke validation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/987)
<!-- Reviewable:end -->
