### PR TITLE
ci: pin the remaining actions to full commit SHAs

### DIFF
--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -12,7 +12,7 @@ jobs:
     name: autoupdate
     runs-on: ubuntu-22.04
     steps:
-      - uses: docker://chinthakagodawita/autoupdate-action:v1
+      - uses: docker://chinthakagodawita/autoupdate-action@sha256:53d7013ad4689b703d2715d4b17d4901bb0a385e495e0b481f37adbe9b3cc3fc # v1
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           PR_FILTER: "labelled"

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Client Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           # The client resolves @starkware-libs/starknet-privacy-sdk via file:../sdk, so an
@@ -20,7 +20,7 @@ jobs:
             client:
               - 'client/**'
               - 'sdk/**'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         if: steps.filter.outputs.client == 'true'
         with:
           node-version: '24'
@@ -39,9 +39,9 @@ jobs:
     name: Client Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: software-mansion/setup-scarb@2a96b748888e3329ee44ac9ac073d930e692b3cd # v1
         with:
           scarb-version: "2.18.0"
-      - uses: software-mansion/setup-universal-sierra-compiler@v1
+      - uses: software-mansion/setup-universal-sierra-compiler@30c139bca57cc0561cfae6f5353825bbc42c9f37 # v1
         if: github.event_name == 'push' || steps.cairo-check.outputs.changed == 'true'
         with:
           universal-sierra-compiler-version: "v2.8.0"

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -92,7 +92,7 @@ jobs:
       # contracts, or this workflow itself change (the last so a change to the job below is exercised by
       # its own PR). Client-only PRs skip it (the steps no-op and the job still reports green, keeping a
       # required check satisfied) rather than being gated on the unrelated Cairo/devnet build.
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
- The repository refuses unpinned actions, so every job in Client CI, Rust CI's test job and the SDK devnet test has failed at start since 2026-09-03
- Reuses the SHAs the other workflows already pin for the same actions
- The autoupdate Docker image is pinned to its digest, the only pin a docker:// reference has

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-privacy/989)
<!-- Reviewable:end -->
