### PR TITLE
refactor(privacy): accept only VALIDATED from is_valid_signature

### DIFF
--- a/packages/privacy/src/tests/mock_stark_account.cairo
+++ b/packages/privacy/src/tests/mock_stark_account.cairo
@@ -9,16 +9,16 @@ pub mod MockStarkAccount {
     use core::ecdsa::check_ecdsa_signature;
     use core::panic_with_felt252;
     use privacy::utils::IAccount;
-    use privacy::utils::constants::LEGACY_VALIDATED;
     use starknet::VALIDATED;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     pub const INVALID_SIG: felt252 = 'INVALID_SIG';
+    const BOOLEAN_TRUE: felt252 = 1;
 
     #[storage]
     struct Storage {
         public_key: felt252,
-        // Whether acceptance is reported as a pre-SNIP-6 boolean instead of `VALIDATED`.
+        // Whether acceptance is reported as the boolean `1` instead of `VALIDATED`.
         returns_legacy_bool: bool,
         // Whether rejection is reported by panicking instead of returning 0.
         panics_on_reject: bool,
@@ -53,7 +53,7 @@ pub mod MockStarkAccount {
                 return 0;
             }
             if self.returns_legacy_bool.read() {
-                LEGACY_VALIDATED
+                BOOLEAN_TRUE
             } else {
                 VALIDATED
             }

--- a/packages/privacy/src/tests/test_client.cairo
+++ b/packages/privacy/src/tests/test_client.cairo
@@ -27,7 +27,7 @@ use privacy::tests::utils_for_tests::{
     deploy_mock_return_garbage, deploy_mock_stark_account,
 };
 use privacy::utils::constants::{
-    ERR_WRAPPER, ESTIMATION_BASE_TX_VERSION, LEGACY_VALIDATED, OPEN_NOTE_SALT, TWO_POW_120, TX_V3,
+    ERR_WRAPPER, ESTIMATION_BASE_TX_VERSION, OPEN_NOTE_SALT, TWO_POW_120, TX_V3,
 };
 use privacy::utils::{
     compute_message_hash, decode_note_amount, encrypt_channel_info, encrypt_user_addr,
@@ -6804,11 +6804,10 @@ fn test_deposit_account_without_src5_routes_to_legacy() {
     stop_cheat_chain_id_global();
 }
 
-/// A pre-SNIP-6 wallet accepts by returning the boolean `1` rather than the `VALIDATED` short
-/// string. SNIP-6 tells consumers to honor both, so a valid signature over the tx hash must
-/// authenticate at check II.
+/// Only `VALIDATED` authenticates: a wallet that answers the boolean `1` for a signature that is
+/// otherwise valid over the tx hash is still rejected with `INVALID_SIGNATURE`.
 #[test]
-fn test_deposit_legacy_bool_wallet_via_tx_hash() {
+fn test_deposit_boolean_answering_wallet_is_rejected() {
     let test: Test = Default::default();
     let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('BOOL_WALLET_SK');
     let depositor = deploy_mock_stark_account(
@@ -6828,64 +6827,8 @@ fn test_deposit_legacy_bool_wallet_via_tx_hash() {
     start_cheat_signature(test.privacy.address, array![r, s].span());
 
     let result = test.privacy.safe_execute_with_calls(calls);
-    assert!(result.is_ok(), "a boolean acceptance felt must authenticate at check II");
-    stop_cheat_transaction_hash(test.privacy.address);
-}
-
-/// The same boolean acceptance felt must also be honored at check III, reached only when the
-/// signature is over the SNIP-12 `CallSet` hash instead of the tx hash.
-#[test]
-fn test_deposit_legacy_bool_wallet_via_snip12_call_set() {
-    start_cheat_chain_id_global('TEST');
-    let test: Test = Default::default();
-    let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('BOOL_WALLET_SK');
-    let depositor = deploy_mock_stark_account(
-        salt: 19, public_key: key.public_key, returns_legacy_bool: true, panics_on_reject: false,
-    );
-
-    let client_actions = [ClientAction::SetViewingKey(SetViewingKeyInput { random: 0x777 })].span();
-    let calls = test
-        .privacy
-        .wrap_inputs_into_calls(
-            user_addr: depositor, user_private_key: 'BOOL_PROTOCOL_PK', :client_actions,
-        );
-
-    // The wallet signs the SNIP-12 CallSet message over exactly these calls.
-    let hash = compute_call_set_hash(depositor, calls.span(), [].span());
-    let (r, s) = key.sign(hash).unwrap();
-    start_cheat_signature(test.privacy.address, array![r, s].span());
-
-    let result = test.privacy.safe_execute_with_calls(calls);
-    assert!(result.is_ok(), "a boolean acceptance felt must authenticate at check III");
-    stop_cheat_chain_id_global();
-}
-
-/// Tolerating the boolean acceptance felt must not weaken rejection: a boolean-style wallet that
-/// rejects (returns 0) over every message still fails with `INVALID_SIGNATURE`.
-#[test]
-fn test_deposit_legacy_bool_wallet_wrong_call_set_reverts() {
-    start_cheat_chain_id_global('TEST');
-    let test: Test = Default::default();
-    let key: StarkCurveKeyPair = KeyPairTrait::from_secret_key('BOOL_WALLET_SK');
-    let depositor = deploy_mock_stark_account(
-        salt: 20, public_key: key.public_key, returns_legacy_bool: true, panics_on_reject: false,
-    );
-
-    let client_actions = [ClientAction::SetViewingKey(SetViewingKeyInput { random: 0x777 })].span();
-    let calls = test
-        .privacy
-        .wrap_inputs_into_calls(
-            user_addr: depositor, user_private_key: 'BOOL_PROTOCOL_PK', :client_actions,
-        );
-
-    // Sign a DIFFERENT CallSet (empty calls) — neither the tx hash nor the real CallSet hash.
-    let wrong_hash = compute_call_set_hash(depositor, [].span(), [].span());
-    let (r, s) = key.sign(wrong_hash).unwrap();
-    start_cheat_signature(test.privacy.address, array![r, s].span());
-
-    let result = test.privacy.safe_execute_with_calls(calls);
     assert_panic_with_felt_error(:result, expected_error: errors::INVALID_SIGNATURE);
-    stop_cheat_chain_id_global();
+    stop_cheat_transaction_hash(test.privacy.address);
 }
 
 /// Regression: a wallet that rejects a mismatched signature by panicking rather than returning 0

--- a/packages/privacy/src/tests/utils_for_tests.cairo
+++ b/packages/privacy/src/tests/utils_for_tests.cairo
@@ -2528,8 +2528,8 @@ pub(crate) fn deploy_mock_custom_account(
 }
 
 /// Deploy a standard-style STARK account mock that verifies a real signature against `public_key`.
-/// `returns_legacy_bool` selects whether it accepts with a pre-SNIP-6 boolean or with `VALIDATED`;
-/// `panics_on_reject` selects whether it rejects by panicking instead of returning 0.
+/// `returns_legacy_bool` selects whether it reports acceptance as the boolean `1` instead of
+/// `VALIDATED`; `panics_on_reject` selects whether it rejects by panicking instead of returning 0.
 pub(crate) fn deploy_mock_stark_account(
     salt: felt252, public_key: felt252, returns_legacy_bool: bool, panics_on_reject: bool,
 ) -> ContractAddress {

--- a/packages/privacy/src/utils.cairo
+++ b/packages/privacy/src/utils.cairo
@@ -21,8 +21,8 @@ use privacy::objects::{
 };
 use privacy::snip12::compute_call_set_hash;
 use privacy::utils::constants::{
-    ENTRYPOINT_FAILED, ERR_WRAPPER, HALF_ORDER, LEGACY_VALIDATED, OK_WRAPPER,
-    OPEN_NOTE_PACKED_VALUE, OPEN_NOTE_SALT, TWO_POW_120,
+    ENTRYPOINT_FAILED, ERR_WRAPPER, HALF_ORDER, OK_WRAPPER, OPEN_NOTE_PACKED_VALUE, OPEN_NOTE_SALT,
+    TWO_POW_120,
 };
 use starknet::account::Call;
 use starknet::storage::{StorageAsPointer, StoragePath};
@@ -60,10 +60,6 @@ pub mod constants {
     pub const OPEN_NOTE_SALT: u128 = 1;
     pub const TWO_POW_120: u128 = 2_u128.pow(120);
     pub const ENTRYPOINT_FAILED: felt252 = 'ENTRYPOINT_FAILED';
-    /// Acceptance felt of a pre-SNIP-6 wallet, which answers `is_valid_signature` with a boolean
-    /// rather than the [`VALIDATED`](starknet::VALIDATED) short string. SNIP-6 tells consumers to
-    /// honor both while such wallets remain in circulation.
-    pub const LEGACY_VALIDATED: felt252 = 1;
     pub const OK_WRAPPER: felt252 = 'PRIVACY_OK_WRAPPER';
     /// Brackets panic data propagated from an external contract call made during client
     /// compilation. Distinct from `OK_WRAPPER` so that a panicking external contract cannot forge
@@ -435,7 +431,7 @@ fn supports_custom_validation(user_addr: ContractAddress) -> bool {
 
 
 fn signature_accepted(validation_result: Result<felt252, Array<felt252>>) -> bool {
-    validation_result == Result::Ok(VALIDATED) || validation_result == Result::Ok(LEGACY_VALIDATED)
+    validation_result == Result::Ok(VALIDATED)
 }
 
 /// Sends server actions to L1.


### PR DESCRIPTION
- SNIP-6 requires the `VALID` short string; the boolean `1` was a transitional allowance for pre-SNIP-6 accounts
- One test pins that a wallet answering the boolean over a correct signature is rejected with `INVALID_SIGNATURE`

**Draft, pending a decision.** The audit asked to *consider* removing the boolean acceptance. Accepting `1` adds no forgery surface (the dispatch goes to the user's own account), so this is compatibility against simplicity. Two facts for the decision:
- SNIP-6: "if the signature is valid, the return value for `is_valid_signature` MUST be the short string literal `VALID`"; it recommends checking "both `true` or `'VALID'`" only for the transition period while bool-returning accounts migrate.
- Starknet v0.14.0 (2025-09) introduced `meta_tx_v0` "to enable calling old accounts (i.e., ones without `__validate__`) via v3 transactions", so pre-SNIP-6 accounts still execute on mainnet; a user holding one would be locked out of the pool by this change. Argent's Cairo 0 account exposes `isValidSignature` only, so it never reached this check; a Braavos Cairo 0 account or an early OpenZeppelin one would have.

@ofir-starkware, the acceptance came in with #934: keep or drop?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/988)
<!-- Reviewable:end -->
